### PR TITLE
Sqlite open function to allow connection to a sqlite file

### DIFF
--- a/src/db/sqlite/src/lib.rs
+++ b/src/db/sqlite/src/lib.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use toasty_core::{
     driver::{operation::Operation, Capability, Driver},
     schema, sql, stmt, Schema,
@@ -19,6 +20,14 @@ impl Sqlite {
         Sqlite {
             connection: Mutex::new(connection),
         }
+    }
+
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Sqlite> {
+        let connection = Connection::open(path)?;
+
+        Ok(Sqlite {
+            connection: Mutex::new(connection),
+        })
     }
 }
 


### PR DESCRIPTION
This pull request allow you to actually open a connection to a sqlite file.

In the current state, you can only open a in-memory database.

Example:

```rs
use toasty_sqlite::Sqlite;
// ...
let driver = Sqlite::open("my_database.db").unwrap();
```