### PR TITLE
use tracing crate, debug! macro, instead of println/dbg

### DIFF
--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = "1"
 async-trait = "0.1"
 std-util = { path = "../std-util" }
 tokio-stream = { version = "0.1.12", default-features = false }
+tracing = "0.1.40"
 
 [dev-dependencies]
 pretty_assertions = "1.2"

--- a/src/core/src/stmt/visit.rs
+++ b/src/core/src/stmt/visit.rs
@@ -1,6 +1,7 @@
 #![allow(unused_variables)]
 
 use super::*;
+use tracing::debug;
 
 pub trait Visit<'stmt>: Sized {
     fn visit<N: Node<'stmt>>(&mut self, i: &N) {
@@ -493,7 +494,7 @@ where
 {
     match node {
         Value::Record(node) => v.visit_value_record(node),
-        _ => println!("TODO! implement visit value type {:#?}", node),
+        _ => debug!("TODO! implement visit value type {:#?}", node),
     }
 }
 

--- a/src/db/sqlite/Cargo.toml
+++ b/src/db/sqlite/Cargo.toml
@@ -9,6 +9,7 @@ toasty-core = { path = "../../core" }
 
 anyhow = "1"
 rusqlite = { version = "0.32", features = ["bundled"] }
+tracing = "0.1.40"
 
 # TODO: get rid of
 serde = { version = "1.0.196", features = ["derive"] }

--- a/src/db/sqlite/src/lib.rs
+++ b/src/db/sqlite/src/lib.rs
@@ -6,6 +6,7 @@ use toasty_core::{
 use anyhow::Result;
 use rusqlite::Connection;
 use std::sync::Mutex;
+use tracing::debug;
 
 #[derive(Debug)]
 pub struct Sqlite {
@@ -39,7 +40,7 @@ impl Driver for Sqlite {
     ) -> Result<stmt::ValueStream<'a>> {
         use Operation::*;
 
-        println!("op={:#?}", op);
+        debug!("op={:#?}", op);
 
         let connection = self.connection.lock().unwrap();
 
@@ -61,7 +62,7 @@ impl Driver for Sqlite {
         let mut params = vec![];
         let sql_str = sql.to_sql_string(schema, &mut params);
 
-        println!("{} {:#?}", sql_str, params);
+        debug!("{} {:#?}", sql_str, params);
 
         let mut stmt = connection.prepare(&sql_str).unwrap();
 
@@ -78,7 +79,7 @@ impl Driver for Sqlite {
                     ))
                     .unwrap();
 
-                println!("sqlite; rows={}", ret);
+                debug!("sqlite; rows={}", ret);
 
                 return Ok(stmt::ValueStream::new());
             }

--- a/src/toasty/Cargo.toml
+++ b/src/toasty/Cargo.toml
@@ -16,3 +16,4 @@ tokio-stream = { version = "0.1.12", default-features = false }
 uuid = { version = "1.3.0", features = ["v4", "fast-rng"] }
 indexmap = "2.1.0"
 by_address = "1.2.1"
+tracing = "0.1.40"

--- a/src/toasty/src/db.rs
+++ b/src/toasty/src/db.rs
@@ -1,6 +1,7 @@
 use crate::{driver::Driver, engine, stmt, Cursor, Model, Result, Statement};
 
 use toasty_core::{stmt::ValueStream, Schema};
+use tracing::debug;
 
 #[derive(Debug)]
 pub struct Db {
@@ -73,7 +74,7 @@ impl Db {
         &'a self,
         statement: Statement<'a, M>,
     ) -> Result<ValueStream<'a>> {
-        dbg!("EXEC: {:#?}", statement);
+        debug!("EXEC: {:#?}", statement);
         // Create a plan to execute the statement
         let mut res = engine::exec(self, statement.untyped).await?;
 

--- a/src/toasty/src/engine.rs
+++ b/src/toasty/src/engine.rs
@@ -8,7 +8,7 @@ mod planner;
 mod verify;
 
 use crate::{Db, Result};
-
+use tracing::debug;
 use toasty_core::{
     eval, sql,
     stmt::{self, Statement, ValueStream},
@@ -23,7 +23,7 @@ pub(crate) async fn exec<'a>(db: &'a Db, stmt: Statement<'a>) -> Result<ValueStr
     // Translate the optimized statement into a series of driver operations.
     let plan = planner::apply(db.driver.capability(), &db.schema, stmt);
 
-    dbg!("PLAN = {:#?}", plan);
+    debug!("PLAN = {:#?}", plan);
 
     // The plan is called once (single entry record stream) with no arguments
     // (empty record).

--- a/src/toasty/src/engine/exec.rs
+++ b/src/toasty/src/engine/exec.rs
@@ -14,6 +14,7 @@ pub(crate) use var_store::VarStore;
 use crate::{driver::operation, engine::*, Result};
 
 use toasty_core::{sql, stmt};
+use tracing::debug;
 
 struct Exec<'stmt> {
     db: &'stmt Db,
@@ -45,7 +46,7 @@ impl<'stmt> Exec<'stmt> {
     }
 
     async fn exec_step(&mut self, action: &Action<'stmt>) -> Result<()> {
-        println!("EXEC = {:#?}", action);
+        debug!("EXEC = {:#?}", action);
 
         match action {
             Action::Associate(action) => self.exec_associate(action).await,

--- a/src/toasty/src/engine/planner/select.rs
+++ b/src/toasty/src/engine/planner/select.rs
@@ -1,4 +1,5 @@
 use super::*;
+use tracing::debug;
 
 #[derive(Debug, Default)]
 pub(super) struct Context<'stmt> {
@@ -15,7 +16,7 @@ impl<'stmt> Planner<'stmt> {
     }
 
     fn plan_select2(&mut self, cx: &Context<'stmt>, mut stmt: stmt::Query<'stmt>) -> plan::VarId {
-        println!("+ plan_select; {:#?}", stmt);
+        debug!("+ plan_select; {:#?}", stmt);
         self.simplify_stmt_query(&mut stmt);
         self.plan_simplified_select(cx, &stmt)
     }
@@ -27,7 +28,7 @@ impl<'stmt> Planner<'stmt> {
     ) -> plan::VarId {
         let stmt = stmt.body.as_select();
 
-        println!(" + plan_simplified_select; {:#?}", stmt);
+        debug!(" + plan_simplified_select; {:#?}", stmt);
 
         let source_model = stmt.source.as_model();
         let model = self.schema.model(source_model.model);
@@ -134,7 +135,7 @@ impl<'stmt> Planner<'stmt> {
         }
 
         if index_plan.index.primary_key {
-            println!("index_filter={:#?}", index_filter);
+            debug!("index_filter={:#?}", index_filter);
             // Is the index filter a set of keys
             if let Some(keys) = self.try_build_key_filter(index, &index_filter) {
                 assert!(index_plan.post_filter.is_none());
@@ -158,7 +159,7 @@ impl<'stmt> Planner<'stmt> {
 
                 let output = self.var_table.register_var();
 
-                println!(
+                debug!(
                     "===>>>> index_filter={:#?}; converted={:#?}",
                     index_filter,
                     sql::Expr::from_stmt(self.schema, table.id, index_filter.clone())

--- a/src/toasty/src/macros.rs
+++ b/src/toasty/src/macros.rs
@@ -1,3 +1,4 @@
+#[allow(unused_macros)]
 macro_rules! dbg {
     ( $( $t:tt )* ) => {{
         if cfg!(debug_assertions) {


### PR DESCRIPTION
To avoid spamming stdout of projects that are using the orm library