### PR TITLE
refactor(sqlite): rename Sqlite::new() to Sqlite::in_memory()

### DIFF
--- a/src/db/sqlite/src/lib.rs
+++ b/src/db/sqlite/src/lib.rs
@@ -13,7 +13,7 @@ pub struct Sqlite {
 }
 
 impl Sqlite {
-    pub fn new() -> Sqlite {
+    pub fn in_memory() -> Sqlite {
         let connection = Connection::open_in_memory().unwrap();
 
         Sqlite {

--- a/tests/client/src/db.rs
+++ b/tests/client/src/db.rs
@@ -46,7 +46,7 @@ pub struct SetupSqlite;
 #[async_trait::async_trait]
 impl Setup for SetupSqlite {
     async fn setup(&self, schema: Schema) -> Db {
-        let driver = toasty_sqlite::Sqlite::new();
+        let driver = toasty_sqlite::Sqlite::in_memory();
         let db = toasty::Db::new(schema, driver).await;
         db.reset_db().await.unwrap();
         db


### PR DESCRIPTION
one has to read the new function to understand that the default behavior is in-memory