### PR TITLE
move dependencies to workspace Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "src/cli",
     "src/codegen",
@@ -23,4 +24,27 @@ members = [
     "tests/client",
 ]
 
-resolver = "2"
+
+[workspace.dependencies]
+anyhow = "1.0.92"
+async-recursion = "1.1.1"
+async-stream = "0.3.6"
+async-trait = "0.1.83"
+by_address = "1.2.1"
+clap = { version = "4.5.20", features = ["derive"] }
+heck = "0.5.0"
+indexmap = "2.6.0"
+pluralizer = "0.4.0"
+pretty_assertions = "1.4.1"
+proc-macro2 = "1.0.37"
+quote = "1.0.18"
+rand = "0.8.5"
+serde = { version = "1.0.214", features = ["derive"] }
+serde_json = "1.0.132"
+std-util = { path = "src/std-util" }
+syn = "2.0.86"
+tokio-stream = { version = "0.1.16", default-features = false }
+toasty-codegen = { path = "src/codegen" }
+toasty-core = { path = "src/core" }
+toasty-driver = { path = "src/driver" }
+uuid = { version = "1.11.0", features = ["v4", "fast-rng"] }

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -6,8 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-toasty-codegen = { path = "../codegen" }
-toasty-core = { path = "../core" }
-
-anyhow = "1.0"
-clap = { version = "3.1.12", features = ["derive"] }
+anyhow.workspace = true
+clap.workspace = true
+toasty-codegen.workspace = true
+toasty-core.workspace = true

--- a/src/codegen/Cargo.toml
+++ b/src/codegen/Cargo.toml
@@ -6,9 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-toasty-core = { path = "../core" }
-std-util = { path = "../std-util" }
-
-syn = "1.0.92"
-proc-macro2 = "1.0.37"
-quote = "1.0.18"
+proc-macro2.workspace = true
+quote.workspace = true
+std-util.workspace = true
+syn.workspace = true
+toasty-core.workspace = true

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
-anyhow = "1"
-async-trait = "0.1"
-std-util = { path = "../std-util" }
-tokio-stream = { version = "0.1.12", default-features = false }
+anyhow.workspace = true
+async-trait.workspace = true
+std-util.workspace = true
+tokio-stream.workspace = true
 
 [dev-dependencies]
-pretty_assertions = "1.2"
+pretty_assertions.workspace = true

--- a/src/db/ddb/Cargo.toml
+++ b/src/db/ddb/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 publish = false
 
 [dependencies]
-toasty-core = { path = "../../core" }
-anyhow = "1"
-aws-sdk-dynamodb = { version = "1.3.0", features = ["test-util"] }
+anyhow.workspace = true
 aws-config = "1"
-serde = { version = "1.0.196", features = ["derive"] }
-serde_json = "1.0.113"
+aws-sdk-dynamodb = { version = "1.3.0", features = ["test-util"] }
+serde.workspace = true
+serde_json.workspace = true
+toasty-core.workspace = true

--- a/src/db/mem/Cargo.toml
+++ b/src/db/mem/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-toasty-driver = { path = "../../driver" }
+toasty-driver.workspace = true

--- a/src/db/sqlite/Cargo.toml
+++ b/src/db/sqlite/Cargo.toml
@@ -5,11 +5,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
-toasty-core = { path = "../../core" }
-
-anyhow = "1"
+anyhow.workspace = true
 rusqlite = { version = "0.32", features = ["bundled"] }
+toasty-core.workspace = true
 
 # TODO: get rid of
-serde = { version = "1.0.196", features = ["derive"] }
-serde_json = "1.0.113"
+serde.workspace = true
+serde_json.workspace = true

--- a/src/macros/Cargo.toml
+++ b/src/macros/Cargo.toml
@@ -8,9 +8,8 @@ publish = false
 proc-macro = true
 
 [dependencies]
-toasty-codegen = { path = "../codegen" }
-toasty-core = { path = "../core" }
-
-proc-macro2 = "1.0.38"
-quote = "1.0.18"
-syn = { version = "1.0.93", features = ["parsing"] }
+proc-macro2.workspace = true
+quote.workspace = true
+syn.workspace = true
+toasty-core.workspace = true
+toasty-codegen.workspace = true

--- a/src/std-util/Cargo.toml
+++ b/src/std-util/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-heck = "0.4.1"
-pluralizer = "0.4.0"
-rand = "0.8.5"
+heck.workspace = true
+pluralizer.workspace = true
+rand.workspace = true

--- a/src/toasty/Cargo.toml
+++ b/src/toasty/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 toasty-macros = { path = "../macros" }
-toasty-core = { path = "../core" }
+toasty-core.workspace = true
 
 anyhow = "1"
 async-stream = "0.3.5"


### PR DESCRIPTION
Makes it easier to ensure that versions are same throughout

Note also bumps crate versions to latest available versions.