### PR TITLE
rm `Value::ty`

### DIFF
--- a/src/core/src/stmt/value.rs
+++ b/src/core/src/stmt/value.rs
@@ -211,26 +211,6 @@ impl Value {
     pub fn take(&mut self) -> Value {
         std::mem::take(self)
     }
-
-    pub fn ty(&self) -> Type {
-        match self {
-            Value::Bool(_) => Type::Bool,
-            Value::I64(_) => Type::I64,
-            Value::Id(v) => Type::Id(v.model_id()),
-            Value::SparseRecord(v) => Type::SparseRecord(v.fields.clone()),
-            Value::Null => Type::Null,
-            Value::Record(v) => Type::Record(v.fields.iter().map(Value::ty).collect()),
-            Value::String(_) => Type::String,
-            Value::List(ref items) => {
-                if items.is_empty() {
-                    Type::List(Box::new(Type::Null))
-                } else {
-                    Type::List(Box::new(items[0].ty()))
-                }
-            }
-            _ => todo!("value={self:#?}"),
-        }
-    }
 }
 
 impl Default for Value {


### PR DESCRIPTION
This is no longer needed