### PR TITLE
Add config options for Serializer  and Formater 

### DIFF
--- a/src/core/src/schema/app.rs
+++ b/src/core/src/schema/app.rs
@@ -12,6 +12,9 @@ use context::Context;
 mod field;
 pub use field::{Field, FieldId, FieldPrimitive, FieldTy};
 
+mod fk;
+pub use fk::{ForeignKey, ForeignKeyField};
+
 mod index;
 pub use index::{Index, IndexField, IndexId};
 

--- a/src/core/src/schema/app/fk.rs
+++ b/src/core/src/schema/app/fk.rs
@@ -1,0 +1,35 @@
+use super::{Field, FieldId, Schema};
+
+#[derive(Debug, PartialEq)]
+pub struct ForeignKey {
+    pub fields: Vec<ForeignKeyField>,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct ForeignKeyField {
+    /// The field on the source model that is acting as the foreign key
+    pub source: FieldId,
+
+    /// The field on the target model that this FK field maps to.
+    pub target: FieldId,
+}
+
+impl ForeignKey {
+    pub(crate) fn placeholder() -> ForeignKey {
+        ForeignKey { fields: vec![] }
+    }
+
+    pub(crate) fn is_placeholder(&self) -> bool {
+        self.fields.is_empty()
+    }
+}
+
+impl ForeignKeyField {
+    pub fn source<'a>(&self, schema: &'a Schema) -> &'a Field {
+        schema.field(self.source)
+    }
+
+    pub fn target<'a>(&self, schema: &'a Schema) -> &'a Field {
+        schema.field(self.target)
+    }
+}

--- a/src/core/src/schema/app/model/from_ast.rs
+++ b/src/core/src/schema/app/model/from_ast.rs
@@ -222,7 +222,7 @@ impl Builder<'_> {
                     expr_ty: stmt::Type::Model(target),
                     pair: None,
                     // This will be populated at a later step.
-                    foreign_key: relation::ForeignKey::placeholder(),
+                    foreign_key: ForeignKey::placeholder(),
                 }
                 .into()
             } else {

--- a/src/core/src/schema/app/relation.rs
+++ b/src/core/src/schema/app/relation.rs
@@ -1,5 +1,5 @@
 mod belongs_to;
-pub use belongs_to::{BelongsTo, ForeignKey, ForeignKeyField};
+pub use belongs_to::BelongsTo;
 
 mod has_many;
 pub use has_many::HasMany;

--- a/src/core/src/schema/app/relation/belongs_to.rs
+++ b/src/core/src/schema/app/relation/belongs_to.rs
@@ -17,20 +17,6 @@ pub struct BelongsTo {
     pub foreign_key: ForeignKey,
 }
 
-#[derive(Debug, PartialEq)]
-pub struct ForeignKey {
-    pub fields: Vec<ForeignKeyField>,
-}
-
-#[derive(Debug, PartialEq)]
-pub struct ForeignKeyField {
-    /// The field on the source model that is acting as the foreign key
-    pub source: FieldId,
-
-    /// The field on the target model that this FK field maps to.
-    pub target: FieldId,
-}
-
 impl BelongsTo {
     pub fn target<'a>(&self, schema: &'a Schema) -> &'a Model {
         schema.model(self.target)
@@ -40,25 +26,5 @@ impl BelongsTo {
 impl From<BelongsTo> for FieldTy {
     fn from(value: BelongsTo) -> Self {
         FieldTy::BelongsTo(value)
-    }
-}
-
-impl ForeignKey {
-    pub(crate) fn placeholder() -> ForeignKey {
-        ForeignKey { fields: vec![] }
-    }
-
-    pub(crate) fn is_placeholder(&self) -> bool {
-        self.fields.is_empty()
-    }
-}
-
-impl ForeignKeyField {
-    pub fn source<'a>(&self, schema: &'a Schema) -> &'a Field {
-        schema.field(self.source)
-    }
-
-    pub fn target<'a>(&self, schema: &'a Schema) -> &'a Field {
-        schema.field(self.target)
     }
 }

--- a/src/core/src/schema/app/schema.rs
+++ b/src/core/src/schema/app/schema.rs
@@ -324,12 +324,7 @@ impl Builder {
         todo!("missing relation attribute")
     }
 
-    fn foreign_key_for(
-        &self,
-        source: &Model,
-        source_field: &Field,
-        target: ModelId,
-    ) -> relation::ForeignKey {
+    fn foreign_key_for(&self, source: &Model, source_field: &Field, target: ModelId) -> ForeignKey {
         let attr = self.cx.get_relation_attr(source_field.id);
 
         assert_eq!(
@@ -347,12 +342,12 @@ impl Builder {
                 .field_by_name(references.as_str())
                 .expect("missing filed");
 
-            fields.push(relation::ForeignKeyField {
+            fields.push(ForeignKeyField {
                 source: field_source.id,
                 target: field_target.id,
             });
         }
 
-        relation::ForeignKey { fields }
+        ForeignKey { fields }
     }
 }

--- a/src/core/src/stmt/sql/serialize.rs
+++ b/src/core/src/stmt/sql/serialize.rs
@@ -5,7 +5,7 @@ use crate::schema::db;
 use crate::stmt::Statement as DataStatement;
 
 use std::{
-    fmt::{self, Write},
+    fmt::{self, Display, Write},
     ops::Deref,
 };
 
@@ -18,6 +18,26 @@ pub struct Serializer<'a> {
     schema: &'a db::Schema,
     quoted_table_names: bool,
     quoted_column_names: bool,
+}
+
+struct MaybeQuote<'a> {
+    value: &'a str,
+    quote: bool,
+}
+
+impl<'a> MaybeQuote<'a> {
+    fn new(value: &'a str, quote: bool) -> Self {
+        Self { value, quote }
+    }
+}
+impl Display for MaybeQuote<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if self.quote {
+            write!(f, "\"{}\"", self.value)
+        } else {
+            write!(f, "{}", self.value)
+        }
+    }
 }
 
 struct Formatter<'a, T> {
@@ -191,10 +211,7 @@ impl<T: Params> Formatter<'_, T> {
         write!(self.dst, " ON ")?;
 
         let table = self.schema.table(stmt.on);
-
-        if self.quoted_table_names {
-            self.ident_str(&table.name)?;
-        }
+        self.ident_str(&table.name, self.quoted_table_names)?;
 
         write!(self.dst, " (")?;
 
@@ -255,9 +272,7 @@ impl<T: Params> Formatter<'_, T> {
     }
 
     fn column_def(&mut self, stmt: &ColumnDef) -> fmt::Result {
-        if self.quoted_column_names {
-            self.ident(&stmt.name)?;
-        }
+        self.ident(&stmt.name, self.quoted_column_names)?;
         write!(self.dst, " ")?;
         self.ty(&stmt.ty)?;
         Ok(())
@@ -278,12 +293,11 @@ impl<T: Params> Formatter<'_, T> {
 
         for table_with_join in delete.from.as_table_with_joins() {
             let table = self.schema.table(table_with_join.table);
-
-            if self.quoted_table_names {
-                write!(self.dst, "\"{}\"", table.name)?;
-            } else {
-                write!(self.dst, "{}", table.name)?;
-            }
+            write!(
+                self.dst,
+                "{}",
+                MaybeQuote::new(&table.name, self.quoted_table_names)
+            )?;
         }
 
         write!(self.dst, " WHERE ")?;
@@ -298,27 +312,26 @@ impl<T: Params> Formatter<'_, T> {
             todo!()
         };
 
-        if self.quoted_table_names {
-            write!(
-                self.dst,
-                "INSERT INTO \"{}\" (",
-                self.schema.table(insert_target).name
-            )?;
-        } else {
-            write!(
-                self.dst,
-                "INSERT INTO {} (",
-                self.schema.table(insert_target).name
-            )?;
-        }
+        write!(
+            self.dst,
+            "INSERT INTO {} (",
+            MaybeQuote::new(
+                &self.schema.table(insert_target).name,
+                self.quoted_table_names
+            )
+        )?;
 
         let mut s = "";
         for column_id in &insert_target.columns {
-            if self.quoted_column_names {
-                write!(self.dst, "{}\"{}\"", s, self.schema.column(*column_id).name)?;
-            } else {
-                write!(self.dst, "{}{}", s, self.schema.column(*column_id).name)?;
-            }
+            write!(
+                self.dst,
+                "{}{}",
+                s,
+                MaybeQuote::new(
+                    &self.schema.column(*column_id).name,
+                    self.quoted_column_names
+                )
+            )?;
             s = ", ";
         }
 
@@ -340,20 +353,19 @@ impl<T: Params> Formatter<'_, T> {
     fn update(&mut self, update: &Update) -> fmt::Result {
         let table = self.schema.table(update.target.as_table().table);
 
-        if self.quoted_table_names {
-            write!(self.dst, "UPDATE \"{}\" SET", table.name)?;
-        } else {
-            write!(self.dst, "UPDATE {} SET", table.name)?;
-        }
+        write!(
+            self.dst,
+            "UPDATE {} SET",
+            MaybeQuote::new(&table.name, self.quoted_table_names)
+        )?;
 
         for (index, assignment) in update.assignments.iter() {
             let column = &table.columns[index];
-
-            if self.quoted_column_names {
-                write!(self.dst, " \"{}\" = ", column.name)?;
-            } else {
-                write!(self.dst, " {} = ", column.name)?;
-            }
+            write!(
+                self.dst,
+                " {} = ",
+                MaybeQuote::new(&column.name, self.quoted_column_names)
+            )?;
 
             self.expr(&assignment.expr)?;
         }
@@ -391,12 +403,11 @@ impl<T: Params> Formatter<'_, T> {
 
         for table_with_join in select.source.as_table_with_joins() {
             let table = self.schema.table(table_with_join.table);
-
-            if self.quoted_table_names {
-                write!(self.dst, "\"{}\"", table.name)?;
-            } else {
-                write!(self.dst, "{}", table.name)?;
-            }
+            write!(
+                self.dst,
+                "{}",
+                MaybeQuote::new(&table.name, self.quoted_table_names)
+            )?;
         }
 
         write!(self.dst, " WHERE ")?;
@@ -465,9 +476,7 @@ impl<T: Params> Formatter<'_, T> {
                 // TODO: at some point we need to conditionally scope the column
                 // name.
                 let column = self.schema.column(expr.column);
-                if self.quoted_column_names {
-                    self.ident_str(&column.name)?;
-                }
+                self.ident_str(&column.name, self.quoted_column_names)?;
             }
             Expr::InList(ExprInList { expr, list }) => {
                 self.expr(expr)?;
@@ -591,9 +600,7 @@ impl<T: Params> Formatter<'_, T> {
     fn name(&mut self, name: &Name) -> fmt::Result {
         let mut s = "";
         for ident in &name.0 {
-            if self.quoted_table_names {
-                self.ident(ident)?;
-            }
+            self.ident(ident, self.quoted_table_names)?;
             write!(self.dst, "{s}")?;
             s = ".";
         }
@@ -601,12 +608,12 @@ impl<T: Params> Formatter<'_, T> {
         Ok(())
     }
 
-    fn ident(&mut self, ident: &Ident) -> fmt::Result {
-        self.ident_str(&ident.0)
+    fn ident(&mut self, ident: &Ident, quote: bool) -> fmt::Result {
+        self.ident_str(&ident.0, quote)
     }
 
-    fn ident_str(&mut self, ident: &str) -> fmt::Result {
-        write!(self.dst, "\"{ident}\"")?;
+    fn ident_str(&mut self, ident: &str, quote: bool) -> fmt::Result {
+        write!(self.dst, "{}", MaybeQuote::new(ident, quote))?;
         Ok(())
     }
 }


### PR DESCRIPTION
Added two config options for quoting table and column name in both the Serializer and Formatter; and change the corresponding code to respect the configs.

Solves issue  **1** from #69 