### PR TITLE
feat: initial implementation of a libsql driver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,13 @@ jobs:
         runs-on: ubuntu-latest
         env:
             AWS_ENDPOINT_URL_DYNAMODB: http://localhost:8000
+        strategy:
+          fail-fast: false
+          matrix:
+            features:
+              - sqlite
+              - libsql
+              - dynamodb
         steps:
         - uses: actions/checkout@v4
         - uses: dtolnay/rust-toolchain@stable
@@ -54,9 +61,10 @@ jobs:
           with:
             save-if: ${{ github.ref == 'refs/heads/main' }}
         - name: Start dynamodb-local
+          if: matrix.features == 'dynamodb'
           run: sudo docker run --name dynamodb -d -p 8000:8000 amazon/dynamodb-local:latest -jar DynamoDBLocal.jar -port 8000
         - name: cargo test
-          run: cargo test --workspace --all-features
+          run: cargo test --workspace --no-default-features --features "${{ matrix.features }}"
 
     test-postgresql:
         needs: check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "src/db/ddb",
     "src/db/sqlite",
     "src/db/pgsql",
+    "src/db/libsql",
 
     # General utilities.
     "src/std-util",
@@ -39,6 +40,7 @@ toasty-macros = { path = "src/macros" }
 toasty-sqlite = { path = "src/db/sqlite" }
 toasty-dynamodb = { path = "src/db/ddb" }
 toasty-pgsql = { path = "src/db/pgsql" }
+toasty-libsql = { path = "src/db/libsql" }
 
 anyhow = "1.0.92"
 async-recursion = "1.1.1"

--- a/examples/composite-key/Cargo.toml
+++ b/examples/composite-key/Cargo.toml
@@ -9,6 +9,7 @@ default = [ "sqlite" ]
 dynamodb = [ "toasty/dynamodb" ]
 postgresql = [ "toasty/postgresql" ]
 sqlite = [ "toasty/sqlite" ]
+libsql = [ "toasty/libsql" ]
 
 [dependencies]
 toasty.workspace = true

--- a/examples/cratehub/Cargo.toml
+++ b/examples/cratehub/Cargo.toml
@@ -9,6 +9,7 @@ default = [ "sqlite" ]
 dynamodb = [ "toasty/dynamodb" ]
 postgresql = [ "toasty/postgresql" ]
 sqlite = [ "toasty/sqlite" ]
+libsql = [ "toasty/libsql" ]
 
 [dependencies]
 toasty.workspace = true

--- a/examples/hello-toasty/Cargo.toml
+++ b/examples/hello-toasty/Cargo.toml
@@ -9,6 +9,7 @@ default = [ "sqlite" ]
 dynamodb = [ "toasty/dynamodb" ]
 postgresql = [ "toasty/postgresql" ]
 sqlite = [ "toasty/sqlite" ]
+libsql = [ "toasty/libsql" ]
 
 [dependencies]
 toasty.workspace = true

--- a/src/db/libsql/Cargo.toml
+++ b/src/db/libsql/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "toasty-libsql"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anyhow.workspace = true
+libsql = "0.6.0"
+toasty-core.workspace = true
+url.workspace = true
+
+# TODO: get rid of
+serde.workspace = true
+serde_json.workspace = true

--- a/src/db/libsql/src/lib.rs
+++ b/src/db/libsql/src/lib.rs
@@ -52,6 +52,12 @@ impl LibSQL {
     }
 }
 
+impl From<libsql::Connection> for LibSQL {
+    fn from(connection: Connection) -> Self {
+        LibSQL { connection }
+    }
+}
+
 #[toasty_core::async_trait]
 impl Driver for LibSQL {
     fn capability(&self) -> &Capability {

--- a/src/db/libsql/src/lib.rs
+++ b/src/db/libsql/src/lib.rs
@@ -1,0 +1,266 @@
+use libsql::{Builder, Connection};
+use std::{fmt::Debug, sync::Arc};
+use toasty_core::{
+    Result,
+    driver::{Capability, Driver, Response, operation::Operation},
+    schema::db::{Schema, Table},
+    stmt,
+};
+use url::Url;
+
+pub struct LibSQL {
+    connection: Connection,
+}
+
+impl Debug for LibSQL {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LibSQL").finish()
+    }
+}
+
+impl LibSQL {
+    pub async fn connect(url: &str, token: Option<String>) -> Result<LibSQL> {
+        let url = Url::parse(url)?;
+
+        if url.scheme() != "libsql" {
+            return Err(anyhow::anyhow!(
+                "connection URL does not have a `libsql` scheme; url={url}"
+            ));
+        }
+
+        if url.path() == ":memory:" {
+            Ok(LibSQL::local(":memory:".to_string()).await?)
+        } else {
+            Ok(LibSQL::remote(url.to_string(), token).await?)
+        }
+    }
+
+    pub async fn local(url: String) -> Result<LibSQL> {
+        let db = Builder::new_local(url).build().await?;
+        Ok(LibSQL {
+            connection: db.connect()?,
+        })
+    }
+
+    pub async fn remote(url: String, token: Option<String>) -> Result<LibSQL> {
+        let db = Builder::new_remote(url, token.unwrap_or(String::from("")))
+            .build()
+            .await?;
+        Ok(LibSQL {
+            connection: db.connect()?,
+        })
+    }
+}
+
+#[toasty_core::async_trait]
+impl Driver for LibSQL {
+    fn capability(&self) -> &Capability {
+        &Capability::Sql
+    }
+
+    async fn register_schema(&mut self, _schema: &Schema) -> Result<()> {
+        Ok(())
+    }
+
+    async fn exec(&self, schema: &Arc<Schema>, op: Operation) -> Result<Response> {
+        use Operation::*;
+
+        let connection = &self.connection;
+
+        let mut sql = match op {
+            QuerySql(op) => op.stmt,
+            Insert(op) => op,
+            _ => todo!(),
+        };
+
+        // SQL doesn't handle pre-condition. This should be moved into toasty's planner.
+        let pre_condition = match &mut sql {
+            stmt::Statement::Update(update) => {
+                if let Some(condition) = update.condition.take() {
+                    update.filter = Some(match update.filter.take() {
+                        Some(filter) => stmt::Expr::and(filter, condition),
+                        None => condition,
+                    });
+
+                    assert!(update.returning.is_none());
+
+                    update.returning = Some(stmt::Returning::Expr(stmt::Expr::record([true])));
+
+                    true
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        };
+
+        let mut params = vec![];
+        let sql_str = stmt::sql::Serializer::new(schema).serialize_stmt(&sql, &mut params);
+
+        let mut stmt = connection.prepare(&sql_str).await?;
+
+        let width = match &sql {
+            stmt::Statement::Query(stmt) => match &*stmt.body {
+                stmt::ExprSet::Select(stmt) => Some(stmt.returning.as_expr().as_record().len()),
+                _ => todo!(),
+            },
+            stmt::Statement::Insert(stmt) => stmt
+                .returning
+                .as_ref()
+                .map(|returning| returning.as_expr().as_record().len()),
+            stmt::Statement::Delete(stmt) => stmt
+                .returning
+                .as_ref()
+                .map(|returning| returning.as_expr().as_record().len()),
+            stmt::Statement::Update(stmt) => {
+                assert!(stmt.condition.is_none(), "stmt={stmt:#?}");
+                stmt.returning
+                    .as_ref()
+                    .map(|returning| returning.as_expr().as_record().len())
+            }
+        };
+
+        if width.is_none() {
+            let count = stmt
+                .execute(libsql::params_from_iter(
+                    params.iter().map(value_from_param),
+                ))
+                .await?;
+
+            return Ok(Response::from_count(count));
+        }
+
+        let mut rows = stmt
+            .query(libsql::params_from_iter(
+                params.iter().map(value_from_param),
+            ))
+            .await?;
+
+        let mut ret = vec![];
+
+        loop {
+            match rows.next().await {
+                Ok(Some(row)) => {
+                    let mut items = vec![];
+
+                    let width = width.unwrap();
+
+                    for index in 0..width {
+                        // TODO: Is this a safe cast?
+                        items.push(load(&row, index as i32));
+                    }
+
+                    ret.push(stmt::ValueRecord::from_vec(items).into());
+                }
+                Ok(None) => break,
+                Err(err) => {
+                    return Err(err.into());
+                }
+            }
+        }
+
+        // Some special handling
+        if sql.is_update() && pre_condition {
+            if ret.is_empty() {
+                // Just assume the precondition failed here... we will
+                // need to make this transactional later.
+                anyhow::bail!("pre condition failed");
+            } else {
+                return Ok(Response::from_count(ret.len()));
+            }
+        }
+
+        Ok(Response::from_value_stream(stmt::ValueStream::from_vec(
+            ret,
+        )))
+    }
+
+    async fn reset_db(&self, schema: &Schema) -> Result<()> {
+        for table in &schema.tables {
+            self.create_table(schema, table).await?;
+        }
+
+        Ok(())
+    }
+}
+
+impl LibSQL {
+    async fn create_table(&self, schema: &Schema, table: &Table) -> Result<()> {
+        let connection = &self.connection;
+
+        let mut params = vec![];
+        let stmt = stmt::sql::Statement::create_table(table).serialize(schema, &mut params);
+        assert!(params.is_empty());
+
+        connection.execute(&stmt, ()).await?;
+
+        // Create any indices
+        for index in &table.indices {
+            // The PK has already been created by the table statement
+            if index.primary_key {
+                continue;
+            }
+
+            let stmt = stmt::sql::Statement::create_index(index).serialize(schema, &mut params);
+            assert!(params.is_empty());
+
+            connection.execute(&stmt, ()).await?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+enum V {
+    Bool(bool),
+    Null,
+    String(String),
+    I64(i64),
+    Id(usize, String),
+}
+
+fn value_from_param(value: &stmt::Value) -> libsql::Value {
+    use libsql::{Value, ValueRef};
+    use stmt::Value::*;
+
+    match value {
+        Bool(true) => Value::Integer(1),
+        Bool(false) => Value::Integer(0),
+        Id(v) => v.to_string().into(),
+        I64(v) => Value::Integer(*v).to_owned(),
+        String(v) => ValueRef::Text(v.as_bytes()).into(),
+        Null => Value::Null,
+        Enum(value_enum) => {
+            let v = match &value_enum.fields[..] {
+                [] => V::Null,
+                [stmt::Value::Bool(v)] => V::Bool(*v),
+                [stmt::Value::String(v)] => V::String(v.to_string()),
+                [stmt::Value::I64(v)] => V::I64(*v),
+                [stmt::Value::Id(id)] => V::Id(id.model_id().0, id.to_string()),
+                _ => todo!("val={:#?}", value_enum.fields),
+            };
+
+            format!(
+                "{}#{}",
+                value_enum.variant,
+                serde_json::to_string(&v).unwrap()
+            )
+            .into()
+        }
+        _ => todo!("value = {:#?}", value),
+    }
+}
+
+fn load(row: &libsql::Row, index: i32) -> stmt::Value {
+    use libsql::Value as SqlValue;
+
+    let value: Option<SqlValue> = row.get(index).unwrap();
+
+    match value {
+        Some(SqlValue::Null) => stmt::Value::Null,
+        Some(SqlValue::Integer(value)) => stmt::Value::I64(value),
+        Some(SqlValue::Text(value)) => stmt::Value::String(value),
+        None => stmt::Value::Null,
+        _ => todo!("value={value:#?}"),
+    }
+}

--- a/src/toasty/Cargo.toml
+++ b/src/toasty/Cargo.toml
@@ -8,6 +8,7 @@ default = []
 dynamodb = ["dep:toasty-dynamodb"]
 postgresql = ["dep:toasty-pgsql"]
 sqlite = ["dep:toasty-sqlite"]
+libsql = ["dep:toasty-libsql"]
 
 
 [dependencies]
@@ -18,6 +19,7 @@ toasty-core.workspace = true
 toasty-dynamodb = { workspace = true, optional = true }
 toasty-pgsql = { workspace = true, optional = true }
 toasty-sqlite = { workspace = true, optional = true }
+toasty-libsql = { workspace = true, optional = true }
 
 anyhow.workspace = true
 async-stream.workspace = true

--- a/tests/client/Cargo.toml
+++ b/tests/client/Cargo.toml
@@ -9,6 +9,9 @@ default = ["sqlite"]
 sqlite = [
     "dep:toasty-sqlite",
 ]
+libsql = [
+    "dep:toasty-libsql",
+]
 dynamodb = [
     "dep:toasty-dynamodb",
     "dep:aws-config",
@@ -23,6 +26,9 @@ toasty-macros = { path = "../../src/macros" }
 
 # Sqlite driver
 toasty-sqlite = { path = "../../src/db/sqlite", optional = true }
+
+# LibSQL driver
+toasty-libsql = { path = "../../src/db/libsql", optional = true }
 
 # DyanmoDB driver
 toasty-dynamodb = { path = "../../src/db/ddb", optional = true }

--- a/tests/client/src/db.rs
+++ b/tests/client/src/db.rs
@@ -3,3 +3,6 @@ pub mod dynamodb;
 
 #[cfg(feature = "sqlite")]
 pub mod sqlite;
+
+#[cfg(feature = "libsql")]
+pub mod libsql;

--- a/tests/client/src/db/libsql.rs
+++ b/tests/client/src/db/libsql.rs
@@ -1,0 +1,21 @@
+use toasty::driver::Capability;
+use toasty::schema::app::Schema;
+use toasty::Db;
+
+use crate::Setup;
+
+pub struct SetupLibSQL;
+
+#[async_trait::async_trait]
+impl Setup for SetupLibSQL {
+    async fn setup(&self, schema: Schema) -> Db {
+        let driver = toasty_libsql::LibSQL::local(":memory:".to_string()).await.unwrap();
+        let db = toasty::Db::new(schema, driver).await.unwrap();
+        db.reset_db().await.unwrap();
+        db
+    }
+
+    fn capability(&self) -> &Capability {
+        &Capability::Sql
+    }
+}

--- a/tests/client/src/db/libsql.rs
+++ b/tests/client/src/db/libsql.rs
@@ -9,7 +9,9 @@ pub struct SetupLibSQL;
 #[async_trait::async_trait]
 impl Setup for SetupLibSQL {
     async fn setup(&self, schema: Schema) -> Db {
-        let driver = toasty_libsql::LibSQL::local(":memory:".to_string()).await.unwrap();
+        let driver = toasty_libsql::LibSQL::local(":memory:".to_string())
+            .await
+            .unwrap();
         let db = toasty::Db::new(schema, driver).await.unwrap();
         db.reset_db().await.unwrap();
         db

--- a/tests/client/src/db/libsql.rs
+++ b/tests/client/src/db/libsql.rs
@@ -1,6 +1,5 @@
 use toasty::driver::Capability;
-use toasty::schema::app::Schema;
-use toasty::Db;
+use toasty::{db, Db};
 
 use crate::Setup;
 
@@ -8,11 +7,8 @@ pub struct SetupLibSQL;
 
 #[async_trait::async_trait]
 impl Setup for SetupLibSQL {
-    async fn setup(&self, schema: Schema) -> Db {
-        let driver = toasty_libsql::LibSQL::local(":memory:".to_string())
-            .await
-            .unwrap();
-        let db = toasty::Db::new(schema, driver).await.unwrap();
+    async fn setup(&self, mut builder: db::Builder) -> Db {
+        let db = builder.connect("libsql::memory:").await.unwrap();
         db.reset_db().await.unwrap();
         db
     }

--- a/tests/client/src/lib.rs
+++ b/tests/client/src/lib.rs
@@ -56,6 +56,17 @@ macro_rules! tests {
                 }
             )*
         }
+
+        #[cfg(feature = "libsql")]
+        mod libsql {
+            $(
+                #[tokio::test]
+                $( #[$attrs] )*
+                async fn $f() {
+                    super::$f($crate::db::libsql::SetupLibSQL).await;
+                }
+            )*
+        }
     };
     (
         $(


### PR DESCRIPTION
This PR aims to implement #78 by introducing a new `toasty-libsql` driver, supporting [`libsql`](https://github.com/tursodatabase/libsql).

It uses a lot of carbon-copy code from the `rusqlite` implementation, as minimal changes are needed to port between SQLite APIs and LibSQL by design.

Outstanding things to check/implement;

- [ ] I don't think `libsql::Database` is `Sync`, but `libsql::Connection` is. However, this means we have _one_ connection for the entire driver instance. I don't want to go as far as opening one connection per execution, but I'd like to look into some method of pooling the connections at some point.
- [x] ~~Token authentication to a LibSQL service needs a second parameter, but I don't know how to pass it just yet. I think some string manipulating/including the token in a query param then taking that parameter and passing it as the token might work.~~ **Implementing this via `impl From<libsql::Connection> for LibSQL` in the driver crate.**
- [ ] I'm doing a cast from `usize` to `i32` in the code for the driver, but I have no idea if that's sensible in the slightest; if there's a more 'safe' way to implement that type conversion I'd be very appreciative, but for now it got the code running.

The new driver currently works properly with all the example codebases, running them with `--features libsql` and setting `TOASTY_CONNECTION_URL` to `libsql::memory:` succeeds without any errors.

Let me know if I'm barking up the right tree here or not! :)