### PR TITLE
WIP for MySQL Driver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         runs-on: ubuntu-latest
         services:
           mysql:
-            image: mysql:8.0
+            image: mysql:9
             env:
               MYSQL_ROOT_PASSWORD: toasty
               MYSQL_USER: toasty

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,14 +67,15 @@ jobs:
           mysql:
             image: mysql:8.0
             env:
+              MYSQL_ROOT_PASSWORD: toasty
               MYSQL_USER: toasty
               MYSQL_PASSWORD: toasty
               MYSQL_DATABASE: toasty
             ports:
               - 3306:3306
-            options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+            options: --health-cmd "mysqladmin ping -h localhost" --health-interval 10s --health-timeout 5s --health-retries 5
         env:
-            TOASTY_CONNECTION_URL: mysql://toasty:toasty@localhost/toasty
+            TOASTY_CONNECTION_URL: mysql://toasty:toasty@localhost:3306/toasty
         steps:
         - uses: actions/checkout@v4
         - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ env:
     RUSTFLAGS: -D warnings
     RUST_BACKTRACE: 1
     TOASTY_TEST_POSTGRES_URL: "postgresql://toasty:toasty@localhost/toasty"
+    TOASTY_TEST_MYSQL_URL: "mysql://toasty:toasty@localhost/toasty"
     AWS_REGION: "foo"
     AWS_ENDPOINT_URL: http://localhost:8000
 
@@ -57,6 +58,33 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: cargo test
         run: cargo test --workspace --no-default-features --features sqlite
+
+    test-mysql:
+        needs: check
+        name: Run tests for MySQL
+        runs-on: ubuntu-latest
+        services:
+          mysql:
+            image: mysql:8.0
+            env:
+              MYSQL_USER: toasty
+              MYSQL_PASSWORD: toasty
+              MYSQL_DATABASE: toasty
+            ports:
+              - 3306:3306
+            options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        env:
+            TOASTY_CONNECTION_URL: mysql://toasty:toasty@localhost/toasty
+        steps:
+        - uses: actions/checkout@v4
+        - uses: dtolnay/rust-toolchain@stable
+        - uses: Swatinem/rust-cache@v2
+          with:
+            save-if: ${{ github.ref == 'refs/heads/main' }}
+#        - name: cargo test
+#          run: cargo test --workspace --no-default-features --features mysql
+#        - name: cargo run --bin example-hello-toasty
+#          run: cargo run --bin example-hello-toasty --features mysql
 
     test-postgresql:
         needs: check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
 
     # Driver implementations
     "crates/toasty-driver-dynamodb",
+    "crates/toasty-driver-mysql",
     "crates/toasty-driver-postgresql",
     "crates/toasty-driver-sqlite",
 
@@ -37,6 +38,7 @@ std-util = { path = "crates/std-util" }
 
 # Driver implementations
 toasty-driver-dynamodb = { path = "crates/toasty-driver-dynamodb" }
+toasty-driver-mysql = { path = "crates/toasty-driver-mysql" }
 toasty-driver-postgresql = { path = "crates/toasty-driver-postgresql" }
 toasty-driver-sqlite = { path = "crates/toasty-driver-sqlite" }
 
@@ -50,6 +52,10 @@ cfg-if = "1.0.0"
 clap = { version = "4.5.20", features = ["derive"] }
 heck = "0.5.0"
 indexmap = "2.6.0"
+mysql_async = { version = "0.35.1", default-features = false, features = [
+    "minimal",
+    "native-tls-tls",
+] }
 pluralizer = "0.4.0"
 postgres = "0.19.10"
 postgres-types = "0.2.9"

--- a/crates/toasty-driver-mysql/Cargo.toml
+++ b/crates/toasty-driver-mysql/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "toasty-driver-mysql"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+toasty-core.workspace = true
+toasty-sql.workspace = true
+
+anyhow.workspace = true
+mysql_async.workspace = true
+tokio.workspace = true
+url.workspace = true

--- a/crates/toasty-driver-mysql/src/lib.rs
+++ b/crates/toasty-driver-mysql/src/lib.rs
@@ -1,0 +1,239 @@
+mod value;
+pub(crate) use value::Value;
+
+use std::sync::Arc;
+
+use mysql_async::{
+    consts::ColumnType::{
+        MYSQL_TYPE_INT24, MYSQL_TYPE_LONG, MYSQL_TYPE_LONGLONG, MYSQL_TYPE_NULL, MYSQL_TYPE_SHORT,
+        MYSQL_TYPE_TINY, MYSQL_TYPE_VARCHAR,
+    },
+    prelude::{Queryable, ToValue},
+    Pool,
+};
+use toasty_core::{
+    driver::{Capability, Operation, Response},
+    schema::db::{Schema, Table},
+    stmt::{self, ValueRecord},
+    Driver, Result,
+};
+use toasty_sql as sql;
+
+use url::Url;
+
+#[derive(Debug)]
+pub struct MySQL {
+    pool: Pool,
+}
+
+impl MySQL {
+    pub fn new(pool: Pool) -> Self {
+        Self { pool }
+    }
+
+    pub async fn connect(url: &str) -> Result<Self> {
+        let url = Url::parse(url)?;
+
+        if url.scheme() != "mysql" {
+            return Err(anyhow::anyhow!(
+                "connection url does not have a `mysql` scheme; url={}",
+                url
+            ));
+        }
+
+        url.host_str()
+            .ok_or_else(|| anyhow::anyhow!("missing host in connection URL; url={}", url))?;
+
+        if url.path().is_empty() {
+            return Err(anyhow::anyhow!(
+                "no database specified - missing path in connection URL; url={}",
+                url
+            ));
+        }
+
+        let pool = Pool::from_url(url.as_ref())?;
+        Ok(Self { pool })
+    }
+
+    pub async fn create_table(&self, schema: &Schema, table: &Table) -> Result<()> {
+        let mut params = Vec::new();
+        let sql = sql::Statement::create_table(table)
+            .serialize_no_quotes(schema, &mut params)
+            .into_inner();
+
+        assert!(
+            params.is_empty(),
+            "creating a table shouldn't involve any parameters"
+        );
+
+        let mut conn = self.pool.get_conn().await?;
+        conn.exec_drop(&sql, ()).await?;
+
+        for index in &table.indices {
+            if index.primary_key {
+                continue;
+            }
+            let sql = sql::Statement::create_index(index)
+                .serialize(schema, &mut params)
+                .into_inner();
+            assert!(
+                params.is_empty(),
+                "creating an index shouldn't involve any parameters"
+            );
+
+            conn.exec_drop(&sql, ()).await?;
+        }
+
+        Ok(())
+    }
+    pub async fn drop_table(&self, schema: &Schema, table: &Table) -> Result<()> {
+        let mut params = Vec::new();
+        let sql = sql::Statement::drop_table_if_exists(table)
+            .serialize_no_quotes(schema, &mut params)
+            .into_numbered_args()
+            .into_inner();
+
+        println!("\n{sql}\n");
+
+        assert!(
+            params.is_empty(),
+            "dropping a table shouldn't involve any parameters"
+        );
+
+        let mut conn = self.pool.get_conn().await?;
+
+        conn.exec_drop(&sql, ()).await?;
+        println!("se dropeo");
+        Ok(())
+    }
+}
+impl From<Pool> for MySQL {
+    fn from(pool: Pool) -> Self {
+        Self { pool }
+    }
+}
+
+#[toasty_core::async_trait]
+impl Driver for MySQL {
+    fn capability(&self) -> &Capability {
+        &Capability::Sql
+    }
+
+    async fn register_schema(&mut self, _schema: &Schema) -> Result<()> {
+        Ok(())
+    }
+
+    async fn exec(&self, schema: &Arc<Schema>, op: Operation) -> Result<Response> {
+        let mut conn = self.pool.get_conn().await?;
+
+        let sql: sql::Statement = match op {
+            Operation::Insert(stmt) => stmt.into(),
+            Operation::QuerySql(query) => query.stmt.into(),
+            op => todo!("op={:#?}", op),
+        };
+
+        let conditional_update =
+            matches!(&sql, sql::Statement::Update(stmt) if stmt.condition.is_some());
+
+        let width = sql.returning_len();
+
+        let mut params = Vec::new();
+        let sql_as_str = sql::Serializer::new(schema)
+            .with_update_in_cte(true)
+            .serialize_stmt(&sql, &mut params)
+            .into_numbered_args()
+            .into_inner();
+
+        let params = params.into_iter().map(Value::from).collect::<Vec<_>>();
+        let args = params
+            .iter()
+            .map(|param| param.to_value())
+            .collect::<Vec<_>>();
+
+        if width.is_none() && !conditional_update {
+            let count = conn
+                .exec::<mysql_async::Row, &String, mysql_async::Params>(
+                    &sql_as_str,
+                    mysql_async::Params::Positional(args),
+                )
+                .await?
+                .len();
+
+            return Ok(Response::from_count(count));
+        }
+
+        let rows: Vec<mysql_async::Row> = conn.exec(&sql_as_str, &args).await?;
+
+        if width.is_none() {
+            let [row] = &rows[..] else { todo!() };
+            let total = row.get::<i64, usize>(0).unwrap();
+            let condition_matched = row.get::<i64, usize>(1).unwrap();
+
+            if total == condition_matched {
+                Ok(Response::from_count(total as _))
+            } else {
+                anyhow::bail!("update condition did not match");
+            }
+        } else {
+            let results = rows.into_iter().map(move |row| {
+                let mut results = Vec::new();
+                for mut i in 0..row.len() {
+                    if conditional_update {
+                        i += 2;
+                    }
+
+                    let column = &row.columns()[i];
+                    results.push(mysql_to_toasty(i, &row, column));
+                }
+
+                Ok(ValueRecord::from_vec(results))
+            });
+
+            Ok(Response::from_value_stream(stmt::ValueStream::from_iter(
+                results,
+            )))
+        }
+    }
+
+    // TODO: Check the boolean from postgress impl
+    async fn reset_db(&self, schema: &Schema) -> Result<()> {
+        println!("vamooo");
+        for table in &schema.tables {
+            self.drop_table(schema, table).await?;
+            // self.create_table(schema, table).await?;
+        }
+
+        Ok(())
+    }
+}
+
+fn mysql_to_toasty(i: usize, row: &mysql_async::Row, column: &mysql_async::Column) -> stmt::Value {
+    match column.column_type() {
+        MYSQL_TYPE_NULL => stmt::Value::Null,
+        MYSQL_TYPE_VARCHAR => row
+            .get(i)
+            .map(stmt::Value::String)
+            .unwrap_or(stmt::Value::Null),
+        MYSQL_TYPE_TINY => {
+            if column.column_length() == 1 {
+                row.get(i)
+                    .map(stmt::Value::Bool)
+                    .unwrap_or(stmt::Value::Null)
+            } else {
+                row.get(i)
+                    .map(stmt::Value::I64)
+                    .unwrap_or(stmt::Value::Null)
+            }
+        }
+        MYSQL_TYPE_SHORT | MYSQL_TYPE_INT24 | MYSQL_TYPE_LONG | MYSQL_TYPE_LONGLONG => {
+            row.get::<i64, usize>(i)
+                .map(stmt::Value::I64)
+                .unwrap_or(stmt::Value::Null);
+            todo!()
+        }
+        _ => todo!(
+            "implement PostgreSQL to toasty conversion for `{:#?}`",
+            column.column_type()
+        ),
+    }
+}

--- a/crates/toasty-driver-mysql/src/lib.rs
+++ b/crates/toasty-driver-mysql/src/lib.rs
@@ -107,7 +107,6 @@ impl MySQL {
         let mut conn = self.pool.get_conn().await?;
 
         conn.exec_drop(&sql, ()).await?;
-        println!("se dropeo");
         Ok(())
     }
 }
@@ -198,9 +197,7 @@ impl Driver for MySQL {
         }
     }
 
-    // TODO: Check the boolean from postgress impl
     async fn reset_db(&self, schema: &Schema) -> Result<()> {
-        println!("vamooo");
         for table in &schema.tables {
             self.drop_table(schema, table, true).await?;
             self.create_table(schema, table).await?;

--- a/crates/toasty-driver-mysql/src/value.rs
+++ b/crates/toasty-driver-mysql/src/value.rs
@@ -1,0 +1,24 @@
+use mysql_async::prelude::ToValue;
+use toasty_core::stmt::Value as CoreValue;
+
+#[derive(Debug)]
+pub struct Value(CoreValue);
+
+impl From<CoreValue> for Value {
+    fn from(value: CoreValue) -> Self {
+        Self(value)
+    }
+}
+
+impl ToValue for Value {
+    fn to_value(&self) -> mysql_async::Value {
+        match &self.0 {
+            CoreValue::Bool(value) => value.to_value(),
+            CoreValue::I64(value) => value.to_value(),
+            CoreValue::Id(id) => id.to_string().to_value(),
+            CoreValue::Null => mysql_async::Value::NULL,
+            CoreValue::String(value) => value.to_value(),
+            value => todo!("{:#?}", value),
+        }
+    }
+}

--- a/crates/toasty/Cargo.toml
+++ b/crates/toasty/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [features]
 default = []
 dynamodb = ["dep:toasty-driver-dynamodb"]
+mysql = ["dep:toasty-driver-mysql"]
 postgresql = ["dep:toasty-driver-postgresql"]
 sqlite = ["dep:toasty-driver-sqlite"]
 
@@ -16,6 +17,7 @@ toasty-core.workspace = true
 
 # Built-in database drivers
 toasty-driver-dynamodb = { workspace = true, optional = true }
+toasty-driver-mysql = { workspace = true, optional = true }
 toasty-driver-postgresql = { workspace = true, optional = true }
 toasty-driver-sqlite = { workspace = true, optional = true }
 

--- a/examples/user-has-one-profile/Cargo.toml
+++ b/examples/user-has-one-profile/Cargo.toml
@@ -5,10 +5,11 @@ edition = "2021"
 publish = false
 
 [features]
-default = [ "sqlite" ]
-dynamodb = [ "toasty/dynamodb" ]
-postgresql = [ "toasty/postgresql" ]
-sqlite = [ "toasty/sqlite" ]
+default = ["sqlite"]
+dynamodb = ["toasty/dynamodb"]
+mysql = ["toasty/mysql"]
+postgresql = ["toasty/postgresql"]
+sqlite = ["toasty/sqlite"]
 
 [dependencies]
 toasty.workspace = true

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [features]
 default = ["sqlite"]
 sqlite = ["toasty/sqlite"]
+mysql = ["toasty/mysql"]
 dynamodb = ["toasty/dynamodb"]
 postgresql = ["toasty/postgresql"]
 

--- a/tests/src/db.rs
+++ b/tests/src/db.rs
@@ -4,5 +4,8 @@ pub mod dynamodb;
 #[cfg(feature = "sqlite")]
 pub mod sqlite;
 
+#[cfg(feature = "mysql")]
+pub mod mysql;
+
 #[cfg(feature = "postgresql")]
 pub mod postgresql;

--- a/tests/src/db/mysql.rs
+++ b/tests/src/db/mysql.rs
@@ -1,0 +1,39 @@
+use toasty::driver::{Capability, CapabilitySql};
+use toasty::{db, Db};
+
+use crate::Setup;
+
+pub struct SetupMySQL;
+
+#[async_trait::async_trait]
+impl Setup for SetupMySQL {
+    async fn setup(&self, mut builder: db::Builder) -> Db {
+        use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
+
+        static CNT: AtomicUsize = AtomicUsize::new(0);
+
+        thread_local! {
+            pub static PREFIX: String = format!("test_{}_", CNT.fetch_add(1, Relaxed));
+        }
+
+        let prefix = PREFIX.with(|k| k.clone());
+
+        let url = std::env::var("TOASTY_TEST_MYSQL_URL")
+            .unwrap_or_else(|_| "mysql://localhost:3306/toasty_test".to_string());
+
+        let db = builder
+            .table_name_prefix(&prefix)
+            .connect(&url)
+            .await
+            .unwrap();
+
+        db.reset_db().await.unwrap();
+        db
+    }
+
+    fn capability(&self) -> &Capability {
+        &Capability::Sql(CapabilitySql {
+            cte_with_update: true,
+        })
+    }
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -56,6 +56,17 @@ macro_rules! tests {
             )*
         }
 
+        #[cfg(feature = "mysql")]
+        mod mysql {
+            $(
+                #[tokio::test]
+                $( #[$attrs] )*
+                async fn $f() {
+                    super::$f($crate::db::mysql::SetupMySQL).await;
+                }
+            )*
+        }
+
         #[cfg(feature = "postgresql")]
         mod postgresql {
             $(


### PR DESCRIPTION
This is an implemenation for the MySql driver heavily guided by the PostgreSQL drive. 

Currently I'm stopped by the the 2nd point on issue #69. Which is that Primary keys and Unique field need to be sized in MySQL, including in foreign keys.

in `crates/toasty-sql/src/serializer/stmt.rs` this two functions I could be able to solve it, I just curently don't understand how could i change it using the Flavor enum so it can format as ` PRIMARY KEY (id(255))` instead of `PRIMARY KEY (id)`
```rust
impl ToSql for ColumnsWithConstraints<'_> {
    fn to_sql<P: Params>(self, f: &mut super::Formatter<'_, P>) {
        let columns = Comma(&self.0.columns);

        if let Some(pk) = &self.0.primary_key {
            fmt!(f, columns ", PRIMARY KEY " pk);
        } else {
            fmt!(f, columns);
        }
    }
}

impl ToSql for &stmt::CreateIndex {
    fn to_sql<P: Params>(self, f: &mut super::Formatter<'_, P>) {
        let table_name = f.serializer.table_name(self.on);
        let columns = Comma(&self.columns);
        let unique = if self.unique { "UNIQUE " } else { "" };

        fmt!(
            f, "CREATE " unique "INDEX " self.name " ON " table_name " (" columns ")"
        );
    }
}
```