### PR TITLE
Switch Model::ID and Primitive::TYPE to methods to avoid const requirement

### DIFF
--- a/crates/toasty-codegen/src/expand/fields.rs
+++ b/crates/toasty-codegen/src/expand/fields.rs
@@ -9,53 +9,10 @@ impl Expand<'_> {
         let toasty = &self.toasty;
         let vis = &self.model.vis;
         let field_struct_ident = &self.model.field_struct_ident;
+        let model_ident = &self.model.ident;
 
-        let fields = self.model.fields.iter().map(move |field| {
-            let field_ident = &field.name.ident;
-
-            match &field.ty {
-                Primitive(ty) => {
-                    quote! {
-                        #vis #field_ident: #toasty::Path<#ty>,
-                    }
-                }
-                BelongsTo(rel) => {
-                    let ty = &rel.ty;
-
-                    quote! {
-                        #vis #field_ident: <#ty as #toasty::Relation>::OneField,
-                    }
-                }
-                HasMany(rel) => {
-                    let ty = &rel.ty;
-
-                    quote! {
-                        #vis #field_ident: <#ty as #toasty::Relation>::ManyField,
-                    }
-                }
-                HasOne(rel) => {
-                    let ty = &rel.ty;
-
-                    quote! {
-                        #vis #field_ident: <#ty as #toasty::Relation>::OneField,
-                    }
-                }
-            }
-        });
-
-        quote!(
-            #vis struct #field_struct_ident {
-                #( #fields )*
-            }
-        )
-    }
-
-    pub(super) fn expand_model_field_struct_init(&self) -> TokenStream {
-        let toasty = &self.toasty;
-        let vis = &self.model.vis;
-        let field_struct_ident = &self.model.field_struct_ident;
-
-        let fields = self
+        // Generate methods that return field paths for the model
+        let methods = self
             .model
             .fields
             .iter()
@@ -65,45 +22,66 @@ impl Expand<'_> {
                 let field_offset = util::int(offset);
 
                 match &field.ty {
-                    Primitive(_) => {
+                    Primitive(ty) => {
                         quote! {
-                            #field_ident: #toasty::Path::from_field_index::<Self>(#field_offset),
+                            #vis fn #field_ident() -> #toasty::Path<#ty> {
+                                #toasty::Path::from_field_index::<#model_ident>(#field_offset)
+                            }
                         }
                     }
                     BelongsTo(rel) => {
                         let ty = &rel.ty;
 
                         quote! {
-                            #field_ident: <#ty as #toasty::Relation>::OneField::from_path(
-                                #toasty::Path::from_field_index::<Self>(#field_offset)
-                            ),
+                            #vis fn #field_ident() -> <#ty as #toasty::Relation>::OneField {
+                                <#ty as #toasty::Relation>::OneField::from_path(
+                                    #toasty::Path::from_field_index::<#model_ident>(#field_offset)
+                                )
+                            }
                         }
                     }
                     HasMany(rel) => {
                         let ty = &rel.ty;
 
                         quote! {
-                            #field_ident: <#ty as #toasty::Relation>::ManyField::from_path(
-                                #toasty::Path::from_field_index::<Self>(#field_offset)
-                            ),
+                            #vis fn #field_ident() -> <#ty as #toasty::Relation>::ManyField {
+                                <#ty as #toasty::Relation>::ManyField::from_path(
+                                    #toasty::Path::from_field_index::<#model_ident>(#field_offset)
+                                )
+                            }
                         }
                     }
                     HasOne(rel) => {
                         let ty = &rel.ty;
 
                         quote! {
-                            #field_ident: <#ty as #toasty::Relation>::OneField::from_path(
-                                #toasty::Path::from_field_index::<Self>(#field_offset)
-                            ),
+                            #vis fn #field_ident() -> <#ty as #toasty::Relation>::OneField {
+                                <#ty as #toasty::Relation>::OneField::from_path(
+                                    #toasty::Path::from_field_index::<#model_ident>(#field_offset)
+                                )
+                            }
                         }
                     }
                 }
             });
 
+        // Generate empty struct and impl block with methods
         quote!(
-            #vis const FIELDS: #field_struct_ident = #field_struct_ident {
-                #( #fields )*
-            };
+            #vis struct #field_struct_ident;
+
+            impl #field_struct_ident {
+                #( #methods )*
+            }
+        )
+    }
+
+    pub(super) fn expand_model_field_struct_init(&self) -> TokenStream {
+        let vis = &self.model.vis;
+        let field_struct_ident = &self.model.field_struct_ident;
+
+        // Generate simple const FIELDS with empty struct initialization
+        quote!(
+            #vis const FIELDS: #field_struct_ident = #field_struct_ident;
         )
     }
 

--- a/crates/toasty-codegen/src/expand/fields.rs
+++ b/crates/toasty-codegen/src/expand/fields.rs
@@ -97,7 +97,7 @@ impl Expand<'_> {
                 let field_name = field.name.ident.to_string();
                 let field_offset = util::int(offset);
 
-                quote!( #field_name => FieldId { model: Self::ID, index: #field_offset }, )
+                quote!( #field_name => FieldId { model: Self::id(), index: #field_offset }, )
             });
 
         quote! {

--- a/crates/toasty-codegen/src/expand/fields.rs
+++ b/crates/toasty-codegen/src/expand/fields.rs
@@ -24,7 +24,7 @@ impl Expand<'_> {
                 match &field.ty {
                     Primitive(ty) => {
                         quote! {
-                            #vis fn #field_ident() -> #toasty::Path<#ty> {
+                            #vis fn #field_ident(&self) -> #toasty::Path<#ty> {
                                 #toasty::Path::from_field_index::<#model_ident>(#field_offset)
                             }
                         }
@@ -33,7 +33,7 @@ impl Expand<'_> {
                         let ty = &rel.ty;
 
                         quote! {
-                            #vis fn #field_ident() -> <#ty as #toasty::Relation>::OneField {
+                            #vis fn #field_ident(&self) -> <#ty as #toasty::Relation>::OneField {
                                 <#ty as #toasty::Relation>::OneField::from_path(
                                     #toasty::Path::from_field_index::<#model_ident>(#field_offset)
                                 )
@@ -44,7 +44,7 @@ impl Expand<'_> {
                         let ty = &rel.ty;
 
                         quote! {
-                            #vis fn #field_ident() -> <#ty as #toasty::Relation>::ManyField {
+                            #vis fn #field_ident(&self) -> <#ty as #toasty::Relation>::ManyField {
                                 <#ty as #toasty::Relation>::ManyField::from_path(
                                     #toasty::Path::from_field_index::<#model_ident>(#field_offset)
                                 )
@@ -55,7 +55,7 @@ impl Expand<'_> {
                         let ty = &rel.ty;
 
                         quote! {
-                            #vis fn #field_ident() -> <#ty as #toasty::Relation>::OneField {
+                            #vis fn #field_ident(&self) -> <#ty as #toasty::Relation>::OneField {
                                 <#ty as #toasty::Relation>::OneField::from_path(
                                     #toasty::Path::from_field_index::<#model_ident>(#field_offset)
                                 )

--- a/crates/toasty-codegen/src/expand/filters.rs
+++ b/crates/toasty-codegen/src/expand/filters.rs
@@ -211,7 +211,7 @@ impl Expand<'_> {
             let field = &self.model.fields[*index];
             let field_ident = &field.name.ident;
 
-            quote!(#model_ident::FIELDS.#field_ident.eq(#field_ident))
+            quote!(#model_ident::FIELDS.#field_ident().eq(#field_ident))
         });
 
         if filter.fields.len() == 1 {
@@ -232,7 +232,7 @@ impl Expand<'_> {
         let lhs = filter.fields.iter().map(|index| {
             let field = &self.model.fields[*index];
             let field_ident = &field.name.ident;
-            quote!(#model_ident::FIELDS.#field_ident)
+            quote!(#model_ident::FIELDS.#field_ident())
         });
 
         let lhs = if filter.fields.len() == 1 {

--- a/crates/toasty-codegen/src/expand/model.rs
+++ b/crates/toasty-codegen/src/expand/model.rs
@@ -65,7 +65,9 @@ impl Expand<'_> {
             }
 
             impl #toasty::Model for #model_ident {
-                const ID: #toasty::ModelId = #toasty::ModelId(#id);
+                fn id() -> #toasty::ModelId {
+                    #toasty::ModelId(#id)
+                }
 
                 fn load(mut record: #toasty::ValueRecord) -> #toasty::Result<Self> {
                     Ok(Self {

--- a/crates/toasty-codegen/src/expand/query.rs
+++ b/crates/toasty-codegen/src/expand/query.rs
@@ -126,7 +126,7 @@ impl Expand<'_> {
                 use #toasty::IntoSelect;
                 <#target as #toasty::Relation>::Query::from_stmt(
                     #toasty::stmt::Association::many_via_one(
-                        self.stmt, #model_ident::FIELDS.#field_ident.into()
+                        self.stmt, #model_ident::FIELDS.#field_ident().into()
                     ).into_select()
                 )
             }
@@ -145,7 +145,7 @@ impl Expand<'_> {
                 use #toasty::IntoSelect;
                 <#target as #toasty::Relation>::Query::from_stmt(
                     #toasty::stmt::Association::many(
-                        self.stmt, #model_ident::FIELDS.#field_ident.into()
+                        self.stmt, #model_ident::FIELDS.#field_ident().into()
                     ).into_select()
                 )
             }
@@ -164,7 +164,7 @@ impl Expand<'_> {
                 use #toasty::IntoSelect;
                 <#target as #toasty::Relation>::Query::from_stmt(
                     #toasty::stmt::Association::many_via_one(
-                        self.stmt, #model_ident::FIELDS.#field_ident.into()
+                        self.stmt, #model_ident::FIELDS.#field_ident().into()
                     ).into_select()
                 )
             }

--- a/crates/toasty-codegen/src/expand/relation.rs
+++ b/crates/toasty-codegen/src/expand/relation.rs
@@ -213,7 +213,7 @@ impl Expand<'_> {
             let target = &fk_field.target;
 
             quote! {
-                <#ty as #toasty::Relation>::Model::FIELDS.#target.eq(&self.#source_field_ident)
+                <#ty as #toasty::Relation>::Model::FIELDS.#target().eq(&self.#source_field_ident)
             }
         });
 
@@ -326,7 +326,7 @@ impl Expand<'_> {
                 #pair_check
 
                 <#ty as #toasty::Relation>::Many::from_stmt(
-                    #toasty::stmt::Association::many(self.into_select(), Self::FIELDS.#field_ident.into())
+                    #toasty::stmt::Association::many(self.into_select(), Self::FIELDS.#field_ident().into())
                 )
             }
         }
@@ -389,7 +389,7 @@ impl Expand<'_> {
                 #pair_check
 
                 <#ty as #toasty::Relation>::One::from_stmt(
-                    #toasty::stmt::Association::one(self.into_select(), Self::FIELDS.#field_ident.into()).into_select()
+                    #toasty::stmt::Association::one(self.into_select(), Self::FIELDS.#field_ident().into()).into_select()
                 )
             }
         }

--- a/crates/toasty-codegen/src/expand/schema.rs
+++ b/crates/toasty-codegen/src/expand/schema.rs
@@ -90,8 +90,8 @@ impl Expand<'_> {
 
                     nullable = quote!(<#ty as #toasty::Relation>::nullable());
                     field_ty = quote!(FieldTy::BelongsTo(BelongsTo {
-                        target:  <#ty as #toasty::Relation>::Model::ID,
-                        expr_ty: Type::Model(<#ty as #toasty::Relation>::Model::ID),
+                        target:  <#ty as #toasty::Relation>::Model::id(),
+                        expr_ty: Type::Model(<#ty as #toasty::Relation>::Model::id()),
                         // The pair is populated at runtime.
                         pair: None,
                         foreign_key: ForeignKey {
@@ -105,8 +105,8 @@ impl Expand<'_> {
 
                     nullable = quote!(<#ty as #toasty::Relation>::nullable());
                     field_ty = quote!(FieldTy::HasMany(HasMany {
-                        target: <#ty as #toasty::Relation>::Model::ID,
-                        expr_ty: Type::List(Box::new(Type::Model(<#ty as #toasty::Relation>::Model::ID))),
+                        target: <#ty as #toasty::Relation>::Model::id(),
+                        expr_ty: Type::List(Box::new(Type::Model(<#ty as #toasty::Relation>::Model::id()))),
                         singular: #singular_name,
                         // The pair is populated at runtime.
                         pair: FieldId {
@@ -120,8 +120,8 @@ impl Expand<'_> {
 
                     nullable = quote!(<#ty as #toasty::Relation>::nullable());
                     field_ty = quote!(FieldTy::HasOne(HasOne {
-                        target: <#ty as #toasty::Relation>::Model::ID,
-                        expr_ty: Type::Model(<#ty as #toasty::Relation>::Model::ID),
+                        target: <#ty as #toasty::Relation>::Model::id(),
+                        expr_ty: Type::Model(<#ty as #toasty::Relation>::Model::id()),
                         // The pair is populated at runtime.
                         pair: FieldId {
                             model: ModelId(usize::MAX),

--- a/crates/toasty-codegen/src/expand/schema.rs
+++ b/crates/toasty-codegen/src/expand/schema.rs
@@ -66,7 +66,7 @@ impl Expand<'_> {
 
                     nullable = quote!(<#ty as #toasty::stmt::Primitive>::NULLABLE);
                     field_ty = quote!(FieldTy::Primitive(FieldPrimitive {
-                        ty: <#ty as #toasty::stmt::Primitive>::TYPE,
+                        ty: <#ty as #toasty::stmt::Primitive>::ty(),
                         storage_ty: #storage_ty,
                     }));
                 }

--- a/crates/toasty/src/cursor.rs
+++ b/crates/toasty/src/cursor.rs
@@ -50,7 +50,7 @@ impl<M: Model> Cursor<M> {
     #[track_caller]
     fn validate_row(&self, record: &stmt::ValueRecord) {
         if cfg!(debug_assertions) {
-            let expect_num_columns = self.schema.app.model(M::ID).fields.len();
+            let expect_num_columns = self.schema.app.model(M::id()).fields.len();
 
             if record.len() != expect_num_columns {
                 panic!("expected row to have {expect_num_columns} columns; {record:#?}");

--- a/crates/toasty/src/model.rs
+++ b/crates/toasty/src/model.rs
@@ -8,7 +8,7 @@ pub trait Model: Sized {
     /// Unique identifier for this model within the schema.
     ///
     /// Identifiers are *not* unique across schemas.
-    const ID: ModelId;
+    fn id() -> ModelId;
 
     /// Load an instance of the model, populating fields using the given row.
     fn load(row: stmt::ValueRecord) -> Result<Self, Error>;
@@ -21,7 +21,9 @@ pub trait Model: Sized {
 // TODO: This is a hack to aid in the transition from schema code gen to proc
 // macro. This should be removed once the proc macro is implemented.
 impl<T: Model> Model for Option<T> {
-    const ID: ModelId = T::ID;
+    fn id() -> ModelId {
+        T::id()
+    }
 
     fn load(row: stmt::ValueRecord) -> Result<Self, Error> {
         Ok(Some(T::load(row)?))

--- a/crates/toasty/src/stmt/association.rs
+++ b/crates/toasty/src/stmt/association.rs
@@ -10,7 +10,7 @@ pub struct Association<T: ?Sized> {
 impl<M: Model> Association<[M]> {
     /// A basic has_many association
     pub fn many<T: Model>(source: Select<T>, path: Path<[M]>) -> Self {
-        assert_eq!(path.untyped.root, T::ID);
+        assert_eq!(path.untyped.root, T::id());
 
         Self {
             untyped: stmt::Association {
@@ -24,7 +24,7 @@ impl<M: Model> Association<[M]> {
     /// A has_one or belongs_to association via a query, which implies there
     /// could be more than one result.
     pub fn many_via_one<T: Model>(source: Select<T>, path: Path<M>) -> Self {
-        assert_eq!(path.untyped.root, T::ID);
+        assert_eq!(path.untyped.root, T::id());
 
         Self {
             untyped: stmt::Association {
@@ -65,7 +65,7 @@ impl<M: Model> Association<[M]> {
 
 impl<M: Model> Association<M> {
     pub fn one<T: Model>(source: Select<T>, path: Path<M>) -> Self {
-        assert_eq!(path.untyped.root, T::ID);
+        assert_eq!(path.untyped.root, T::id());
 
         Self {
             untyped: stmt::Association {
@@ -89,7 +89,7 @@ impl<T: Model> IntoSelect for Association<[T]> {
     fn into_select(self) -> Select<T> {
         Select::from_untyped(
             stmt::Query::builder(stmt::SourceModel {
-                model: T::ID,
+                model: T::id(),
                 via: Some(self.untyped),
                 include: vec![],
             })
@@ -104,7 +104,7 @@ impl<T: Model> IntoSelect for Association<T> {
     fn into_select(self) -> Select<T> {
         Select::from_untyped(
             stmt::Query::builder(stmt::SourceModel {
-                model: T::ID,
+                model: T::id(),
                 via: Some(self.untyped),
                 include: vec![],
             })

--- a/crates/toasty/src/stmt/id.rs
+++ b/crates/toasty/src/stmt/id.rs
@@ -42,7 +42,7 @@ impl<M: Model> IntoExpr<Self> for Id<M> {
 
 impl<M: Model> IntoExpr<Id<M>> for String {
     fn into_expr(self) -> Expr<Id<M>> {
-        Expr::from_value(stmt::Id::from_string(M::ID, self).into())
+        Expr::from_value(stmt::Id::from_string(M::id(), self).into())
     }
 
     fn by_ref(&self) -> Expr<Id<M>> {
@@ -52,7 +52,7 @@ impl<M: Model> IntoExpr<Id<M>> for String {
 
 impl<M: Model> IntoExpr<Id<M>> for &str {
     fn into_expr(self) -> Expr<Id<M>> {
-        Expr::from_value(stmt::Id::from_string(M::ID, self.into()).into())
+        Expr::from_value(stmt::Id::from_string(M::id(), self.into()).into())
     }
 
     fn by_ref(&self) -> Expr<Id<M>> {
@@ -62,7 +62,7 @@ impl<M: Model> IntoExpr<Id<M>> for &str {
 
 impl<M: Model> IntoExpr<Id<M>> for &String {
     fn into_expr(self) -> Expr<Id<M>> {
-        Expr::from_value(stmt::Id::from_string(M::ID, self.into()).into())
+        Expr::from_value(stmt::Id::from_string(M::id(), self.into()).into())
     }
 
     fn by_ref(&self) -> Expr<Id<M>> {

--- a/crates/toasty/src/stmt/insert.rs
+++ b/crates/toasty/src/stmt/insert.rs
@@ -16,7 +16,7 @@ impl<M: Model> Insert<M> {
     pub fn blank() -> Self {
         Self {
             untyped: stmt::Insert {
-                target: stmt::InsertTarget::Model(M::ID),
+                target: stmt::InsertTarget::Model(M::id()),
                 source: stmt::Query::new(vec![stmt::ExprRecord::from_vec(vec![]).into()]),
                 returning: Some(stmt::Returning::Star),
             },

--- a/crates/toasty/src/stmt/path.rs
+++ b/crates/toasty/src/stmt/path.rs
@@ -17,7 +17,7 @@ impl<T: ?Sized> Path<T> {
         }
     }
 
-    pub const fn root() -> Self
+    pub fn root() -> Self
     where
         T: Model,
     {
@@ -30,7 +30,7 @@ impl<T: ?Sized> Path<T> {
         }
     }
 
-    pub const fn from_field_index<M: Model>(index: usize) -> Self {
+    pub fn from_field_index<M: Model>(index: usize) -> Self {
         Self {
             untyped: stmt::Path::from_index(M::id(), index),
             _p: PhantomData,

--- a/crates/toasty/src/stmt/path.rs
+++ b/crates/toasty/src/stmt/path.rs
@@ -23,7 +23,7 @@ impl<T: ?Sized> Path<T> {
     {
         Self {
             untyped: stmt::Path {
-                root: T::ID,
+                root: T::id(),
                 projection: stmt::Projection::identity(),
             },
             _p: PhantomData,
@@ -32,7 +32,7 @@ impl<T: ?Sized> Path<T> {
 
     pub const fn from_field_index<M: Model>(index: usize) -> Self {
         Self {
-            untyped: stmt::Path::from_index(M::ID, index),
+            untyped: stmt::Path::from_index(M::id(), index),
             _p: PhantomData,
         }
     }

--- a/crates/toasty/src/stmt/primitive.rs
+++ b/crates/toasty/src/stmt/primitive.rs
@@ -3,7 +3,7 @@ use crate::{stmt::Id, Model, Result};
 use toasty_core::stmt;
 
 pub trait Primitive: Sized {
-    const TYPE: stmt::Type;
+    fn ty() -> stmt::Type;
     const NULLABLE: bool = false;
 
     fn load(value: stmt::Value) -> Result<Self>;
@@ -15,7 +15,9 @@ pub trait Primitive: Sized {
 }
 
 impl Primitive for i8 {
-    const TYPE: stmt::Type = stmt::Type::I8;
+    fn ty() -> stmt::Type {
+        stmt::Type::I8
+    }
 
     fn load(value: stmt::Value) -> Result<Self> {
         value.try_into()
@@ -23,7 +25,9 @@ impl Primitive for i8 {
 }
 
 impl Primitive for i16 {
-    const TYPE: stmt::Type = stmt::Type::I16;
+    fn ty() -> stmt::Type {
+        stmt::Type::I16
+    }
 
     fn load(value: stmt::Value) -> Result<Self> {
         value.try_into()
@@ -31,7 +35,9 @@ impl Primitive for i16 {
 }
 
 impl Primitive for i32 {
-    const TYPE: stmt::Type = stmt::Type::I32;
+    fn ty() -> stmt::Type {
+        stmt::Type::I32
+    }
 
     fn load(value: stmt::Value) -> Result<Self> {
         value.try_into()
@@ -39,7 +45,9 @@ impl Primitive for i32 {
 }
 
 impl Primitive for i64 {
-    const TYPE: stmt::Type = stmt::Type::I64;
+    fn ty() -> stmt::Type {
+        stmt::Type::I64
+    }
 
     fn load(value: stmt::Value) -> Result<Self> {
         value.try_into()
@@ -47,7 +55,9 @@ impl Primitive for i64 {
 }
 
 impl Primitive for u8 {
-    const TYPE: stmt::Type = stmt::Type::U8;
+    fn ty() -> stmt::Type {
+        stmt::Type::U8
+    }
 
     fn load(value: stmt::Value) -> Result<Self> {
         value.try_into()
@@ -55,7 +65,9 @@ impl Primitive for u8 {
 }
 
 impl Primitive for u16 {
-    const TYPE: stmt::Type = stmt::Type::U16;
+    fn ty() -> stmt::Type {
+        stmt::Type::U16
+    }
 
     fn load(value: stmt::Value) -> Result<Self> {
         value.try_into()
@@ -63,7 +75,9 @@ impl Primitive for u16 {
 }
 
 impl Primitive for u32 {
-    const TYPE: stmt::Type = stmt::Type::U32;
+    fn ty() -> stmt::Type {
+        stmt::Type::U32
+    }
 
     fn load(value: stmt::Value) -> Result<Self> {
         value.try_into()
@@ -71,7 +85,9 @@ impl Primitive for u32 {
 }
 
 impl Primitive for u64 {
-    const TYPE: stmt::Type = stmt::Type::U64;
+    fn ty() -> stmt::Type {
+        stmt::Type::U64
+    }
 
     fn load(value: stmt::Value) -> Result<Self> {
         value.try_into()
@@ -79,7 +95,9 @@ impl Primitive for u64 {
 }
 
 impl Primitive for String {
-    const TYPE: stmt::Type = stmt::Type::String;
+    fn ty() -> stmt::Type {
+        stmt::Type::String
+    }
 
     fn load(value: stmt::Value) -> Result<Self> {
         match value {
@@ -90,7 +108,9 @@ impl Primitive for String {
 }
 
 impl<T: Model> Primitive for Id<T> {
-    const TYPE: stmt::Type = stmt::Type::Id(T::id());
+    fn ty() -> stmt::Type {
+        stmt::Type::Id(T::id())
+    }
 
     fn load(value: stmt::Value) -> Result<Self> {
         match value {
@@ -101,7 +121,9 @@ impl<T: Model> Primitive for Id<T> {
 }
 
 impl<T: Primitive> Primitive for Option<T> {
-    const TYPE: stmt::Type = T::TYPE;
+    fn ty() -> stmt::Type {
+        T::ty()
+    }
     const NULLABLE: bool = true;
 
     fn load(value: stmt::Value) -> Result<Self> {

--- a/crates/toasty/src/stmt/primitive.rs
+++ b/crates/toasty/src/stmt/primitive.rs
@@ -90,7 +90,7 @@ impl Primitive for String {
 }
 
 impl<T: Model> Primitive for Id<T> {
-    const TYPE: stmt::Type = stmt::Type::Id(T::ID);
+    const TYPE: stmt::Type = stmt::Type::Id(T::id());
 
     fn load(value: stmt::Value) -> Result<Self> {
         match value {

--- a/crates/toasty/src/stmt/select.rs
+++ b/crates/toasty/src/stmt/select.rs
@@ -36,7 +36,7 @@ impl<M: Model> Select<M> {
     }
 
     pub fn filter(expr: Expr<bool>) -> Self {
-        Self::from_untyped(stmt::Query::filter(M::ID, expr.untyped))
+        Self::from_untyped(stmt::Query::filter(M::id(), expr.untyped))
     }
 
     // TODO: why are these by value?
@@ -69,7 +69,7 @@ impl<M: Model> Select<M> {
 impl<M: Model> Select<M> {
     pub fn all() -> Self {
         let filter = stmt::Expr::Value(Value::from_bool(true));
-        Self::from_untyped(stmt::Query::filter(M::ID, filter))
+        Self::from_untyped(stmt::Query::filter(M::id(), filter))
     }
 }
 

--- a/crates/toasty/src/stmt/update.rs
+++ b/crates/toasty/src/stmt/update.rs
@@ -11,9 +11,9 @@ impl<M: Model> Update<M> {
     pub fn new(mut selection: Select<M>) -> Self {
         if let stmt::ExprSet::Values(values) = &mut selection.untyped.body {
             let rows = std::mem::take(&mut values.rows);
-            let filter = stmt::Expr::in_list(stmt::Expr::key(M::ID), rows);
+            let filter = stmt::Expr::in_list(stmt::Expr::key(M::id()), rows);
             selection.untyped.body =
-                stmt::ExprSet::Select(Box::new(stmt::Select::new(M::ID, filter)));
+                stmt::ExprSet::Select(Box::new(stmt::Select::new(M::id(), filter)));
         }
 
         let mut stmt = selection.untyped.update();
@@ -63,7 +63,7 @@ impl<M: Model> Default for Update<M> {
     fn default() -> Self {
         Self {
             untyped: stmt::Update {
-                target: stmt::UpdateTarget::Model(M::ID),
+                target: stmt::UpdateTarget::Model(M::id()),
                 assignments: stmt::Assignments::default(),
                 filter: Some(stmt::Expr::from(false)),
                 condition: None,

--- a/examples/composite-key/src/main.rs
+++ b/examples/composite-key/src/main.rs
@@ -76,7 +76,7 @@ async fn main() -> toasty::Result<()> {
 
     let mut todos = user
         .todos()
-        .query(Todo::FIELDS.order.eq(1))
+        .query(Todo::FIELDS.order().eq(1))
         .all(&db)
         .await?;
 

--- a/tests/tests/belongs_to_self_referential.rs
+++ b/tests/tests/belongs_to_self_referential.rs
@@ -71,7 +71,7 @@ async fn crud_person_self_referential(s: impl Setup) {
 
     // Try preloading this time
     let p1 = Person::filter_by_id(&p1.id)
-        .include(Person::FIELDS.children)
+        .include(Person::FIELDS.children())
         .get(&db)
         .await
         .unwrap();

--- a/tests/tests/has_many_crud_multi_relations.rs
+++ b/tests/tests/has_many_crud_multi_relations.rs
@@ -174,7 +174,7 @@ async fn crud_user_todos_categories(s: impl Setup) {
         &expect,
         category
             .todos()
-            .query(Todo::FIELDS.user.eq(&user))
+            .query(Todo::FIELDS.user().eq(&user))
             .collect::<Vec<_>>(&db)
             .await
             .unwrap(),
@@ -185,7 +185,7 @@ async fn crud_user_todos_categories(s: impl Setup) {
         &db,
         &expect,
         user.todos()
-            .query(Todo::FIELDS.category.eq(&category))
+            .query(Todo::FIELDS.category().eq(&category))
             .collect::<Vec<_>>(&db)
             .await
             .unwrap(),
@@ -196,7 +196,7 @@ async fn crud_user_todos_categories(s: impl Setup) {
         &db,
         &expect,
         Todo::filter_by_user_id(&user.id)
-            .filter(Todo::FIELDS.category.eq(&category))
+            .filter(Todo::FIELDS.category().eq(&category))
             .collect::<Vec<_>>(&db)
             .await
             .unwrap(),

--- a/tests/tests/has_many_preload.rs
+++ b/tests/tests/has_many_preload.rs
@@ -38,7 +38,7 @@ async fn basic_has_many_and_belongs_to_preload(s: impl Setup) {
 
     // Find the user, include TODOs
     let user = User::filter_by_id(&user.id)
-        .include(User::FIELDS.todos)
+        .include(User::FIELDS.todos())
         .get(&db)
         .await
         .unwrap();
@@ -49,7 +49,7 @@ async fn basic_has_many_and_belongs_to_preload(s: impl Setup) {
     let id = user.todos.get()[0].id.clone();
 
     let todo = Todo::filter_by_id(&id)
-        .include(Todo::FIELDS.user)
+        .include(Todo::FIELDS.user())
         .get(&db)
         .await
         .unwrap();

--- a/tests/tests/has_many_scoped_query.rs
+++ b/tests/tests/has_many_scoped_query.rs
@@ -72,7 +72,7 @@ async fn scoped_query_eq(s: impl Setup) {
     // Query todos scoped by user 1
     let todos = u1
         .todos()
-        .query(Todo::FIELDS.order.eq(0))
+        .query(Todo::FIELDS.order().eq(0))
         .collect::<Vec<_>>(&db)
         .await
         .unwrap();
@@ -85,7 +85,7 @@ async fn scoped_query_eq(s: impl Setup) {
     // Querying todos scoped by user 2
     let todos = u2
         .todos()
-        .query(Todo::FIELDS.order.eq(0))
+        .query(Todo::FIELDS.order().eq(0))
         .all(&db)
         .await
         .unwrap()
@@ -111,7 +111,7 @@ async fn scoped_query_eq(s: impl Setup) {
     // Query for order 0 todos again
     let mut todos = u1
         .todos()
-        .query(Todo::FIELDS.order.eq(0))
+        .query(Todo::FIELDS.order().eq(0))
         .all(&db)
         .await
         .unwrap();
@@ -129,7 +129,7 @@ async fn scoped_query_eq(s: impl Setup) {
     // Query for non-existent TODOs
     let todos = u2
         .todos()
-        .query(Todo::FIELDS.order.eq(1))
+        .query(Todo::FIELDS.order().eq(1))
         .all(&db)
         .await
         .unwrap()
@@ -186,7 +186,7 @@ async fn scoped_query_gt(s: impl Setup) {
     // Find all != 2
     let todos: Vec<_> = user
         .todos()
-        .query(Todo::FIELDS.order.ne(2))
+        .query(Todo::FIELDS.order().ne(2))
         .collect(&db)
         .await
         .unwrap();
@@ -203,7 +203,7 @@ async fn scoped_query_gt(s: impl Setup) {
     // Find all greater than 2
     let todos: Vec<_> = user
         .todos()
-        .query(Todo::FIELDS.order.gt(2))
+        .query(Todo::FIELDS.order().gt(2))
         .collect(&db)
         .await
         .unwrap();
@@ -216,7 +216,7 @@ async fn scoped_query_gt(s: impl Setup) {
     // Find all greater than or equal to 2
     let todos: Vec<_> = user
         .todos()
-        .query(Todo::FIELDS.order.ge(2))
+        .query(Todo::FIELDS.order().ge(2))
         .collect(&db)
         .await
         .unwrap();
@@ -229,7 +229,7 @@ async fn scoped_query_gt(s: impl Setup) {
     // Find all less than to 2
     let todos: Vec<_> = user
         .todos()
-        .query(Todo::FIELDS.order.lt(2))
+        .query(Todo::FIELDS.order().lt(2))
         .collect(&db)
         .await
         .unwrap();
@@ -242,7 +242,7 @@ async fn scoped_query_gt(s: impl Setup) {
     // Find all less than or equal to 2
     let todos: Vec<_> = user
         .todos()
-        .query(Todo::FIELDS.order.le(2))
+        .query(Todo::FIELDS.order().le(2))
         .collect(&db)
         .await
         .unwrap();

--- a/tests/tests/has_one_crud_basic.rs
+++ b/tests/tests/has_one_crud_basic.rs
@@ -601,7 +601,7 @@ async fn associate_has_one_by_val_on_update_query_with_filter(_s: impl Setup) {
 
     // Getting this to work will require a big chunk of work in the planner.
     User::filter_by_id(&u1.id)
-        .filter(User::FIELDS.name.eq("anon"))
+        .filter(User::FIELDS.name().eq("anon"))
         .update()
         .profile(&p1)
         .exec(&db)

--- a/tests/tests/one_model_query.rs
+++ b/tests/tests/one_model_query.rs
@@ -106,7 +106,7 @@ async fn query_partition_key_string_eq(s: impl Setup) {
     }
 
     // Query on the partition key only
-    let teams = Team::filter(Team::FIELDS.league.eq("EPL"))
+    let teams = Team::filter(Team::FIELDS.league().eq("EPL"))
         .collect::<Vec<_>>(&db)
         .await
         .unwrap();
@@ -122,9 +122,9 @@ async fn query_partition_key_string_eq(s: impl Setup) {
     // Query on the partition key and local key
     let teams = Team::filter(
         Team::FIELDS
-            .league
+            .league()
             .eq("MLS")
-            .and(Team::FIELDS.name.eq("Portland Timbers")),
+            .and(Team::FIELDS.name().eq("Portland Timbers")),
     )
     .all(&db)
     .await
@@ -141,9 +141,9 @@ async fn query_partition_key_string_eq(s: impl Setup) {
     // Query on the partition key and a non-index field
     let teams = Team::filter(
         Team::FIELDS
-            .league
+            .league()
             .eq("MLS")
-            .and(Team::FIELDS.founded.eq(2009)),
+            .and(Team::FIELDS.founded().eq(2009)),
     )
     .all(&db)
     .await
@@ -160,10 +160,10 @@ async fn query_partition_key_string_eq(s: impl Setup) {
     // Query on the partition key, local key, and a non-index field with a match
     let teams = Team::filter(
         Team::FIELDS
-            .league
+            .league()
             .eq("MLS")
-            .and(Team::FIELDS.founded.eq(2009))
-            .and(Team::FIELDS.name.eq("Portland Timbers")),
+            .and(Team::FIELDS.founded().eq(2009))
+            .and(Team::FIELDS.name().eq("Portland Timbers")),
     )
     .all(&db)
     .await
@@ -183,10 +183,10 @@ async fn query_partition_key_string_eq(s: impl Setup) {
     // Query on the partition key, local key, and a non-index field without a match
     let teams = Team::filter(
         Team::FIELDS
-            .league
+            .league()
             .eq("MLS")
-            .and(Team::FIELDS.founded.eq(2009))
-            .and(Team::FIELDS.name.eq("LA Galaxy")),
+            .and(Team::FIELDS.founded().eq(2009))
+            .and(Team::FIELDS.name().eq("LA Galaxy")),
     )
     .all(&db)
     .await
@@ -241,7 +241,7 @@ async fn query_local_key_cmp(s: impl Setup) {
     }
 
     let events: Vec<_> = Event::filter_by_kind("info")
-        .filter(Event::FIELDS.timestamp.ne(10))
+        .filter(Event::FIELDS.timestamp().ne(10))
         .collect(&db)
         .await
         .unwrap();
@@ -252,7 +252,7 @@ async fn query_local_key_cmp(s: impl Setup) {
     );
 
     let events: Vec<_> = Event::filter_by_kind("info")
-        .filter(Event::FIELDS.timestamp.gt(10))
+        .filter(Event::FIELDS.timestamp().gt(10))
         .collect(&db)
         .await
         .unwrap();
@@ -263,7 +263,7 @@ async fn query_local_key_cmp(s: impl Setup) {
     );
 
     let events: Vec<_> = Event::filter_by_kind("info")
-        .filter(Event::FIELDS.timestamp.ge(10))
+        .filter(Event::FIELDS.timestamp().ge(10))
         .collect(&db)
         .await
         .unwrap();
@@ -274,7 +274,7 @@ async fn query_local_key_cmp(s: impl Setup) {
     );
 
     let events: Vec<_> = Event::filter_by_kind("info")
-        .filter(Event::FIELDS.timestamp.lt(10))
+        .filter(Event::FIELDS.timestamp().lt(10))
         .collect(&db)
         .await
         .unwrap();
@@ -285,7 +285,7 @@ async fn query_local_key_cmp(s: impl Setup) {
     );
 
     let events: Vec<_> = Event::filter_by_kind("info")
-        .filter(Event::FIELDS.timestamp.le(10))
+        .filter(Event::FIELDS.timestamp().le(10))
         .collect(&db)
         .await
         .unwrap();
@@ -346,7 +346,7 @@ async fn query_arbitrary_constraint(s: impl Setup) {
             .unwrap();
     }
 
-    let events: Vec<_> = Event::filter(Event::FIELDS.timestamp.gt(12))
+    let events: Vec<_> = Event::filter(Event::FIELDS.timestamp().gt(12))
         .collect(&db)
         .await
         .unwrap();
@@ -358,9 +358,9 @@ async fn query_arbitrary_constraint(s: impl Setup) {
 
     let events: Vec<_> = Event::filter(
         Event::FIELDS
-            .timestamp
+            .timestamp()
             .gt(12)
-            .and(Event::FIELDS.kind.ne("info")),
+            .and(Event::FIELDS.kind().ne("info")),
     )
     .collect(&db)
     .await
@@ -375,9 +375,9 @@ async fn query_arbitrary_constraint(s: impl Setup) {
 
     let events: Vec<_> = Event::filter(
         Event::FIELDS
-            .kind
+            .kind()
             .eq("info")
-            .and(Event::FIELDS.timestamp.ne(10)),
+            .and(Event::FIELDS.timestamp().ne(10)),
     )
     .collect(&db)
     .await
@@ -390,9 +390,9 @@ async fn query_arbitrary_constraint(s: impl Setup) {
 
     let events: Vec<_> = Event::filter(
         Event::FIELDS
-            .kind
+            .kind()
             .eq("info")
-            .and(Event::FIELDS.timestamp.gt(10)),
+            .and(Event::FIELDS.timestamp().gt(10)),
     )
     .collect(&db)
     .await
@@ -405,9 +405,9 @@ async fn query_arbitrary_constraint(s: impl Setup) {
 
     let events: Vec<_> = Event::filter(
         Event::FIELDS
-            .kind
+            .kind()
             .eq("info")
-            .and(Event::FIELDS.timestamp.ge(10)),
+            .and(Event::FIELDS.timestamp().ge(10)),
     )
     .collect(&db)
     .await
@@ -420,9 +420,9 @@ async fn query_arbitrary_constraint(s: impl Setup) {
 
     let events: Vec<_> = Event::filter(
         Event::FIELDS
-            .kind
+            .kind()
             .eq("info")
-            .and(Event::FIELDS.timestamp.lt(10)),
+            .and(Event::FIELDS.timestamp().lt(10)),
     )
     .collect(&db)
     .await
@@ -435,9 +435,9 @@ async fn query_arbitrary_constraint(s: impl Setup) {
 
     let events: Vec<_> = Event::filter(
         Event::FIELDS
-            .kind
+            .kind()
             .eq("info")
-            .and(Event::FIELDS.timestamp.le(10)),
+            .and(Event::FIELDS.timestamp().le(10)),
     )
     .collect(&db)
     .await

--- a/tests/tests/one_model_sort_limit.rs
+++ b/tests/tests/one_model_sort_limit.rs
@@ -24,7 +24,7 @@ async fn sort_asc(s: impl Setup) {
     }
 
     let foos_asc: Vec<_> = Foo::all()
-        .order_by(Foo::FIELDS.order.asc())
+        .order_by(Foo::FIELDS.order().asc())
         .collect(&db)
         .await
         .unwrap();
@@ -36,7 +36,7 @@ async fn sort_asc(s: impl Setup) {
     }
 
     let foos_desc: Vec<_> = Foo::all()
-        .order_by(Foo::FIELDS.order.desc())
+        .order_by(Foo::FIELDS.order().desc())
         .collect(&db)
         .await
         .unwrap();
@@ -60,7 +60,7 @@ async fn paginate(s: impl Setup) {
     }
 
     let foos: Vec<_> = Foo::all()
-        .order_by(Foo::FIELDS.order.desc())
+        .order_by(Foo::FIELDS.order().desc())
         .paginate(10)
         .collect(&db)
         .await
@@ -72,7 +72,7 @@ async fn paginate(s: impl Setup) {
     }
 
     let foos: Vec<_> = Foo::all()
-        .order_by(Foo::FIELDS.order.desc())
+        .order_by(Foo::FIELDS.order().desc())
         .paginate(10)
         .after(90)
         .collect(&db)


### PR DESCRIPTION
It is not possible to generate unique numbers statically with Rust, so we need to remove the const requirement.