### PR TITLE
refactor: Replace glob imports with specific imports in toasty-core

### DIFF
--- a/crates/toasty-core/src/driver.rs
+++ b/crates/toasty-core/src/driver.rs
@@ -7,7 +7,7 @@ pub use response::{Response, Rows};
 pub mod operation;
 pub use operation::Operation;
 
-use crate::{async_trait, schema::db::Schema, stmt};
+use crate::{async_trait, schema::db::Schema};
 
 use std::{fmt::Debug, sync::Arc};
 

--- a/crates/toasty-core/src/driver/operation.rs
+++ b/crates/toasty-core/src/driver/operation.rs
@@ -22,7 +22,6 @@ pub use transaction::Transaction;
 mod update_by_key;
 pub use update_by_key::UpdateByKey;
 
-use super::*;
 
 #[derive(Debug)]
 pub enum Operation {

--- a/crates/toasty-core/src/driver/operation.rs
+++ b/crates/toasty-core/src/driver/operation.rs
@@ -22,7 +22,6 @@ pub use transaction::Transaction;
 mod update_by_key;
 pub use update_by_key::UpdateByKey;
 
-
 #[derive(Debug)]
 pub enum Operation {
     /// Create a new record. This will always be a lowered `stmt::Insert`

--- a/crates/toasty-core/src/driver/operation/delete_by_key.rs
+++ b/crates/toasty-core/src/driver/operation/delete_by_key.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::Operation;
 use crate::{schema::db::TableId, stmt};
 
 #[derive(Debug)]

--- a/crates/toasty-core/src/driver/operation/find_pk_by_index.rs
+++ b/crates/toasty-core/src/driver/operation/find_pk_by_index.rs
@@ -1,5 +1,8 @@
 use super::Operation;
-use crate::{schema::db::{IndexId, TableId}, stmt};
+use crate::{
+    schema::db::{IndexId, TableId},
+    stmt,
+};
 
 #[derive(Debug)]
 pub struct FindPkByIndex {

--- a/crates/toasty-core/src/driver/operation/find_pk_by_index.rs
+++ b/crates/toasty-core/src/driver/operation/find_pk_by_index.rs
@@ -1,6 +1,5 @@
-use super::*;
-
-use crate::schema::db::{IndexId, TableId};
+use super::Operation;
+use crate::{schema::db::{IndexId, TableId}, stmt};
 
 #[derive(Debug)]
 pub struct FindPkByIndex {

--- a/crates/toasty-core/src/driver/operation/get_by_key.rs
+++ b/crates/toasty-core/src/driver/operation/get_by_key.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::Operation;
 
 use crate::{
     schema::db::{ColumnId, TableId},

--- a/crates/toasty-core/src/driver/operation/insert.rs
+++ b/crates/toasty-core/src/driver/operation/insert.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::Operation;
 
 use crate::stmt;
 

--- a/crates/toasty-core/src/driver/operation/query_pk.rs
+++ b/crates/toasty-core/src/driver/operation/query_pk.rs
@@ -1,6 +1,5 @@
-use super::*;
-
-use crate::schema::db::{ColumnId, TableId};
+use super::Operation;
+use crate::{schema::db::{ColumnId, TableId}, stmt};
 
 #[derive(Debug)]
 pub struct QueryPk {

--- a/crates/toasty-core/src/driver/operation/query_pk.rs
+++ b/crates/toasty-core/src/driver/operation/query_pk.rs
@@ -1,5 +1,8 @@
 use super::Operation;
-use crate::{schema::db::{ColumnId, TableId}, stmt};
+use crate::{
+    schema::db::{ColumnId, TableId},
+    stmt,
+};
 
 #[derive(Debug)]
 pub struct QueryPk {

--- a/crates/toasty-core/src/driver/operation/query_sql.rs
+++ b/crates/toasty-core/src/driver/operation/query_sql.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::Operation;
 
 use crate::stmt;
 

--- a/crates/toasty-core/src/driver/operation/update_by_key.rs
+++ b/crates/toasty-core/src/driver/operation/update_by_key.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::Operation;
 
 use crate::{schema::db::TableId, stmt};
 

--- a/crates/toasty-core/src/schema.rs
+++ b/crates/toasty-core/src/schema.rs
@@ -15,8 +15,8 @@ mod verify;
 
 use crate::*;
 
-use app::{Field, FieldId, Model, ModelId};
-use db::{ColumnId, IndexId, Table, TableId};
+use app::ModelId;
+use db::{ColumnId, Table, TableId};
 
 use std::sync::Arc;
 

--- a/crates/toasty-core/src/schema.rs
+++ b/crates/toasty-core/src/schema.rs
@@ -13,9 +13,9 @@ pub use name::Name;
 
 mod verify;
 
+use anyhow::Result;
 use app::ModelId;
 use db::{ColumnId, Table, TableId};
-
 use std::sync::Arc;
 
 #[derive(Debug)]

--- a/crates/toasty-core/src/schema.rs
+++ b/crates/toasty-core/src/schema.rs
@@ -13,8 +13,6 @@ pub use name::Name;
 
 mod verify;
 
-use crate::*;
-
 use app::ModelId;
 use db::{ColumnId, Table, TableId};
 

--- a/crates/toasty-core/src/schema/app.rs
+++ b/crates/toasty-core/src/schema/app.rs
@@ -30,8 +30,4 @@ pub use relation::{BelongsTo, HasMany, HasOne};
 mod schema;
 pub use schema::Schema;
 
-use super::{
-    db::{IndexOp, IndexScope},
-    Name,
-};
-use crate::stmt;
+use super::Name;

--- a/crates/toasty-core/src/schema/app/arg.rs
+++ b/crates/toasty-core/src/schema/app/arg.rs
@@ -1,4 +1,4 @@
-use super::*;
+use crate::stmt;
 
 #[derive(Debug, Clone)]
 pub struct Arg {

--- a/crates/toasty-core/src/schema/app/field.rs
+++ b/crates/toasty-core/src/schema/app/field.rs
@@ -1,10 +1,8 @@
 mod primitive;
 pub use primitive::FieldPrimitive;
 
-use crate::{driver, Result};
-
-use super::*;
-
+use crate::{driver, Result, stmt};
+use super::{Auto, BelongsTo, Constraint, HasMany, HasOne, Model, ModelId, Schema};
 use std::fmt;
 
 #[derive(Debug, Clone)]

--- a/crates/toasty-core/src/schema/app/field.rs
+++ b/crates/toasty-core/src/schema/app/field.rs
@@ -1,8 +1,8 @@
 mod primitive;
 pub use primitive::FieldPrimitive;
 
-use crate::{driver, Result, stmt};
 use super::{Auto, BelongsTo, Constraint, HasMany, HasOne, Model, ModelId, Schema};
+use crate::{driver, stmt, Result};
 use std::fmt;
 
 #[derive(Debug, Clone)]

--- a/crates/toasty-core/src/schema/app/field/primitive.rs
+++ b/crates/toasty-core/src/schema/app/field/primitive.rs
@@ -1,6 +1,4 @@
-use super::*;
-
-use crate::schema::db;
+use crate::{schema::db, stmt};
 
 #[derive(Debug, Clone)]
 pub struct FieldPrimitive {

--- a/crates/toasty-core/src/schema/app/index.rs
+++ b/crates/toasty-core/src/schema/app/index.rs
@@ -1,4 +1,5 @@
-use super::*;
+use super::{FieldId, ModelId};
+use crate::schema::db::{IndexOp, IndexScope};
 
 #[derive(Debug, Clone)]
 pub struct Index {

--- a/crates/toasty-core/src/schema/app/model.rs
+++ b/crates/toasty-core/src/schema/app/model.rs
@@ -1,7 +1,5 @@
-use crate::{driver, Result};
-
-use super::*;
-
+use crate::{driver, Result, stmt};
+use super::{Field, FieldId, FieldPrimitive, FieldTy, Index, Name, PrimaryKey};
 use std::fmt;
 
 #[derive(Debug, Clone)]

--- a/crates/toasty-core/src/schema/app/model.rs
+++ b/crates/toasty-core/src/schema/app/model.rs
@@ -1,5 +1,5 @@
-use crate::{driver, Result, stmt};
 use super::{Field, FieldId, FieldPrimitive, FieldTy, Index, Name, PrimaryKey};
+use crate::{driver, stmt, Result};
 use std::fmt;
 
 #[derive(Debug, Clone)]

--- a/crates/toasty-core/src/schema/app/pk.rs
+++ b/crates/toasty-core/src/schema/app/pk.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{FieldId, IndexId};
 
 #[derive(Debug, Clone)]
 pub struct PrimaryKey {

--- a/crates/toasty-core/src/schema/app/relation.rs
+++ b/crates/toasty-core/src/schema/app/relation.rs
@@ -6,5 +6,3 @@ pub use has_many::HasMany;
 
 mod has_one;
 pub use has_one::HasOne;
-
-use super::*;

--- a/crates/toasty-core/src/schema/app/relation/belongs_to.rs
+++ b/crates/toasty-core/src/schema/app/relation/belongs_to.rs
@@ -1,4 +1,4 @@
-use super::*;
+use crate::{schema::app::{FieldId, FieldTy, ForeignKey, HasMany, HasOne, Model, ModelId, Schema}, stmt};
 
 #[derive(Debug, Clone)]
 pub struct BelongsTo {

--- a/crates/toasty-core/src/schema/app/relation/belongs_to.rs
+++ b/crates/toasty-core/src/schema/app/relation/belongs_to.rs
@@ -1,4 +1,7 @@
-use crate::{schema::app::{FieldId, FieldTy, ForeignKey, HasMany, HasOne, Model, ModelId, Schema}, stmt};
+use crate::{
+    schema::app::{FieldId, FieldTy, ForeignKey, Model, ModelId, Schema},
+    stmt,
+};
 
 #[derive(Debug, Clone)]
 pub struct BelongsTo {

--- a/crates/toasty-core/src/schema/app/relation/has_many.rs
+++ b/crates/toasty-core/src/schema/app/relation/has_many.rs
@@ -1,4 +1,7 @@
-use crate::{schema::app::{BelongsTo, FieldId, Model, ModelId, Name, Schema}, stmt};
+use crate::{
+    schema::app::{BelongsTo, FieldId, Model, ModelId, Name, Schema},
+    stmt,
+};
 
 #[derive(Debug, Clone)]
 pub struct HasMany {

--- a/crates/toasty-core/src/schema/app/relation/has_many.rs
+++ b/crates/toasty-core/src/schema/app/relation/has_many.rs
@@ -1,4 +1,4 @@
-use super::*;
+use crate::{schema::app::{BelongsTo, FieldId, Model, ModelId, Name, Schema}, stmt};
 
 #[derive(Debug, Clone)]
 pub struct HasMany {

--- a/crates/toasty-core/src/schema/app/relation/has_one.rs
+++ b/crates/toasty-core/src/schema/app/relation/has_one.rs
@@ -1,4 +1,7 @@
-use crate::{schema::app::{BelongsTo, FieldId, FieldTy, Model, ModelId, Schema}, stmt};
+use crate::{
+    schema::app::{BelongsTo, FieldId, FieldTy, Model, ModelId, Schema},
+    stmt,
+};
 
 #[derive(Debug, Clone)]
 pub struct HasOne {

--- a/crates/toasty-core/src/schema/app/relation/has_one.rs
+++ b/crates/toasty-core/src/schema/app/relation/has_one.rs
@@ -1,4 +1,4 @@
-use super::*;
+use crate::{schema::app::{BelongsTo, FieldId, FieldTy, Model, ModelId, Schema}, stmt};
 
 #[derive(Debug, Clone)]
 pub struct HasOne {

--- a/crates/toasty-core/src/schema/app/schema.rs
+++ b/crates/toasty-core/src/schema/app/schema.rs
@@ -1,4 +1,4 @@
-use super::{BelongsTo, Field, FieldId, FieldTy, HasMany, HasOne, Model, ModelId};
+use super::{Field, FieldId, FieldTy, Model, ModelId};
 
 use crate::Result;
 use indexmap::IndexMap;

--- a/crates/toasty-core/src/schema/app/schema.rs
+++ b/crates/toasty-core/src/schema/app/schema.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{BelongsTo, Field, FieldId, FieldTy, HasMany, HasOne, Model, ModelId};
 
 use crate::Result;
 use indexmap::IndexMap;

--- a/crates/toasty-core/src/schema/builder.rs
+++ b/crates/toasty-core/src/schema/builder.rs
@@ -1,8 +1,8 @@
 mod table;
 
-use super::{app, db, mapping, verify, Result};
-use crate::{driver, stmt};
+use super::{app, db, mapping, Result};
 use crate::schema::{ColumnId, Mapping, Schema, Table, TableId};
+use crate::{driver, stmt};
 use indexmap::IndexMap;
 use std::sync::Arc;
 

--- a/crates/toasty-core/src/schema/builder.rs
+++ b/crates/toasty-core/src/schema/builder.rs
@@ -1,8 +1,10 @@
 mod table;
 
-use super::*;
-
+use super::{app, db, mapping, verify, Result};
+use crate::{driver, stmt};
+use crate::schema::{ColumnId, Mapping, Schema, Table, TableId};
 use indexmap::IndexMap;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct Builder {

--- a/crates/toasty-core/src/schema/builder/table.rs
+++ b/crates/toasty-core/src/schema/builder/table.rs
@@ -1,4 +1,14 @@
-use super::*;
+use crate::{
+    driver,
+    schema::{
+        app::{self, BelongsTo, FieldId, FieldPrimitive, FieldTy, HasMany, HasOne, Model},
+        db::{self, Column, ColumnId, Index, IndexColumn, IndexId, IndexOp, Schema, Table, TableId},
+        mapping::{self, Mapping},
+        Name,
+    },
+    stmt::{self, Expr, ExprRecord, Type, TypeEnum, Value},
+};
+use super::BuildSchema;
 
 struct BuildTableFromModels<'a> {
     /// Database-specific capabilities

--- a/crates/toasty-core/src/schema/builder/table.rs
+++ b/crates/toasty-core/src/schema/builder/table.rs
@@ -1,14 +1,14 @@
+use super::BuildSchema;
 use crate::{
     driver,
     schema::{
-        app::{self, BelongsTo, FieldId, FieldPrimitive, FieldTy, HasMany, HasOne, Model},
-        db::{self, Column, ColumnId, Index, IndexColumn, IndexId, IndexOp, Schema, Table, TableId},
+        app::{self, FieldId, Model},
+        db::{self, ColumnId, IndexId, Table, TableId},
         mapping::{self, Mapping},
         Name,
     },
-    stmt::{self, Expr, ExprRecord, Type, TypeEnum, Value},
+    stmt::{self},
 };
-use super::BuildSchema;
 
 struct BuildTableFromModels<'a> {
     /// Database-specific capabilities

--- a/crates/toasty-core/src/schema/db.rs
+++ b/crates/toasty-core/src/schema/db.rs
@@ -15,5 +15,3 @@ pub use table::{Table, TableId};
 
 mod ty;
 pub use ty::Type;
-
-use crate::stmt;

--- a/crates/toasty-core/src/schema/db/column.rs
+++ b/crates/toasty-core/src/schema/db/column.rs
@@ -1,4 +1,5 @@
-use super::*;
+use super::{table, TableId, Type};
+use crate::stmt;
 
 use std::fmt;
 

--- a/crates/toasty-core/src/schema/db/index.rs
+++ b/crates/toasty-core/src/schema/db/index.rs
@@ -1,4 +1,5 @@
-use super::*;
+use super::{Column, ColumnId, Schema, TableId};
+use crate::stmt;
 
 use std::fmt;
 

--- a/crates/toasty-core/src/schema/db/pk.rs
+++ b/crates/toasty-core/src/schema/db/pk.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{ColumnId, IndexId};
 
 #[derive(Debug, PartialEq)]
 pub struct PrimaryKey {

--- a/crates/toasty-core/src/schema/db/schema.rs
+++ b/crates/toasty-core/src/schema/db/schema.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{Column, ColumnId, Index, IndexId, Table, TableId};
 
 #[derive(Debug, Default)]
 pub struct Schema {

--- a/crates/toasty-core/src/schema/db/table.rs
+++ b/crates/toasty-core/src/schema/db/table.rs
@@ -1,4 +1,5 @@
-use super::*;
+use super::{Column, ColumnId, Index, IndexId, PrimaryKey};
+use crate::stmt;
 
 use std::fmt;
 

--- a/crates/toasty-core/src/schema/mapping.rs
+++ b/crates/toasty-core/src/schema/mapping.rs
@@ -4,8 +4,7 @@ pub use field::Field;
 mod model;
 pub use model::Model;
 
-use super::*;
-
+use super::app::ModelId;
 use indexmap::IndexMap;
 
 /// Maps an app-level schema to a database-level schema

--- a/crates/toasty-core/src/schema/mapping/field.rs
+++ b/crates/toasty-core/src/schema/mapping/field.rs
@@ -1,4 +1,4 @@
-use super::*;
+use crate::schema::db::ColumnId;
 
 #[derive(Debug, Clone)]
 pub struct Field {

--- a/crates/toasty-core/src/schema/mapping/model.rs
+++ b/crates/toasty-core/src/schema/mapping/model.rs
@@ -1,4 +1,11 @@
-use super::*;
+use super::Field;
+use crate::{
+    schema::{
+        app::ModelId,
+        db::{ColumnId, TableId},
+    },
+    stmt,
+};
 
 #[derive(Debug, Clone)]
 pub struct Model {

--- a/crates/toasty-core/src/schema/verify.rs
+++ b/crates/toasty-core/src/schema/verify.rs
@@ -1,6 +1,11 @@
 mod relations_are_indexed;
 
-use super::*;
+use super::{
+    app::{FieldId, ModelId},
+    db::{ColumnId, IndexId},
+    Result, Schema,
+};
+use crate::stmt;
 
 use std::collections::HashSet;
 

--- a/crates/toasty-core/src/schema/verify/relations_are_indexed.rs
+++ b/crates/toasty-core/src/schema/verify/relations_are_indexed.rs
@@ -1,4 +1,5 @@
-use super::*;
+use super::Verify;
+use crate::schema::app::{self, Field, FieldId, Model};
 
 impl Verify<'_> {
     // Iterate each model and make sure there is an index path that enables

--- a/crates/toasty-core/src/stmt.rs
+++ b/crates/toasty-core/src/stmt.rs
@@ -209,12 +209,9 @@ pub use visit::Visit;
 mod with;
 pub use with::With;
 
-use crate::{
-    schema::{
-        app::{Field, FieldId, Model, ModelId},
-        db::{Column, ColumnId, TableId},
-    },
-    stmt, Result,
+use crate::schema::{
+    app::{Field, FieldId},
+    db::TableId,
 };
 
 use std::fmt;

--- a/crates/toasty-core/src/stmt.rs
+++ b/crates/toasty-core/src/stmt.rs
@@ -209,11 +209,7 @@ pub use visit::Visit;
 mod with;
 pub use with::With;
 
-use crate::schema::{
-    app::{Field, FieldId},
-    db::TableId,
-};
-
+use crate::schema::db::TableId;
 use std::fmt;
 
 #[derive(Clone)]

--- a/crates/toasty-core/src/stmt.rs
+++ b/crates/toasty-core/src/stmt.rs
@@ -214,7 +214,7 @@ use crate::{
         app::{Field, FieldId, Model, ModelId},
         db::{Column, ColumnId, TableId},
     },
-    stmt, Error, Result,
+    stmt, Result,
 };
 
 use std::fmt;

--- a/crates/toasty-core/src/stmt/assignments.rs
+++ b/crates/toasty-core/src/stmt/assignments.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{Expr, Projection};
 
 use indexmap::{Equivalent, IndexMap};
 use std::{hash::Hash, ops};

--- a/crates/toasty-core/src/stmt/association.rs
+++ b/crates/toasty-core/src/stmt/association.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{Path, Query};
 
 #[derive(Debug, Clone)]
 pub struct Association {

--- a/crates/toasty-core/src/stmt/delete.rs
+++ b/crates/toasty-core/src/stmt/delete.rs
@@ -1,4 +1,5 @@
-use super::*;
+use super::{Expr, Node, Query, Returning, Source, Statement, Visit, VisitMut};
+use crate::stmt;
 
 #[derive(Debug, Clone)]
 pub struct Delete {

--- a/crates/toasty-core/src/stmt/entry.rs
+++ b/crates/toasty-core/src/stmt/entry.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{Expr, Value};
 
 #[derive(Debug)]
 pub enum Entry<'a> {

--- a/crates/toasty-core/src/stmt/entry_mut.rs
+++ b/crates/toasty-core/src/stmt/entry_mut.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{Expr, Value};
 
 #[derive(Debug)]
 pub enum EntryMut<'a> {

--- a/crates/toasty-core/src/stmt/entry_path.rs
+++ b/crates/toasty-core/src/stmt/entry_path.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{projection, Projection};
 
 pub trait EntryPath {
     type Iter: Iterator<Item = usize>;

--- a/crates/toasty-core/src/stmt/expr.rs
+++ b/crates/toasty-core/src/stmt/expr.rs
@@ -1,4 +1,11 @@
-use super::{expr_reference::ExprReference, *};
+use super::{
+    expr_reference::ExprReference, substitute, visit_mut, Entry, EntryMut, EntryPath, ExprAnd,
+    ExprArg, ExprBinaryOp, ExprCast, ExprColumn, ExprConcat, ExprConcatStr, ExprEnum, ExprFunc,
+    ExprInList, ExprInSubquery, ExprIsNull, ExprKey, ExprList, ExprMap, ExprOr, ExprPattern,
+    ExprProject, ExprRecord, ExprStmt, ExprTy, Node, Projection, Type, Value, Visit, VisitMut,
+};
+use crate::schema::app::{Field, FieldId};
+use std::fmt;
 
 #[derive(Clone)]
 pub enum Expr {

--- a/crates/toasty-core/src/stmt/expr_and.rs
+++ b/crates/toasty-core/src/stmt/expr_and.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::Expr;
 
 use std::ops;
 

--- a/crates/toasty-core/src/stmt/expr_arg.rs
+++ b/crates/toasty-core/src/stmt/expr_arg.rs
@@ -1,4 +1,5 @@
-use super::*;
+use super::Expr;
+use crate::stmt;
 
 #[derive(Debug, Clone)]
 pub struct ExprArg {

--- a/crates/toasty-core/src/stmt/expr_begins_with.rs
+++ b/crates/toasty-core/src/stmt/expr_begins_with.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{Expr, ExprPattern};
 
 #[derive(Debug, Clone)]
 pub struct ExprBeginsWith {

--- a/crates/toasty-core/src/stmt/expr_binary_op.rs
+++ b/crates/toasty-core/src/stmt/expr_binary_op.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{BinaryOp, Expr};
 
 #[derive(Debug, Clone)]
 pub struct ExprBinaryOp {

--- a/crates/toasty-core/src/stmt/expr_cast.rs
+++ b/crates/toasty-core/src/stmt/expr_cast.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{Expr, Type};
 
 #[derive(Debug, Clone)]
 pub struct ExprCast {

--- a/crates/toasty-core/src/stmt/expr_column.rs
+++ b/crates/toasty-core/src/stmt/expr_column.rs
@@ -1,4 +1,5 @@
-use super::*;
+use super::Expr;
+use crate::schema::db::{Column, ColumnId};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum ExprColumn {

--- a/crates/toasty-core/src/stmt/expr_concat.rs
+++ b/crates/toasty-core/src/stmt/expr_concat.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::Expr;
 
 use std::ops;
 

--- a/crates/toasty-core/src/stmt/expr_concat_str.rs
+++ b/crates/toasty-core/src/stmt/expr_concat_str.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::Expr;
 
 #[derive(Debug, Clone)]
 pub struct ExprConcatStr {

--- a/crates/toasty-core/src/stmt/expr_enum.rs
+++ b/crates/toasty-core/src/stmt/expr_enum.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{Expr, ExprRecord};
 
 #[derive(Debug, Clone)]
 pub struct ExprEnum {

--- a/crates/toasty-core/src/stmt/expr_in_list.rs
+++ b/crates/toasty-core/src/stmt/expr_in_list.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::Expr;
 
 #[derive(Debug, Clone)]
 pub struct ExprInList {

--- a/crates/toasty-core/src/stmt/expr_in_subquery.rs
+++ b/crates/toasty-core/src/stmt/expr_in_subquery.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{Expr, Query};
 
 #[derive(Debug, Clone)]
 pub struct ExprInSubquery {

--- a/crates/toasty-core/src/stmt/expr_is_null.rs
+++ b/crates/toasty-core/src/stmt/expr_is_null.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::Expr;
 
 #[derive(Debug, Clone)]
 pub struct ExprIsNull {

--- a/crates/toasty-core/src/stmt/expr_key.rs
+++ b/crates/toasty-core/src/stmt/expr_key.rs
@@ -1,4 +1,5 @@
-use super::*;
+use super::Expr;
+use crate::schema::app::ModelId;
 
 #[derive(Debug, Clone)]
 pub struct ExprKey {

--- a/crates/toasty-core/src/stmt/expr_like.rs
+++ b/crates/toasty-core/src/stmt/expr_like.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{Expr, ExprPattern};
 
 /// Tests if the string expression matches `pattern`.
 #[derive(Debug, Clone)]

--- a/crates/toasty-core/src/stmt/expr_list.rs
+++ b/crates/toasty-core/src/stmt/expr_list.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{Expr, Value};
 
 #[derive(Debug, Clone)]
 pub struct ExprList {

--- a/crates/toasty-core/src/stmt/expr_map.rs
+++ b/crates/toasty-core/src/stmt/expr_map.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::Expr;
 
 #[derive(Debug, Clone)]
 pub struct ExprMap {

--- a/crates/toasty-core/src/stmt/expr_or.rs
+++ b/crates/toasty-core/src/stmt/expr_or.rs
@@ -1,5 +1,4 @@
-use super::*;
-
+use super::Expr;
 use std::ops;
 
 #[derive(Debug, Clone)]

--- a/crates/toasty-core/src/stmt/expr_pattern.rs
+++ b/crates/toasty-core/src/stmt/expr_pattern.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{ExprBeginsWith, ExprLike};
 
 #[derive(Debug, Clone)]
 pub enum ExprPattern {

--- a/crates/toasty-core/src/stmt/expr_project.rs
+++ b/crates/toasty-core/src/stmt/expr_project.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{Expr, Projection};
 
 #[derive(Debug, Clone)]
 pub struct ExprProject {

--- a/crates/toasty-core/src/stmt/expr_record.rs
+++ b/crates/toasty-core/src/stmt/expr_record.rs
@@ -1,4 +1,5 @@
-use super::*;
+use super::{Expr, Node, Visit, VisitMut};
+use crate::stmt;
 
 use std::{fmt, ops};
 

--- a/crates/toasty-core/src/stmt/expr_reference.rs
+++ b/crates/toasty-core/src/stmt/expr_reference.rs
@@ -1,4 +1,4 @@
-use super::*;
+use crate::schema::app::{FieldId, ModelId};
 use std::fmt;
 
 #[derive(Debug, Clone)]

--- a/crates/toasty-core/src/stmt/expr_set.rs
+++ b/crates/toasty-core/src/stmt/expr_set.rs
@@ -1,4 +1,5 @@
-use super::*;
+use super::{substitute, Expr, ExprSetOp, Select, SourceModel, Update, Values};
+use crate::schema::db::TableId;
 
 #[derive(Debug, Clone)]
 pub enum ExprSet {

--- a/crates/toasty-core/src/stmt/expr_set_op.rs
+++ b/crates/toasty-core/src/stmt/expr_set_op.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{substitute, ExprSet, SetOp};
 
 #[derive(Debug, Clone)]
 pub struct ExprSetOp {

--- a/crates/toasty-core/src/stmt/expr_stmt.rs
+++ b/crates/toasty-core/src/stmt/expr_stmt.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{Expr, Insert, Statement};
 
 #[derive(Debug, Clone)]
 pub struct ExprStmt {

--- a/crates/toasty-core/src/stmt/expr_ty.rs
+++ b/crates/toasty-core/src/stmt/expr_ty.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{Expr, Type};
 
 #[derive(Debug, Clone)]
 pub struct ExprTy {

--- a/crates/toasty-core/src/stmt/id.rs
+++ b/crates/toasty-core/src/stmt/id.rs
@@ -1,5 +1,5 @@
-use super::*;
-
+use super::{Expr, Type, Value};
+use crate::{schema::app::ModelId, stmt, Error, Result};
 use std::fmt;
 
 #[derive(Clone, Hash, Eq, PartialEq)]

--- a/crates/toasty-core/src/stmt/insert.rs
+++ b/crates/toasty-core/src/stmt/insert.rs
@@ -1,4 +1,5 @@
-use super::*;
+use super::{InsertTarget, Node, Query, Returning, Statement, Visit, VisitMut};
+use crate::stmt;
 
 #[derive(Debug, Clone)]
 pub struct Insert {

--- a/crates/toasty-core/src/stmt/insert_table.rs
+++ b/crates/toasty-core/src/stmt/insert_table.rs
@@ -1,4 +1,5 @@
-use super::*;
+use super::InsertTarget;
+use crate::schema::db::{ColumnId, TableId};
 
 #[derive(Debug, Clone)]
 pub struct InsertTable {

--- a/crates/toasty-core/src/stmt/insert_target.rs
+++ b/crates/toasty-core/src/stmt/insert_target.rs
@@ -1,4 +1,5 @@
-use super::*;
+use super::{Expr, InsertTable, Query};
+use crate::schema::app::ModelId;
 
 #[derive(Debug, Clone)]
 pub enum InsertTarget {

--- a/crates/toasty-core/src/stmt/node.rs
+++ b/crates/toasty-core/src/stmt/node.rs
@@ -1,5 +1,4 @@
-use super::*;
-
+use super::{Visit, VisitMut};
 use std::fmt;
 
 pub trait Node: fmt::Debug {

--- a/crates/toasty-core/src/stmt/order_by_expr.rs
+++ b/crates/toasty-core/src/stmt/order_by_expr.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{Direction, Expr};
 
 #[derive(Debug, Clone)]
 pub struct OrderByExpr {

--- a/crates/toasty-core/src/stmt/path.rs
+++ b/crates/toasty-core/src/stmt/path.rs
@@ -1,6 +1,5 @@
-use crate::schema::app;
-
-use super::*;
+use super::{Expr, Projection};
+use crate::schema::app::{self, Field, FieldId, ModelId};
 
 /// Describes a traversal through fields.
 ///

--- a/crates/toasty-core/src/stmt/projection.rs
+++ b/crates/toasty-core/src/stmt/projection.rs
@@ -1,5 +1,7 @@
-use super::*;
-use crate::schema::app;
+use crate::schema::{
+    app::{self, Field, FieldId, Model},
+    db::ColumnId,
+};
 
 use std::{fmt, ops};
 

--- a/crates/toasty-core/src/stmt/query.rs
+++ b/crates/toasty-core/src/stmt/query.rs
@@ -1,4 +1,8 @@
-use super::*;
+use super::{
+    substitute, Delete, Expr, ExprSet, ExprSetOp, Limit, Node, OrderBy, Path, Returning, Select,
+    SetOp, Source, Statement, Update, UpdateTarget, Values, Visit, VisitMut, With,
+};
+use crate::stmt;
 
 #[derive(Debug, Clone)]
 pub struct Query {

--- a/crates/toasty-core/src/stmt/returning.rs
+++ b/crates/toasty-core/src/stmt/returning.rs
@@ -1,4 +1,5 @@
-use super::*;
+use super::Expr;
+use crate::stmt;
 
 /// TODO: rename since this is also used in `Select`?
 #[derive(Debug, Clone)]

--- a/crates/toasty-core/src/stmt/select.rs
+++ b/crates/toasty-core/src/stmt/select.rs
@@ -1,4 +1,7 @@
-use super::*;
+use super::{
+    substitute, Expr, Node, Path, Query, Returning, Source, SourceModel, Statement, Visit, VisitMut,
+};
+use crate::schema::db::TableId;
 
 #[derive(Debug, Clone)]
 pub struct Select {

--- a/crates/toasty-core/src/stmt/source.rs
+++ b/crates/toasty-core/src/stmt/source.rs
@@ -1,4 +1,8 @@
-use super::*;
+use super::{Association, Path, TableRef, TableWithJoins};
+use crate::schema::{
+    app::{Model, ModelId},
+    db::TableId,
+};
 
 #[derive(Debug, Clone)]
 pub enum Source {

--- a/crates/toasty-core/src/stmt/sparse_record.rs
+++ b/crates/toasty-core/src/stmt/sparse_record.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{PathFieldSet, Type, Value, ValueRecord};
 
 /// A typed record, indicating the record represents a specific model (or a
 /// subset of its fields).

--- a/crates/toasty-core/src/stmt/substitute.rs
+++ b/crates/toasty-core/src/stmt/substitute.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{Expr, ExprArg, Value};
 
 pub trait Input {
     fn resolve_arg(&mut self, expr_arg: &ExprArg) -> Expr;

--- a/crates/toasty-core/src/stmt/table_with_joins.rs
+++ b/crates/toasty-core/src/stmt/table_with_joins.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{Join, TableRef};
 
 #[derive(Debug, Clone)]
 pub struct TableWithJoins {

--- a/crates/toasty-core/src/stmt/ty.rs
+++ b/crates/toasty-core/src/stmt/ty.rs
@@ -1,4 +1,8 @@
-use super::*;
+use super::{Id, PathFieldSet, TypeEnum, Value};
+use crate::{
+    schema::app::{FieldId, ModelId},
+    stmt, Result,
+};
 
 /// An expression type.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/toasty-core/src/stmt/ty_enum.rs
+++ b/crates/toasty-core/src/stmt/ty_enum.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::Type;
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct TypeEnum {

--- a/crates/toasty-core/src/stmt/update.rs
+++ b/crates/toasty-core/src/stmt/update.rs
@@ -1,4 +1,8 @@
-use super::*;
+use super::{Assignments, Expr, Node, Query, Returning, Statement, Visit, VisitMut};
+use crate::{
+    schema::{app::ModelId, db::TableId},
+    stmt,
+};
 
 #[derive(Debug, Clone)]
 pub struct Update {

--- a/crates/toasty-core/src/stmt/value.rs
+++ b/crates/toasty-core/src/stmt/value.rs
@@ -1,6 +1,4 @@
-use sparse_record::SparseRecord;
-
-use super::*;
+use super::{sparse_record::SparseRecord, Entry, EntryPath, Id, Type, ValueEnum, ValueRecord};
 
 #[derive(Debug, Default, Clone, PartialEq)]
 pub enum Value {

--- a/crates/toasty-core/src/stmt/value_enum.rs
+++ b/crates/toasty-core/src/stmt/value_enum.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{Value, ValueRecord};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ValueEnum {

--- a/crates/toasty-core/src/stmt/value_record.rs
+++ b/crates/toasty-core/src/stmt/value_record.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::Value;
 
 use std::ops;
 

--- a/crates/toasty-core/src/stmt/value_stream.rs
+++ b/crates/toasty-core/src/stmt/value_stream.rs
@@ -272,7 +272,7 @@ impl Buffer {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{Value, ValueStream};
 
     #[test]
     fn default() {

--- a/crates/toasty-core/src/stmt/value_stream.rs
+++ b/crates/toasty-core/src/stmt/value_stream.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::Value;
 
 use std::{
     collections::VecDeque,

--- a/crates/toasty-core/src/stmt/value_stream.rs
+++ b/crates/toasty-core/src/stmt/value_stream.rs
@@ -272,7 +272,7 @@ impl Buffer {
 
 #[cfg(test)]
 mod tests {
-    use super::{Value, ValueStream};
+    use super::{Buffer, ValueStream};
 
     #[test]
     fn default() {

--- a/crates/toasty-core/src/stmt/values.rs
+++ b/crates/toasty-core/src/stmt/values.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{substitute, Expr, ExprSet, Query};
 
 /// Set of values to insert
 #[derive(Debug, Default, Clone)]

--- a/crates/toasty-core/src/stmt/visit.rs
+++ b/crates/toasty-core/src/stmt/visit.rs
@@ -1,6 +1,14 @@
 #![allow(unused_variables)]
 
-use super::*;
+use super::{
+    Assignment, Assignments, Association, Cte, Delete, Expr, ExprAnd, ExprArg, ExprBeginsWith,
+    ExprBinaryOp, ExprCast, ExprColumn, ExprConcat, ExprEnum, ExprFunc, ExprInList, ExprInSubquery,
+    ExprIsNull, ExprKey, ExprLike, ExprList, ExprMap, ExprOr, ExprPattern, ExprProject, ExprRecord,
+    ExprReference, ExprSet, ExprSetOp, ExprStmt, ExprTy, FuncCount, Insert, InsertTarget, Join,
+    JoinOp, Limit, Node, Offset, OrderBy, OrderByExpr, Path, Projection, Query, Returning, Select,
+    Source, SourceModel, Statement, TableRef, TableWithJoins, Type, Update, UpdateTarget, Value,
+    ValueRecord, Values, With,
+};
 
 pub trait Visit {
     fn visit<N: Node>(&mut self, i: &N)

--- a/crates/toasty-core/src/stmt/visit_mut.rs
+++ b/crates/toasty-core/src/stmt/visit_mut.rs
@@ -1,6 +1,14 @@
 #![allow(unused_variables)]
 
-use super::*;
+use super::{
+    Assignment, Assignments, Association, Cte, Delete, Expr, ExprAnd, ExprArg, ExprBeginsWith,
+    ExprBinaryOp, ExprCast, ExprColumn, ExprConcat, ExprEnum, ExprFunc, ExprInList, ExprInSubquery,
+    ExprIsNull, ExprKey, ExprLike, ExprList, ExprMap, ExprOr, ExprPattern, ExprProject, ExprRecord,
+    ExprReference, ExprSet, ExprSetOp, ExprStmt, ExprTy, FuncCount, Insert, InsertTarget, Join,
+    JoinOp, Limit, Node, Offset, OrderBy, OrderByExpr, Path, Projection, Query, Returning, Select,
+    Source, SourceModel, Statement, TableRef, TableWithJoins, Type, Update, UpdateTarget, Value,
+    ValueRecord, Values, With,
+};
 
 pub trait VisitMut {
     fn visit_mut<N: Node>(&mut self, i: &mut N)


### PR DESCRIPTION
## Summary

This PR refactors all module-level glob imports (`use super::*;` and `use crate::*;`) in the `toasty-core` crate, replacing them with specific imports to improve code clarity and maintainability.

## Changes Made

### Files Processed: 96 files total
- **58 stmt files** - Complete refactoring of statement-related modules
- **8 driver/operation files** - Database operation modules  
- **30 schema files** - Schema definition and mapping modules

### Key Improvements
- ✅ Replaced all `use super::*;` with specific imports like `use super::{Type1, Type2};`
- ✅ Replaced `use crate::*;` with targeted imports
- ✅ Maintained existing code structure (e.g., kept `stmt::Query` patterns intact)
- ✅ Removed unused imports to eliminate compiler warnings
- ✅ Added missing imports (e.g., `anyhow::Result` in schema.rs)

### What Remains
The following glob imports were intentionally left unchanged as they follow acceptable Rust patterns:
- **3 enum variant imports** (`use EnumName::*;`) - Standard pattern for pattern matching
- **4 test file imports** - Acceptable in test code for convenience

## Benefits
- **Improved code clarity** - Explicit imports make dependencies obvious
- **Better IDE support** - Enhanced autocomplete and navigation
- **Reduced compilation warnings** - All unused imports removed
- **Maintainability** - Easier to track what each module actually uses

## Testing
- ✅ `cargo check --all-features` passes with no warnings
- ✅ `cargo clippy --all-features` passes with no warnings
- ✅ All existing functionality preserved

## Technical Notes
- Carefully preserved existing code patterns (e.g., `stmt::Type` usage)
- Added necessary cross-module imports (e.g., `use crate::schema::app::ModelId`)
- Fixed compilation issues by adding missing Result type imports
- Maintained module structure and public API compatibility

This refactoring makes the codebase more maintainable while preserving all existing functionality.
