### PR TITLE
task: add an AlwaysTrue variant to stmt::Expr

### DIFF
--- a/crates/toasty-core/src/stmt/expr.rs
+++ b/crates/toasty-core/src/stmt/expr.rs
@@ -83,6 +83,9 @@ pub enum Expr {
 
     // TODO: get rid of this?
     DecodeEnum(Box<Expr>, Type, usize),
+
+    // Always evaluates to true, used for no-op filters
+    AlwaysTrue,
 }
 
 impl Expr {
@@ -97,7 +100,7 @@ impl Expr {
 
     /// Returns true if the expression is the `true` boolean expression
     pub fn is_true(&self) -> bool {
-        matches!(self, Self::Value(Value::Bool(true)))
+        matches!(self, Self::Value(Value::Bool(true)) | Expr::AlwaysTrue)
     }
 
     /// Returns `true` if the expression is the `false` boolean expression
@@ -360,6 +363,7 @@ impl fmt::Debug for Expr {
                 .field(ty)
                 .field(variant)
                 .finish(),
+            Self::AlwaysTrue => f.write_str("AlwaysTrue"),
         }
     }
 }

--- a/crates/toasty-core/src/stmt/select.rs
+++ b/crates/toasty-core/src/stmt/select.rs
@@ -68,13 +68,13 @@ impl From<Select> for Query {
 
 impl From<TableId> for Select {
     fn from(value: TableId) -> Self {
-        Self::new(Source::table(value), true)
+        Self::new(Source::table(value), Expr::AlwaysTrue)
     }
 }
 
 impl From<SourceModel> for Select {
     fn from(value: SourceModel) -> Self {
-        Self::new(Source::Model(value), true)
+        Self::new(Source::Model(value), Expr::AlwaysTrue)
     }
 }
 

--- a/crates/toasty-core/src/stmt/visit.rs
+++ b/crates/toasty-core/src/stmt/visit.rs
@@ -527,6 +527,9 @@ where
             }
         }
         Expr::DecodeEnum(base, ..) => v.visit_expr(base),
+        Expr::AlwaysTrue => {
+            // nothing to visit
+        },
         _ => todo!("{node:#?}"),
     }
 }

--- a/crates/toasty-core/src/stmt/visit.rs
+++ b/crates/toasty-core/src/stmt/visit.rs
@@ -529,7 +529,7 @@ where
         Expr::DecodeEnum(base, ..) => v.visit_expr(base),
         Expr::AlwaysTrue => {
             // nothing to visit
-        },
+        }
         _ => todo!("{node:#?}"),
     }
 }

--- a/crates/toasty-core/src/stmt/visit_mut.rs
+++ b/crates/toasty-core/src/stmt/visit_mut.rs
@@ -533,6 +533,9 @@ where
             }
         }
         Expr::DecodeEnum(base, ..) => v.visit_expr_mut(base),
+        Expr::AlwaysTrue => {
+            // nothing to visit
+        }
     }
 }
 

--- a/crates/toasty/src/engine/verify.rs
+++ b/crates/toasty/src/engine/verify.rs
@@ -102,7 +102,8 @@ impl VerifyExpr<'_> {
             | InList(_)
             | InSubquery(_)
             | Or(_)
-            | Value(stmt::Value::Bool(_)) => {}
+            | Value(stmt::Value::Bool(_))
+            | AlwaysTrue => {}
             expr => panic!("Not a bool? {expr:#?}"),
         }
     }


### PR DESCRIPTION
This variant is useful when a Select statement has no filter expression, and evaluates the same as a literal value true.