### PR TITLE
Derive `Clone` on relation types

### DIFF
--- a/crates/toasty/src/relation/belongs_to.rs
+++ b/crates/toasty/src/relation/belongs_to.rs
@@ -4,6 +4,7 @@ use toasty_core::stmt::Value;
 
 use std::fmt;
 
+#[derive(Clone)]
 pub struct BelongsTo<T> {
     value: Option<Box<T>>,
 }

--- a/crates/toasty/src/relation/has_many.rs
+++ b/crates/toasty/src/relation/has_many.rs
@@ -4,6 +4,7 @@ use toasty_core::stmt::Value;
 
 use std::fmt;
 
+#[derive(Clone)]
 pub struct HasMany<T> {
     values: Option<Vec<T>>,
 }

--- a/crates/toasty/src/relation/has_one.rs
+++ b/crates/toasty/src/relation/has_one.rs
@@ -4,6 +4,7 @@ use toasty_core::stmt::Value;
 
 use std::fmt;
 
+#[derive(Clone)]
 pub struct HasOne<T> {
     value: Option<Box<T>>,
 }


### PR DESCRIPTION
This makes it possible to derive `Clone` on types that also derive `toasty::Model`.