### PR TITLE
feat: add support for enum fields

### DIFF
--- a/crates/toasty-core/src/schema/builder/table.rs
+++ b/crates/toasty-core/src/schema/builder/table.rs
@@ -120,7 +120,9 @@ impl BuildTableFromModels<'_> {
 
         // Hax
         for column in &mut self.table.columns {
-            if let stmt::Type::Enum(_) = column.ty {
+            if column.primary_key && matches!(column.ty, stmt::Type::Enum(_)) {
+                // this is a hack to support the internal representation of primary keys
+                // having this here blocks us from using enums as primary keys
                 column.ty = stmt::Type::String;
             }
         }
@@ -640,6 +642,7 @@ fn stmt_ty_to_table(ty: stmt::Type) -> stmt::Type {
         stmt::Type::U64 => stmt::Type::U64,
         stmt::Type::String => stmt::Type::String,
         stmt::Type::Id(_) => stmt::Type::String,
+        stmt::Type::Enum(t) => stmt::Type::Enum(t),
         _ => todo!("{ty:#?}"),
     }
 }

--- a/crates/toasty-core/src/schema/db/ty.rs
+++ b/crates/toasty-core/src/schema/db/ty.rs
@@ -43,6 +43,7 @@ impl Type {
                 // TODO: not really correct, but we are getting rid of ID types
                 // most likely.
                 stmt::Type::Id(_) => Ok(db.default_string_type.clone()),
+                stmt::Type::Enum(_) => Ok(db.default_string_type.clone()),
                 _ => anyhow::bail!("unsupported type: {ty:?}"),
             },
         }

--- a/crates/toasty-core/src/stmt/value.rs
+++ b/crates/toasty-core/src/stmt/value.rs
@@ -165,7 +165,25 @@ impl Value {
                 _ => false,
             },
             Self::String(_) => ty.is_string(),
-            _ => todo!("value={self:#?}, ty={ty:#?}"),
+            Self::Enum(value) => match ty {
+                Type::Enum(type_enum) => {
+                    if let Some(variant) = type_enum
+                        .variants
+                        .iter()
+                        .find(|v| v.discriminant == value.variant)
+                    {
+                        variant.fields.len() == value.fields.len()
+                            && value
+                                .fields
+                                .iter()
+                                .zip(variant.fields.iter())
+                                .all(|(f, fty)| f.is_a(fty))
+                    } else {
+                        false
+                    }
+                }
+                _ => false,
+            },
         }
     }
 

--- a/crates/toasty-macros/Cargo.toml
+++ b/crates/toasty-macros/Cargo.toml
@@ -14,3 +14,4 @@ toasty-codegen.workspace = true
 proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true
+anyhow.workspace = true

--- a/crates/toasty-macros/src/lib.rs
+++ b/crates/toasty-macros/src/lib.rs
@@ -1,7 +1,9 @@
 extern crate proc_macro;
 
 use proc_macro::TokenStream;
+use proc_macro2::Ident;
 use quote::quote;
+use syn::{Fields, Variant};
 
 #[proc_macro_derive(
     Model,
@@ -12,6 +14,71 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
         Ok(output) => output.into(),
         Err(e) => e.to_compile_error().into(),
     }
+}
+
+fn compute_type_variant(enum_ident: &Ident, variant: &Variant) -> proc_macro2::TokenStream {
+    let ident = &variant.ident;
+    let fields = match variant.fields {
+        Fields::Unit => quote!(Vec::new()),
+        _ => todo!("fields unsupported vor enum #{ident}"),
+    };
+    quote!(EnumVariant { discriminant: #enum_ident::#ident as usize, fields: #fields })
+}
+
+fn discriminant_match(enum_ident: &Ident, variant: &Variant) -> proc_macro2::TokenStream {
+    let ident = &variant.ident;
+    quote!(
+        if v == #enum_ident::#ident as usize {
+            return Ok(#enum_ident::#ident);
+        }
+    )
+}
+
+#[proc_macro_derive(ToastyEnum)]
+pub fn derive_enum(input: TokenStream) -> TokenStream {
+    let item: syn::ItemEnum = syn::parse(input).unwrap();
+    let ident = &item.ident;
+    let compute_type_variants = item.variants.iter().map(|v| compute_type_variant(ident, v));
+    let discriminant_matches = item.variants.iter().map(|v| discriminant_match(ident, v));
+    quote! {
+    const _: () = {
+    use anyhow::Result;
+    use toasty::{self, stmt::{Primitive, IntoExpr, Expr}};
+    use toasty_core::{self, stmt::{self, EnumVariant, TypeEnum, ValueRecord}};
+    impl Primitive for #ident {
+        fn ty() -> stmt::Type {
+            stmt::Type::Enum(TypeEnum {
+                variants: vec![#(#compute_type_variants,)*]
+            })
+        }
+
+        fn load(value: stmt::Value) -> Result<Self> {
+            let stmt::Value::Enum(value_enum) = value else {
+                anyhow::bail!("not an enum: #{value:#?}");
+            };
+
+            let v = value_enum.variant;
+            #(#discriminant_matches)*
+            anyhow::bail!("not matching any discriminant: #{v}");
+        }
+    }
+
+    impl IntoExpr<#ident> for #ident {
+        fn into_expr(self) -> Expr<#ident> {
+            let variant = self as usize;
+            Expr::from_untyped(stmt::Expr::Value(stmt::Value::Enum(stmt::ValueEnum {
+                variant,
+                fields: ValueRecord { fields: Vec::new() }
+            })))
+        }
+
+        fn by_ref(&self) -> Expr<#ident> {
+            todo!()
+        }
+    }
+    };
+    }
+    .into()
 }
 
 #[proc_macro]

--- a/crates/toasty/src/engine/planner/kv.rs
+++ b/crates/toasty/src/engine/planner/kv.rs
@@ -9,19 +9,14 @@ impl Planner<'_> {
         index_plan: &mut IndexPlan<'_>,
         input: Option<plan::Input>,
     ) -> plan::Input {
-        let key_ty = self.index_key_ty(index_plan.index);
+        let key_ty = self.pk_ty_for_index(index_plan.index);
         let pk_by_index_out = self
             .var_table
             .register_var(stmt::Type::list(key_ty.clone()));
 
         // In this case, we have to flatten the returned record into a single value
         let project_key = if index_plan.index.columns.len() == 1 {
-            let arg_ty = stmt::Type::Record(vec![self
-                .schema
-                .db
-                .column(index_plan.index.columns[0].column)
-                .ty
-                .clone()]);
+            let arg_ty = stmt::Type::Record(vec![key_ty.clone()]);
 
             eval::Func::from_stmt_unchecked(
                 stmt::Expr::arg_project(0, [0]),

--- a/crates/toasty/src/engine/planner/ty.rs
+++ b/crates/toasty/src/engine/planner/ty.rs
@@ -9,6 +9,18 @@ impl Planner<'_> {
     }
     */
 
+    pub(crate) fn pk_ty_for_index(&self, index: &Index) -> stmt::Type {
+        let table = self.schema.db.table(index.id.table);
+        if table.primary_key.columns.len() == 1 {
+            table.primary_key_column(0).ty.clone()
+        } else {
+            stmt::Type::Record(table.primary_key_columns()
+                .map(|id| id.ty.clone())
+                .collect(),
+            )
+        }
+    }
+
     pub(crate) fn index_key_ty(&self, index: &Index) -> stmt::Type {
         match &index.columns[..] {
             [id] => self.schema.db.column(id.column).ty.clone(),

--- a/crates/toasty/src/lib.rs
+++ b/crates/toasty/src/lib.rs
@@ -23,7 +23,7 @@ pub mod schema;
 pub mod stmt;
 pub use stmt::Statement;
 
-pub use toasty_macros::{create, query, Model};
+pub use toasty_macros::{create, query, Model, ToastyEnum};
 
 pub use anyhow::{Error, Result};
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -30,6 +30,7 @@ rusqlite.workspace = true
 std-util.workspace = true
 tempfile.workspace = true
 trybuild.workspace = true
+anyhow.workspace = true
 env_logger = "0.11.8"
 
 [dev-dependencies]

--- a/tests/tests/index_enum.rs
+++ b/tests/tests/index_enum.rs
@@ -1,0 +1,54 @@
+use tests::{models, tests, DbTest};
+use toasty::{self, stmt::Id, ToastyEnum};
+
+async fn index_enum(test: &mut DbTest) {
+    #[derive(toasty::Model)]
+    struct LogEntry {
+        #[key]
+        #[auto]
+        request_id: Id<Self>,
+
+        #[index]
+        log_level: LogLevel,
+
+        message: String,
+    }
+
+    #[derive(Debug, PartialEq, ToastyEnum, Clone)]
+    enum LogLevel {
+        Debug,
+        Info,
+        Warn,
+        Error,
+    }
+
+    let db = test.setup_db(models!(LogEntry)).await;
+
+    {
+        use LogLevel::{Debug, Error, Warn};
+        for (log_level, message) in [
+            (Debug, "initializing"),
+            (Warn, "something fishy"),
+            (Error, "null pointer"),
+        ] {
+            LogEntry::create()
+                .log_level(log_level)
+                .message(message)
+                .exec(&db)
+                .await
+                .expect("failed to create entry");
+        }
+
+        let res = LogEntry::filter_by_log_level(Warn).all(&db).await.unwrap();
+        let entries = res.collect::<Vec<LogEntry>>().await.unwrap();
+        assert_eq!(
+            vec![(Warn, "something fishy".to_string())],
+            entries
+                .iter()
+                .map(|le| (le.log_level.clone(), le.message.clone()))
+                .collect::<Vec<(LogLevel, String)>>()
+        );
+    }
+}
+
+tests!(index_enum);


### PR DESCRIPTION
This is just the most basic change to get enums working at all for regular fields (not primary key fields). Ideally serialization would be pushed into the engine rather than being implemented by drivers.  Also, ideally there would be some configuration to control the mapping to table columns and database types; you might want to store the fields of an enum in a separate column, for example, or have a "None" value of the enum map to a null value in the database to facilitate sparse indexes in a database like DynamoDB.