### PR TITLE
Add support for UUIDs using the `uuid` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ mysql_async = { version = "0.35.1", default-features = false, features = [
 ] }
 pluralizer = "0.4.0"
 postgres = "0.19.10"
-postgres-types = "0.2.9"
+postgres-types = { version = "0.2.9", features = ["with-uuid-1"] }
 pretty_assertions = "1.4.1"
 proc-macro2 = "1.0.37"
 quote = "1.0.18"

--- a/crates/toasty-core/Cargo.toml
+++ b/crates/toasty-core/Cargo.toml
@@ -12,6 +12,7 @@ bit-set = "0.8.0"
 indexmap.workspace = true
 std-util.workspace = true
 tokio-stream.workspace = true
+uuid.workspace = true
 
 [features]
 assert-struct = ["dep:assert-struct"]

--- a/crates/toasty-core/src/driver/capability.rs
+++ b/crates/toasty-core/src/driver/capability.rs
@@ -42,7 +42,10 @@ impl Capability {
         match &self.storage_types.default_string_type {
             db::Type::VarChar(len) => Some(*len),
             db::Type::Text => None, // Text types typically have very large or unlimited length
-            db::Type::Boolean | db::Type::Integer(_) | db::Type::UnsignedInteger(_) => {
+            db::Type::Boolean
+            | db::Type::Integer(_)
+            | db::Type::UnsignedInteger(_)
+            | db::Type::Uuid => {
                 // These types shouldn't be used as default string types, but handle them gracefully
                 None
             }

--- a/crates/toasty-core/src/schema/builder/table.rs
+++ b/crates/toasty-core/src/schema/builder/table.rs
@@ -647,6 +647,7 @@ fn stmt_ty_to_table(ty: stmt::Type) -> stmt::Type {
         stmt::Type::U32 => stmt::Type::U32,
         stmt::Type::U64 => stmt::Type::U64,
         stmt::Type::String => stmt::Type::String,
+        stmt::Type::Uuid => stmt::Type::Uuid,
         stmt::Type::Id(_) => stmt::Type::String,
         _ => todo!("{ty:#?}"),
     }

--- a/crates/toasty-core/src/schema/db/ty.rs
+++ b/crates/toasty-core/src/schema/db/ty.rs
@@ -14,6 +14,10 @@ pub enum Type {
     /// Unconstrained text type
     Text,
 
+    /// 128-bit universally unique identifier (UUID)
+    Uuid,
+
+    /// Text type with an explicit maximum length
     VarChar(u64),
 
     /// User-specified unrecognized type
@@ -41,6 +45,7 @@ impl Type {
                 stmt::Type::U32 => Ok(Type::UnsignedInteger(4)),
                 stmt::Type::U64 => Ok(Type::UnsignedInteger(8)),
                 stmt::Type::String => Ok(db.default_string_type.clone()),
+                stmt::Type::Uuid => Ok(Type::Uuid),
                 // Gotta support some app-level types as well for now.
                 //
                 // TODO: not really correct, but we are getting rid of ID types

--- a/crates/toasty-core/src/stmt/ty.rs
+++ b/crates/toasty-core/src/stmt/ty.rs
@@ -37,6 +37,9 @@ pub enum Type {
     /// Unsigned 64-bit integer
     U64,
 
+    /// 128-bit universally unique identifier (UUID)
+    Uuid,
+
     /// An opaque type that uniquely identifies an instance of a model.
     Id(ModelId),
 
@@ -111,6 +114,10 @@ impl Type {
 
     pub fn is_record(&self) -> bool {
         matches!(self, Self::Record(..))
+    }
+
+    pub fn is_uuid(&self) -> bool {
+        matches!(self, Self::Uuid)
     }
 
     pub fn cast(&self, value: Value) -> Result<Value> {

--- a/crates/toasty-core/src/stmt/value.rs
+++ b/crates/toasty-core/src/stmt/value.rs
@@ -53,6 +53,9 @@ pub enum Value {
 
     /// String value, either borrowed or owned
     String(String),
+
+    /// 128-bit universally unique identifier (UUID)
+    Uuid(uuid::Uuid),
 }
 
 impl Value {
@@ -175,6 +178,7 @@ impl Value {
                 _ => false,
             },
             Self::String(_) => ty.is_string(),
+            Self::Uuid(_) => ty.is_uuid(),
             _ => todo!("value={self:#?}, ty={ty:#?}"),
         }
     }
@@ -198,6 +202,7 @@ impl Value {
             Value::U16(_) => Type::U16,
             Value::U32(_) => Type::U32,
             Value::U64(_) => Type::U64,
+            Value::Uuid(_) => Type::Uuid,
         }
     }
 
@@ -281,6 +286,23 @@ impl TryFrom<Value> for String {
         match value {
             Value::String(value) => Ok(value),
             _ => Err(anyhow!("value is not of type string")),
+        }
+    }
+}
+
+impl From<uuid::Uuid> for Value {
+    fn from(value: uuid::Uuid) -> Self {
+        Self::Uuid(value)
+    }
+}
+
+impl TryFrom<Value> for uuid::Uuid {
+    type Error = crate::Error;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Uuid(value) => Ok(value),
+            _ => Err(anyhow!("value is not of type UUID")),
         }
     }
 }

--- a/crates/toasty-driver-dynamodb/Cargo.toml
+++ b/crates/toasty-driver-dynamodb/Cargo.toml
@@ -13,3 +13,4 @@ aws-sdk-dynamodb.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 url.workspace = true
+uuid.workspace = true

--- a/crates/toasty-driver-dynamodb/src/lib.rs
+++ b/crates/toasty-driver-dynamodb/src/lib.rs
@@ -183,6 +183,7 @@ fn ddb_val(val: &stmt::Value) -> AttributeValue {
         stmt::Value::U16(val) => AttributeValue::N(val.to_string()),
         stmt::Value::U32(val) => AttributeValue::N(val.to_string()),
         stmt::Value::U64(val) => AttributeValue::N(val.to_string()),
+        stmt::Value::Uuid(val) => AttributeValue::S(val.to_string()),
         stmt::Value::Id(val) => AttributeValue::S(val.to_string()),
         stmt::Value::Enum(val) => {
             let v = match &val.fields[..] {
@@ -225,6 +226,7 @@ fn ddb_to_val(ty: &stmt::Type, val: &AttributeValue) -> stmt::Value {
         (Type::U16, N(val)) => stmt::Value::from(val.parse::<u16>().unwrap()),
         (Type::U32, N(val)) => stmt::Value::from(val.parse::<u32>().unwrap()),
         (Type::U64, N(val)) => stmt::Value::from(val.parse::<u64>().unwrap()),
+        (Type::Uuid, S(val)) => stmt::Value::from(val.parse::<uuid::Uuid>().unwrap()),
         (Type::Id(model), S(val)) => stmt::Value::from(stmt::Id::from_string(*model, val.clone())),
         (Type::Enum(..), S(val)) => {
             let (variant, rest) = val.split_once("#").unwrap();

--- a/crates/toasty-driver-mysql/Cargo.toml
+++ b/crates/toasty-driver-mysql/Cargo.toml
@@ -11,3 +11,4 @@ anyhow.workspace = true
 mysql_async.workspace = true
 tokio.workspace = true
 url.workspace = true
+uuid.workspace = true

--- a/crates/toasty-driver-mysql/src/lib.rs
+++ b/crates/toasty-driver-mysql/src/lib.rs
@@ -225,9 +225,12 @@ fn mysql_to_toasty(
     match column.column_type() {
         MYSQL_TYPE_NULL => stmt::Value::Null,
 
-        MYSQL_TYPE_VARCHAR | MYSQL_TYPE_VAR_STRING | MYSQL_TYPE_BLOB => {
-            assert!(ty.is_string());
-            extract_or_null(row, i, stmt::Value::String)
+        MYSQL_TYPE_VARCHAR | MYSQL_TYPE_VAR_STRING | MYSQL_TYPE_STRING | MYSQL_TYPE_BLOB => {
+            match ty {
+                stmt::Type::String => extract_or_null(row, i, stmt::Value::String),
+                stmt::Type::Uuid => extract_or_null(row, i, stmt::Value::Uuid),
+                _ => todo!("ty={ty:#?}"),
+            }
         }
 
         MYSQL_TYPE_TINY | MYSQL_TYPE_SHORT | MYSQL_TYPE_INT24 | MYSQL_TYPE_LONG

--- a/crates/toasty-driver-mysql/src/value.rs
+++ b/crates/toasty-driver-mysql/src/value.rs
@@ -25,6 +25,7 @@ impl ToValue for Value {
             CoreValue::Id(id) => id.to_string().to_value(),
             CoreValue::Null => mysql_async::Value::NULL,
             CoreValue::String(value) => value.to_value(),
+            CoreValue::Uuid(value) => value.to_value(),
             value => todo!("{:#?}", value),
         }
     }

--- a/crates/toasty-driver-postgresql/Cargo.toml
+++ b/crates/toasty-driver-postgresql/Cargo.toml
@@ -9,6 +9,8 @@ toasty-sql.workspace = true
 
 anyhow.workspace = true
 postgres.workspace = true
+postgres-types.workspace = true
 tokio.workspace = true
 tokio-postgres.workspace = true
+uuid.workspace = true
 url.workspace = true

--- a/crates/toasty-driver-postgresql/src/lib.rs
+++ b/crates/toasty-driver-postgresql/src/lib.rs
@@ -294,6 +294,14 @@ fn postgres_to_toasty(
                 _ => stmt::Value::I64(v), // Default fallback
             })
             .unwrap_or(stmt::Value::Null)
+    } else if column.type_() == &Type::UUID {
+        row.get::<usize, Option<uuid::Uuid>>(index)
+            .map(|v| match expected_ty {
+                stmt::Type::Uuid => stmt::Value::Uuid(v),
+                stmt::Type::String => stmt::Value::String(v.to_string()),
+                _ => stmt::Value::Uuid(v),
+            })
+            .unwrap_or(stmt::Value::Null)
     } else {
         todo!(
             "implement PostgreSQL to toasty conversion for `{:#?}`",
@@ -315,6 +323,7 @@ fn postgres_ty_for_value(value: &stmt::Value) -> Type {
         stmt::Value::U64(_) => Type::INT8,
         stmt::Value::Id(_) => Type::TEXT,
         stmt::Value::String(_) => Type::TEXT,
+        stmt::Value::Uuid(_) => Type::UUID,
         stmt::Value::Null => Type::TEXT, // Default for NULL values
         _ => todo!("postgres_ty_for_value: {value:#?}"),
     }

--- a/crates/toasty-driver-postgresql/src/value.rs
+++ b/crates/toasty-driver-postgresql/src/value.rs
@@ -119,10 +119,11 @@ impl ToSql for Value {
             stmt::Value::Id(value) => value.to_string().to_sql(ty, out),
             stmt::Value::Null => Ok(IsNull::Yes),
             stmt::Value::String(value) => value.to_sql(ty, out),
+            stmt::Value::Uuid(value) => value.to_sql(ty, out),
             value => todo!("{value:#?}"),
         }
     }
 
-    accepts!(BOOL, INT2, INT4, INT8, TEXT, VARCHAR);
+    accepts!(BOOL, INT2, INT4, INT8, TEXT, VARCHAR, UUID);
     to_sql_checked!();
 }

--- a/crates/toasty-driver-sqlite/Cargo.toml
+++ b/crates/toasty-driver-sqlite/Cargo.toml
@@ -11,6 +11,7 @@ toasty-sql.workspace = true
 anyhow.workspace = true
 rusqlite.workspace = true
 url.workspace = true
+uuid.workspace = true
 
 # TODO: get rid of
 serde.workspace = true

--- a/crates/toasty-sql/src/serializer/ty.rs
+++ b/crates/toasty-sql/src/serializer/ty.rs
@@ -37,6 +37,18 @@ impl ToSql for &db::Type {
                 }
             }
             db::Type::Text => fmt!(cx, f, "TEXT"),
+            db::Type::Uuid => {
+                fmt!(
+                    cx,
+                    f,
+                    // PostgreSQL has a native UUID type. For the others we fall back to binary blobs.
+                    match f.serializer.flavor {
+                        Flavor::Postgresql => "UUID",
+                        Flavor::Sqlite => "BLOB",
+                        Flavor::Mysql => "BINARY(16)",
+                    }
+                );
+            }
             db::Type::VarChar(size) => fmt!(cx, f, "VARCHAR(" size ")"),
             db::Type::Custom(custom) => fmt!(cx, f, custom.as_str()),
         }

--- a/crates/toasty/src/stmt/into_expr.rs
+++ b/crates/toasty/src/stmt/into_expr.rs
@@ -33,6 +33,7 @@ impl_into_expr_for_copy! {
     U16(u16);
     U32(u32);
     U64(u64);
+    Uuid(uuid::Uuid);
 }
 
 // Pointer-sized integers convert through their fixed-size equivalents

--- a/crates/toasty/src/stmt/primitive.rs
+++ b/crates/toasty/src/stmt/primitive.rs
@@ -100,3 +100,16 @@ impl<T: Primitive> Primitive for Option<T> {
         }
     }
 }
+
+impl Primitive for uuid::Uuid {
+    fn ty() -> stmt::Type {
+        stmt::Type::Uuid
+    }
+
+    fn load(value: stmt::Value) -> Result<Self> {
+        match value {
+            stmt::Value::Uuid(v) => Ok(v),
+            _ => anyhow::bail!("cannot convert value to uuid::Uuid {value:#?}"),
+        }
+    }
+}

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -33,4 +33,7 @@ tempfile.workspace = true
 trybuild.workspace = true
 env_logger = "0.11.8"
 
+# Third-party types
+uuid.workspace = true
+
 [dev-dependencies]

--- a/tests/tests/tys.rs
+++ b/tests/tests/tys.rs
@@ -158,4 +158,25 @@ fn gen_string(length: usize, pattern: &str) -> String {
     }
 }
 
-tests!(ty_i8, ty_i16, ty_i32, ty_i64, ty_isize, ty_u8, ty_u16, ty_u32, ty_u64, ty_usize, ty_str,);
+async fn ty_uuid(test: &mut DbTest) {
+    #[derive(Debug, toasty::Model)]
+    struct Foo {
+        #[key]
+        #[auto]
+        id: Id<Self>,
+        val: uuid::Uuid,
+    }
+
+    let db = test.setup_db(models!(Foo)).await;
+    for _ in 0..16 {
+        let val = uuid::Uuid::new_v4();
+        let created = Foo::create().val(val).exec(&db).await.unwrap();
+        let read = Foo::get_by_id(&db, &created.id).await.unwrap();
+        assert_eq!(read.val, val);
+    }
+}
+
+tests!(
+    ty_i8, ty_i16, ty_i32, ty_i64, ty_isize, ty_u8, ty_u16, ty_u32, ty_u64, ty_usize, ty_str,
+    ty_uuid
+);


### PR DESCRIPTION
Important considerations:
* While PostgreSQL has native UUIDs, I chose binary blobs for MySQL and SQLite as they likely have better performance (and size) characteristics, especially when used as primary keys (often the case for UUIDs).
* I chose to serialize to strings for DynamoDB. I saw DynamoDB has blobs as well, but it felt fitting for the NoSQL style to have them as strings. Might be wrong, perhaps the same performance consideration above is more important.
* The `uuid` dependency is non-optional and already was before I started. However it might be worth making it optional with a feature flag in the future.