### PR TITLE
stmt: rm impl Default for stmt::Expr

### DIFF
--- a/crates/toasty-core/src/schema/builder.rs
+++ b/crates/toasty-core/src/schema/builder.rs
@@ -89,7 +89,7 @@ impl Builder {
                         })
                         .collect(),
                     model_to_table: stmt::ExprRecord::default(),
-                    model_pk_to_table: stmt::Expr::default(),
+                    model_pk_to_table: stmt::Expr::null(),
                     table_to_model: TableToModel::default(),
                 },
             );

--- a/crates/toasty-core/src/stmt/expr.rs
+++ b/crates/toasty-core/src/stmt/expr.rs
@@ -243,12 +243,6 @@ impl Expr {
     }
 }
 
-impl Default for Expr {
-    fn default() -> Self {
-        Self::Value(Value::default())
-    }
-}
-
 impl Node for Expr {
     fn visit<V: Visit>(&self, mut visit: V) {
         visit.visit_expr(self);

--- a/crates/toasty/src/engine/simplify.rs
+++ b/crates/toasty/src/engine/simplify.rs
@@ -271,7 +271,7 @@ impl<'a> Simplify<'a> {
                     assert!(row.len() <= width);
 
                     while row.len() < width {
-                        row.push(stmt::Expr::default());
+                        row.push(stmt::Expr::null());
                     }
                 }
                 stmt::Expr::Value(stmt::Value::Record(row)) => {

--- a/crates/toasty/src/stmt/insert.rs
+++ b/crates/toasty/src/stmt/insert.rs
@@ -68,7 +68,7 @@ impl<M: Model> Insert<M> {
         let row = self.current_mut();
 
         while row.fields.len() <= field {
-            row.fields.push(stmt::Expr::default());
+            row.fields.push(stmt::Expr::null());
         }
 
         &mut row[field]


### PR DESCRIPTION
Returning NULL as the default is not ideal as we want to generally avoid NULL in favor of richer expressions.