### PR TITLE
Add rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
My tests were failing locally but passing in the CI because I have my rustup set to nightly Rust by default. This `rust-toolchain.toml` makes sure every developer uses stable rust.