### PR TITLE
feat: adds simplification for `ExprOr` statements

### DIFF
--- a/crates/toasty/src/engine/simplify.rs
+++ b/crates/toasty/src/engine/simplify.rs
@@ -9,6 +9,7 @@ mod expr_in_list;
 mod expr_is_null;
 mod expr_list;
 mod expr_map;
+mod expr_or;
 mod expr_record;
 mod stmt_query;
 mod value;
@@ -61,22 +62,19 @@ impl VisitMut for Simplify<'_> {
 
         // If an in-subquery expression, then try lifting it.
         let maybe_expr = match i {
-            Expr::Any(expr_any) => self.simplify_expr_any(expr_any),
-            Expr::And(expr_and) => self.simplify_expr_and(expr_and),
-            Expr::BinaryOp(expr_binary_op) => self.simplify_expr_binary_op(
-                expr_binary_op.op,
-                &mut expr_binary_op.lhs,
-                &mut expr_binary_op.rhs,
-            ),
+            Expr::Any(expr) => self.simplify_expr_any(expr),
+            Expr::And(expr) => self.simplify_expr_and(expr),
+            Expr::BinaryOp(expr) => {
+                self.simplify_expr_binary_op(expr.op, &mut expr.lhs, &mut expr.rhs)
+            }
             Expr::Cast(expr) => self.simplify_expr_cast(expr),
             Expr::ConcatStr(expr) => self.simplify_expr_concat_str(expr),
-            Expr::Exists(expr_exists) => self.simplify_expr_exists(expr_exists),
+            Expr::Exists(expr) => self.simplify_expr_exists(expr),
             Expr::InList(expr) => self.simplify_expr_in_list(expr),
-            Expr::InSubquery(expr_in_subquery) => {
-                self.lift_in_subquery(&expr_in_subquery.expr, &expr_in_subquery.query)
-            }
+            Expr::InSubquery(expr) => self.lift_in_subquery(&expr.expr, &expr.query),
             Expr::List(expr) => self.simplify_expr_list(expr),
             Expr::Map(_) => self.simplify_expr_map(i),
+            Expr::Or(expr) => self.simplify_expr_or(expr),
             Expr::Record(expr) => self.simplify_expr_record(expr),
             Expr::IsNull(expr) => self.simplify_expr_is_null(expr),
             _ => None,

--- a/crates/toasty/src/engine/simplify/expr_or.rs
+++ b/crates/toasty/src/engine/simplify/expr_or.rs
@@ -1,0 +1,177 @@
+use super::Simplify;
+use std::mem;
+use toasty_core::stmt;
+
+impl Simplify<'_> {
+    pub(super) fn simplify_expr_or(&mut self, expr: &mut stmt::ExprOr) -> Option<stmt::Expr> {
+        // Flatten any nested ors
+        for i in 0..expr.operands.len() {
+            if let stmt::Expr::Or(or) = &mut expr.operands[i] {
+                let mut nested = mem::take(&mut or.operands);
+                expr.operands[i] = false.into();
+                expr.operands.append(&mut nested);
+            }
+        }
+
+        // `or(..., true, ...) → true`
+        if expr.operands.iter().any(|e| e.is_true()) {
+            return Some(true.into());
+        }
+
+        // `or(..., false, ...) → or(..., ...)`
+        expr.operands.retain(|expr| !expr.is_false());
+
+        if expr.operands.is_empty() {
+            Some(false.into())
+        } else if expr.operands.len() == 1 {
+            Some(expr.operands.remove(0))
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::simplify::test::test_schema;
+    use toasty_core::stmt::{Expr, ExprOr};
+
+    /// Builds `or(a, or(b, c))`, a nested OR structure for testing flattening.
+    fn nested_or(a: Expr, b: Expr, c: Expr) -> ExprOr {
+        ExprOr {
+            operands: vec![
+                a,
+                Expr::Or(ExprOr {
+                    operands: vec![b, c],
+                }),
+            ],
+        }
+    }
+
+    #[test]
+    fn flatten_all_symbolic() {
+        let schema = test_schema();
+        let mut simplify = Simplify::new(&schema);
+
+        // `or(A, or(B, C)) → or(A, B, C)`
+        let mut expr = nested_or(Expr::arg(0), Expr::arg(1), Expr::arg(2));
+        let result = simplify.simplify_expr_or(&mut expr);
+
+        assert!(result.is_none());
+        assert_eq!(expr.operands.len(), 3);
+        assert_eq!(expr.operands[0], Expr::arg(0));
+        assert_eq!(expr.operands[1], Expr::arg(1));
+        assert_eq!(expr.operands[2], Expr::arg(2));
+    }
+
+    #[test]
+    fn flatten_with_false_in_outer() {
+        let schema = test_schema();
+        let mut simplify = Simplify::new(&schema);
+
+        // `or(false, or(B, C)) → or(B, C)`
+        let mut expr = nested_or(false.into(), Expr::arg(1), Expr::arg(2));
+        let result = simplify.simplify_expr_or(&mut expr);
+
+        assert!(result.is_none());
+        assert_eq!(expr.operands.len(), 2);
+        assert_eq!(expr.operands[0], Expr::arg(1));
+        assert_eq!(expr.operands[1], Expr::arg(2));
+    }
+
+    #[test]
+    fn flatten_with_false_in_nested_first() {
+        let schema = test_schema();
+        let mut simplify = Simplify::new(&schema);
+
+        // `or(A, or(false, C)) → or(A, C)`
+        let mut expr = nested_or(Expr::arg(0), false.into(), Expr::arg(2));
+        let result = simplify.simplify_expr_or(&mut expr);
+
+        assert!(result.is_none());
+        assert_eq!(expr.operands.len(), 2);
+        assert_eq!(expr.operands[0], Expr::arg(0));
+        assert_eq!(expr.operands[1], Expr::arg(2));
+    }
+
+    #[test]
+    fn flatten_outer_false_nested_one_false() {
+        let schema = test_schema();
+        let mut simplify = Simplify::new(&schema);
+
+        // `or(false, or(false, C)) → C`
+        let mut expr = nested_or(false.into(), false.into(), Expr::arg(2));
+        let result = simplify.simplify_expr_or(&mut expr);
+
+        assert!(result.is_some());
+        assert_eq!(result.unwrap(), Expr::arg(2));
+    }
+
+    #[test]
+    fn flatten_outer_symbolic_nested_all_false() {
+        let schema = test_schema();
+        let mut simplify = Simplify::new(&schema);
+
+        // `or(A, or(false, false)) → A`
+        let mut expr = nested_or(Expr::arg(0), false.into(), false.into());
+        let result = simplify.simplify_expr_or(&mut expr);
+
+        assert!(result.is_some());
+        assert_eq!(result.unwrap(), Expr::arg(0));
+    }
+
+    #[test]
+    fn flatten_all_false() {
+        let schema = test_schema();
+        let mut simplify = Simplify::new(&schema);
+
+        // `or(false, or(false, false)) → false`
+        let mut expr = nested_or(false.into(), false.into(), false.into());
+        let result = simplify.simplify_expr_or(&mut expr);
+
+        assert!(result.is_some());
+        assert!(result.unwrap().is_false());
+    }
+
+    #[test]
+    fn flatten_with_true_in_outer() {
+        let schema = test_schema();
+        let mut simplify = Simplify::new(&schema);
+
+        // `or(true, or(B, C)) → true`
+        let mut expr = nested_or(true.into(), Expr::arg(1), Expr::arg(2));
+        let result = simplify.simplify_expr_or(&mut expr);
+
+        assert!(result.is_some());
+        assert!(result.unwrap().is_true());
+    }
+
+    #[test]
+    fn flatten_with_true_in_nested() {
+        let schema = test_schema();
+        let mut simplify = Simplify::new(&schema);
+
+        // `or(A, or(true, C)) → true`
+        let mut expr = nested_or(Expr::arg(0), true.into(), Expr::arg(2));
+        let result = simplify.simplify_expr_or(&mut expr);
+
+        assert!(result.is_some());
+        assert!(result.unwrap().is_true());
+    }
+
+    #[test]
+    fn single_operand_unwrapped() {
+        let schema = test_schema();
+        let mut simplify = Simplify::new(&schema);
+
+        // `or(arg(0)) → arg(0)`
+        let mut expr = ExprOr {
+            operands: vec![Expr::arg(0)],
+        };
+        let result = simplify.simplify_expr_or(&mut expr);
+
+        assert!(result.is_some());
+        assert_eq!(result.unwrap(), Expr::arg(0));
+    }
+}


### PR DESCRIPTION
This PR adds `true` short-circuiting for OR statements alongside the other relevant simplifications used in `expr_and.rs`.