### PR TITLE
docs: clarify that `ExprRecord` works like a Rust tuple

### DIFF
--- a/crates/toasty-core/src/stmt/expr_record.rs
+++ b/crates/toasty-core/src/stmt/expr_record.rs
@@ -5,8 +5,8 @@ use std::{fmt, ops};
 
 /// A record of expressions.
 ///
-/// Represents a fixed-size collection of expressions accessed by position,
-/// similar to a tuple or row.
+/// Represents a fixed-size, heterogeneous collection of expressions accessed by
+/// position. Like Rust tuples, each field can have a different type.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
This PR addresses @carllerche's comment to me in Discord that we should note the similarity between Rust tuples and `ExprRecord`.