### PR TITLE
revise: uses Toasty macros for test model generation

### DIFF
--- a/crates/toasty/src/engine/simplify/expr_binary_op.rs
+++ b/crates/toasty/src/engine/simplify/expr_binary_op.rs
@@ -101,86 +101,40 @@ impl Simplify<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate as toasty;
+    use crate::Model as _;
     use toasty_core::{
         driver::Capability,
-        schema::{
-            app::{
-                Field, FieldId, FieldName, FieldPrimitive, Index, IndexField, IndexId, Model,
-                ModelId, PrimaryKey,
-            },
-            db::{IndexOp, IndexScope},
-            Builder, Name,
-        },
+        schema::{app, Builder},
         stmt::{BinaryOp, ExprCast, Id, Type, Value},
     };
 
-    fn test_schema() -> (toasty_core::Schema, Model) {
-        let model_id = ModelId(0);
-        let field_id = FieldId {
-            model: model_id,
-            index: 0,
-        };
-        let index_id = IndexId {
-            model: model_id,
-            index: 0,
-        };
+    #[derive(toasty::Model)]
+    struct User {
+        #[key]
+        id: String,
+    }
 
-        let model = Model {
-            id: model_id,
-            name: Name::new("User"),
-            fields: vec![Field {
-                id: field_id,
-                name: FieldName {
-                    app_name: "id".to_string(),
-                    storage_name: None,
-                },
-                ty: FieldTy::Primitive(FieldPrimitive {
-                    ty: Type::String,
-                    storage_ty: None,
-                }),
-                nullable: false,
-                primary_key: true,
-                auto: None,
-                constraints: vec![],
-            }],
-            primary_key: PrimaryKey {
-                fields: vec![field_id],
-                index: index_id,
-            },
-            indices: vec![Index {
-                id: index_id,
-                fields: vec![IndexField {
-                    field: field_id,
-                    op: IndexOp::Eq,
-                    scope: IndexScope::Local,
-                }],
-                unique: true,
-                primary_key: true,
-            }],
-            table_name: None,
-        };
+    fn test_schema() -> toasty_core::Schema {
+        let app_schema =
+            app::Schema::from_macro(&[User::schema()]).expect("schema should build from macro");
 
-        let mut app_schema = toasty_core::schema::app::Schema::default();
-        app_schema.models.insert(model_id, model.clone());
-
-        let schema = Builder::new()
+        Builder::new()
             .build(app_schema, &Capability::SQLITE)
-            .expect("schema should build");
-
-        (schema, model)
+            .expect("schema should build")
     }
 
     #[test]
     fn cast_id_on_lhs_unwrapped() {
-        let (schema, _) = test_schema();
+        let schema = test_schema();
         let mut simplify = Simplify::new(&schema);
 
         // `eq(cast(arg(0), Id), Id("abc")) → eq(arg(0), "abc")`
         let mut lhs = Expr::Cast(ExprCast {
             expr: Box::new(Expr::arg(0)),
-            ty: Type::Id(ModelId(0)),
+            ty: Type::Id(User::id()),
         });
-        let mut rhs = Expr::Value(Value::Id(Id::from_string(ModelId(0), "abc".to_string())));
+        let mut rhs = Expr::Value(Value::Id(Id::from_string(User::id(), "abc".to_string())));
 
         let result = simplify.simplify_expr_binary_op(BinaryOp::Eq, &mut lhs, &mut rhs);
 
@@ -191,14 +145,14 @@ mod tests {
 
     #[test]
     fn cast_id_on_rhs_unwrapped() {
-        let (schema, _model) = test_schema();
+        let schema = test_schema();
         let mut simplify = Simplify::new(&schema);
 
         // `eq(Id("xyz"), cast(arg(0), Id)) → eq("xyz", arg(0))`
-        let mut lhs = Expr::Value(Value::Id(Id::from_string(ModelId(0), "xyz".to_string())));
+        let mut lhs = Expr::Value(Value::Id(Id::from_string(User::id(), "xyz".to_string())));
         let mut rhs = Expr::Cast(ExprCast {
             expr: Box::new(Expr::arg(0)),
-            ty: Type::Id(ModelId(0)),
+            ty: Type::Id(User::id()),
         });
 
         let result = simplify.simplify_expr_binary_op(BinaryOp::Eq, &mut lhs, &mut rhs);
@@ -210,7 +164,7 @@ mod tests {
 
     #[test]
     fn non_id_cast_not_unwrapped() {
-        let (schema, _model) = test_schema();
+        let schema = test_schema();
         let mut simplify = Simplify::new(&schema);
 
         // `eq(cast(arg(0), String), "test")`, non-Id cast is not unwrapped
@@ -228,7 +182,7 @@ mod tests {
 
     #[test]
     fn plain_values_unchanged() {
-        let (schema, _model) = test_schema();
+        let schema = test_schema();
         let mut simplify = Simplify::new(&schema);
 
         // `eq(1, 2)`, plain values are unchanged

--- a/crates/toasty/src/engine/simplify/lift_in_subquery.rs
+++ b/crates/toasty/src/engine/simplify/lift_in_subquery.rs
@@ -219,18 +219,36 @@ impl LiftBelongsTo<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate as toasty;
+    use crate::Model as _;
     use toasty_core::{
         driver::Capability,
-        schema::{
-            app::{
-                BelongsTo, Field, FieldName, FieldPrimitive, ForeignKey, ForeignKeyField, HasMany,
-                Index, IndexField, IndexId, Model, ModelId, PrimaryKey,
-            },
-            db::{IndexOp, IndexScope},
-            Builder, Name,
-        },
-        stmt::{Expr, ExprBinaryOp, Query, Type, Value},
+        schema::{app, app::ModelId, Builder},
+        stmt::{Expr, ExprBinaryOp, Query, Value},
     };
+
+    #[allow(dead_code)]
+    #[derive(toasty::Model)]
+    struct User {
+        #[key]
+        id: i64,
+
+        #[has_many]
+        posts: toasty::HasMany<Post>,
+    }
+
+    #[allow(dead_code)]
+    #[derive(toasty::Model)]
+    struct Post {
+        #[key]
+        id: i64,
+
+        #[index]
+        user_id: i64,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: toasty::BelongsTo<User>,
+    }
 
     /// Schema with `User` and `Post` models in a `HasMany`/`BelongsTo`
     /// relationship.
@@ -239,205 +257,46 @@ mod tests {
         user_model: ModelId,
         user_id: FieldId,
         post_model: ModelId,
-        post_author: FieldId,
+        post_user: FieldId,
     }
 
     impl UserPostSchema {
         fn new() -> Self {
-            let user_model = ModelId(0);
-            let post_model = ModelId(1);
-
-            let user_id = FieldId {
-                model: user_model,
-                index: 0,
-            };
-            let user_posts = FieldId {
-                model: user_model,
-                index: 1,
-            };
-
-            let post_id = FieldId {
-                model: post_model,
-                index: 0,
-            };
-            let post_user_id = FieldId {
-                model: post_model,
-                index: 1,
-            };
-            let post_author = FieldId {
-                model: post_model,
-                index: 2,
-            };
-
-            let user_model_def = Model {
-                id: user_model,
-                name: Name::new("User"),
-                fields: vec![
-                    Field {
-                        id: user_id,
-                        name: FieldName {
-                            app_name: "id".to_string(),
-                            storage_name: None,
-                        },
-                        ty: FieldTy::Primitive(FieldPrimitive {
-                            ty: Type::I64,
-                            storage_ty: None,
-                        }),
-                        nullable: false,
-                        primary_key: true,
-                        auto: None,
-                        constraints: vec![],
-                    },
-                    Field {
-                        id: user_posts,
-                        name: FieldName {
-                            app_name: "posts".to_string(),
-                            storage_name: None,
-                        },
-                        ty: FieldTy::HasMany(HasMany {
-                            target: post_model,
-                            expr_ty: Type::List(Box::new(Type::Model(post_model))),
-                            singular: Name::new("post"),
-                            pair: post_author,
-                        }),
-                        nullable: false,
-                        primary_key: false,
-                        auto: None,
-                        constraints: vec![],
-                    },
-                ],
-                primary_key: PrimaryKey {
-                    fields: vec![user_id],
-                    index: IndexId {
-                        model: user_model,
-                        index: 0,
-                    },
-                },
-                indices: vec![Index {
-                    id: IndexId {
-                        model: user_model,
-                        index: 0,
-                    },
-                    fields: vec![IndexField {
-                        field: user_id,
-                        op: IndexOp::Eq,
-                        scope: IndexScope::Local,
-                    }],
-                    unique: true,
-                    primary_key: true,
-                }],
-                table_name: None,
-            };
-
-            let post_model_def = Model {
-                id: post_model,
-                name: Name::new("Post"),
-                fields: vec![
-                    Field {
-                        id: post_id,
-                        name: FieldName {
-                            app_name: "id".to_string(),
-                            storage_name: None,
-                        },
-                        ty: FieldTy::Primitive(FieldPrimitive {
-                            ty: Type::I64,
-                            storage_ty: None,
-                        }),
-                        nullable: false,
-                        primary_key: true,
-                        auto: None,
-                        constraints: vec![],
-                    },
-                    Field {
-                        id: post_user_id,
-                        name: FieldName {
-                            app_name: "user_id".to_string(),
-                            storage_name: None,
-                        },
-                        ty: FieldTy::Primitive(FieldPrimitive {
-                            ty: Type::I64,
-                            storage_ty: None,
-                        }),
-                        nullable: false,
-                        primary_key: false,
-                        auto: None,
-                        constraints: vec![],
-                    },
-                    Field {
-                        id: post_author,
-                        name: FieldName {
-                            app_name: "author".to_string(),
-                            storage_name: None,
-                        },
-                        ty: FieldTy::BelongsTo(BelongsTo {
-                            target: user_model,
-                            expr_ty: Type::Model(user_model),
-                            pair: Some(user_posts),
-                            foreign_key: ForeignKey {
-                                fields: vec![ForeignKeyField {
-                                    source: post_user_id,
-                                    target: user_id,
-                                }],
-                            },
-                        }),
-                        nullable: false,
-                        primary_key: false,
-                        auto: None,
-                        constraints: vec![],
-                    },
-                ],
-                primary_key: PrimaryKey {
-                    fields: vec![post_id],
-                    index: IndexId {
-                        model: post_model,
-                        index: 0,
-                    },
-                },
-                indices: vec![
-                    Index {
-                        id: IndexId {
-                            model: post_model,
-                            index: 0,
-                        },
-                        fields: vec![IndexField {
-                            field: post_id,
-                            op: IndexOp::Eq,
-                            scope: IndexScope::Local,
-                        }],
-                        unique: true,
-                        primary_key: true,
-                    },
-                    Index {
-                        id: IndexId {
-                            model: post_model,
-                            index: 1,
-                        },
-                        fields: vec![IndexField {
-                            field: post_user_id,
-                            op: IndexOp::Eq,
-                            scope: IndexScope::Local,
-                        }],
-                        unique: false,
-                        primary_key: false,
-                    },
-                ],
-                table_name: None,
-            };
-
-            let mut app_schema = toasty_core::schema::app::Schema::default();
-            app_schema.models.insert(user_model, user_model_def);
-            app_schema.models.insert(post_model, post_model_def);
+            let app_schema = app::Schema::from_macro(&[User::schema(), Post::schema()])
+                .expect("schema should build from macro");
 
             let schema = Builder::new()
                 .build(app_schema, &Capability::SQLITE)
                 .expect("schema should build");
+
+            let user_model = User::id();
+            let post_model = Post::id();
+
+            // Find field IDs by name from the generated schema
+            let user_id = schema
+                .app
+                .model(user_model)
+                .fields
+                .iter()
+                .find(|f| f.name.app_name == "id")
+                .unwrap()
+                .id;
+
+            let post_user = schema
+                .app
+                .model(post_model)
+                .fields
+                .iter()
+                .find(|f| f.name.app_name == "user")
+                .unwrap()
+                .id;
 
             Self {
                 schema,
                 user_model,
                 user_id,
                 post_model,
-                post_author,
+                post_user,
             }
         }
     }
@@ -450,8 +309,8 @@ mod tests {
         let post_source: stmt::Source = s.post_model.into();
         let mut scoped_simplify = simplify.scope(&post_source);
 
-        // `lift_in_subquery(author, select(User, eq(id, 42))) → eq(user_id, 42)`
-        let expr = Expr::ref_self_field(s.post_author);
+        // `lift_in_subquery(user, select(User, eq(id, 42))) → eq(user_id, 42)`
+        let expr = Expr::ref_self_field(s.post_user);
         let filter = Expr::eq(
             Expr::ref_self_field(s.user_id),
             Expr::Value(Value::from(42i64)),

--- a/crates/toasty/src/engine/simplify/rewrite_root_path_expr.rs
+++ b/crates/toasty/src/engine/simplify/rewrite_root_path_expr.rs
@@ -19,85 +19,40 @@ impl Simplify<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate as toasty;
+    use crate::Model as _;
     use toasty_core::{
         driver::Capability,
-        schema::{
-            app::{
-                Field, FieldId, FieldName, FieldPrimitive, FieldTy, Index, IndexField, IndexId,
-                ModelId, PrimaryKey,
-            },
-            db::{IndexOp, IndexScope},
-            Builder, Name,
-        },
-        stmt::{Expr, ExprBinaryOp, Type, Value},
+        schema::{app, Builder},
+        stmt::{Expr, ExprBinaryOp, Value},
     };
+
+    #[derive(toasty::Model)]
+    struct User {
+        #[key]
+        id: i64,
+    }
 
     /// Creates a schema with a single `User` model containing an `id` primary
     /// key field.
-    fn test_schema() -> (toasty_core::Schema, Model) {
-        let model_id = ModelId(0);
-        let field_id = FieldId {
-            model: model_id,
-            index: 0,
-        };
-        let index_id = IndexId {
-            model: model_id,
-            index: 0,
-        };
+    fn test_schema() -> toasty_core::Schema {
+        let app_schema =
+            app::Schema::from_macro(&[User::schema()]).expect("schema should build from macro");
 
-        let model = Model {
-            id: model_id,
-            name: Name::new("User"),
-            fields: vec![Field {
-                id: field_id,
-                name: FieldName {
-                    app_name: "id".to_string(),
-                    storage_name: None,
-                },
-                ty: FieldTy::Primitive(FieldPrimitive {
-                    ty: Type::I64,
-                    storage_ty: None,
-                }),
-                nullable: false,
-                primary_key: true,
-                auto: None,
-                constraints: vec![],
-            }],
-            primary_key: PrimaryKey {
-                fields: vec![field_id],
-                index: index_id,
-            },
-            indices: vec![Index {
-                id: index_id,
-                fields: vec![IndexField {
-                    field: field_id,
-                    op: IndexOp::Eq,
-                    scope: IndexScope::Local,
-                }],
-                unique: true,
-                primary_key: true,
-            }],
-            table_name: None,
-        };
-
-        let mut app_schema = toasty_core::schema::app::Schema::default();
-        app_schema.models.insert(model_id, model.clone());
-
-        let schema = Builder::new()
+        Builder::new()
             .build(app_schema, &Capability::SQLITE)
-            .expect("schema should build");
-
-        (schema, model)
+            .expect("schema should build")
     }
 
     #[test]
     fn single_pk_field_becomes_eq_expr() {
-        let (schema, model) = test_schema();
+        let schema = test_schema();
+        let model = schema.app.model(User::id());
         let mut simplify = Simplify::new(&schema);
 
         // `rewrite_root_path_expr(model, 42) → eq(ref(pk), 42)`
         let val = Expr::Value(Value::from(42i64));
-        let result = simplify.rewrite_root_path_expr(&model, val);
+        let result = simplify.rewrite_root_path_expr(model, val);
 
         let Expr::BinaryOp(ExprBinaryOp { op, lhs, rhs }) = result else {
             panic!("expected result to be an `Expr::BinaryOp`");


### PR DESCRIPTION
This PR is a response to [this comment](https://github.com/tokio-rs/toasty/pull/204#discussion_r2572650874)—the tests now use Toasty macros to generate the models.