### PR TITLE
feat: introduces self-comparison simplifications

### DIFF
--- a/crates/toasty/src/engine/simplify/expr_binary_op.rs
+++ b/crates/toasty/src/engine/simplify/expr_binary_op.rs
@@ -155,6 +155,7 @@ mod tests {
         #[key]
         id: String,
 
+        #[allow(dead_code)]
         name: Option<String>,
     }
 


### PR DESCRIPTION
This PR adds self-comparison simplifications. Concretely, it simplifies expressions where non-`null` fields are checked for equality (or inequality) against themselves. Notably, this optimization cannot be performed for `null` fields because `null` != `null` in many cases. We're effectively implementing [this case](https://github.com/apache/datafusion/blob/main/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs#L826-L843) in DataFusion.

This PR should be considered after #211.