### PR TITLE
feat: adds the complement law simplifications

### DIFF
--- a/crates/toasty-core/src/stmt/expr.rs
+++ b/crates/toasty-core/src/stmt/expr.rs
@@ -146,6 +146,33 @@ impl Expr {
         matches!(self, Self::Arg(_))
     }
 
+    /// Returns true if the expression is always non-nullable.
+    ///
+    /// This method is conservative and only returns true for expressions we can
+    /// prove are non-nullable.
+    pub fn is_always_non_nullable(&self) -> bool {
+        match self {
+            // A constant value is non-nullable if it's not null.
+            Self::Value(value) => !value.is_null(),
+            // Boolean logic expressions always evaluate to true or false.
+            Self::And(_) | Self::Or(_) | Self::Not(_) => true,
+            // ANY returns true if any item matches, always boolean.
+            Self::Any(_) => true,
+            // Comparisons always evaluate to true or false.
+            Self::BinaryOp(_) => true,
+            // IS NULL checks always evaluate to true or false.
+            Self::IsNull(_) => true,
+            // EXISTS checks always evaluate to true or false.
+            Self::Exists(_) => true,
+            // IN expressions always evaluate to true or false.
+            Self::InList(_) | Self::InSubquery(_) => true,
+            // Pattern matching always evaluates to true or false.
+            Self::Pattern(_) => true,
+            // For other expressions, we cannot prove non-nullability.
+            _ => false,
+        }
+    }
+
     pub fn into_value(self) -> Value {
         match self {
             Self::Value(value) => value,

--- a/crates/toasty/src/engine/simplify/expr_and.rs
+++ b/crates/toasty/src/engine/simplify/expr_and.rs
@@ -54,6 +54,11 @@ impl Simplify<'_> {
             }
         });
 
+        // Complement law, `a and not(a)` → `false` (only if `a` is non-nullable)
+        if self.try_complement_and(expr) {
+            return Some(false.into());
+        }
+
         if expr.operands.is_empty() {
             Some(true.into())
         } else if expr.operands.len() == 1 {
@@ -61,6 +66,38 @@ impl Simplify<'_> {
         } else {
             None
         }
+    }
+
+    /// Checks for complement law: `a and not(a)` → `false`
+    /// Returns true if a complementary pair is found and both are non-nullable.
+    fn try_complement_and(&self, expr: &stmt::ExprAnd) -> bool {
+        // Collect all NOT expressions and their inner expressions
+        let negated: Vec<_> = expr
+            .operands
+            .iter()
+            .filter_map(|op| {
+                if let stmt::Expr::Not(not_expr) = op {
+                    Some(not_expr.expr.as_ref())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // Check if any operand has its negation also present
+        for operand in &expr.operands {
+            // Skip NOT expressions themselves
+            if matches!(operand, stmt::Expr::Not(_)) {
+                continue;
+            }
+
+            // Check if not(operand) exists and operand is non-nullable
+            if negated.contains(&operand) && operand.is_always_non_nullable() {
+                return true;
+            }
+        }
+
+        false
     }
 }
 
@@ -369,5 +406,87 @@ mod tests {
         assert_eq!(expr.operands.len(), 2);
         assert_eq!(expr.operands[0], Expr::arg(0));
         assert_eq!(expr.operands[1], Expr::arg(1));
+    }
+
+    #[test]
+    fn complement_basic() {
+        use toasty_core::stmt::ExprNot;
+
+        let schema = test_schema();
+        let mut simplify = Simplify::new(&schema);
+
+        // `a and not(a)` → `false` (where a is a non-nullable comparison)
+        let a = Expr::eq(Expr::arg(0), Expr::arg(1));
+        let mut expr = ExprAnd {
+            operands: vec![a.clone(), Expr::Not(ExprNot { expr: Box::new(a) })],
+        };
+        let result = simplify.simplify_expr_and(&mut expr);
+
+        assert!(result.is_some());
+        assert!(result.unwrap().is_false());
+    }
+
+    #[test]
+    fn complement_with_other_operands() {
+        use toasty_core::stmt::ExprNot;
+
+        let schema = test_schema();
+        let mut simplify = Simplify::new(&schema);
+
+        // `a and b and not(a)` → `false`
+        let a = Expr::eq(Expr::arg(0), Expr::arg(1));
+        let mut expr = ExprAnd {
+            operands: vec![
+                a.clone(),
+                Expr::arg(2),
+                Expr::Not(ExprNot { expr: Box::new(a) }),
+            ],
+        };
+        let result = simplify.simplify_expr_and(&mut expr);
+
+        assert!(result.is_some());
+        assert!(result.unwrap().is_false());
+    }
+
+    #[test]
+    fn complement_nullable_not_simplified() {
+        use toasty_core::stmt::ExprNot;
+
+        let schema = test_schema();
+        let mut simplify = Simplify::new(&schema);
+
+        // `a and not(a)` where `a` is an arg (nullable) → no change
+        let a = Expr::arg(0);
+        let mut expr = ExprAnd {
+            operands: vec![a.clone(), Expr::Not(ExprNot { expr: Box::new(a) })],
+        };
+        let result = simplify.simplify_expr_and(&mut expr);
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn complement_multiple_repetitions() {
+        use toasty_core::stmt::ExprNot;
+
+        let schema = test_schema();
+        let mut simplify = Simplify::new(&schema);
+
+        // `a and a and not(a) and not(a)` → `false`
+        let a = Expr::eq(Expr::arg(0), Expr::arg(1));
+        let mut expr = ExprAnd {
+            operands: vec![
+                a.clone(),
+                a.clone(),
+                Expr::Not(ExprNot {
+                    expr: Box::new(a.clone()),
+                }),
+                Expr::Not(ExprNot { expr: Box::new(a) }),
+            ],
+        };
+        let result = simplify.simplify_expr_and(&mut expr);
+
+        assert!(result.is_some());
+        assert!(result.unwrap().is_false());
     }
 }

--- a/crates/toasty/src/engine/simplify/expr_or.rs
+++ b/crates/toasty/src/engine/simplify/expr_or.rs
@@ -60,6 +60,11 @@ impl Simplify<'_> {
             return Some(factored);
         }
 
+        // Complement law, `a or not(a)` → `true` (only if `a` is non-nullable)
+        if self.try_complement_or(expr) {
+            return Some(true.into());
+        }
+
         if expr.operands.is_empty() {
             Some(false.into())
         } else if expr.operands.len() == 1 {
@@ -132,6 +137,39 @@ impl Simplify<'_> {
         };
         result.push(stmt::Expr::Or(or_expr));
         Some(stmt::Expr::and_from_vec(result))
+    }
+
+    /// Checks for complement law: `a or not(a)` → `true`
+    ///
+    /// Returns true if a complementary pair is found and both are non-nullable.
+    fn try_complement_or(&self, expr: &stmt::ExprOr) -> bool {
+        // Collect all NOT expressions and their inner expressions
+        let negated: Vec<_> = expr
+            .operands
+            .iter()
+            .filter_map(|op| {
+                if let stmt::Expr::Not(not_expr) = op {
+                    Some(not_expr.expr.as_ref())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // Check if any operand has its negation also present
+        for operand in &expr.operands {
+            // Skip NOT expressions themselves
+            if matches!(operand, stmt::Expr::Not(_)) {
+                continue;
+            }
+
+            // Check if not(operand) exists and operand is non-nullable
+            if negated.contains(&operand) && operand.is_always_non_nullable() {
+                return true;
+            }
+        }
+
+        false
     }
 }
 
@@ -529,5 +567,87 @@ mod tests {
         let result = simplify.simplify_expr_or(&mut expr);
 
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn complement_basic() {
+        use toasty_core::stmt::ExprNot;
+
+        let schema = test_schema();
+        let mut simplify = Simplify::new(&schema);
+
+        // `a or not(a)` → `true` (where a is a non-nullable comparison)
+        let a = Expr::eq(Expr::arg(0), Expr::arg(1));
+        let mut expr = ExprOr {
+            operands: vec![a.clone(), Expr::Not(ExprNot { expr: Box::new(a) })],
+        };
+        let result = simplify.simplify_expr_or(&mut expr);
+
+        assert!(result.is_some());
+        assert!(result.unwrap().is_true());
+    }
+
+    #[test]
+    fn complement_with_other_operands() {
+        use toasty_core::stmt::ExprNot;
+
+        let schema = test_schema();
+        let mut simplify = Simplify::new(&schema);
+
+        // `a or b or not(a)` → `true`
+        let a = Expr::eq(Expr::arg(0), Expr::arg(1));
+        let mut expr = ExprOr {
+            operands: vec![
+                a.clone(),
+                Expr::arg(2),
+                Expr::Not(ExprNot { expr: Box::new(a) }),
+            ],
+        };
+        let result = simplify.simplify_expr_or(&mut expr);
+
+        assert!(result.is_some());
+        assert!(result.unwrap().is_true());
+    }
+
+    #[test]
+    fn complement_nullable_not_simplified() {
+        use toasty_core::stmt::ExprNot;
+
+        let schema = test_schema();
+        let mut simplify = Simplify::new(&schema);
+
+        // `a or not(a)` where `a` is an arg (nullable) → no change
+        let a = Expr::arg(0);
+        let mut expr = ExprOr {
+            operands: vec![a.clone(), Expr::Not(ExprNot { expr: Box::new(a) })],
+        };
+        let result = simplify.simplify_expr_or(&mut expr);
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn complement_multiple_repetitions() {
+        use toasty_core::stmt::ExprNot;
+
+        let schema = test_schema();
+        let mut simplify = Simplify::new(&schema);
+
+        // `a or a or not(a) or not(a)` → `true`
+        let a = Expr::eq(Expr::arg(0), Expr::arg(1));
+        let mut expr = ExprOr {
+            operands: vec![
+                a.clone(),
+                a.clone(),
+                Expr::Not(ExprNot {
+                    expr: Box::new(a.clone()),
+                }),
+                Expr::Not(ExprNot { expr: Box::new(a) }),
+            ],
+        };
+        let result = simplify.simplify_expr_or(&mut expr);
+
+        assert!(result.is_some());
+        assert!(result.unwrap().is_true());
     }
 }


### PR DESCRIPTION
This PR implements the [complement laws](https://en.wikipedia.org/wiki/Complement_(set_theory)) for AND and OR statements.

This should be merged in after #219 and #214.