### PR TITLE
feat: adds canonicalization simplification

### DIFF
--- a/crates/toasty-core/src/stmt/op_binary.rs
+++ b/crates/toasty-core/src/stmt/op_binary.rs
@@ -30,6 +30,23 @@ impl BinaryOp {
             _ => todo!(),
         }
     }
+
+    /// Returns the operator that represents an equivalent comparison when the
+    /// operands are commuted (swapped).
+    ///
+    /// For example, `5 < x` becomes `x > 5`, so `Lt.commute()` returns `Gt`.
+    /// Symmetric operators like `Eq` and `Ne` return themselves.
+    pub fn commute(self) -> Self {
+        match self {
+            Self::Eq => Self::Eq,
+            Self::Ne => Self::Ne,
+            Self::Ge => Self::Le,
+            Self::Gt => Self::Lt,
+            Self::Le => Self::Ge,
+            Self::Lt => Self::Gt,
+            Self::IsA => Self::IsA,
+        }
+    }
 }
 
 impl fmt::Display for BinaryOp {

--- a/crates/toasty/src/engine/simplify/expr_binary_op.rs
+++ b/crates/toasty/src/engine/simplify/expr_binary_op.rs
@@ -102,6 +102,11 @@ impl Simplify<'_> {
 
                 Some(self.rewrite_root_path_expr(model, other.take()))
             }
+            // Canonicalization, `literal <op> col` → `col <op_commuted> literal`
+            (Expr::Value(_), rhs) if !rhs.is_value() => {
+                std::mem::swap(lhs, rhs);
+                Some(Expr::binary_op(lhs.take(), op.commute(), rhs.take()))
+            }
             _ => {
                 // For now, just make sure there are no relations in the expression
                 stmt::visit::for_each_expr(lhs, |expr| {
@@ -436,6 +441,115 @@ mod tests {
         // `5 < null` is not simplified
         let mut lhs = Expr::Value(Value::from(5i64));
         let mut rhs = Expr::Value(Value::Null);
+
+        let result = simplify.simplify_expr_binary_op(BinaryOp::Lt, &mut lhs, &mut rhs);
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn canonicalize_eq_literal_on_left() {
+        let schema = test_schema();
+        let mut simplify = Simplify::new(&schema);
+
+        // `5 = x` → `x = 5`
+        let mut lhs = Expr::Value(Value::from(5i64));
+        let mut rhs = Expr::arg(0);
+
+        let result = simplify.simplify_expr_binary_op(BinaryOp::Eq, &mut lhs, &mut rhs);
+
+        let Some(Expr::BinaryOp(binary_op)) = result else {
+            panic!("expected BinaryOp");
+        };
+        assert_eq!(binary_op.op, BinaryOp::Eq);
+        assert!(matches!(*binary_op.lhs, Expr::Arg(_)));
+        assert!(matches!(*binary_op.rhs, Expr::Value(Value::I64(5))));
+    }
+
+    #[test]
+    fn canonicalize_lt_literal_on_left() {
+        let schema = test_schema();
+        let mut simplify = Simplify::new(&schema);
+
+        // `5 < x` → `x > 5`
+        let mut lhs = Expr::Value(Value::from(5i64));
+        let mut rhs = Expr::arg(0);
+
+        let result = simplify.simplify_expr_binary_op(BinaryOp::Lt, &mut lhs, &mut rhs);
+
+        let Some(Expr::BinaryOp(binary_op)) = result else {
+            panic!("expected BinaryOp");
+        };
+        assert_eq!(binary_op.op, BinaryOp::Gt);
+        assert!(matches!(*binary_op.lhs, Expr::Arg(_)));
+        assert!(matches!(*binary_op.rhs, Expr::Value(Value::I64(5))));
+    }
+
+    #[test]
+    fn canonicalize_gt_literal_on_left() {
+        let schema = test_schema();
+        let mut simplify = Simplify::new(&schema);
+
+        // `5 > x` → `x < 5`
+        let mut lhs = Expr::Value(Value::from(5i64));
+        let mut rhs = Expr::arg(0);
+
+        let result = simplify.simplify_expr_binary_op(BinaryOp::Gt, &mut lhs, &mut rhs);
+
+        let Some(Expr::BinaryOp(binary_op)) = result else {
+            panic!("expected BinaryOp");
+        };
+        assert_eq!(binary_op.op, BinaryOp::Lt);
+        assert!(matches!(*binary_op.lhs, Expr::Arg(_)));
+        assert!(matches!(*binary_op.rhs, Expr::Value(Value::I64(5))));
+    }
+
+    #[test]
+    fn canonicalize_le_literal_on_left() {
+        let schema = test_schema();
+        let mut simplify = Simplify::new(&schema);
+
+        // `5 <= x` → `x >= 5`
+        let mut lhs = Expr::Value(Value::from(5i64));
+        let mut rhs = Expr::arg(0);
+
+        let result = simplify.simplify_expr_binary_op(BinaryOp::Le, &mut lhs, &mut rhs);
+
+        let Some(Expr::BinaryOp(binary_op)) = result else {
+            panic!("expected BinaryOp");
+        };
+        assert_eq!(binary_op.op, BinaryOp::Ge);
+        assert!(matches!(*binary_op.lhs, Expr::Arg(_)));
+        assert!(matches!(*binary_op.rhs, Expr::Value(Value::I64(5))));
+    }
+
+    #[test]
+    fn canonicalize_ge_literal_on_left() {
+        let schema = test_schema();
+        let mut simplify = Simplify::new(&schema);
+
+        // `5 >= x` → `x <= 5`
+        let mut lhs = Expr::Value(Value::from(5i64));
+        let mut rhs = Expr::arg(0);
+
+        let result = simplify.simplify_expr_binary_op(BinaryOp::Ge, &mut lhs, &mut rhs);
+
+        let Some(Expr::BinaryOp(binary_op)) = result else {
+            panic!("expected BinaryOp");
+        };
+        assert_eq!(binary_op.op, BinaryOp::Le);
+        assert!(matches!(*binary_op.lhs, Expr::Arg(_)));
+        assert!(matches!(*binary_op.rhs, Expr::Value(Value::I64(5))));
+    }
+
+    #[test]
+    fn no_canonicalize_when_literal_on_right() {
+        let schema = test_schema();
+        let mut simplify = Simplify::new(&schema);
+
+        // `x < 5` is already canonical, no change
+        let mut lhs = Expr::arg(0);
+        let mut rhs = Expr::Value(Value::from(5i64));
 
         let result = simplify.simplify_expr_binary_op(BinaryOp::Lt, &mut lhs, &mut rhs);
 


### PR DESCRIPTION
This PR adds canonicalization simplifications. Briefly, values are always normalized to be on the RHS. See #215 for more details.