### PR TITLE
feat: adds arithemetic operations to the IR

### DIFF
--- a/crates/toasty-core/src/stmt.rs
+++ b/crates/toasty-core/src/stmt.rs
@@ -111,6 +111,9 @@ pub use expr_set::ExprSet;
 mod expr_set_op;
 pub use expr_set_op::ExprSetOp;
 
+mod expr_unary_op;
+pub use expr_unary_op::ExprUnaryOp;
+
 mod expr_stmt;
 pub use expr_stmt::ExprStmt;
 
@@ -160,6 +163,9 @@ pub use offset::Offset;
 
 mod op_binary;
 pub use op_binary::BinaryOp;
+
+mod op_unary;
+pub use op_unary::UnaryOp;
 
 mod order_by;
 pub use order_by::OrderBy;

--- a/crates/toasty-core/src/stmt/expr.rs
+++ b/crates/toasty-core/src/stmt/expr.rs
@@ -4,8 +4,8 @@ use super::{
     expr_reference::ExprReference, Entry, EntryMut, EntryPath, ExprAnd, ExprAny, ExprArg,
     ExprBinaryOp, ExprCast, ExprConcat, ExprConcatStr, ExprEnum, ExprFunc, ExprInList,
     ExprInSubquery, ExprIsNull, ExprKey, ExprList, ExprMap, ExprNot, ExprOr, ExprPattern,
-    ExprProject, ExprRecord, ExprStmt, ExprTy, Node, Projection, Substitute, Type, Value, Visit,
-    VisitMut,
+    ExprProject, ExprRecord, ExprStmt, ExprTy, ExprUnaryOp, Node, Projection, Substitute, Type,
+    Value, Visit, VisitMut,
 };
 use std::fmt;
 
@@ -21,7 +21,7 @@ pub enum Expr {
     /// An argument when the expression is a function body
     Arg(ExprArg),
 
-    /// Binary expression
+    /// Binary operation expression
     BinaryOp(ExprBinaryOp),
 
     /// Cast an expression to a different type
@@ -91,6 +91,9 @@ pub enum Expr {
 
     /// A type reference. This is used by the "is a" expression
     Type(ExprTy),
+
+    /// Unary operation expression
+    UnaryOp(ExprUnaryOp),
 
     /// Evaluates to a constant value reference
     Value(Value),
@@ -432,6 +435,7 @@ impl fmt::Debug for Expr {
             Self::List(e) => e.fmt(f),
             Self::Stmt(e) => e.fmt(f),
             Self::Type(e) => e.fmt(f),
+            Self::UnaryOp(e) => e.fmt(f),
             Self::Value(e) => e.fmt(f),
             Self::DecodeEnum(expr, ty, variant) => f
                 .debug_tuple("DecodeEnum")

--- a/crates/toasty-core/src/stmt/expr_binary_op.rs
+++ b/crates/toasty-core/src/stmt/expr_binary_op.rs
@@ -73,6 +73,26 @@ impl Expr {
     pub fn is_a(lhs: impl Into<Self>, rhs: impl Into<Self>) -> Self {
         Expr::binary_op(lhs, BinaryOp::IsA, rhs)
     }
+
+    pub fn add(lhs: impl Into<Self>, rhs: impl Into<Self>) -> Self {
+        Expr::binary_op(lhs, BinaryOp::Add, rhs)
+    }
+
+    pub fn sub(lhs: impl Into<Self>, rhs: impl Into<Self>) -> Self {
+        Expr::binary_op(lhs, BinaryOp::Sub, rhs)
+    }
+
+    pub fn mul(lhs: impl Into<Self>, rhs: impl Into<Self>) -> Self {
+        Expr::binary_op(lhs, BinaryOp::Mul, rhs)
+    }
+
+    pub fn div(lhs: impl Into<Self>, rhs: impl Into<Self>) -> Self {
+        Expr::binary_op(lhs, BinaryOp::Div, rhs)
+    }
+
+    pub fn modulo(lhs: impl Into<Self>, rhs: impl Into<Self>) -> Self {
+        Expr::binary_op(lhs, BinaryOp::Mod, rhs)
+    }
 }
 
 impl From<ExprBinaryOp> for Expr {

--- a/crates/toasty-core/src/stmt/expr_unary_op.rs
+++ b/crates/toasty-core/src/stmt/expr_unary_op.rs
@@ -1,0 +1,48 @@
+use super::{Expr, UnaryOp};
+
+/// A unary operation expression.
+///
+/// Applies a unary operator to a single operand.
+///
+/// # Examples
+///
+/// ```text
+/// -x        // negation
+/// -5        // negative literal
+/// -(a + b)  // negation of expression
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExprUnaryOp {
+    /// The unary operator.
+    pub op: UnaryOp,
+
+    /// The operand expression.
+    pub expr: Box<Expr>,
+}
+
+impl Expr {
+    /// Creates a unary operation expression.
+    pub fn unary_op(op: UnaryOp, expr: impl Into<Self>) -> Self {
+        ExprUnaryOp {
+            op,
+            expr: Box::new(expr.into()),
+        }
+        .into()
+    }
+
+    /// Creates a negation expression (`-x`).
+    pub fn neg(expr: impl Into<Self>) -> Self {
+        Self::unary_op(UnaryOp::Neg, expr)
+    }
+
+    /// Returns true if this is a `UnaryOp` expression.
+    pub fn is_unary_op(&self) -> bool {
+        matches!(self, Self::UnaryOp(_))
+    }
+}
+
+impl From<ExprUnaryOp> for Expr {
+    fn from(value: ExprUnaryOp) -> Self {
+        Self::UnaryOp(value)
+    }
+}

--- a/crates/toasty-core/src/stmt/op_unary.rs
+++ b/crates/toasty-core/src/stmt/op_unary.rs
@@ -1,0 +1,23 @@
+use std::fmt;
+
+/// Unary operators for expressions.
+// TODO: consider pulling logical negation (`Not`) into this enum.
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub enum UnaryOp {
+    /// Arithmetic negation (`-x`)
+    Neg,
+}
+
+impl fmt::Display for UnaryOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            UnaryOp::Neg => "-".fmt(f),
+        }
+    }
+}
+
+impl fmt::Debug for UnaryOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}

--- a/crates/toasty-core/src/stmt/visit.rs
+++ b/crates/toasty-core/src/stmt/visit.rs
@@ -5,10 +5,10 @@ use super::{
     ExprBeginsWith, ExprBinaryOp, ExprCast, ExprColumn, ExprConcat, ExprEnum, ExprExists, ExprFunc,
     ExprInList, ExprInSubquery, ExprIsNull, ExprKey, ExprLike, ExprList, ExprMap, ExprNot, ExprOr,
     ExprPattern, ExprProject, ExprRecord, ExprReference, ExprSet, ExprSetOp, ExprStmt, ExprTy,
-    Filter, FuncCount, FuncLastInsertId, Insert, InsertTarget, Join, JoinOp, Limit, Node, Offset,
-    OrderBy, OrderByExpr, Path, Projection, Query, Returning, Select, Source, SourceModel,
-    SourceTable, SourceTableId, Statement, TableDerived, TableFactor, TableRef, TableWithJoins,
-    Type, Update, UpdateTarget, Value, ValueRecord, Values, With,
+    ExprUnaryOp, Filter, FuncCount, FuncLastInsertId, Insert, InsertTarget, Join, JoinOp, Limit,
+    Node, Offset, OrderBy, OrderByExpr, Path, Projection, Query, Returning, Select, Source,
+    SourceModel, SourceTable, SourceTableId, Statement, TableDerived, TableFactor, TableRef,
+    TableWithJoins, Type, Update, UpdateTarget, Value, ValueRecord, Values, With,
 };
 
 pub trait Visit {
@@ -153,6 +153,10 @@ pub trait Visit {
 
     fn visit_expr_ty(&mut self, i: &ExprTy) {
         visit_expr_ty(self, i);
+    }
+
+    fn visit_expr_unary_op(&mut self, i: &ExprUnaryOp) {
+        visit_expr_unary_op(self, i);
     }
 
     fn visit_expr_pattern(&mut self, i: &ExprPattern) {
@@ -417,6 +421,10 @@ impl<V: Visit> Visit for &mut V {
         Visit::visit_expr_ty(&mut **self, i);
     }
 
+    fn visit_expr_unary_op(&mut self, i: &ExprUnaryOp) {
+        Visit::visit_expr_unary_op(&mut **self, i);
+    }
+
     fn visit_expr_pattern(&mut self, i: &ExprPattern) {
         Visit::visit_expr_pattern(&mut **self, i);
     }
@@ -609,6 +617,7 @@ where
         Expr::List(expr) => v.visit_expr_list(expr),
         Expr::Stmt(expr) => v.visit_expr_stmt(expr),
         Expr::Type(expr) => v.visit_expr_ty(expr),
+        Expr::UnaryOp(expr) => v.visit_expr_unary_op(expr),
         Expr::Value(expr) => v.visit_value(expr),
         // HAX
         Expr::ConcatStr(expr) => {
@@ -855,6 +864,13 @@ where
     V: Visit + ?Sized,
 {
     v.visit_type(&node.ty);
+}
+
+pub fn visit_expr_unary_op<V>(v: &mut V, node: &ExprUnaryOp)
+where
+    V: Visit + ?Sized,
+{
+    v.visit_expr(&node.expr);
 }
 
 pub fn visit_expr_pattern<V>(v: &mut V, node: &ExprPattern)

--- a/crates/toasty-core/src/stmt/visit_mut.rs
+++ b/crates/toasty-core/src/stmt/visit_mut.rs
@@ -5,10 +5,10 @@ use super::{
     ExprBeginsWith, ExprBinaryOp, ExprCast, ExprColumn, ExprConcat, ExprEnum, ExprExists, ExprFunc,
     ExprInList, ExprInSubquery, ExprIsNull, ExprKey, ExprLike, ExprList, ExprMap, ExprNot, ExprOr,
     ExprPattern, ExprProject, ExprRecord, ExprReference, ExprSet, ExprSetOp, ExprStmt, ExprTy,
-    Filter, FuncCount, FuncLastInsertId, Insert, InsertTarget, Join, JoinOp, Limit, Node, Offset,
-    OrderBy, OrderByExpr, Path, Projection, Query, Returning, Select, Source, SourceModel,
-    SourceTable, SourceTableId, Statement, TableDerived, TableFactor, TableRef, TableWithJoins,
-    Type, Update, UpdateTarget, Value, ValueRecord, Values, With,
+    ExprUnaryOp, Filter, FuncCount, FuncLastInsertId, Insert, InsertTarget, Join, JoinOp, Limit,
+    Node, Offset, OrderBy, OrderByExpr, Path, Projection, Query, Returning, Select, Source,
+    SourceModel, SourceTable, SourceTableId, Statement, TableDerived, TableFactor, TableRef,
+    TableWithJoins, Type, Update, UpdateTarget, Value, ValueRecord, Values, With,
 };
 
 pub trait VisitMut {
@@ -153,6 +153,10 @@ pub trait VisitMut {
 
     fn visit_expr_ty_mut(&mut self, i: &mut ExprTy) {
         visit_expr_ty_mut(self, i);
+    }
+
+    fn visit_expr_unary_op_mut(&mut self, i: &mut ExprUnaryOp) {
+        visit_expr_unary_op_mut(self, i);
     }
 
     fn visit_expr_pattern_mut(&mut self, i: &mut ExprPattern) {
@@ -417,6 +421,10 @@ impl<V: VisitMut> VisitMut for &mut V {
         VisitMut::visit_expr_ty_mut(&mut **self, i);
     }
 
+    fn visit_expr_unary_op_mut(&mut self, i: &mut ExprUnaryOp) {
+        VisitMut::visit_expr_unary_op_mut(&mut **self, i);
+    }
+
     fn visit_expr_pattern_mut(&mut self, i: &mut ExprPattern) {
         VisitMut::visit_expr_pattern_mut(&mut **self, i);
     }
@@ -609,6 +617,7 @@ where
         Expr::List(expr) => v.visit_expr_list_mut(expr),
         Expr::Stmt(expr) => v.visit_expr_stmt_mut(expr),
         Expr::Type(expr) => v.visit_expr_ty_mut(expr),
+        Expr::UnaryOp(expr) => v.visit_expr_unary_op_mut(expr),
         Expr::Value(expr) => v.visit_value_mut(expr),
         // HAX
         Expr::ConcatStr(expr) => {
@@ -855,6 +864,13 @@ where
     V: VisitMut + ?Sized,
 {
     v.visit_type_mut(&mut node.ty);
+}
+
+pub fn visit_expr_unary_op_mut<V>(v: &mut V, node: &mut ExprUnaryOp)
+where
+    V: VisitMut + ?Sized,
+{
+    v.visit_expr_mut(&mut node.expr);
 }
 
 pub fn visit_expr_pattern_mut<V>(v: &mut V, node: &mut ExprPattern)

--- a/crates/toasty-sql/src/serializer/expr.rs
+++ b/crates/toasty-sql/src/serializer/expr.rs
@@ -96,6 +96,9 @@ impl ToSql for &stmt::Expr {
                 let stmt = &*expr.stmt;
                 fmt!(cx, f, "(" stmt ")");
             }
+            UnaryOp(expr) => {
+                fmt!(cx, f, expr.op "(" expr.expr ")");
+            }
             Value(expr) => expr.to_sql(cx, f),
             Default => match f.serializer.flavor {
                 Flavor::Postgresql | Flavor::Mysql => fmt!(cx, f, "DEFAULT"),
@@ -116,7 +119,20 @@ impl ToSql for &stmt::BinaryOp {
             stmt::BinaryOp::Lt => "<",
             stmt::BinaryOp::Le => "<=",
             stmt::BinaryOp::Ne => "<>",
+            stmt::BinaryOp::Add => "+",
+            stmt::BinaryOp::Sub => "-",
+            stmt::BinaryOp::Mul => "*",
+            stmt::BinaryOp::Div => "/",
+            stmt::BinaryOp::Mod => "%",
             _ => todo!(),
+        })
+    }
+}
+
+impl ToSql for &stmt::UnaryOp {
+    fn to_sql<P: Params>(self, _cx: &ExprContext<'_>, f: &mut super::Formatter<'_, P>) {
+        f.dst.push_str(match self {
+            stmt::UnaryOp::Neg => "-",
         })
     }
 }

--- a/crates/toasty/src/engine/simplify.rs
+++ b/crates/toasty/src/engine/simplify.rs
@@ -12,6 +12,7 @@ mod expr_map;
 mod expr_not;
 mod expr_or;
 mod expr_record;
+mod expr_unary_op;
 mod stmt_query;
 mod value;
 
@@ -79,6 +80,7 @@ impl VisitMut for Simplify<'_> {
             Expr::Or(expr) => self.simplify_expr_or(expr),
             Expr::Record(expr) => self.simplify_expr_record(expr),
             Expr::IsNull(expr) => self.simplify_expr_is_null(expr),
+            Expr::UnaryOp(expr) => self.simplify_expr_unary_op(expr),
             _ => None,
         };
 

--- a/crates/toasty/src/engine/simplify/expr_unary_op.rs
+++ b/crates/toasty/src/engine/simplify/expr_unary_op.rs
@@ -1,0 +1,178 @@
+use super::Simplify;
+use toasty_core::stmt::{self, Expr};
+
+impl Simplify<'_> {
+    pub(super) fn simplify_expr_unary_op(&self, expr: &mut stmt::ExprUnaryOp) -> Option<Expr> {
+        match expr.op {
+            stmt::UnaryOp::Neg => self.simplify_neg(expr),
+        }
+    }
+
+    fn simplify_neg(&self, expr: &mut stmt::ExprUnaryOp) -> Option<Expr> {
+        // Double negation: `--x` → `x`
+        if let Expr::UnaryOp(inner) = expr.expr.as_mut() {
+            if matches!(inner.op, stmt::UnaryOp::Neg) {
+                return Some(inner.expr.take());
+            }
+        }
+
+        // Null propagation: `-null` → `null`
+        if expr.expr.is_value_null() {
+            return Some(Expr::null());
+        }
+
+        // Constant folding: `-5` → `-5` as value
+        if let Expr::Value(val) = expr.expr.as_ref() {
+            return fold_neg(val);
+        }
+
+        None
+    }
+}
+
+/// Folds negation of constant values.
+///
+/// Returns `None` if the negation would overflow.
+fn fold_neg(val: &stmt::Value) -> Option<Expr> {
+    let result = match val {
+        stmt::Value::I8(v) => stmt::Value::I8(v.checked_neg()?),
+        stmt::Value::I16(v) => stmt::Value::I16(v.checked_neg()?),
+        stmt::Value::I32(v) => stmt::Value::I32(v.checked_neg()?),
+        stmt::Value::I64(v) => stmt::Value::I64(v.checked_neg()?),
+        _ => return None,
+    };
+    Some(Expr::Value(result))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::simplify::test::test_schema;
+    use toasty_core::stmt::{ExprUnaryOp, UnaryOp, Value};
+
+    fn neg_expr(expr: Expr) -> ExprUnaryOp {
+        ExprUnaryOp {
+            op: UnaryOp::Neg,
+            expr: Box::new(expr),
+        }
+    }
+
+    #[test]
+    fn double_negation_eliminated() {
+        let schema = test_schema();
+        let simplify = Simplify::new(&schema);
+
+        // `--x` → `x`
+        let inner = Expr::neg(Expr::arg(0));
+        let mut expr = neg_expr(inner);
+
+        let result = simplify.simplify_expr_unary_op(&mut expr);
+
+        assert!(matches!(result, Some(Expr::Arg(_))));
+    }
+
+    #[test]
+    fn triple_negation_reduces_to_single() {
+        let schema = test_schema();
+        let simplify = Simplify::new(&schema);
+
+        // `---x` → `-x`
+        let inner = Expr::neg(Expr::neg(Expr::arg(0)));
+        let mut expr = neg_expr(inner);
+
+        let result = simplify.simplify_expr_unary_op(&mut expr);
+
+        assert!(matches!(result, Some(Expr::UnaryOp(_))));
+    }
+
+    #[test]
+    fn neg_null_becomes_null() {
+        let schema = test_schema();
+        let simplify = Simplify::new(&schema);
+
+        // `-null` → `null`
+        let mut expr = neg_expr(Expr::null());
+
+        let result = simplify.simplify_expr_unary_op(&mut expr);
+
+        assert!(matches!(result, Some(Expr::Value(Value::Null))));
+    }
+
+    #[test]
+    fn neg_constant_folding() {
+        let schema = test_schema();
+        let simplify = Simplify::new(&schema);
+
+        // `-5` → `-5` as value
+        let mut expr = neg_expr(Expr::Value(Value::I64(5)));
+
+        let result = simplify.simplify_expr_unary_op(&mut expr);
+
+        assert!(matches!(result, Some(Expr::Value(Value::I64(-5)))));
+    }
+
+    #[test]
+    fn neg_zero_stays_zero() {
+        let schema = test_schema();
+        let simplify = Simplify::new(&schema);
+
+        // `-0` → `0`
+        let mut expr = neg_expr(Expr::Value(Value::I64(0)));
+
+        let result = simplify.simplify_expr_unary_op(&mut expr);
+
+        assert!(matches!(result, Some(Expr::Value(Value::I64(0)))));
+    }
+
+    #[test]
+    fn neg_negative_becomes_positive() {
+        let schema = test_schema();
+        let simplify = Simplify::new(&schema);
+
+        // `-(-3)` → `3` (constant in literal)
+        let mut expr = neg_expr(Expr::Value(Value::I64(-3)));
+
+        let result = simplify.simplify_expr_unary_op(&mut expr);
+
+        assert!(matches!(result, Some(Expr::Value(Value::I64(3)))));
+    }
+
+    #[test]
+    fn neg_i32_constant_folding() {
+        let schema = test_schema();
+        let simplify = Simplify::new(&schema);
+
+        // `-5i32` → `-5i32` as value
+        let mut expr = neg_expr(Expr::Value(Value::I32(5)));
+
+        let result = simplify.simplify_expr_unary_op(&mut expr);
+
+        assert!(matches!(result, Some(Expr::Value(Value::I32(-5)))));
+    }
+
+    #[test]
+    fn neg_non_constant_not_simplified() {
+        let schema = test_schema();
+        let simplify = Simplify::new(&schema);
+
+        // `-x` where x is not a constant
+        let mut expr = neg_expr(Expr::arg(0));
+
+        let result = simplify.simplify_expr_unary_op(&mut expr);
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn neg_i8_min_not_simplified() {
+        let schema = test_schema();
+        let simplify = Simplify::new(&schema);
+
+        // `-i8::MIN` would overflow, so not simplified
+        let mut expr = neg_expr(Expr::Value(Value::I8(i8::MIN)));
+
+        let result = simplify.simplify_expr_unary_op(&mut expr);
+
+        assert!(result.is_none());
+    }
+}


### PR DESCRIPTION
This PR adds arithmetic operations to the IR along with some simplifications. I think it should really be a discussion ground as to whether supporting arithmetic representations is going to be useful in `toasty` down the line. I can see it being useful in things like precomputed columns and customized select statements where you want to do the operations within the database rather than in Rust. Open to thoughts.