### PR TITLE
Move Capability to Driver

### DIFF
--- a/crates/toasty-core/src/driver.rs
+++ b/crates/toasty-core/src/driver.rs
@@ -13,6 +13,9 @@ use std::{fmt::Debug, sync::Arc};
 
 #[async_trait]
 pub trait Driver: Debug + Send + Sync + 'static {
+    /// Describes the driver's capability, which informs the query planner.
+    fn capability(&self) -> &'static Capability;
+
     /// Creates a new connection to the database.
     ///
     /// This method is called by the [`Pool`] whenever a [`Connection`] is requested while none is
@@ -28,9 +31,6 @@ pub trait Driver: Debug + Send + Sync + 'static {
 
 #[async_trait]
 pub trait Connection: Debug + Send + 'static {
-    /// Describes the driver's capability, which informs the query planner.
-    fn capability(&self) -> &'static Capability;
-
     /// Execute a database operation
     async fn exec(&mut self, schema: &Arc<Schema>, plan: Operation) -> crate::Result<Response>;
 

--- a/crates/toasty-driver-dynamodb/src/lib.rs
+++ b/crates/toasty-driver-dynamodb/src/lib.rs
@@ -39,6 +39,10 @@ impl DynamoDb {
 
 #[async_trait]
 impl Driver for DynamoDb {
+    fn capability(&self) -> &'static Capability {
+        &Capability::DYNAMODB
+    }
+
     async fn connect(&self) -> toasty_core::Result<Box<dyn toasty_core::driver::Connection>> {
         Ok(Box::new(Connection::connect(&self.url).await?))
     }
@@ -107,10 +111,6 @@ impl Connection {
 
 #[async_trait]
 impl toasty_core::driver::Connection for Connection {
-    fn capability(&self) -> &'static Capability {
-        &Capability::DYNAMODB
-    }
-
     async fn exec(&mut self, schema: &Arc<Schema>, op: Operation) -> Result<Response> {
         self.exec2(schema, op).await
     }

--- a/crates/toasty-driver-integration-suite/src/logging_driver.rs
+++ b/crates/toasty-driver-integration-suite/src/logging_driver.rs
@@ -32,6 +32,10 @@ impl LoggingDriver {
 
 #[async_trait]
 impl Driver for LoggingDriver {
+    fn capability(&self) -> &'static Capability {
+        self.inner.capability()
+    }
+
     async fn connect(&self) -> Result<Box<dyn Connection>> {
         Ok(Box::new(LoggingConnection {
             inner: self.inner.connect().await?,
@@ -59,10 +63,6 @@ pub struct LoggingConnection {
 
 #[async_trait]
 impl Connection for LoggingConnection {
-    fn capability(&self) -> &'static Capability {
-        self.inner.capability()
-    }
-
     async fn exec(&mut self, schema: &Arc<Schema>, operation: Operation) -> Result<Response> {
         // Clone the operation for logging
         let operation_clone = operation.clone();

--- a/crates/toasty-driver-integration-suite/src/test.rs
+++ b/crates/toasty-driver-integration-suite/src/test.rs
@@ -22,9 +22,6 @@ pub struct Test {
 
     /// List of all tables created during the test. These will need to be removed later.
     tables: Vec<String>,
-
-    /// Cached driver capability
-    capability: &'static toasty::driver::Capability,
 }
 
 impl Test {
@@ -34,20 +31,12 @@ impl Test {
             .build()
             .expect("failed to create Tokio runtime");
 
-        // Get capability early
-        let driver = setup.driver();
-        let capability = runtime.block_on(async {
-            let conn = driver.connect().await.expect("failed to connect");
-            conn.capability()
-        });
-
         Test {
             setup,
             isolate: Isolate::new(),
             runtime: Some(runtime),
             exec_log: ExecLog::new(Arc::new(Mutex::new(Vec::new()))),
             tables: vec![],
-            capability,
         }
     }
 
@@ -79,7 +68,7 @@ impl Test {
 
     /// Get the driver capability
     pub fn capability(&self) -> &'static toasty::driver::Capability {
-        self.capability
+        self.setup.driver().capability()
     }
 
     /// Get the execution log for assertions

--- a/crates/toasty-driver-mysql/src/lib.rs
+++ b/crates/toasty-driver-mysql/src/lib.rs
@@ -66,6 +66,10 @@ impl From<Pool> for MySQL {
 
 #[async_trait]
 impl Driver for MySQL {
+    fn capability(&self) -> &'static Capability {
+        &Capability::MYSQL
+    }
+
     async fn connect(&self) -> Result<Box<dyn toasty_core::driver::Connection>> {
         let conn = self
             .pool
@@ -164,10 +168,6 @@ impl From<Conn> for Connection {
 
 #[async_trait]
 impl toasty_core::driver::Connection for Connection {
-    fn capability(&self) -> &'static Capability {
-        &Capability::MYSQL
-    }
-
     async fn exec(&mut self, schema: &Arc<Schema>, op: Operation) -> Result<Response> {
         let (sql, ret, last_insert_id_hack): (sql::Statement, _, _) = match op {
             Operation::QuerySql(op) => (op.stmt.into(), op.ret, op.last_insert_id_hack),

--- a/crates/toasty-driver-postgresql/src/lib.rs
+++ b/crates/toasty-driver-postgresql/src/lib.rs
@@ -79,6 +79,10 @@ impl PostgreSQL {
 
 #[async_trait]
 impl Driver for PostgreSQL {
+    fn capability(&self) -> &'static Capability {
+        &Capability::POSTGRESQL
+    }
+
     async fn connect(&self) -> toasty_core::Result<Box<dyn toasty_core::driver::Connection>> {
         Ok(Box::new(
             Connection::connect(self.config.clone(), tokio_postgres::NoTls).await?,
@@ -206,10 +210,6 @@ impl From<Client> for Connection {
 
 #[async_trait]
 impl toasty_core::driver::Connection for Connection {
-    fn capability(&self) -> &'static Capability {
-        &Capability::POSTGRESQL
-    }
-
     async fn exec(&mut self, schema: &Arc<Schema>, op: Operation) -> Result<Response> {
         let (sql, ret_tys): (sql::Statement, _) = match op {
             Operation::Insert(op) => (op.stmt.into(), None),

--- a/crates/toasty-driver-sqlite/src/lib.rs
+++ b/crates/toasty-driver-sqlite/src/lib.rs
@@ -57,6 +57,10 @@ impl Sqlite {
 
 #[async_trait]
 impl Driver for Sqlite {
+    fn capability(&self) -> &'static Capability {
+        &Capability::SQLITE
+    }
+
     async fn connect(&self) -> toasty_core::Result<Box<dyn toasty_core::Connection>> {
         let connection = match self {
             Sqlite::File(path) => Connection::open(path)?,
@@ -92,10 +96,6 @@ impl Connection {
 
 #[toasty_core::async_trait]
 impl toasty_core::driver::Connection for Connection {
-    fn capability(&self) -> &'static Capability {
-        &Capability::SQLITE
-    }
-
     async fn exec(&mut self, schema: &Arc<Schema>, op: Operation) -> Result<Response> {
         let (sql, ret_tys): (sql::Statement, _) = match op {
             Operation::QuerySql(op) => {

--- a/crates/toasty/src/db/builder.rs
+++ b/crates/toasty/src/db/builder.rs
@@ -46,7 +46,7 @@ impl Builder {
     }
 
     pub async fn build(&mut self, driver: impl Driver) -> Result<Db> {
-        let pool = Pool::new(driver).await?;
+        let pool = Pool::new(driver)?;
 
         // Validate capability consistency
         pool.capability().validate()?;

--- a/crates/toasty/src/db/connect.rs
+++ b/crates/toasty/src/db/connect.rs
@@ -82,6 +82,10 @@ impl Connect {
 
 #[async_trait]
 impl Driver for Connect {
+    fn capability(&self) -> &'static Capability {
+        self.driver.capability()
+    }
+
     async fn connect(&self) -> Result<Box<dyn Connection>> {
         self.driver.connect().await
     }

--- a/tests/src/logging_driver.rs
+++ b/tests/src/logging_driver.rs
@@ -32,6 +32,10 @@ impl LoggingDriver {
 
 #[async_trait]
 impl Driver for LoggingDriver {
+    fn capability(&self) -> &'static Capability {
+        self.inner.capability()
+    }
+
     async fn connect(&self) -> Result<Box<dyn Connection>> {
         Ok(Box::new(LoggingConnection {
             inner: self.inner.connect().await?,
@@ -59,10 +63,6 @@ pub struct LoggingConnection {
 
 #[async_trait]
 impl Connection for LoggingConnection {
-    fn capability(&self) -> &'static Capability {
-        self.inner.capability()
-    }
-
     async fn exec(&mut self, schema: &Arc<Schema>, operation: Operation) -> Result<Response> {
         // Clone the operation for logging
         let operation_clone = operation.clone();


### PR DESCRIPTION
This pr removes a [`TODO!`](https://github.com/tokio-rs/toasty/blob/194d327baa89d5687e4d963c92bd2eb41e6f93d6/crates/toasty/src/db/pool.rs#L43) comment by moving the capability method from `Connection` to `Driver`.