### PR TITLE
Run DynamoDB tests serially to prevent port conflicts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
         - name: Start dynamodb-local
           run: sudo docker run --name dynamodb -d -p 8000:8000 amazon/dynamodb-local:latest -jar DynamoDBLocal.jar -port 8000
         - name: cargo test
-          run: cargo test --workspace --no-default-features --features dynamodb
+          run: cargo test --workspace --no-default-features --features dynamodb -- --test-threads 1
 
     test-all-os:
         needs: check


### PR DESCRIPTION
## Summary
Modified the CI workflow to run DynamoDB integration tests with a single thread to prevent concurrent test execution issues.

## Changes
- Updated the `cargo test` command in the DynamoDB CI job to include `-- --test-threads 1` flag
- This ensures tests run sequentially rather than in parallel

## Details
DynamoDB-local runs on a fixed port (8000) during testing. Running tests in parallel can cause port binding conflicts when multiple test instances attempt to connect simultaneously. By forcing single-threaded test execution, we ensure each test has exclusive access to the DynamoDB-local instance, preventing flaky test failures due to resource contention.

https://claude.ai/code/session_01LmrW43Hj2BJWzU4ovEjtey