### PR TITLE
Support "postgres" URL scheme for PostgreSQL

### DIFF
--- a/crates/toasty-driver-postgresql/src/lib.rs
+++ b/crates/toasty-driver-postgresql/src/lib.rs
@@ -31,7 +31,7 @@ impl PostgreSQL {
         let url_str = url.into();
         let url = Url::parse(&url_str).map_err(toasty_core::Error::driver_operation_failed)?;
 
-        if url.scheme() != "postgresql" {
+        if !matches!(url.scheme(), "postgresql" | "postgres") {
             return Err(toasty_core::Error::invalid_connection_url(format!(
                 "connection URL does not have a `postgresql` scheme; url={}",
                 url

--- a/crates/toasty/src/db/connect.rs
+++ b/crates/toasty/src/db/connect.rs
@@ -56,9 +56,9 @@ impl Connect {
             }
 
             #[cfg(feature = "postgresql")]
-            "postgresql" => Box::new(toasty_driver_postgresql::PostgreSQL::new(url)?),
+            "postgresql" | "postgres" => Box::new(toasty_driver_postgresql::PostgreSQL::new(url)?),
             #[cfg(not(feature = "postgresql"))]
-            "postgresql" => {
+            "postgresql" | "postgres" => {
                 return Err(toasty_core::Error::unsupported_feature(
                     "`postgresql` feature not enabled",
                 ))


### PR DESCRIPTION
Postgres supports both `postgres://` as well as `postgresql://` URL scheme (see https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS) so I think we should, too.