### PR TITLE
Use batch execute for applying Postgres migrations

### DIFF
--- a/crates/toasty-driver-postgresql/src/lib.rs
+++ b/crates/toasty-driver-postgresql/src/lib.rs
@@ -382,7 +382,7 @@ impl toasty_core::driver::Connection for Connection {
         // Execute each migration statement
         for statement in migration.statements() {
             if let Err(e) = transaction
-                .execute(statement, &[])
+                .batch_execute(statement)
                 .await
                 .map_err(toasty_core::Error::driver_operation_failed)
             {


### PR DESCRIPTION
The current migration system has "statement breakpoints" to support databases which don't support executing multiple statements in a single command. Postgres does support it, but only if you use `tokio_postgres`'s `batch_execute` which is currently not the case.