### PR TITLE
Remove dead enum code and serde from drivers

### DIFF
--- a/crates/toasty-core/src/schema/db/ty.rs
+++ b/crates/toasty-core/src/schema/db/ty.rs
@@ -150,8 +150,6 @@ impl Type {
                 // TODO: not really correct, but we are getting rid of ID types
                 // most likely.
                 stmt::Type::Id(_) => Ok(db.default_string_type.clone()),
-                // Enum types are stored as strings in the database
-                stmt::Type::Enum(_) => Ok(db.default_string_type.clone()),
                 _ => Err(crate::Error::unsupported_feature(format!(
                     "type {:?} is not supported by this database",
                     ty

--- a/crates/toasty-core/src/stmt.rs
+++ b/crates/toasty-core/src/stmt.rs
@@ -219,7 +219,7 @@ mod ty;
 pub use ty::Type;
 
 mod ty_enum;
-pub use ty_enum::{EnumVariant, TypeEnum};
+pub use ty_enum::TypeEnum;
 
 #[cfg(feature = "jiff")]
 mod ty_jiff;

--- a/crates/toasty-core/src/stmt/ty_enum.rs
+++ b/crates/toasty-core/src/stmt/ty_enum.rs
@@ -3,29 +3,7 @@ use super::Type;
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TypeEnum {
-    pub variants: Vec<EnumVariant>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct EnumVariant {
-    /// Enum discriminant
-    pub discriminant: usize,
-
-    /// Enum fields
-    pub fields: Vec<Type>,
-}
-
-impl TypeEnum {
-    pub fn insert_variant(&mut self) -> &mut EnumVariant {
-        let discriminant = self.variants.len();
-        self.variants.push(EnumVariant {
-            discriminant,
-            fields: vec![],
-        });
-
-        &mut self.variants[discriminant]
-    }
+    // Will be populated in Phase 2 of embedded enum support
 }
 
 impl From<TypeEnum> for Type {

--- a/crates/toasty-driver-dynamodb/Cargo.toml
+++ b/crates/toasty-driver-dynamodb/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 toasty-core.workspace = true
 aws-config.workspace = true
 aws-sdk-dynamodb.workspace = true
-serde.workspace = true
-serde_json.workspace = true
+
 url.workspace = true
 uuid.workspace = true

--- a/crates/toasty-driver-dynamodb/src/type.rs
+++ b/crates/toasty-driver-dynamodb/src/type.rs
@@ -10,7 +10,7 @@ impl TypeExt for stmt::Type {
     fn to_ddb_type(&self) -> ScalarAttributeType {
         match self {
             stmt::Type::Bool => ScalarAttributeType::N,
-            stmt::Type::String | stmt::Type::Enum(..) => ScalarAttributeType::S,
+            stmt::Type::String => ScalarAttributeType::S,
             stmt::Type::I8 | stmt::Type::I16 | stmt::Type::I32 | stmt::Type::I64 => {
                 ScalarAttributeType::N
             }

--- a/crates/toasty-driver-dynamodb/src/value.rs
+++ b/crates/toasty-driver-dynamodb/src/value.rs
@@ -1,8 +1,5 @@
 use aws_sdk_dynamodb::types::AttributeValue;
-use toasty_core::{
-    schema::app,
-    stmt::{self, Value as CoreValue},
-};
+use toasty_core::stmt::{self, Value as CoreValue};
 
 #[derive(Debug)]
 pub struct Value(CoreValue);
@@ -40,41 +37,6 @@ impl Value {
             (Type::Id(model), AV::S(val)) => {
                 stmt::Value::from(stmt::Id::from_string(*model, val.clone()))
             }
-            (Type::Enum(..), AV::S(val)) => {
-                let (variant, rest) = val.split_once("#").unwrap();
-                let variant: usize = variant.parse().unwrap();
-                let v: V = serde_json::from_str(rest).unwrap();
-                let value = match v {
-                    V::Bool(v) => stmt::Value::Bool(v),
-                    V::Null => stmt::Value::Null,
-                    V::String(v) => stmt::Value::String(v),
-                    V::Id(model, v) => {
-                        stmt::Value::Id(stmt::Id::from_string(app::ModelId(model), v))
-                    }
-                    V::I8(v) => stmt::Value::I8(v),
-                    V::I16(v) => stmt::Value::I16(v),
-                    V::I32(v) => stmt::Value::I32(v),
-                    V::I64(v) => stmt::Value::I64(v),
-                    V::U8(v) => stmt::Value::U8(v),
-                    V::U16(v) => stmt::Value::U16(v),
-                    V::U32(v) => stmt::Value::U32(v),
-                    V::U64(v) => stmt::Value::U64(v),
-                };
-
-                if value.is_null() {
-                    stmt::ValueEnum {
-                        variant,
-                        fields: stmt::ValueRecord::from_vec(vec![]),
-                    }
-                    .into()
-                } else {
-                    stmt::ValueEnum {
-                        variant,
-                        fields: stmt::ValueRecord::from_vec(vec![value]),
-                    }
-                    .into()
-                }
-            }
             _ => todo!("ty={:#?}; value={:#?}", ty, val),
         };
 
@@ -99,28 +61,6 @@ impl Value {
             stmt::Value::Bytes(val) => AV::B(val.clone().into()),
             stmt::Value::Uuid(val) => AV::S(val.to_string()),
             stmt::Value::Id(val) => AV::S(val.to_string()),
-            stmt::Value::Enum(val) => {
-                let v = match &val.fields[..] {
-                    [] => V::Null,
-                    [stmt::Value::Bool(v)] => V::Bool(*v),
-                    [stmt::Value::String(v)] => V::String(v.to_string()),
-                    [stmt::Value::I8(v)] => V::I8(*v),
-                    [stmt::Value::I16(v)] => V::I16(*v),
-                    [stmt::Value::I32(v)] => V::I32(*v),
-                    [stmt::Value::I64(v)] => V::I64(*v),
-                    [stmt::Value::U8(v)] => V::U8(*v),
-                    [stmt::Value::U16(v)] => V::U16(*v),
-                    [stmt::Value::U32(v)] => V::U32(*v),
-                    [stmt::Value::U64(v)] => V::U64(*v),
-                    [stmt::Value::Id(id)] => V::Id(id.model_id().0, id.to_string()),
-                    _ => todo!("val={:#?}", val.fields),
-                };
-                AV::S(format!(
-                    "{}#{}",
-                    val.variant,
-                    serde_json::to_string(&v).unwrap()
-                ))
-            }
             stmt::Value::List(vals) => {
                 let items = vals
                     .iter()
@@ -131,20 +71,4 @@ impl Value {
             _ => todo!("{:#?}", self.0),
         }
     }
-}
-
-#[derive(serde::Serialize, serde::Deserialize)]
-enum V {
-    Bool(bool),
-    Null,
-    String(String),
-    I8(i8),
-    I16(i16),
-    I32(i32),
-    I64(i64),
-    U8(u8),
-    U16(u16),
-    U32(u32),
-    U64(u64),
-    Id(usize, String),
 }

--- a/crates/toasty-driver-sqlite/Cargo.toml
+++ b/crates/toasty-driver-sqlite/Cargo.toml
@@ -11,6 +11,3 @@ rusqlite.workspace = true
 url.workspace = true
 uuid.workspace = true
 
-# TODO: get rid of
-serde.workspace = true
-serde_json.workspace = true

--- a/crates/toasty-driver-sqlite/src/value.rs
+++ b/crates/toasty-driver-sqlite/src/value.rs
@@ -72,36 +72,7 @@ impl ToSql for Value {
             Value::String(v) => Ok(ToSqlOutput::Borrowed(ValueRef::Text(v.as_bytes()))),
             Value::Bytes(v) => Ok(ToSqlOutput::Borrowed(ValueRef::Blob(&v[..]))),
             Value::Null => Ok(ToSqlOutput::Owned(SqlValue::Null)),
-            Value::Enum(value_enum) => {
-                let v = match &value_enum.fields[..] {
-                    [] => V::Null,
-                    [stmt::Value::Bool(v)] => V::Bool(*v),
-                    [stmt::Value::String(v)] => V::String(v.to_string()),
-                    [stmt::Value::I64(v)] => V::I64(*v),
-                    [stmt::Value::Id(id)] => V::Id(id.model_id().0, id.to_string()),
-                    _ => todo!("val={:#?}", value_enum.fields),
-                };
-
-                Ok(ToSqlOutput::Owned(
-                    format!(
-                        "{}#{}",
-                        value_enum.variant,
-                        serde_json::to_string(&v).unwrap()
-                    )
-                    .into(),
-                ))
-            }
             _ => todo!("value = {:#?}", self.0),
         }
     }
-}
-
-#[derive(serde::Serialize, serde::Deserialize)]
-enum V {
-    Bool(bool),
-    Null,
-    String(String),
-    I8(i8),
-    I64(i64),
-    Id(usize, String),
 }

--- a/crates/toasty-sql/src/stmt/ty.rs
+++ b/crates/toasty-sql/src/stmt/ty.rs
@@ -30,7 +30,6 @@ impl ColumnType {
                     Self::Text
                 }
             }
-            stmt::Type::Enum(_) => Self::Text,
             _ => todo!("ty={:#?}", ty),
         }
     }


### PR DESCRIPTION
## Summary

- Remove old single-column JSON serialization code for enums from both drivers (the `V` serde helper enums and associated arms in `from_sql`/`to_sql`/`from_ddb`/`to_ddb`)
- Strip `EnumVariant` from `TypeEnum` (dead code — `insert_variant()` was never called from codegen); keep `TypeEnum` as an empty placeholder for the upcoming embedded enum implementation
- Remove dead `Type::Enum` arms from `toasty-sql` and `toasty-core`'s db schema type mapping
- Remove `serde` and `serde_json` dependencies from `toasty-driver-sqlite` and `toasty-driver-dynamodb` (the TODO comment in sqlite's Cargo.toml is now resolved)