### PR TITLE
Add database function expressions to roadmap

### DIFF
--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -58,6 +58,28 @@ Toasty is an easy-to-use ORM for Rust that supports both SQL and NoSQL databases
 - Subquery improvements
 - Better conditional/dynamic query building ergonomics
 
+**Database Function Expressions**
+- Allow database-side functions (e.g. `NOW()`, `CURRENT_TIMESTAMP`) as expressions in create and update operations
+- User API: field setters accept `toasty::stmt` helpers like `toasty::stmt::now()` that resolve to `core::stmt::ExprFunc` variants
+  ```rust
+  // Set updated_at to the database's current time instead of a Rust-side value
+  user.update()
+      .updated_at(toasty::stmt::now())
+      .exec(&db)
+      .await?;
+
+  // Also usable in create operations
+  User::create()
+      .name("Alice")
+      .created_at(toasty::stmt::now())
+      .exec(&db)
+      .await?;
+  ```
+- Extend `ExprFunc` enum in `toasty-core` with new function variants (e.g. `Now`)
+- SQL serialization for each function across supported databases (`NOW()` for PostgreSQL/MySQL, `datetime('now')` for SQLite)
+- Codegen: update field setter generation to accept both value types and function expressions
+- Future: support additional scalar functions (e.g. `COALESCE`, `LOWER`, `UPPER`, `LENGTH`)
+
 **Raw SQL Support**
 - Execute arbitrary SQL statements directly
 - Parameterized queries with type-safe bindings


### PR DESCRIPTION
## Summary
This PR updates the project roadmap to document planned support for database-side function expressions in create and update operations.

## Changes
- Added "Database Function Expressions" section to the roadmap outlining a feature to allow database functions (e.g., `NOW()`, `CURRENT_TIMESTAMP`) as expressions in ORM operations
- Documented the proposed user-facing API with `toasty::stmt` helper functions that resolve to `core::stmt::ExprFunc` variants
- Included concrete usage examples showing how to set fields to database-computed values in both `create()` and `update()` operations
- Outlined implementation requirements:
  - Extend `ExprFunc` enum in `toasty-core` with new function variants
  - Add SQL serialization for each function across supported databases (PostgreSQL, MySQL, SQLite)
  - Update codegen to generate field setters accepting both value types and function expressions
- Noted future expansion to support additional scalar functions (COALESCE, LOWER, UPPER, LENGTH)

## Notes
This is a roadmap documentation update that captures planned functionality for database function expressions support.

https://claude.ai/code/session_01SgGkn3M88YCpTzUvt6yJEH