### PR TITLE
Add transaction isolation levels and read-only mode to Operation::Transaction

### DIFF
--- a/crates/toasty-core/src/driver.rs
+++ b/crates/toasty-core/src/driver.rs
@@ -5,7 +5,7 @@ mod response;
 pub use response::{Response, Rows};
 
 pub mod operation;
-pub use operation::Operation;
+pub use operation::{IsolationLevel, Operation};
 
 use crate::{
     async_trait,

--- a/crates/toasty-core/src/driver/operation.rs
+++ b/crates/toasty-core/src/driver/operation.rs
@@ -17,7 +17,7 @@ mod query_sql;
 pub use query_sql::QuerySql;
 
 mod transaction;
-pub use transaction::Transaction;
+pub use transaction::{IsolationLevel, Transaction};
 
 mod update_by_key;
 pub use update_by_key::UpdateByKey;

--- a/crates/toasty-core/src/driver/operation/transaction.rs
+++ b/crates/toasty-core/src/driver/operation/transaction.rs
@@ -1,9 +1,27 @@
 use super::Operation;
 
+/// Isolation levels supported across SQL backends.
+///
+/// Not all backends support all levels — the driver will return an error
+/// if an unsupported level is requested.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IsolationLevel {
+    ReadUncommitted,
+    ReadCommitted,
+    RepeatableRead,
+    Serializable,
+}
+
 #[derive(Debug, Clone)]
 pub enum Transaction {
-    /// Start a transaction
-    Start,
+    /// Start a transaction with optional configuration.
+    ///
+    /// When `isolation` is `None` and `read_only` is `false`, the database's
+    /// default isolation level and read-write mode are used.
+    Start {
+        isolation: Option<IsolationLevel>,
+        read_only: bool,
+    },
 
     /// Commit a transaction
     Commit,
@@ -19,6 +37,16 @@ pub enum Transaction {
 
     /// Rollback to a savepoint, undoing work since it was created
     RollbackToSavepoint(usize),
+}
+
+impl Transaction {
+    /// Start a transaction with database defaults.
+    pub fn start() -> Self {
+        Self::Start {
+            isolation: None,
+            read_only: false,
+        }
+    }
 }
 
 impl From<Transaction> for Operation {

--- a/crates/toasty-sql/src/serializer.rs
+++ b/crates/toasty-sql/src/serializer.rs
@@ -30,7 +30,7 @@ mod value;
 use crate::stmt::Statement;
 
 use toasty_core::{
-    driver::operation::Transaction,
+    driver::operation::{IsolationLevel, Transaction},
     schema::db::{self, Index, Table},
 };
 
@@ -102,15 +102,61 @@ impl<'a> Serializer<'a> {
     /// while other databases use `BEGIN`). Savepoints are named `sp_{id}`.
     pub fn serialize_transaction(&self, op: &Transaction) -> String {
         match op {
-            Transaction::Start => match self.flavor {
-                Flavor::Mysql => "START TRANSACTION".to_string(),
-                _ => "BEGIN".to_string(),
-            },
+            Transaction::Start {
+                isolation,
+                read_only,
+            } => self.serialize_transaction_start(*isolation, *read_only),
             Transaction::Commit => "COMMIT".to_string(),
             Transaction::Rollback => "ROLLBACK".to_string(),
             Transaction::Savepoint(id) => format!("SAVEPOINT sp_{id}"),
             Transaction::ReleaseSavepoint(id) => format!("RELEASE SAVEPOINT sp_{id}"),
             Transaction::RollbackToSavepoint(id) => format!("ROLLBACK TO SAVEPOINT sp_{id}"),
+        }
+    }
+
+    fn serialize_transaction_start(
+        &self,
+        isolation: Option<IsolationLevel>,
+        read_only: bool,
+    ) -> String {
+        fn isolation_level_str(level: IsolationLevel) -> &'static str {
+            match level {
+                IsolationLevel::ReadUncommitted => "READ UNCOMMITTED",
+                IsolationLevel::ReadCommitted => "READ COMMITTED",
+                IsolationLevel::RepeatableRead => "REPEATABLE READ",
+                IsolationLevel::Serializable => "SERIALIZABLE",
+            }
+        }
+
+        match self.flavor {
+            Flavor::Mysql => {
+                let mut sql = String::new();
+                if let Some(level) = isolation {
+                    sql.push_str("SET TRANSACTION ISOLATION LEVEL ");
+                    sql.push_str(isolation_level_str(level));
+                    sql.push_str("; ");
+                }
+                sql.push_str("START TRANSACTION");
+                if read_only {
+                    sql.push_str(" READ ONLY");
+                }
+                sql
+            }
+            Flavor::Postgresql => {
+                let mut sql = String::from("BEGIN");
+                if let Some(level) = isolation {
+                    sql.push_str(" ISOLATION LEVEL ");
+                    sql.push_str(isolation_level_str(level));
+                }
+                if read_only {
+                    sql.push_str(" READ ONLY");
+                }
+                sql
+            }
+            Flavor::Sqlite => {
+                // SQLite doesn't support per-transaction isolation levels or read-only mode
+                "BEGIN".to_string()
+            }
         }
     }
 

--- a/crates/toasty/src/engine/exec.rs
+++ b/crates/toasty/src/engine/exec.rs
@@ -79,7 +79,7 @@ impl Engine {
 
         if plan.needs_transaction {
             exec.connection
-                .exec(&self.schema.db, Transaction::Start.into())
+                .exec(&self.schema.db, Transaction::start().into())
                 .await?;
             exec.in_transaction = true;
         }

--- a/crates/toasty/src/engine/exec/rmw.rs
+++ b/crates/toasty/src/engine/exec/rmw.rs
@@ -45,7 +45,7 @@ impl Exec<'_> {
             )
         } else {
             (
-                Transaction::Start,
+                Transaction::start(),
                 Transaction::Commit,
                 Transaction::Rollback,
             )


### PR DESCRIPTION
Adds `IsolationLevel` enum and read-only mode that can be configured in `operation::Transaction::Start` and is serialized to SQL depending on dialect.