### PR TITLE
Add transaction error variants

### DIFF
--- a/crates/toasty-core/src/error/read_only_transaction.rs
+++ b/crates/toasty-core/src/error/read_only_transaction.rs
@@ -1,0 +1,31 @@
+use super::Error;
+
+#[derive(Debug)]
+pub(super) struct ReadOnlyTransaction {
+    message: Box<str>,
+}
+
+impl std::error::Error for ReadOnlyTransaction {}
+
+impl core::fmt::Display for ReadOnlyTransaction {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "read-only transaction: {}", self.message)
+    }
+}
+
+impl Error {
+    /// Creates a read-only transaction error.
+    ///
+    /// Returned when a write operation is attempted inside a read-only
+    /// transaction (e.g. PostgreSQL SQLSTATE 25006, MySQL error 1792).
+    pub fn read_only_transaction(message: impl Into<String>) -> Error {
+        Error::from(super::ErrorKind::ReadOnlyTransaction(ReadOnlyTransaction {
+            message: message.into().into(),
+        }))
+    }
+
+    /// Returns `true` if this error is a read-only transaction error.
+    pub fn is_read_only_transaction(&self) -> bool {
+        matches!(self.kind(), super::ErrorKind::ReadOnlyTransaction(_))
+    }
+}

--- a/crates/toasty-core/src/error/serialization_failure.rs
+++ b/crates/toasty-core/src/error/serialization_failure.rs
@@ -1,0 +1,33 @@
+use super::Error;
+
+#[derive(Debug)]
+pub(super) struct SerializationFailure {
+    message: Box<str>,
+}
+
+impl std::error::Error for SerializationFailure {}
+
+impl core::fmt::Display for SerializationFailure {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "transaction serialization failure: {}", self.message)
+    }
+}
+
+impl Error {
+    /// Creates a serialization failure error.
+    ///
+    /// Returned when the database aborts a transaction due to a serialization
+    /// conflict (e.g. PostgreSQL SQLSTATE 40001, MySQL error 1213).
+    pub fn serialization_failure(message: impl Into<String>) -> Error {
+        Error::from(super::ErrorKind::SerializationFailure(
+            SerializationFailure {
+                message: message.into().into(),
+            },
+        ))
+    }
+
+    /// Returns `true` if this error is a serialization failure.
+    pub fn is_serialization_failure(&self) -> bool {
+        matches!(self.kind(), super::ErrorKind::SerializationFailure(_))
+    }
+}

--- a/crates/toasty-core/src/error/transaction_timeout.rs
+++ b/crates/toasty-core/src/error/transaction_timeout.rs
@@ -1,0 +1,29 @@
+use std::time::Duration;
+
+use crate::{error::ErrorKind, Error};
+
+#[derive(Debug)]
+pub(super) struct TransactionTimeout {
+    duration: Duration,
+}
+
+impl Error {
+    /// Returned when the transaction closure exceeds the configured timeout.
+    /// The transaction is automatically rolled back.
+    pub fn transaction_timeout(duration: Duration) -> Error {
+        ErrorKind::TransactionTimeout(TransactionTimeout { duration }).into()
+    }
+
+    /// Returns `true` if this error is a transaction timeout.
+    pub fn is_transaction_timeout(&self) -> bool {
+        matches!(self.kind(), ErrorKind::TransactionTimeout(_))
+    }
+}
+
+impl std::error::Error for TransactionTimeout {}
+
+impl core::fmt::Display for TransactionTimeout {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Transaction timed out after {:?}", self.duration)
+    }
+}

--- a/crates/toasty-driver-dynamodb/src/lib.rs
+++ b/crates/toasty-driver-dynamodb/src/lib.rs
@@ -10,7 +10,7 @@ use toasty_core::{
     driver::{operation::Operation, Capability, Driver, Response},
     schema::db::{Column, ColumnId, Migration, Schema, SchemaDiff, Table},
     stmt::{self, ExprContext},
-    Result,
+    Error, Result,
 };
 
 use aws_sdk_dynamodb::{
@@ -200,6 +200,9 @@ impl Connection {
                     _ => todo!("op={:#?}", op),
                 }
             }
+            Operation::Transaction(_) => Err(Error::unsupported_feature(
+                "transactions are not supported by the DynamoDB driver",
+            )),
             _ => todo!("op={op:#?}"),
         }
     }

--- a/crates/toasty-driver-postgresql/src/lib.rs
+++ b/crates/toasty-driver-postgresql/src/lib.rs
@@ -269,10 +269,17 @@ impl toasty_core::driver::Connection for Connection {
     async fn exec(&mut self, schema: &Arc<Schema>, op: Operation) -> Result<Response> {
         if let Operation::Transaction(ref t) = op {
             let sql = sql::Serializer::postgresql(schema).serialize_transaction(t);
-            self.client
-                .execute(&sql as &str, &[])
-                .await
-                .map_err(toasty_core::Error::driver_operation_failed)?;
+            self.client.batch_execute(&sql).await.map_err(|e| {
+                if let Some(db_err) = e.as_db_error() {
+                    match db_err.code().code() {
+                        "40001" => toasty_core::Error::serialization_failure(db_err.message()),
+                        "25006" => toasty_core::Error::read_only_transaction(db_err.message()),
+                        _ => toasty_core::Error::driver_operation_failed(e),
+                    }
+                } else {
+                    toasty_core::Error::driver_operation_failed(e)
+                }
+            })?;
             return Ok(Response::count(0));
         }
 


### PR DESCRIPTION
Extracts out error variants from #343. 

I believe the rollback error is no longer necessary if we go for the drop guard API in #374.

The timeout error is currently unused but I think it would be good to add later on.