### PR TITLE
fix: bound Relation trait by Sized

### DIFF
--- a/crates/toasty/src/relation.rs
+++ b/crates/toasty/src/relation.rs
@@ -13,7 +13,7 @@ use super::Model;
 
 use toasty_core::schema::app::FieldId;
 
-pub trait Relation {
+pub trait Relation: Sized {
     /// The target model
     type Model: Model;
 


### PR DESCRIPTION
Add `Sized` bound to the `Relation` trait to ensure trait objects are properly constrained.

This prevents potential issues with unsized types and aligns with Rust trait object semantics.