### PR TITLE
simplify: OR tautology elimination for enum variants

### DIFF
--- a/crates/toasty/src/engine/simplify/expr_or.rs
+++ b/crates/toasty/src/engine/simplify/expr_or.rs
@@ -1,4 +1,5 @@
 use super::Simplify;
+use bit_set::BitSet;
 use std::mem;
 use toasty_core::stmt;
 
@@ -68,6 +69,12 @@ impl Simplify<'_> {
 
         // Complement law, `a or not(a)` → `true` (only if `a` is non-nullable)
         if self.try_complement_or(expr) {
+            return Some(true.into());
+        }
+
+        // Variant tautology: `is_variant(x, 0) or is_variant(x, 1)` covering all
+        // variants of the enum → `true`
+        if self.try_variant_tautology_or(expr) {
             return Some(true.into());
         }
 
@@ -181,6 +188,46 @@ impl Simplify<'_> {
         }
 
         false
+    }
+
+    /// Checks for variant tautology: when all variants of an enum are tested
+    /// via `IsVariant` on the same expression, the OR is always true.
+    ///
+    /// `is_variant(x, 0) or is_variant(x, 1)` over `{0, 1}` → `true`
+    fn try_variant_tautology_or(&self, expr: &stmt::ExprOr) -> bool {
+        // Find the first IsVariant to use as anchor
+        let Some(first) = expr.operands.iter().find_map(|op| match op {
+            stmt::Expr::IsVariant(iv) => Some(iv),
+            _ => None,
+        }) else {
+            return false;
+        };
+
+        let anchor_expr = &first.expr;
+        let model_id = first.variant.model;
+        let num_variants = self
+            .schema()
+            .app
+            .model(model_id)
+            .expect_embedded_enum()
+            .variants
+            .len();
+
+        let mut seen = BitSet::with_capacity(num_variants);
+
+        for operand in &expr.operands {
+            let stmt::Expr::IsVariant(iv) = operand else {
+                continue;
+            };
+
+            if iv.expr != *anchor_expr || iv.variant.model != model_id {
+                return false;
+            }
+
+            seen.insert(iv.variant.index);
+        }
+
+        seen.len() == num_variants
     }
 
     /// Converts disjunctive equality chains to IN lists.

--- a/crates/toasty/src/engine/simplify/tests/expr_or.rs
+++ b/crates/toasty/src/engine/simplify/tests/expr_or.rs
@@ -1,4 +1,4 @@
-use super::test_schema;
+use super::{test_schema, test_schema_with};
 use crate::engine::simplify::Simplify;
 use toasty_core::stmt::{Expr, ExprOr};
 
@@ -814,4 +814,308 @@ fn error_or_true_becomes_true() {
 
     assert!(result.is_some());
     assert!(result.unwrap().is_true());
+}
+
+// Variant tautology tests
+
+mod variant_tautology {
+    use super::*;
+    use crate as toasty;
+    use crate::model::Register;
+    use toasty_core::schema::app::VariantId;
+
+    #[derive(Debug, PartialEq, toasty::Embed)]
+    enum TwoVariant {
+        #[column(variant = 1)]
+        A,
+        #[column(variant = 2)]
+        B,
+    }
+
+    #[derive(Debug, PartialEq, toasty::Embed)]
+    enum ThreeVariant {
+        #[column(variant = 1)]
+        X,
+        #[column(variant = 2)]
+        Y,
+        #[column(variant = 3)]
+        Z,
+    }
+
+    #[test]
+    fn all_two_variants_becomes_true() {
+        let schema = test_schema_with(&[TwoVariant::schema()]);
+        let mut simplify = Simplify::new(&schema);
+
+        let model_id = TwoVariant::id();
+
+        // `is_variant(x, 0) or is_variant(x, 1)` → `true`
+        let mut expr = ExprOr {
+            operands: vec![
+                Expr::is_variant(
+                    Expr::arg(0),
+                    VariantId {
+                        model: model_id,
+                        index: 0,
+                    },
+                ),
+                Expr::is_variant(
+                    Expr::arg(0),
+                    VariantId {
+                        model: model_id,
+                        index: 1,
+                    },
+                ),
+            ],
+        };
+        let result = simplify.simplify_expr_or(&mut expr);
+
+        assert!(result.is_some());
+        assert!(result.unwrap().is_true());
+    }
+
+    #[test]
+    fn all_three_variants_becomes_true() {
+        let schema = test_schema_with(&[ThreeVariant::schema()]);
+        let mut simplify = Simplify::new(&schema);
+
+        let model_id = ThreeVariant::id();
+
+        // `is_variant(x, 0) or is_variant(x, 1) or is_variant(x, 2)` → `true`
+        let mut expr = ExprOr {
+            operands: vec![
+                Expr::is_variant(
+                    Expr::arg(0),
+                    VariantId {
+                        model: model_id,
+                        index: 0,
+                    },
+                ),
+                Expr::is_variant(
+                    Expr::arg(0),
+                    VariantId {
+                        model: model_id,
+                        index: 1,
+                    },
+                ),
+                Expr::is_variant(
+                    Expr::arg(0),
+                    VariantId {
+                        model: model_id,
+                        index: 2,
+                    },
+                ),
+            ],
+        };
+        let result = simplify.simplify_expr_or(&mut expr);
+
+        assert!(result.is_some());
+        assert!(result.unwrap().is_true());
+    }
+
+    #[test]
+    fn subset_of_variants_not_simplified() {
+        let schema = test_schema_with(&[ThreeVariant::schema()]);
+        let mut simplify = Simplify::new(&schema);
+
+        let model_id = ThreeVariant::id();
+
+        // `is_variant(x, 0) or is_variant(x, 1)` over 3-variant enum → no change
+        let mut expr = ExprOr {
+            operands: vec![
+                Expr::is_variant(
+                    Expr::arg(0),
+                    VariantId {
+                        model: model_id,
+                        index: 0,
+                    },
+                ),
+                Expr::is_variant(
+                    Expr::arg(0),
+                    VariantId {
+                        model: model_id,
+                        index: 1,
+                    },
+                ),
+            ],
+        };
+        let result = simplify.simplify_expr_or(&mut expr);
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn single_variant_of_two_not_simplified() {
+        let schema = test_schema_with(&[TwoVariant::schema()]);
+        let mut simplify = Simplify::new(&schema);
+
+        let model_id = TwoVariant::id();
+
+        // `is_variant(x, 0) or other` — only 1 of 2 variants → no tautology
+        let mut expr = ExprOr {
+            operands: vec![
+                Expr::is_variant(
+                    Expr::arg(0),
+                    VariantId {
+                        model: model_id,
+                        index: 0,
+                    },
+                ),
+                Expr::arg(1),
+            ],
+        };
+        let result = simplify.simplify_expr_or(&mut expr);
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn all_variants_with_extra_operands_becomes_true() {
+        let schema = test_schema_with(&[TwoVariant::schema()]);
+        let mut simplify = Simplify::new(&schema);
+
+        let model_id = TwoVariant::id();
+
+        // `is_variant(x, 0) or other_expr or is_variant(x, 1)` → `true`
+        let mut expr = ExprOr {
+            operands: vec![
+                Expr::is_variant(
+                    Expr::arg(0),
+                    VariantId {
+                        model: model_id,
+                        index: 0,
+                    },
+                ),
+                Expr::arg(5),
+                Expr::is_variant(
+                    Expr::arg(0),
+                    VariantId {
+                        model: model_id,
+                        index: 1,
+                    },
+                ),
+            ],
+        };
+        let result = simplify.simplify_expr_or(&mut expr);
+
+        assert!(result.is_some());
+        assert!(result.unwrap().is_true());
+    }
+
+    #[test]
+    fn different_inner_exprs_not_simplified() {
+        let schema = test_schema_with(&[TwoVariant::schema()]);
+        let mut simplify = Simplify::new(&schema);
+
+        let model_id = TwoVariant::id();
+
+        // `is_variant(x, 0) or is_variant(y, 1)` — different inner exprs → no change
+        let mut expr = ExprOr {
+            operands: vec![
+                Expr::is_variant(
+                    Expr::arg(0),
+                    VariantId {
+                        model: model_id,
+                        index: 0,
+                    },
+                ),
+                Expr::is_variant(
+                    Expr::arg(1),
+                    VariantId {
+                        model: model_id,
+                        index: 1,
+                    },
+                ),
+            ],
+        };
+        let result = simplify.simplify_expr_or(&mut expr);
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn duplicate_variants_not_simplified() {
+        let schema = test_schema_with(&[ThreeVariant::schema()]);
+        let mut simplify = Simplify::new(&schema);
+
+        let model_id = ThreeVariant::id();
+
+        // `is_variant(x, 0) or is_variant(x, 0) or is_variant(x, 1)` — duplicates
+        // cover only 2 of 3 variants after dedup → no tautology
+        let mut expr = ExprOr {
+            operands: vec![
+                Expr::is_variant(
+                    Expr::arg(0),
+                    VariantId {
+                        model: model_id,
+                        index: 0,
+                    },
+                ),
+                Expr::is_variant(
+                    Expr::arg(0),
+                    VariantId {
+                        model: model_id,
+                        index: 0,
+                    },
+                ),
+                Expr::is_variant(
+                    Expr::arg(0),
+                    VariantId {
+                        model: model_id,
+                        index: 1,
+                    },
+                ),
+            ],
+        };
+        let result = simplify.simplify_expr_or(&mut expr);
+
+        // Idempotent fires first, removing the duplicate. Then 2 of 3 → no tautology.
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn reversed_order_becomes_true() {
+        let schema = test_schema_with(&[TwoVariant::schema()]);
+        let mut simplify = Simplify::new(&schema);
+
+        let model_id = TwoVariant::id();
+
+        // `is_variant(x, 1) or is_variant(x, 0)` (reversed) → `true`
+        let mut expr = ExprOr {
+            operands: vec![
+                Expr::is_variant(
+                    Expr::arg(0),
+                    VariantId {
+                        model: model_id,
+                        index: 1,
+                    },
+                ),
+                Expr::is_variant(
+                    Expr::arg(0),
+                    VariantId {
+                        model: model_id,
+                        index: 0,
+                    },
+                ),
+            ],
+        };
+        let result = simplify.simplify_expr_or(&mut expr);
+
+        assert!(result.is_some());
+        assert!(result.unwrap().is_true());
+    }
+
+    #[test]
+    fn no_is_variant_operands_not_simplified() {
+        let schema = test_schema();
+        let mut simplify = Simplify::new(&schema);
+
+        // `arg(0) or arg(1)` — no IsVariant at all → no tautology
+        let mut expr = ExprOr {
+            operands: vec![Expr::arg(0), Expr::arg(1)],
+        };
+        let result = simplify.simplify_expr_or(&mut expr);
+
+        assert!(result.is_none());
+    }
 }

--- a/docs/design/embedded-enums-data-carrying-impl.md
+++ b/docs/design/embedded-enums-data-carrying-impl.md
@@ -240,15 +240,15 @@ Equivalent encoding to be determined when implementing the DynamoDB driver phase
 6. **Integration tests**: CRUD for data-carrying enums; full-value equality filter;
    variant-only filter (`is_email()`); unit enum variant filter (`is_pending()`).
 
+7. **Variant+field filter** (`contact().email().matches(|e| e.address().eq("x"))`):
+   per-variant field accessors with closure-based `.matches()` API.
+
+8. **OR tautology elimination**: `is_variant(x, 0) or is_variant(x, 1)` covering all
+   variants of an enum folds to `true` in the OR simplifier.
+
 ### Remaining
 
-- **Variant+field filter** (`contact().email().address().eq("x")`): per-variant field
-  accessors that project into the variant's data fields. Requires generating
-  accessor methods on the fields struct for each variant's fields.
-
 - **Partial updates**: within-variant partial update builder.
-
-- **OR tautology elimination**: `is_bar() || is_baz()` over `{Bar, Baz}` → `TRUE`.
 
 - **DynamoDB**: equivalent encoding in the DynamoDB driver.
 


### PR DESCRIPTION
## Changes

- Add variant tautology detection to OR simplification
- When all variants of an enum are tested via `IsVariant` on the same expression, the OR simplifies to `true`
- Example: `is_variant(x, 0) or is_variant(x, 1)` over a 2-variant enum → `true`

## Implementation Details

- New `try_variant_tautology_or()` method in `expr_or.rs` using `BitSet` to track covered variants
- Validates all operands test the same inner expression and enum model
- Comprehensive test suite covering:
  - All variants covered (becomes true)
  - Partial variant coverage (no simplification)
  - Different inner expressions (no simplification)
  - Mixed operand types (non-IsVariant operands ignored)
  - Order independence

## Documentation

- Updated design doc to mark OR tautology elimination as complete