### PR TITLE
fix: fully qualify Register::id() in Embed derive codegen

### DIFF
--- a/crates/toasty-codegen/src/expand.rs
+++ b/crates/toasty-codegen/src/expand.rs
@@ -105,7 +105,7 @@ pub(super) fn embedded_model(model: &Model) -> TokenStream {
             const NULLABLE: bool = false;
 
             fn ty() -> #toasty::Type {
-                #toasty::Type::Model(Self::id())
+                #toasty::Type::Model(<Self as #toasty::Register>::id())
             }
 
             fn load(value: #toasty::Value) -> #toasty::Result<Self> {
@@ -130,7 +130,7 @@ pub(super) fn embedded_model(model: &Model) -> TokenStream {
             fn field_ty(_storage_ty: Option<#toasty::schema::db::Type>) -> #toasty::schema::app::FieldTy {
                 #toasty::schema::app::FieldTy::Embedded(
                     #toasty::schema::app::Embedded {
-                        target: Self::id(),
+                        target: <Self as #toasty::Register>::id(),
                         expr_ty: Self::ty(),
                     }
                 )
@@ -242,7 +242,7 @@ pub(super) fn embedded_enum(model: &Model) -> TokenStream {
             ) -> #toasty::schema::app::FieldTy {
                 #toasty::schema::app::FieldTy::Embedded(
                     #toasty::schema::app::Embedded {
-                        target: Self::id(),
+                        target: <Self as #toasty::Register>::id(),
                         expr_ty: Self::ty(),
                     }
                 )

--- a/crates/toasty-codegen/src/expand/embedded_enum.rs
+++ b/crates/toasty-codegen/src/expand/embedded_enum.rs
@@ -402,7 +402,7 @@ impl Expand<'_> {
     pub(super) fn expand_enum_primitive_ty(&self) -> TokenStream {
         let toasty = &self.toasty;
         if self.expand_enum_has_data_variants() {
-            quote! { #toasty::Type::Model(Self::id()) }
+            quote! { #toasty::Type::Model(<Self as #toasty::Register>::id()) }
         } else {
             quote! { #toasty::Type::I64 }
         }

--- a/tests/tests/embed_no_trait_import.rs
+++ b/tests/tests/embed_no_trait_import.rs
@@ -1,0 +1,32 @@
+//! Test that `#[derive(Embed)]` works without importing toasty traits.
+//!
+//! Regression test: the generated code previously called `Self::id()` inside
+//! the `Primitive` impl without qualifying the `Register` trait, causing
+//! `E0599: no variant or associated item named 'id'` when the user had not
+//! imported `toasty::Register` (or `toasty::Embed`) in scope.
+
+// Intentionally no `use toasty::*` or `use toasty::{Embed, Register}` here.
+
+#[derive(Debug, toasty::Embed)]
+pub enum AuthTokenKind {
+    #[column(variant = 0)]
+    EmailVerification,
+    #[column(variant = 1)]
+    PasswordReset,
+}
+
+#[derive(Debug, toasty::Embed)]
+pub struct Address {
+    street: String,
+    city: String,
+}
+
+/// If this compiles, the fix is working: generated code fully qualifies trait methods.
+#[test]
+fn embed_compiles_without_trait_imports() {
+    let _ = AuthTokenKind::EmailVerification;
+    let _ = Address {
+        street: "123 Main".into(),
+        city: "Springfield".into(),
+    };
+}


### PR DESCRIPTION
## Summary
Fully qualify `Register::id()` calls in generated `Embed` derive code to fix compilation errors when the `Register` trait is not imported.

## Changes
- Updated `Embed` derive codegen to use `<Self as toasty::Register>::id()` instead of `Self::id()` in:
  - `embedded_model()` - Type impl (2 occurrences)
  - `embedded_enum()` - FieldTy impl (1 occurrence)
  - `expand_enum_primitive_ty()` - enum primitive type expansion (1 occurrence)
- Added regression test `embed_no_trait_import.rs` to verify `#[derive(Embed)]` works without explicit trait imports

## Motivation
Previously, generated code called unqualified `Self::id()` which required users to import `toasty::Register` or `toasty::Embed` traits. The fix allows the derive macro to work seamlessly without requiring manual trait imports.