### PR TITLE
feat: support indexing embedded struct fields

### DIFF
--- a/crates/toasty-codegen/src/expand/schema.rs
+++ b/crates/toasty-codegen/src/expand/schema.rs
@@ -36,6 +36,7 @@ impl Expand<'_> {
                             id,
                             name: #name,
                             fields: #fields,
+                            indices: #indices,
                         }
                     )
                 }

--- a/crates/toasty-core/src/schema/app/model.rs
+++ b/crates/toasty-core/src/schema/app/model.rs
@@ -91,6 +91,13 @@ pub struct EmbeddedStruct {
 
     /// Fields contained by the embedded struct
     pub fields: Vec<Field>,
+
+    /// Indices defined on this embedded struct's fields.
+    ///
+    /// These reference fields within this embedded struct (not the parent model).
+    /// The schema builder propagates them to physical DB indexes on the parent
+    /// table's flattened columns.
+    pub indices: Vec<Index>,
 }
 
 impl EmbeddedStruct {

--- a/crates/toasty-core/src/schema/builder/table.rs
+++ b/crates/toasty-core/src/schema/builder/table.rs
@@ -183,47 +183,77 @@ impl BuildTableFromModels<'_> {
         }
         .build_mapping(root);
 
-        self.populate_model_indices(model.id(), root);
+        let model_fields = &self.mapping.model(model.id()).fields;
+        let mut indices = Vec::new();
+        self.collect_indices(&root.fields, model_fields, &root.indices, &mut indices);
+
+        for index in indices {
+            if index.primary_key {
+                self.table.primary_key.columns = index.columns.iter().map(|c| c.column).collect();
+            }
+
+            self.table.indices.push(index);
+        }
     }
 
-    fn populate_model_indices(&mut self, model_id: app::ModelId, root: &ModelRoot) {
-        for model_index in &root.indices {
+    /// Collects DB-level indices from app-level index definitions, then recurses
+    /// into embedded struct fields to collect their indices as well.
+    fn collect_indices(
+        &self,
+        fields: &[app::Field],
+        field_mappings: &[mapping::Field],
+        indices: &[app::Index],
+        out: &mut Vec<db::Index>,
+    ) {
+        for app_index in indices {
             let mut index = db::Index {
                 id: IndexId {
                     table: self.table.id,
-                    index: self.table.indices.len(),
+                    index: out.len(),
                 },
                 name: String::new(),
                 on: self.table.id,
                 columns: vec![],
-                unique: model_index.unique,
-                primary_key: model_index.primary_key,
+                unique: app_index.unique,
+                primary_key: app_index.primary_key,
             };
 
-            for index_field in &model_index.fields {
-                let column = self.mapping.model(model_id).fields[index_field.field.index]
+            for index_field in &app_index.fields {
+                let column = field_mappings[index_field.field.index]
                     .as_primitive()
-                    .unwrap()
+                    .expect("indexed field should map to a primitive column")
                     .column;
 
-                match &root.fields[index_field.field.index].ty {
-                    app::FieldTy::Primitive(_) => index.columns.push(db::IndexColumn {
-                        column,
-                        op: index_field.op,
-                        scope: index_field.scope,
-                    }),
-                    app::FieldTy::Embedded(_) => todo!("embedded field indexing"),
-                    app::FieldTy::BelongsTo(_) => todo!(),
-                    app::FieldTy::HasMany(_) => todo!(),
-                    app::FieldTy::HasOne(_) => todo!(),
-                }
-
-                if model_index.primary_key {
-                    self.table.primary_key.columns.push(column);
-                }
+                index.columns.push(db::IndexColumn {
+                    column,
+                    op: index_field.op,
+                    scope: index_field.scope,
+                });
             }
 
-            self.table.indices.push(index);
+            out.push(index);
+        }
+
+        for (field_index, field) in fields.iter().enumerate() {
+            let app::FieldTy::Embedded(embedded) = &field.ty else {
+                continue;
+            };
+
+            let app::Model::EmbeddedStruct(embedded_struct) = self.app.model(embedded.target)
+            else {
+                continue;
+            };
+
+            let field_mapping = field_mappings[field_index]
+                .as_struct()
+                .expect("embedded struct field should have struct mapping");
+
+            self.collect_indices(
+                &embedded_struct.fields,
+                &field_mapping.fields,
+                &embedded_struct.indices,
+                out,
+            );
         }
     }
 

--- a/crates/toasty-core/tests/schema_resolve_field.rs
+++ b/crates/toasty-core/tests/schema_resolve_field.rs
@@ -142,6 +142,7 @@ fn schema() -> Schema {
             prim_field(ADDRESS, 0, "street"),
             prim_field(ADDRESS, 1, "city"),
         ],
+        indices: vec![],
     });
 
     let user = Model::Root(ModelRoot {

--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -8,6 +8,7 @@ pub mod default_and_update;
 pub mod embedded_enum_data;
 pub mod embedded_enum_unit;
 pub mod embedded_struct;
+pub mod embedded_struct_index;
 pub mod field_auto;
 pub mod field_column_name;
 pub mod field_column_type;

--- a/crates/toasty-driver-integration-suite/src/tests/embedded_struct_index.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embedded_struct_index.rs
@@ -1,0 +1,178 @@
+use crate::prelude::*;
+
+/// Tests that `#[unique]` and `#[index]` on embedded struct fields produce
+/// physical DB indices on the flattened columns.
+#[driver_test]
+pub async fn embedded_struct_index_schema(test: &mut Test) {
+    #[derive(Debug, toasty::Embed)]
+    struct Contact {
+        #[unique]
+        email: String,
+        #[index]
+        country: String,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        id: String,
+        name: String,
+        #[allow(dead_code)]
+        contact: Contact,
+    }
+
+    let db = test.setup_db(models!(User, Contact)).await;
+    let schema = db.schema();
+
+    // The embedded struct should carry its indices in the app schema
+    assert_struct!(schema.app.models, #{
+        Contact::id(): toasty::schema::app::Model::EmbeddedStruct(_ {
+            indices.len(): 2,
+            ..
+        }),
+        ..
+    });
+
+    // The DB table should have indices on the flattened embedded columns.
+    // Index 0: primary key (id)
+    // Index 1: unique on contact_email
+    // Index 2: non-unique on contact_country
+    let table = &schema.db.tables[0];
+    let contact_email_col = table
+        .columns
+        .iter()
+        .find(|c| c.name == "contact_email")
+        .expect("contact_email column should exist");
+    let contact_country_col = table
+        .columns
+        .iter()
+        .find(|c| c.name == "contact_country")
+        .expect("contact_country column should exist");
+
+    // Should have 3 indices total: PK + unique email + non-unique country
+    assert_eq!(table.indices.len(), 3);
+
+    // Unique index on contact_email
+    let email_index = &table.indices[1];
+    assert!(email_index.unique);
+    assert!(!email_index.primary_key);
+    assert_eq!(email_index.columns.len(), 1);
+    assert_eq!(email_index.columns[0].column, contact_email_col.id);
+
+    // Non-unique index on contact_country
+    let country_index = &table.indices[2];
+    assert!(!country_index.unique);
+    assert!(!country_index.primary_key);
+    assert_eq!(country_index.columns.len(), 1);
+    assert_eq!(country_index.columns[0].column, contact_country_col.id);
+}
+
+/// Tests that unique constraint on embedded struct field is enforced at the
+/// database level and that filtering by indexed embedded fields works.
+#[driver_test]
+pub async fn embedded_struct_unique_index_enforced(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Embed)]
+    struct Contact {
+        #[unique]
+        email: String,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        id: String,
+        name: String,
+        contact: Contact,
+    }
+
+    let mut db = test.setup_db(models!(User, Contact)).await;
+
+    // Create a user with a contact email
+    User::create()
+        .id("1")
+        .name("Alice")
+        .contact(Contact {
+            email: "alice@example.com".to_string(),
+        })
+        .exec(&mut db)
+        .await?;
+
+    // Creating another user with the same contact email should fail
+    assert_err!(
+        User::create()
+            .id("2")
+            .name("Bob")
+            .contact(Contact {
+                email: "alice@example.com".to_string(),
+            })
+            .exec(&mut db)
+            .await
+    );
+
+    // Creating a user with a different email works
+    User::create()
+        .id("3")
+        .name("Charlie")
+        .contact(Contact {
+            email: "charlie@example.com".to_string(),
+        })
+        .exec(&mut db)
+        .await?;
+
+    // Filter by the indexed embedded field
+    let users = User::filter(User::fields().contact().email().eq("alice@example.com"))
+        .collect::<Vec<_>>(&mut db)
+        .await?;
+
+    assert_eq!(users.len(), 1);
+    assert_eq!(users[0].name, "Alice");
+
+    Ok(())
+}
+
+/// Tests that `#[index]` on a field inside a nested embedded struct (embed
+/// within embed) produces a physical DB index on the deeply-flattened column.
+#[driver_test]
+pub async fn nested_embedded_struct_index(test: &mut Test) {
+    #[derive(Debug, toasty::Embed)]
+    struct Geo {
+        #[index]
+        city: String,
+        zip: String,
+    }
+
+    #[derive(Debug, toasty::Embed)]
+    struct Address {
+        street: String,
+        #[allow(dead_code)]
+        geo: Geo,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        id: String,
+        #[allow(dead_code)]
+        address: Address,
+    }
+
+    let db = test.setup_db(models!(User, Address, Geo)).await;
+    let schema = db.schema();
+
+    let table = &schema.db.tables[0];
+
+    // The nested embedded field should be flattened to address_geo_city
+    let city_col = table
+        .columns
+        .iter()
+        .find(|c| c.name == "address_geo_city")
+        .expect("address_geo_city column should exist");
+
+    // Should have 2 indices: PK + non-unique on address_geo_city
+    assert_eq!(table.indices.len(), 2);
+
+    let city_index = &table.indices[1];
+    assert!(!city_index.unique);
+    assert_eq!(city_index.columns.len(), 1);
+    assert_eq!(city_index.columns[0].column, city_col.id);
+}

--- a/crates/toasty-macros/src/lib.rs
+++ b/crates/toasty-macros/src/lib.rs
@@ -16,7 +16,7 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
     }
 }
 
-#[proc_macro_derive(Embed, attributes(column))]
+#[proc_macro_derive(Embed, attributes(column, index, unique))]
 pub fn derive_embed(input: TokenStream) -> TokenStream {
     match toasty_codegen::generate_embed(input.into()) {
         Ok(output) => output.into(),


### PR DESCRIPTION
## Changes

- Add `indices` field to `EmbeddedStruct` to track index definitions on embedded struct fields
- Refactor `populate_model_indices()` into recursive `collect_indices()` that propagates indices from embedded structs to physical DB indices on flattened columns
- Support nested embedded struct indexing (embed within embed)
- Update codegen to include `indices` in schema expansion
- Add `#[index]` and `#[unique]` attributes to `#[derive(Embed)]` macro
- Add comprehensive integration tests for embedded struct indexing
  - Schema validation for flattened indices
  - Unique constraint enforcement at DB level
  - Nested embedded struct index support