### PR TITLE
feat: add #[serialize] attribute bookkeeping and design doc

### DIFF
--- a/crates/toasty-codegen/src/expand.rs
+++ b/crates/toasty-codegen/src/expand.rs
@@ -127,7 +127,10 @@ pub(super) fn embedded_model(model: &Model) -> TokenStream {
                 #update_struct_ident { stmt, projection }
             }
 
-            fn field_ty(_storage_ty: Option<#toasty::schema::db::Type>) -> #toasty::schema::app::FieldTy {
+            fn field_ty(
+                _storage_ty: Option<#toasty::schema::db::Type>,
+                _serialize: Option<#toasty::schema::app::SerializeFormat>,
+            ) -> #toasty::schema::app::FieldTy {
                 #toasty::schema::app::FieldTy::Embedded(
                     #toasty::schema::app::Embedded {
                         target: Self::id(),
@@ -189,6 +192,7 @@ pub(super) fn embedded_enum(model: &Model) -> TokenStream {
                         discriminant: #toasty::schema::app::FieldPrimitive {
                             ty: #toasty::Type::I64,
                             storage_ty: ::std::option::Option::None,
+                            serialize: ::std::option::Option::None,
                         },
                         variants: vec![ #( #variant_tokens ),* ],
                         fields: vec![ #( #field_tokens ),* ],
@@ -239,6 +243,7 @@ pub(super) fn embedded_enum(model: &Model) -> TokenStream {
 
             fn field_ty(
                 _storage_ty: Option<#toasty::schema::db::Type>,
+                _serialize: Option<#toasty::schema::app::SerializeFormat>,
             ) -> #toasty::schema::app::FieldTy {
                 #toasty::schema::app::FieldTy::Embedded(
                     #toasty::schema::app::Embedded {

--- a/crates/toasty-codegen/src/expand/embedded_enum.rs
+++ b/crates/toasty-codegen/src/expand/embedded_enum.rs
@@ -249,7 +249,7 @@ impl Expand<'_> {
                             app_name: #app_name.to_string(),
                             storage_name: None,
                         },
-                        ty: <#ty as #toasty::stmt::Primitive>::field_ty(None),
+                        ty: <#ty as #toasty::stmt::Primitive>::field_ty(None, None),
                         nullable: <#ty as #toasty::stmt::Primitive>::NULLABLE,
                         primary_key: false,
                         auto: None,

--- a/crates/toasty-codegen/src/expand/schema.rs
+++ b/crates/toasty-codegen/src/expand/schema.rs
@@ -1,5 +1,5 @@
 use super::{util, Expand};
-use crate::schema::{AutoStrategy, Column, FieldTy, ModelKind, Name, UuidVersion};
+use crate::schema::{AutoStrategy, Column, FieldTy, ModelKind, Name, SerializeFormat, UuidVersion};
 
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -87,8 +87,15 @@ impl Expand<'_> {
                         _ => quote!(None),
                     };
 
+                    let serialize = match &field.attrs.serialize {
+                        Some(SerializeFormat::Json) => {
+                            quote!(Some(#toasty::schema::app::SerializeFormat::Json))
+                        }
+                        None => quote!(None),
+                    };
+
                     nullable = quote!(<#ty as #toasty::stmt::Primitive>::NULLABLE);
-                    field_ty = quote!(<#ty as #toasty::stmt::Primitive>::field_ty(#storage_ty));
+                    field_ty = quote!(<#ty as #toasty::stmt::Primitive>::field_ty(#storage_ty, #serialize));
                 }
                 FieldTy::BelongsTo(rel) => {
                     let ty = &rel.ty;

--- a/crates/toasty-codegen/src/schema.rs
+++ b/crates/toasty-codegen/src/schema.rs
@@ -8,7 +8,7 @@ mod error;
 pub(crate) use error::ErrorSet;
 
 mod field;
-pub(crate) use field::{Field, FieldAttr, FieldTy};
+pub(crate) use field::{Field, FieldAttr, FieldTy, SerializeFormat};
 
 mod fk;
 pub(crate) use fk::ForeignKeyField;

--- a/crates/toasty-codegen/src/schema/field.rs
+++ b/crates/toasty-codegen/src/schema/field.rs
@@ -4,6 +4,12 @@ use super::{BelongsTo, Column, ErrorSet, HasMany, HasOne, Name};
 
 use syn::spanned::Spanned;
 
+/// Codegen-level representation of a serialization format.
+#[derive(Debug, Clone)]
+pub(crate) enum SerializeFormat {
+    Json,
+}
+
 #[derive(Debug)]
 pub(crate) struct Field {
     /// Index of field in the containing model
@@ -51,6 +57,9 @@ pub(crate) struct FieldAttr {
 
     /// Expression to apply on create and update: `#[update(<expr>)]`
     pub(crate) update_expr: Option<syn::Expr>,
+
+    /// Serialization format for the field: `#[serialize(json)]`
+    pub(crate) serialize: Option<SerializeFormat>,
 }
 
 #[derive(Debug)]
@@ -94,6 +103,7 @@ impl Field {
             column: None,
             default_expr: None,
             update_expr: None,
+            serialize: None,
         };
 
         let mut ty = None;
@@ -190,6 +200,23 @@ impl Field {
                 } else {
                     attrs.update_expr = Some(attr.parse_args()?);
                 }
+            } else if attr.path().is_ident("serialize") {
+                if attrs.serialize.is_some() {
+                    errs.push(syn::Error::new_spanned(
+                        attr,
+                        "duplicate #[serialize] attribute",
+                    ));
+                } else {
+                    let format: syn::Ident = attr.parse_args()?;
+                    if format == "json" {
+                        attrs.serialize = Some(SerializeFormat::Json);
+                    } else {
+                        errs.push(syn::Error::new_spanned(
+                            &format,
+                            "unsupported serialization format; expected `json`",
+                        ));
+                    }
+                }
             } else if attr.path().is_ident("toasty") {
                 // todo
             }
@@ -229,6 +256,13 @@ impl Field {
             errs.push(syn::Error::new_spanned(
                 field,
                 "#[update] cannot be used on relation fields",
+            ));
+        }
+
+        if ty.is_some() && attrs.serialize.is_some() {
+            errs.push(syn::Error::new_spanned(
+                field,
+                "#[serialize] cannot be used on relation fields",
             ));
         }
 

--- a/crates/toasty-codegen/src/schema/model.rs
+++ b/crates/toasty-codegen/src/schema/model.rs
@@ -358,6 +358,7 @@ impl Model {
                         column: None,
                         default_expr: None,
                         update_expr: None,
+                        serialize: None,
                     },
                     name,
                     ty: FieldTy::Primitive(ty.clone()),

--- a/crates/toasty-core/src/schema/app.rs
+++ b/crates/toasty-core/src/schema/app.rs
@@ -13,7 +13,7 @@ mod embedded;
 pub use embedded::Embedded;
 
 mod field;
-pub use field::{Field, FieldId, FieldName, FieldPrimitive, FieldTy};
+pub use field::{Field, FieldId, FieldName, FieldPrimitive, FieldTy, SerializeFormat};
 
 mod fk;
 pub use fk::{ForeignKey, ForeignKeyField};

--- a/crates/toasty-core/src/schema/app/field.rs
+++ b/crates/toasty-core/src/schema/app/field.rs
@@ -1,5 +1,5 @@
 mod primitive;
-pub use primitive::FieldPrimitive;
+pub use primitive::{FieldPrimitive, SerializeFormat};
 
 use super::{
     AutoStrategy, BelongsTo, Constraint, Embedded, HasMany, HasOne, Model, ModelId, Schema,

--- a/crates/toasty-core/src/schema/app/field/primitive.rs
+++ b/crates/toasty-core/src/schema/app/field/primitive.rs
@@ -1,5 +1,12 @@
 use crate::{schema::db, stmt};
 
+/// The serialization format used to store a field value.
+#[derive(Debug, Clone)]
+pub enum SerializeFormat {
+    /// Serialize as JSON using serde_json.
+    Json,
+}
+
 #[derive(Debug, Clone)]
 pub struct FieldPrimitive {
     /// The field's primitive type
@@ -9,4 +16,8 @@ pub struct FieldPrimitive {
     ///
     /// This is specified as a hint.
     pub storage_ty: Option<db::Type>,
+
+    /// If set, the field value is serialized using the specified format
+    /// before being stored in the database.
+    pub serialize: Option<SerializeFormat>,
 }

--- a/crates/toasty-core/tests/schema_missing_model.rs
+++ b/crates/toasty-core/tests/schema_missing_model.rs
@@ -14,6 +14,7 @@ fn make_id_field(model_id: ModelId) -> Field {
         ty: FieldTy::Primitive(FieldPrimitive {
             ty: stmt::Type::String,
             storage_ty: None,
+            serialize: None,
         }),
         nullable: false,
         primary_key: true,

--- a/crates/toasty-core/tests/schema_resolve_field.rs
+++ b/crates/toasty-core/tests/schema_resolve_field.rs
@@ -17,6 +17,7 @@ fn id_field(model: ModelId) -> Field {
         ty: FieldTy::Primitive(FieldPrimitive {
             ty: stmt::Type::String,
             storage_ty: None,
+            serialize: None,
         }),
         nullable: false,
         primary_key: true,
@@ -36,6 +37,7 @@ fn prim_field(model: ModelId, index: usize, name: &str) -> Field {
         ty: FieldTy::Primitive(FieldPrimitive {
             ty: stmt::Type::String,
             storage_ty: None,
+            serialize: None,
         }),
         nullable: false,
         primary_key: false,
@@ -55,6 +57,7 @@ fn variant_field(model: ModelId, index: usize, name: &str, variant_index: usize)
         ty: FieldTy::Primitive(FieldPrimitive {
             ty: stmt::Type::String,
             storage_ty: None,
+            serialize: None,
         }),
         nullable: false,
         primary_key: false,
@@ -98,6 +101,7 @@ fn schema() -> Schema {
         discriminant: FieldPrimitive {
             ty: stmt::Type::I64,
             storage_ty: None,
+            serialize: None,
         },
         variants: vec![
             EnumVariant {
@@ -118,6 +122,7 @@ fn schema() -> Schema {
         discriminant: FieldPrimitive {
             ty: stmt::Type::I64,
             storage_ty: None,
+            serialize: None,
         },
         variants: vec![
             EnumVariant {

--- a/crates/toasty-core/tests/stmt_infer_expr_reference_ty.rs
+++ b/crates/toasty-core/tests/stmt_infer_expr_reference_ty.rs
@@ -77,6 +77,7 @@ fn model_root(id: usize, field_types: &[(Type, &str)]) -> ModelRoot {
             ty: FieldTy::Primitive(FieldPrimitive {
                 ty: ty.clone(),
                 storage_ty: None,
+                serialize: None,
             }),
             nullable: false,
             primary_key: i == 0,

--- a/crates/toasty/src/stmt/primitive.rs
+++ b/crates/toasty/src/stmt/primitive.rs
@@ -62,10 +62,12 @@ pub trait Primitive: Sized {
     /// Embedded types override this to return Embedded field type.
     fn field_ty(
         storage_ty: Option<toasty_core::schema::db::Type>,
+        serialize: Option<toasty_core::schema::app::SerializeFormat>,
     ) -> toasty_core::schema::app::FieldTy {
         toasty_core::schema::app::FieldTy::Primitive(toasty_core::schema::app::FieldPrimitive {
             ty: Self::ty(),
             storage_ty,
+            serialize,
         })
     }
 }

--- a/docs/design/serialize-fields.md
+++ b/docs/design/serialize-fields.md
@@ -1,0 +1,181 @@
+# Serialized Field Implementation Design
+
+Builds on the `#[serialize]` bookkeeping already in place (attribute parsing,
+`SerializeFormat` enum, `FieldPrimitive.serialize` field). This document covers
+the runtime serialization/deserialization codegen.
+
+## User-Facing API
+
+```rust
+#[derive(Model)]
+struct User {
+    #[key]
+    #[auto]
+    id: uuid::Uuid,
+
+    name: String,
+
+    #[serialize(json)]
+    tags: Vec<String>,
+
+    #[serialize(json)]
+    metadata: Option<HashMap<String, String>>,
+}
+```
+
+Fields annotated with `#[serialize(json)]` are stored as JSON text in a single
+database column. The field's Rust type must implement `serde::Serialize` and
+`serde::DeserializeOwned`. The database column type defaults to `String`/`TEXT`.
+
+## Value Encoding
+
+A serialized field stores a JSON string in the database. The value stream uses
+`Value::String` for serialized fields, not the field's logical Rust type.
+
+```
+Rust value ──serde_json::to_string──► Value::String(json) ──► DB column (TEXT)
+DB column (TEXT) ──► Value::String(json) ──serde_json::from_str──► Rust value
+```
+
+## Schema Changes
+
+For serialized fields, `field_ty` bypasses `<T as Primitive>::field_ty()` and
+constructs `FieldPrimitive` directly with `ty: Type::String`. The user's Rust
+type `T` does not need to implement `Primitive` — it only needs `Serialize` +
+`DeserializeOwned`.
+
+```rust
+// Non-serialized (existing behavior):
+field_ty = <T as Primitive>::field_ty(storage_ty, serialize);
+nullable = <T as Primitive>::NULLABLE;
+
+// Serialized:
+field_ty = FieldTy::Primitive(FieldPrimitive {
+    ty: Type::String,
+    storage_ty,
+    serialize,
+});
+nullable = is_option_type(ty);  // detected at the syn::Type level
+```
+
+`is_option_type` checks whether the outermost type path segment is `Option`.
+
+## Codegen Changes
+
+### `Primitive::load` / `Model::load`
+
+For serialized fields, the generated load code reads a `String` from the record
+and deserializes it:
+
+```rust
+// Required field:
+field_name: {
+    let json_str = <String as Primitive>::load(record[i].take())?;
+    serde_json::from_str(&json_str)
+        .map_err(|e| Error::from_args(
+            format_args!("failed to deserialize field '{}': {}", "field_name", e)
+        ))?
+},
+
+// Option<T> field:
+field_name: {
+    let value = record[i].take();
+    if value.is_null() {
+        None
+    } else {
+        let json_str = <String as Primitive>::load(value)?;
+        Some(serde_json::from_str(&json_str)
+            .map_err(|e| Error::from_args(
+                format_args!("failed to deserialize field '{}': {}", "field_name", e)
+            ))?)
+    }
+},
+```
+
+Non-serialized fields are unchanged: `<T as Primitive>::load(record[i].take())?`.
+
+### Reload (root model and embedded)
+
+Reload match arms follow the same pattern: load as `String`, then deserialize.
+For `Option<T>`, check null first.
+
+### Create builder setters
+
+Serialized field setters accept the concrete Rust type (not `impl IntoExpr<T>`,
+since `T` does not implement `IntoExpr`) and serialize to a `String` expression:
+
+```rust
+// Required field:
+pub fn field_name(mut self, field_name: FieldType) -> Self {
+    let json = serde_json::to_string(&field_name).expect("failed to serialize");
+    self.stmt.set(index, <String as IntoExpr<String>>::into_expr(json));
+    self
+}
+
+// Option<T> field:
+pub fn field_name(mut self, field_name: Option<InnerType>) -> Self {
+    match &field_name {
+        Some(v) => {
+            let json = serde_json::to_string(v).expect("failed to serialize");
+            self.stmt.set(index, <String as IntoExpr<String>>::into_expr(json));
+        }
+        None => {
+            self.stmt.set(index, Expr::<String>::from_value(Value::Null));
+        }
+    }
+    self
+}
+```
+
+### Update builder setters
+
+Same pattern as create: accept the concrete type, serialize to JSON, store as
+`String` expression.
+
+## Dependencies
+
+`serde_json` is added as an optional dependency of the `toasty` crate, gated
+behind the existing `serde` feature:
+
+```toml
+# crates/toasty/Cargo.toml
+[features]
+serde = ["dep:serde_core", "dep:serde_json"]
+
+[dependencies]
+serde_json = { workspace = true, optional = true }
+```
+
+Generated code references `serde_json` through the codegen support module:
+
+```rust
+// crates/toasty/src/lib.rs, in codegen_support
+#[cfg(feature = "serde")]
+pub use serde_json;
+```
+
+If a user writes `#[serialize(json)]` without enabling the `serde` feature, the
+generated code fails to compile because `codegen_support::serde_json` does not
+exist. The compiler error points at the generated `serde_json::from_str` call.
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `crates/toasty/Cargo.toml` | Add `serde_json` optional dep, update `serde` feature |
+| `crates/toasty/src/lib.rs` | Re-export `serde_json` in `codegen_support` |
+| `crates/toasty-codegen/src/expand/schema.rs` | Construct `FieldPrimitive` directly for serialized fields with `ty: String` |
+| `crates/toasty-codegen/src/expand/model.rs` | Deserialize in `expand_load_body()` and `expand_embedded_reload_body()` |
+| `crates/toasty-codegen/src/expand/create.rs` | Serialize in create setter for serialized fields |
+| `crates/toasty-codegen/src/expand/update.rs` | Serialize in update setter, deserialize in reload arms |
+| `crates/toasty-driver-integration-suite/Cargo.toml` | Add `serde`, `serde_json` deps, enable `serde` feature |
+| `crates/toasty-driver-integration-suite/src/tests/serialize.rs` | Integration tests |
+
+## Integration Tests
+
+New file `serialize.rs` in the driver integration suite. Test cases:
+
+- Round-trip a `Vec<String>` field through create and read-back
+- Round-trip an `Option<T>` serialized field with `Some` and `None` values
+- Update a serialized field and verify the new value persists
+- Round-trip a custom struct with `serde::Serialize + DeserializeOwned`


### PR DESCRIPTION
## Summary

Add foundational support for the `#[serialize]` attribute to enable field-level serialization (e.g., storing complex types as JSON in database columns).

## Changes

### Bookkeeping & Infrastructure
- Add `SerializeFormat` enum to codegen and core schemas
- Parse `#[serialize(json)]` attribute on model fields with validation
- Add `serialize` field to `FieldPrimitive` struct
- Update `Primitive::field_ty()` signature to accept serialization format parameter
- Thread serialization metadata through field expansion in schema and embedded types

### Validation
- Reject duplicate `#[serialize]` attributes
- Reject `#[serialize]` on relation fields (belongs_to, has_one, has_many)
- Validate only `json` format is supported

### Documentation
- Add comprehensive design document (`docs/design/serialize-fields.md`) covering:
  - User-facing API and attribute syntax
  - Value encoding strategy (JSON strings in database)
  - Schema and codegen changes needed
  - Load/reload/create/update builder patterns
  - Dependency management via optional `serde_json` feature
  - Integration test approach

### Test Updates
Update existing schema tests to include new `serialize` field in `FieldPrimitive` constructors.

## Notes

This PR establishes the schema and attribute infrastructure. Runtime serialization/deserialization codegen will follow in subsequent PRs as outlined in the design document.