### PR TITLE
chore: remove unused ToStatement trait

### DIFF
--- a/crates/toasty/src/stmt.rs
+++ b/crates/toasty/src/stmt.rs
@@ -34,9 +34,6 @@ mod primitive_jiff;
 mod select;
 pub use select::Select;
 
-mod to_statement;
-pub use to_statement::ToStatement;
-
 mod update;
 pub use update::Update;
 

--- a/crates/toasty/src/stmt/to_statement.rs
+++ b/crates/toasty/src/stmt/to_statement.rs
@@ -1,7 +1,0 @@
-use super::Statement;
-
-pub trait ToStatement {
-    type Model;
-
-    fn to_statement(self) -> Statement<Self::Model>;
-}


### PR DESCRIPTION
- Remove `ToStatement` trait definition from `crates/toasty/src/stmt/to_statement.rs`
- Remove module import and public export from `crates/toasty/src/stmt.rs`

This trait is no longer used and can be safely removed to reduce code complexity.