### PR TITLE
feat: implement batch queries

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -1,3 +1,4 @@
+pub mod batch_query;
 pub mod belongs_to_configured;
 pub mod belongs_to_one_way;
 pub mod belongs_to_self_referential;

--- a/crates/toasty-driver-integration-suite/src/tests/batch_query.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/batch_query.rs
@@ -1,0 +1,172 @@
+use crate::prelude::*;
+
+#[driver_test(id(ID), requires(sql))]
+pub async fn batch_two_models(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+        #[index]
+        name: String,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Post {
+        #[key]
+        #[auto]
+        id: ID,
+        #[index]
+        title: String,
+    }
+
+    let mut db = t.setup_db(models!(User, Post)).await;
+
+    User::create().name("Alice").exec(&mut db).await?;
+    User::create().name("Bob").exec(&mut db).await?;
+    Post::create().title("Hello").exec(&mut db).await?;
+
+    let (users, posts): (Vec<User>, Vec<Post>) = toasty::batch((
+        User::filter_by_name("Alice"),
+        Post::filter_by_title("Hello"),
+    ))
+    .exec(&mut db)
+    .await?;
+
+    assert_struct!(users, [_ { name: "Alice" }]);
+    assert_struct!(posts, [_ { title: "Hello" }]);
+
+    Ok(())
+}
+
+#[driver_test(id(ID), requires(sql))]
+pub async fn batch_one_empty(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+        #[index]
+        name: String,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Post {
+        #[key]
+        #[auto]
+        id: ID,
+        #[index]
+        title: String,
+    }
+
+    let mut db = t.setup_db(models!(User, Post)).await;
+
+    User::create().name("Alice").exec(&mut db).await?;
+
+    let (users, posts): (Vec<User>, Vec<Post>) = toasty::batch((
+        User::filter_by_name("Alice"),
+        Post::filter_by_title("nonexistent"),
+    ))
+    .exec(&mut db)
+    .await?;
+
+    assert_struct!(users, [_ { name: "Alice" }]);
+    assert!(posts.is_empty());
+
+    Ok(())
+}
+
+#[driver_test(id(ID), requires(sql))]
+pub async fn batch_same_model(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+        #[index]
+        name: String,
+    }
+
+    let mut db = t.setup_db(models!(User)).await;
+
+    User::create().name("Alice").exec(&mut db).await?;
+    User::create().name("Bob").exec(&mut db).await?;
+    User::create().name("Carol").exec(&mut db).await?;
+
+    let (alices, bobs): (Vec<User>, Vec<User>) =
+        toasty::batch((User::filter_by_name("Alice"), User::filter_by_name("Bob")))
+            .exec(&mut db)
+            .await?;
+
+    assert_struct!(alices, [_ { name: "Alice" }]);
+    assert_struct!(bobs, [_ { name: "Bob" }]);
+
+    Ok(())
+}
+
+#[driver_test(id(ID), requires(sql))]
+pub async fn batch_three_queries(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+        #[index]
+        name: String,
+    }
+
+    let mut db = t.setup_db(models!(User)).await;
+
+    User::create().name("Alice").exec(&mut db).await?;
+    User::create().name("Bob").exec(&mut db).await?;
+    User::create().name("Carol").exec(&mut db).await?;
+
+    let (alices, bobs, carols): (Vec<User>, Vec<User>, Vec<User>) = toasty::batch((
+        User::filter_by_name("Alice"),
+        User::filter_by_name("Bob"),
+        User::filter_by_name("Carol"),
+    ))
+    .exec(&mut db)
+    .await?;
+
+    assert_struct!(alices, [_ { name: "Alice" }]);
+    assert_struct!(bobs, [_ { name: "Bob" }]);
+    assert_struct!(carols, [_ { name: "Carol" }]);
+
+    Ok(())
+}
+
+#[driver_test(id(ID), requires(sql))]
+pub async fn batch_both_empty(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+        #[index]
+        name: String,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Post {
+        #[key]
+        #[auto]
+        id: ID,
+        #[index]
+        title: String,
+    }
+
+    let mut db = t.setup_db(models!(User, Post)).await;
+
+    let (users, posts): (Vec<User>, Vec<Post>) = toasty::batch((
+        User::filter_by_name("nobody"),
+        Post::filter_by_title("nothing"),
+    ))
+    .exec(&mut db)
+    .await?;
+
+    assert!(users.is_empty());
+    assert!(posts.is_empty());
+
+    Ok(())
+}

--- a/crates/toasty/src/batch.rs
+++ b/crates/toasty/src/batch.rs
@@ -1,2 +1,5 @@
 mod create;
 pub use create::CreateMany;
+
+mod query;
+pub use query::{batch, Batch};

--- a/crates/toasty/src/batch/query.rs
+++ b/crates/toasty/src/batch/query.rs
@@ -1,0 +1,40 @@
+use crate::stmt::IntoStatement;
+use crate::{Executor, ExecutorExt, Load, Result, Statement};
+
+/// A batch of queries composed into a single statement.
+///
+/// Created by [`batch()`](crate::batch). The composed statement flows through
+/// the standard engine pipeline and the result is deserialized via [`Load`].
+pub struct Batch<T> {
+    stmt: Statement<T>,
+}
+
+/// Compose multiple independent queries into a single batched statement.
+///
+/// The queries are sent to the database in a single round-trip and the results
+/// come back as a typed tuple matching the input queries.
+///
+/// # Examples
+///
+/// ```ignore
+/// let (active_users, recent_posts) = toasty::batch((
+///     User::find_by_active(true),
+///     Post::find_recent(100),
+/// )).exec(&mut db).await?;
+/// ```
+pub fn batch<T, Q: IntoStatement<T>>(queries: Q) -> Batch<T>
+where
+    T: Load,
+{
+    Batch {
+        stmt: queries.into_statement(),
+    }
+}
+
+impl<T: Load> Batch<T> {
+    /// Execute the batched queries and return the deserialized results.
+    pub async fn exec(self, executor: &mut dyn Executor) -> Result<T> {
+        let value = executor.exec_one(self.stmt).await?;
+        T::load(value)
+    }
+}

--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -385,7 +385,13 @@ impl visit_mut::VisitMut for LowerStatement<'_, '_> {
                     panic!()
                 };
 
-                assert!(self.cx.is_returning(), "cx={:#?}", self.cx);
+                // Expr::Stmt subqueries are valid in returning expressions (e.g.,
+                // INCLUDE preloading) and in VALUES bodies of batch queries.
+                debug_assert!(
+                    self.cx.is_returning() || matches!(self.cx, LoweringContext::Statement),
+                    "cx={:#?}",
+                    self.cx,
+                );
 
                 // For now, we assume nested sub-statements cannot be executed on the
                 // target database. Eventually, we will need to make this smarter.

--- a/crates/toasty/src/engine/plan/statement.rs
+++ b/crates/toasty/src/engine/plan/statement.rs
@@ -93,6 +93,22 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
     fn plan(&mut self, mut stmt: stmt::Statement) -> Result<()> {
         let mut returning = stmt.take_returning();
 
+        // For single VALUES queries (e.g., batch queries), the VALUES body is
+        // the output expression. Extract it as a returning value so the planner
+        // can wire up sub-statement dependencies.
+        if returning.is_none() {
+            if let stmt::Statement::Query(query) = &mut stmt {
+                if let stmt::ExprSet::Values(values) = &mut query.body {
+                    returning = Some(stmt::Returning::Value(if query.single {
+                        assert_eq!(1, values.rows.len());
+                        values.rows.drain(..).next().unwrap()
+                    } else {
+                        stmt::Expr::list(std::mem::take(&mut values.rows))
+                    }));
+                }
+            }
+        }
+
         // No queries are single at this point.
         match &mut stmt {
             stmt::Statement::Query(stmt) => stmt.single = false,

--- a/crates/toasty/src/lib.rs
+++ b/crates/toasty/src/lib.rs
@@ -2,7 +2,7 @@ mod apply_update;
 pub use apply_update::{ApplyUpdate, Query};
 
 mod batch;
-pub use batch::CreateMany;
+pub use batch::{batch, Batch, CreateMany};
 
 pub mod cursor;
 pub use cursor::Cursor;
@@ -57,7 +57,7 @@ pub mod codegen_support {
         register::generate_unique_id,
         relation::Relation,
         relation::{BelongsTo, HasMany, HasOne},
-        stmt::{self, IntoExpr, IntoInsert, IntoSelect, Path},
+        stmt::{self, IntoExpr, IntoInsert, IntoSelect, IntoStatement, Path},
         Db, Embed, Error, Executor, ExecutorExt, Load, Model, Register, Result, Statement,
     };
     #[cfg(feature = "serde")]

--- a/crates/toasty/src/load.rs
+++ b/crates/toasty/src/load.rs
@@ -9,3 +9,35 @@ use toasty_core::stmt;
 pub trait Load: Sized {
     fn load(value: stmt::Value) -> Result<Self, Error>;
 }
+
+impl<T: Load> Load for Vec<T> {
+    fn load(value: stmt::Value) -> Result<Self, Error> {
+        match value {
+            stmt::Value::List(items) => items.into_iter().map(T::load).collect(),
+            _ => Err(Error::type_conversion(value, "Vec<T>")),
+        }
+    }
+}
+
+macro_rules! impl_load_for_tuple {
+    ( $( $T:ident ),+ ; $( $idx:tt ),+ ) => {
+        impl< $( $T: Load ),+ > Load for ( $( $T, )+ ) {
+            fn load(value: stmt::Value) -> Result<Self, Error> {
+                match value {
+                    stmt::Value::Record(mut record) => Ok((
+                        $( $T::load(record[$idx].take())?, )+
+                    )),
+                    _ => Err(Error::type_conversion(value, "tuple")),
+                }
+            }
+        }
+    };
+}
+
+impl_load_for_tuple!(A, B; 0, 1);
+impl_load_for_tuple!(A, B, C; 0, 1, 2);
+impl_load_for_tuple!(A, B, C, D; 0, 1, 2, 3);
+impl_load_for_tuple!(A, B, C, D, E; 0, 1, 2, 3, 4);
+impl_load_for_tuple!(A, B, C, D, E, F; 0, 1, 2, 3, 4, 5);
+impl_load_for_tuple!(A, B, C, D, E, F, G; 0, 1, 2, 3, 4, 5, 6);
+impl_load_for_tuple!(A, B, C, D, E, F, G, H; 0, 1, 2, 3, 4, 5, 6, 7);

--- a/crates/toasty/src/stmt.rs
+++ b/crates/toasty/src/stmt.rs
@@ -19,6 +19,9 @@ pub use into_insert::IntoInsert;
 mod into_select;
 pub use into_select::IntoSelect;
 
+mod into_statement;
+pub use into_statement::IntoStatement;
+
 mod paginate;
 pub use paginate::Paginate;
 

--- a/crates/toasty/src/stmt/into_statement.rs
+++ b/crates/toasty/src/stmt/into_statement.rs
@@ -1,0 +1,53 @@
+use super::{IntoSelect, Statement};
+
+use std::marker::PhantomData;
+
+use toasty_core::stmt;
+
+/// Convert a value into a [`Statement`].
+///
+/// This trait bridges query builders to `Statement<T>`. It is blanket-
+/// implemented for anything that implements [`IntoSelect`].
+pub trait IntoStatement<T> {
+    fn into_statement(self) -> Statement<T>;
+}
+
+/// Blanket implementation: any `IntoSelect` type can produce a `Statement`
+/// for its model type.
+impl<T: IntoSelect> IntoStatement<T::Model> for T {
+    fn into_statement(self) -> Statement<T::Model> {
+        self.into_select().into()
+    }
+}
+
+macro_rules! impl_into_statement_for_tuple {
+    ( $( $T:ident : $Q:ident ),+ ; $n:tt ; $( $idx:tt ),+ ) => {
+        impl< $( $T, $Q ),+ > IntoStatement<( $( Vec<$T>, )+ )> for ( $( $Q, )+ )
+        where
+            $( $Q: IntoStatement<$T>, )+
+        {
+            fn into_statement(self) -> Statement<( $( Vec<$T>, )+ )> {
+                let exprs: Vec<stmt::Expr> = vec![
+                    $( stmt::Expr::stmt(self.$idx.into_statement().untyped), )+
+                ];
+
+                let query = stmt::Query::new_single(
+                    stmt::Values::from(stmt::Expr::record(exprs)),
+                );
+
+                Statement {
+                    untyped: query.into(),
+                    _p: PhantomData,
+                }
+            }
+        }
+    };
+}
+
+impl_into_statement_for_tuple!(T1: Q1, T2: Q2; 2; 0, 1);
+impl_into_statement_for_tuple!(T1: Q1, T2: Q2, T3: Q3; 3; 0, 1, 2);
+impl_into_statement_for_tuple!(T1: Q1, T2: Q2, T3: Q3, T4: Q4; 4; 0, 1, 2, 3);
+impl_into_statement_for_tuple!(T1: Q1, T2: Q2, T3: Q3, T4: Q4, T5: Q5; 5; 0, 1, 2, 3, 4);
+impl_into_statement_for_tuple!(T1: Q1, T2: Q2, T3: Q3, T4: Q4, T5: Q5, T6: Q6; 6; 0, 1, 2, 3, 4, 5);
+impl_into_statement_for_tuple!(T1: Q1, T2: Q2, T3: Q3, T4: Q4, T5: Q5, T6: Q6, T7: Q7; 7; 0, 1, 2, 3, 4, 5, 6);
+impl_into_statement_for_tuple!(T1: Q1, T2: Q2, T3: Q3, T4: Q4, T5: Q5, T6: Q6, T7: Q7, T8: Q8; 8; 0, 1, 2, 3, 4, 5, 6, 7);


### PR DESCRIPTION
## Summary

- Adds `toasty::batch()` API for composing multiple independent queries into a single round-trip, with results returned as a typed tuple of vectors
- New `IntoStatement<T>` trait bridging query builders to `Statement<T>`, with blanket impl for `IntoSelect` and tuple impls for arities 2-8
- `Load` impls for `Vec<T>` and tuples to deserialize batch results
- Engine: lowerer allows `Expr::Stmt` in VALUES body context; planner extracts single VALUES body as `Returning::Value` for sub-statement dependency wiring

## Test plan

- [x] 5 integration tests (10 variants with ID type expansion): two models, one empty result, same model different filters, three queries, both empty
- [x] All 429 existing integration tests pass
- [x] `cargo clippy` clean, `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)