### PR TITLE
fix order by expressions for timestamps

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/jiff.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/jiff.rs
@@ -298,6 +298,54 @@ pub async fn ty_timestamp_as_text(test: &mut Test) -> Result<(), BoxError> {
     Ok(())
 }
 
+#[driver_test(id(ID), requires(sql))]
+pub async fn order_by_timestamp(test: &mut Test) -> Result<(), BoxError> {
+    use jiff::Timestamp;
+
+    #[derive(Debug, toasty::Model)]
+    #[allow(dead_code)]
+    struct Foo {
+        #[key]
+        #[auto]
+        id: ID,
+
+        #[column(type = text)]
+        val: Timestamp,
+    }
+
+    let mut db = test.setup_db(models!(Foo)).await;
+
+    let timestamps = vec![
+        Timestamp::from_second(1609459200)?, // 2021-01-01
+        Timestamp::from_second(946684800)?,  // 2000-01-01
+        Timestamp::from_second(1735689600)?, // 2025-01-01
+    ];
+
+    for val in &timestamps {
+        Foo::create().val(*val).exec(&mut db).await?;
+    }
+
+    let asc: Vec<_> = Foo::all()
+        .order_by(Foo::fields().val().asc())
+        .collect(&mut db)
+        .await?;
+
+    assert_eq!(asc.len(), 3);
+    assert!(asc[0].val < asc[1].val);
+    assert!(asc[1].val < asc[2].val);
+
+    let desc: Vec<_> = Foo::all()
+        .order_by(Foo::fields().val().desc())
+        .collect(&mut db)
+        .await?;
+
+    assert_eq!(desc.len(), 3);
+    assert!(desc[0].val > desc[1].val);
+    assert!(desc[1].val > desc[2].val);
+
+    Ok(())
+}
+
 #[driver_test(id(ID))]
 pub async fn ty_date_as_text(test: &mut Test) -> Result<()> {
     use jiff::civil::Date;

--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -196,6 +196,15 @@ impl LowerStatement<'_, '_> {
 }
 
 impl visit_mut::VisitMut for LowerStatement<'_, '_> {
+    fn visit_order_by_expr_mut(&mut self, node: &mut stmt::OrderByExpr) {
+        self.visit_expr_mut(&mut node.expr);
+
+        // Strip any Cast wrapper — ORDER BY should use the raw column reference.
+        if let stmt::Expr::Cast(expr_cast) = &mut node.expr {
+            node.expr = expr_cast.expr.take();
+        }
+    }
+
     fn visit_assignments_mut(&mut self, i: &mut stmt::Assignments) {
         let mut assignments = stmt::Assignments::default();
         let mapping = self.mapping_unwrap();


### PR DESCRIPTION
The engine adds cast expressions to types when the database and column types don't match. For order by expressions there should never be a cast since we're only referring to the column.

This pr removes the unwanted casts in the order by expression and allows for ordering by columns where the database and column types don't match.