### PR TITLE
feat: support update and delete statements in toasty::batch

### DIFF
--- a/crates/toasty-codegen/src/expand/filters.rs
+++ b/crates/toasty-codegen/src/expand/filters.rs
@@ -98,7 +98,8 @@ impl Expand<'_> {
 
             #vis async fn #delete_method_ident(#self_arg executor: &mut dyn #toasty::Executor, #( #args ),* ) -> #toasty::Result<()> {
                 #base #filter_method_ident( #( #arg_idents ),* )
-                    .delete(executor)
+                    .delete()
+                    .exec(executor)
                     .await
             }
         }

--- a/crates/toasty-codegen/src/expand/model.rs
+++ b/crates/toasty-codegen/src/expand/model.rs
@@ -67,12 +67,9 @@ impl Expand<'_> {
                     #query_struct_ident::from_stmt(#toasty::stmt::Select::filter(expr))
                 }
 
-                #vis async fn delete(self, executor: &mut dyn #toasty::Executor) -> #toasty::Result<()> {
+                #vis fn delete(self) -> #toasty::stmt::Delete<#model_ident> {
                     use #toasty::IntoSelect;
-                    use #toasty::ExecutorExt;
-                    let stmt = self.into_select().delete();
-                    executor.exec(stmt).await?;
-                    Ok(())
+                    self.into_select().delete()
                 }
             }
 

--- a/crates/toasty-codegen/src/expand/query.rs
+++ b/crates/toasty-codegen/src/expand/query.rs
@@ -48,10 +48,8 @@ impl Expand<'_> {
                     #update_struct_ident::from(self)
                 }
 
-                #vis async fn delete(self, executor: &mut dyn #toasty::Executor) -> #toasty::Result<()> {
-                    use #toasty::ExecutorExt;
-                    executor.exec(self.stmt.delete()).await?;
-                    Ok(())
+                #vis fn delete(self) -> #toasty::stmt::Delete<#model_ident> {
+                    self.stmt.delete()
                 }
 
                 #vis async fn collect<#collect_ty>(self, executor: &mut dyn #toasty::Executor) -> #toasty::Result<#collect_ty>

--- a/crates/toasty-codegen/src/expand/update.rs
+++ b/crates/toasty-codegen/src/expand/update.rs
@@ -271,6 +271,14 @@ impl Expand<'_> {
                     s
                 }
             }
+
+            impl #toasty::IntoStatement for #update_struct_ident {
+                type Output = ();
+
+                fn into_statement(self) -> #toasty::Statement<()> {
+                    #toasty::Statement::from_untyped_stmt(self.stmt.into_untyped_stmt())
+                }
+            }
         }
     }
 

--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -1,6 +1,7 @@
 pub mod batch_create_statements;
 pub mod batch_query;
 pub mod batch_query_dynamic;
+pub mod batch_update_delete;
 pub mod belongs_to_configured;
 pub mod belongs_to_one_way;
 pub mod belongs_to_self_referential;

--- a/crates/toasty-driver-integration-suite/src/tests/batch_update_delete.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/batch_update_delete.rs
@@ -1,0 +1,181 @@
+use crate::prelude::*;
+
+/// Batch two updates of the same model.
+#[driver_test(id(ID), requires(sql))]
+pub async fn batch_two_updates_same_model(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+        #[index]
+        name: String,
+    }
+
+    let mut db = t.setup_db(models!(User)).await;
+    User::create().name("Alice").exec(&mut db).await?;
+    User::create().name("Bob").exec(&mut db).await?;
+
+    t.log().clear();
+    let ((), ()): ((), ()) = toasty::batch((
+        User::filter_by_name("Alice").update().name("Alice2"),
+        User::filter_by_name("Bob").update().name("Bob2"),
+    ))
+    .exec(&mut db)
+    .await?;
+
+    // Verify updates applied
+    let alice: Vec<User> = User::filter_by_name("Alice2").collect(&mut db).await?;
+    assert_eq!(alice.len(), 1);
+    let bob: Vec<User> = User::filter_by_name("Bob2").collect(&mut db).await?;
+    assert_eq!(bob.len(), 1);
+
+    Ok(())
+}
+
+/// Batch two deletes of the same model.
+#[driver_test(id(ID), requires(sql))]
+pub async fn batch_two_deletes_same_model(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+        #[index]
+        name: String,
+    }
+
+    let mut db = t.setup_db(models!(User)).await;
+    User::create().name("Alice").exec(&mut db).await?;
+    User::create().name("Bob").exec(&mut db).await?;
+    User::create().name("Carol").exec(&mut db).await?;
+
+    t.log().clear();
+    let ((), ()): ((), ()) = toasty::batch((
+        User::filter_by_name("Alice").delete(),
+        User::filter_by_name("Bob").delete(),
+    ))
+    .exec(&mut db)
+    .await?;
+
+    // Verify deletes applied, Carol remains
+    let all: Vec<User> = User::all().collect(&mut db).await?;
+    assert_eq!(all.len(), 1);
+    assert_eq!(all[0].name, "Carol");
+
+    Ok(())
+}
+
+/// Batch mixing update and delete of different models.
+#[driver_test(id(ID), requires(sql))]
+pub async fn batch_update_and_delete(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+        #[index]
+        name: String,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Post {
+        #[key]
+        #[auto]
+        id: ID,
+        #[index]
+        title: String,
+    }
+
+    let mut db = t.setup_db(models!(User, Post)).await;
+    User::create().name("Alice").exec(&mut db).await?;
+    Post::create().title("Hello").exec(&mut db).await?;
+
+    t.log().clear();
+    let ((), ()): ((), ()) = toasty::batch((
+        User::filter_by_name("Alice").update().name("Alice2"),
+        Post::filter_by_title("Hello").delete(),
+    ))
+    .exec(&mut db)
+    .await?;
+
+    // User updated
+    let users: Vec<User> = User::filter_by_name("Alice2").collect(&mut db).await?;
+    assert_eq!(users.len(), 1);
+
+    // Post deleted
+    let posts: Vec<Post> = Post::all().collect(&mut db).await?;
+    assert_eq!(posts.len(), 0);
+
+    Ok(())
+}
+
+/// Batch all four statement types: query, create, update, delete.
+#[driver_test(id(ID), requires(sql))]
+pub async fn batch_all_four_statement_types(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+        #[index]
+        name: String,
+    }
+
+    let mut db = t.setup_db(models!(User)).await;
+    User::create().name("Alice").exec(&mut db).await?;
+    User::create().name("Bob").exec(&mut db).await?;
+
+    t.log().clear();
+    let (queried, created, (), ()): (Vec<User>, User, (), ()) = toasty::batch((
+        User::filter_by_name("Alice"),
+        User::create().name("Carol"),
+        User::filter_by_name("Alice").update().name("Alice2"),
+        User::filter_by_name("Bob").delete(),
+    ))
+    .exec(&mut db)
+    .await?;
+
+    assert_struct!(queried, [_ { name: "Alice" }]);
+    assert_eq!(created.name, "Carol");
+
+    // Verify update applied
+    let alice: Vec<User> = User::filter_by_name("Alice2").collect(&mut db).await?;
+    assert_eq!(alice.len(), 1);
+
+    // Verify delete applied
+    let bob: Vec<User> = User::filter_by_name("Bob").collect(&mut db).await?;
+    assert_eq!(bob.len(), 0);
+
+    // Carol was created
+    let carol: Vec<User> = User::filter_by_name("Carol").collect(&mut db).await?;
+    assert_eq!(carol.len(), 1);
+
+    Ok(())
+}
+
+/// Batch a delete using the model instance builder.
+#[driver_test(id(ID), requires(sql))]
+pub async fn batch_instance_delete(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+        name: String,
+    }
+
+    let mut db = t.setup_db(models!(User)).await;
+    let alice = User::create().name("Alice").exec(&mut db).await?;
+    let bob = User::create().name("Bob").exec(&mut db).await?;
+
+    t.log().clear();
+    let ((), ()): ((), ()) = toasty::batch((alice.delete(), bob.delete()))
+        .exec(&mut db)
+        .await?;
+
+    let all: Vec<User> = User::all().collect(&mut db).await?;
+    assert_eq!(all.len(), 0);
+
+    Ok(())
+}

--- a/crates/toasty-driver-integration-suite/src/tests/embedded_enum_data.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embedded_enum_data.rs
@@ -182,8 +182,8 @@ pub async fn data_variant_roundtrip(test: &mut Test) -> Result<()> {
     );
 
     // Clean up.
-    alice.delete(&mut db).await?;
-    bob.delete(&mut db).await?;
+    alice.delete().exec(&mut db).await?;
+    bob.delete().exec(&mut db).await?;
     Ok(())
 }
 

--- a/crates/toasty-driver-integration-suite/src/tests/embedded_enum_unit.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embedded_enum_unit.rs
@@ -110,7 +110,7 @@ pub async fn create_and_query_enum(t: &mut Test) -> Result<()> {
 
     // Delete: cleanup
     let id = user.id;
-    user.delete(&mut db).await?;
+    user.delete().exec(&mut db).await?;
     assert_err!(User::get_by_id(&mut db, &id).await);
     Ok(())
 }

--- a/crates/toasty-driver-integration-suite/src/tests/embedded_struct.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embedded_struct.rs
@@ -228,7 +228,7 @@ pub async fn create_and_query_embedded(t: &mut Test) -> Result<()> {
 
     // Delete: cleanup
     let id = user.id;
-    user.delete(&mut db).await?;
+    user.delete().exec(&mut db).await?;
     assert_err!(User::get_by_id(&mut db, &id).await);
     Ok(())
 }
@@ -1144,7 +1144,7 @@ pub async fn crud_nested_embedded(t: &mut Test) -> Result<()> {
 
     // Delete: cleanup
     let id = company.id;
-    company.delete(&mut db).await?;
+    company.delete().exec(&mut db).await?;
     assert_err!(Company::get_by_id(&mut db, &id).await);
     Ok(())
 }

--- a/crates/toasty-driver-integration-suite/src/tests/has_many_crud_basic.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/has_many_crud_basic.rs
@@ -163,7 +163,7 @@ pub async fn crud_user_todos(test: &mut Test) -> Result<()> {
 
     // Delete a TODO by value
     let todo = Todo::get_by_id(&mut db, &ids[0]).await?;
-    todo.delete(&mut db).await?;
+    todo.delete().exec(&mut db).await?;
 
     // Can no longer get the todo via id
     assert_err!(Todo::get_by_id(&mut db, &ids[0]).await);
@@ -172,7 +172,11 @@ pub async fn crud_user_todos(test: &mut Test) -> Result<()> {
     assert_err!(user.todos().get_by_id(&mut db, &ids[0]).await);
 
     // Delete a TODO by scope
-    user.todos().filter_by_id(ids[1]).delete(&mut db).await?;
+    user.todos()
+        .filter_by_id(ids[1])
+        .delete()
+        .exec(&mut db)
+        .await?;
 
     // Can no longer get the todo via id
     assert_err!(Todo::get_by_id(&mut db, &ids[1]).await);
@@ -206,7 +210,7 @@ pub async fn crud_user_todos(test: &mut Test) -> Result<()> {
     let id = user.id;
 
     // Delete the user and associated TODOs are deleted
-    user.delete(&mut db).await?;
+    user.delete().exec(&mut db).await?;
     assert_err!(User::get_by_id(&mut db, &id).await);
     assert_err!(Todo::get_by_id(&mut db, &ids[2]).await);
     Ok(())
@@ -319,7 +323,12 @@ pub async fn scoped_find_by_id(test: &mut Test) -> Result<()> {
     assert_eq!(reloaded.title, todo.title);
 
     // Deleting the TODO from the user 2 scope fails
-    user2.todos().filter_by_id(todo.id).delete(&mut db).await?;
+    user2
+        .todos()
+        .filter_by_id(todo.id)
+        .delete()
+        .exec(&mut db)
+        .await?;
     let reloaded = user1.todos().get_by_id(&mut db, &todo.id).await?;
     assert_eq!(reloaded.id, todo.id);
     Ok(())
@@ -488,7 +497,7 @@ pub async fn has_many_when_fk_is_composite(test: &mut Test) -> Result<()> {
 
     // Delete a TODO by value
     let todo = Todo::get_by_user_id_and_id(&mut db, &user.id, &ids[0]).await?;
-    todo.delete(&mut db).await?;
+    todo.delete().exec(&mut db).await?;
 
     // Can no longer get the todo via id
     assert_err!(Todo::get_by_user_id_and_id(&mut db, &user.id, &ids[0]).await);
@@ -497,7 +506,11 @@ pub async fn has_many_when_fk_is_composite(test: &mut Test) -> Result<()> {
     assert_err!(user.todos().get_by_id(&mut db, &ids[0]).await);
 
     // Delete a TODO by scope
-    user.todos().filter_by_id(ids[1]).delete(&mut db).await?;
+    user.todos()
+        .filter_by_id(ids[1])
+        .delete()
+        .exec(&mut db)
+        .await?;
 
     // Can no longer get the todo via id
     assert_err!(Todo::get_by_user_id_and_id(&mut db, &user.id, &ids[1]).await);
@@ -605,7 +618,7 @@ pub async fn delete_when_belongs_to_optional(test: &mut Test) -> Result<()> {
     }
 
     // Delete the user
-    user.delete(&mut db).await?;
+    user.delete().exec(&mut db).await?;
 
     // All the todos still exist and `user` is set to `None`.
     for id in ids {

--- a/crates/toasty-driver-integration-suite/src/tests/has_one_crud_basic.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/has_one_crud_basic.rs
@@ -95,7 +95,7 @@ pub async fn crud_has_one_bi_direction_optional(test: &mut Test) -> Result<()> {
     assert_eq!(&user.id, profile_reloaded.user_id.as_ref().unwrap());
 
     // Deleting the profile will nullify the profile field for the user
-    profile_reloaded.delete(&mut db).await?;
+    profile_reloaded.delete().exec(&mut db).await?;
 
     let mut user_reloaded = User::get_by_id(&mut db, &user.id).await?;
     assert_none!(user_reloaded.profile().get(&mut db).await?);
@@ -110,7 +110,7 @@ pub async fn crud_has_one_bi_direction_optional(test: &mut Test) -> Result<()> {
     let profile_id = user_reloaded.profile().get(&mut db).await?.unwrap().id;
 
     // Delete the user
-    user_reloaded.delete(&mut db).await?;
+    user_reloaded.delete().exec(&mut db).await?;
 
     let profile_reloaded = Profile::get_by_id(&mut db, &profile_id).await?;
     assert_none!(profile_reloaded.user_id);
@@ -160,7 +160,7 @@ pub async fn crud_has_one_required_belongs_to_optional(test: &mut Test) -> Resul
     assert_eq!(user.id, profile.user().get(&mut db).await?.unwrap().id);
 
     // Deleting the user leaves the profile in place.
-    user.delete(&mut db).await?;
+    user.delete().exec(&mut db).await?;
     let profile_reloaded = Profile::get_by_id(&mut db, &profile.id).await?;
     assert_none!(profile_reloaded.user_id);
 
@@ -317,7 +317,7 @@ pub async fn crud_has_one_optional_belongs_to_required(test: &mut Test) -> Resul
     assert_eq!(user.id, profile.user().get(&mut db).await?.id);
 
     // Deleting the user also deletes the profile
-    user.delete(&mut db).await?;
+    user.delete().exec(&mut db).await?;
     assert_err!(Profile::get_by_id(&mut db, &profile.id).await);
     Ok(())
 }

--- a/crates/toasty-driver-integration-suite/src/tests/one_model_crud.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/one_model_crud.rs
@@ -63,10 +63,10 @@ pub async fn crud_no_fields(t: &mut Test) -> Result<()> {
         if i.is_even() {
             // Delete by object
             let val = Foo::get_by_id(&mut db, &id).await?;
-            val.delete(&mut db).await?;
+            val.delete().exec(&mut db).await?;
         } else {
             // Delete by ID
-            Foo::filter_by_id(id).delete(&mut db).await?;
+            Foo::filter_by_id(id).delete().exec(&mut db).await?;
         }
 
         // Assert deleted
@@ -183,7 +183,7 @@ pub async fn crud_one_string(test: &mut Test) -> Result<()> {
 
     // Delete the record (instance method — generates full-key filter).
     test.log().clear();
-    reload.delete(&mut db).await?;
+    reload.delete().exec(&mut db).await?;
 
     let (op, resp) = test.log().pop();
     if is_sql {
@@ -212,7 +212,7 @@ pub async fn crud_one_string(test: &mut Test) -> Result<()> {
     assert_err!(Foo::get_by_id(&mut db, &created.id).await);
 
     // Delete by ID
-    Foo::filter_by_id(ids[0]).delete(&mut db).await?;
+    Foo::filter_by_id(ids[0]).delete().exec(&mut db).await?;
 
     // It is gone
     assert_err!(Foo::get_by_id(&mut db, &ids[0]).await);
@@ -274,7 +274,7 @@ pub async fn unique_index_required_field_update(test: &mut Test) -> Result<()> {
     assert_ne!(user.id, user_alt_email.id);
 
     // Deleting the user then reuse the email address
-    user.delete(&mut db).await?;
+    user.delete().exec(&mut db).await?;
 
     // Finding by the email returns None
     assert_none!(User::filter_by_email(email).first(&mut db).await?);

--- a/crates/toasty-driver-integration-suite/src/tests/one_model_crud_basic_driver_ops.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/one_model_crud_basic_driver_ops.rs
@@ -181,7 +181,7 @@ pub async fn basic_crud(test: &mut Test) -> Result<()> {
     });
 
     // ========== DELETE ==========
-    User::filter_by_id(user_id).delete(&mut db).await?;
+    User::filter_by_id(user_id).delete().exec(&mut db).await?;
 
     // Check the DELETE operation
     let (op, resp) = test.log().pop();

--- a/crates/toasty-driver-integration-suite/src/tests/one_model_partitioned_crud.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/one_model_partitioned_crud.rs
@@ -162,7 +162,8 @@ pub async fn delete_by_partition_key(test: &mut Test) {
 
     // Delete all todos for "alice" using only the partition key filter.
     Todo::filter_by_user_id("alice")
-        .delete(&mut db)
+        .delete()
+        .exec(&mut db)
         .await
         .unwrap();
 

--- a/crates/toasty-driver-integration-suite/src/tests/tx_interactive.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/tx_interactive.rs
@@ -194,7 +194,7 @@ pub async fn delete_rolled_back(t: &mut Test) -> Result<()> {
     let user = User::create().name("Alice").exec(&mut db).await?;
 
     let mut tx = db.transaction().await?;
-    User::filter_by_id(user.id).delete(&mut tx).await?;
+    User::filter_by_id(user.id).delete().exec(&mut tx).await?;
     tx.rollback().await?;
 
     let reloaded = User::get_by_id(&mut db, user.id).await?;

--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -466,8 +466,6 @@ impl visit_mut::VisitMut for LowerStatement<'_, '_> {
     }
 
     fn visit_stmt_delete_mut(&mut self, stmt: &mut stmt::Delete) {
-        assert!(stmt.returning.is_none(), "TODO; stmt={stmt:#?}");
-
         // Create a new expr scope for the statement, and lower all parts
         // *except* the source field (since it is borrowed).
         let mut lower = self.scope_expr(&stmt.from);

--- a/crates/toasty/src/engine/lower/returning.rs
+++ b/crates/toasty/src/engine/lower/returning.rs
@@ -307,7 +307,9 @@ impl LowerStatement<'_, '_> {
         };
 
         let stmt::Returning::Expr(project) = returning else {
-            todo!("returning={returning:#?}")
+            // Already a constant value (e.g., empty record for batch
+            // unit-returning); nothing to constantize.
+            return;
         };
 
         project.substitute(input);

--- a/crates/toasty/src/engine/verify.rs
+++ b/crates/toasty/src/engine/verify.rs
@@ -51,6 +51,21 @@ impl stmt::Visit for Verify<'_> {
         .verify_filter(&i.filter);
     }
 
+    fn visit_expr_stmt(&mut self, i: &stmt::ExprStmt) {
+        // Mutation sub-statements (delete, update, insert) embedded in
+        // expressions must have a returning clause so their result can be
+        // used as a value. Query sub-statements produce results implicitly.
+        if !i.stmt.is_query() {
+            assert!(
+                i.stmt.returning().is_some(),
+                "mutation sub-statement in expression must have a returning clause; stmt={:#?}",
+                i.stmt
+            );
+        }
+
+        stmt::visit::visit_expr_stmt(self, i);
+    }
+
     fn visit_stmt_update(&mut self, i: &stmt::Update) {
         stmt::visit::visit_stmt_update(self, i);
 

--- a/crates/toasty/src/executor_ext.rs
+++ b/crates/toasty/src/executor_ext.rs
@@ -50,7 +50,7 @@ pub trait ExecutorExt: Executor {
     /// Delete all records matching the query.
     fn delete<M>(&mut self, query: stmt::Select<M>) -> impl Future<Output = Result<()>> {
         async move {
-            self.exec(query.delete()).await?;
+            self.exec(query.delete().into()).await?;
             Ok(())
         }
     }

--- a/crates/toasty/src/load.rs
+++ b/crates/toasty/src/load.rs
@@ -10,6 +10,12 @@ pub trait Load: Sized {
     fn load(value: stmt::Value) -> Result<Self, Error>;
 }
 
+impl Load for () {
+    fn load(_value: stmt::Value) -> Result<Self, Error> {
+        Ok(())
+    }
+}
+
 impl<T: Load> Load for Vec<T> {
     fn load(value: stmt::Value) -> Result<Self, Error> {
         match value {

--- a/crates/toasty/src/stmt.rs
+++ b/crates/toasty/src/stmt.rs
@@ -49,6 +49,16 @@ pub struct Statement<M> {
     _p: PhantomData<M>,
 }
 
+impl<M> Statement<M> {
+    /// Wrap a raw untyped statement.
+    pub fn from_untyped_stmt(untyped: stmt::Statement) -> Self {
+        Self {
+            untyped,
+            _p: PhantomData,
+        }
+    }
+}
+
 impl<M: Model> Statement<M> {
     pub fn from_untyped(query: impl IntoSelect<Model = M>) -> Self {
         Self {

--- a/crates/toasty/src/stmt/delete.rs
+++ b/crates/toasty/src/stmt/delete.rs
@@ -1,4 +1,5 @@
-use super::Statement;
+use super::{IntoStatement, Statement};
+use crate::{Executor, ExecutorExt, Model, Result};
 use std::marker::PhantomData;
 use toasty_core::stmt;
 
@@ -11,6 +12,23 @@ impl<M> Delete<M> {
     pub const fn from_untyped(untyped: stmt::Delete) -> Self {
         Self {
             untyped,
+            _p: PhantomData,
+        }
+    }
+
+    pub async fn exec(self, executor: &mut dyn Executor) -> Result<()> {
+        let stmt: Statement<M> = self.into();
+        executor.exec(stmt).await?;
+        Ok(())
+    }
+}
+
+impl<M: Model> IntoStatement for Delete<M> {
+    type Output = ();
+
+    fn into_statement(self) -> Statement<()> {
+        Statement {
+            untyped: self.untyped.into(),
             _p: PhantomData,
         }
     }

--- a/crates/toasty/src/stmt/into_statement.rs
+++ b/crates/toasty/src/stmt/into_statement.rs
@@ -36,7 +36,11 @@ macro_rules! impl_into_statement_for_tuple {
 
             fn into_statement(self) -> Statement<Self::Output> {
                 let exprs: Vec<stmt::Expr> = vec![
-                    $( stmt::Expr::stmt(self.$idx.into_statement().untyped), )+
+                    $( {
+                        let mut untyped = self.$idx.into_statement().untyped;
+                        ensure_batch_returning(&mut untyped);
+                        stmt::Expr::stmt(untyped)
+                    }, )+
                 ];
 
                 let query = stmt::Query::new_single(
@@ -60,10 +64,26 @@ impl_into_statement_for_tuple!(Q1, Q2, Q3, Q4, Q5, Q6; 6; 0, 1, 2, 3, 4, 5);
 impl_into_statement_for_tuple!(Q1, Q2, Q3, Q4, Q5, Q6, Q7; 7; 0, 1, 2, 3, 4, 5, 6);
 impl_into_statement_for_tuple!(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8; 8; 0, 1, 2, 3, 4, 5, 6, 7);
 
+/// Ensure a sub-statement has a returning clause for batch composition.
+///
+/// Mutation statements (delete, update) without a returning clause default to
+/// returning a count. In a batch, every sub-statement must produce a value, so
+/// we set an empty record returning (`Returning::Value(Expr::record([]))`)
+/// which represents unit.
+fn ensure_batch_returning(stmt: &mut stmt::Statement) {
+    if !stmt.is_query() && stmt.returning().is_none() {
+        stmt.set_returning(stmt::Returning::Value(stmt::Expr::record::<stmt::Expr>([])));
+    }
+}
+
 /// Helper to build a batched statement from an iterator of queries.
 fn batch_from_iter<Q: IntoStatement>(iter: impl Iterator<Item = Q>) -> Statement<Vec<Q::Output>> {
     let exprs: Vec<stmt::Expr> = iter
-        .map(|q| stmt::Expr::stmt(q.into_statement().untyped))
+        .map(|q| {
+            let mut untyped = q.into_statement().untyped;
+            ensure_batch_returning(&mut untyped);
+            stmt::Expr::stmt(untyped)
+        })
         .collect();
 
     let query = stmt::Query::new_single(stmt::Values::from(stmt::Expr::record(exprs)));

--- a/crates/toasty/src/stmt/select.rs
+++ b/crates/toasty/src/stmt/select.rs
@@ -1,4 +1,4 @@
-use super::{Delete, Expr, IntoSelect, Statement, Value};
+use super::{Delete, Expr, IntoSelect, Value};
 use crate::Model;
 use std::{fmt, marker::PhantomData};
 use toasty_core::stmt;
@@ -65,9 +65,8 @@ impl<M> Select<M> {
         self
     }
 
-    // TODO: not quite right
-    pub fn delete(self) -> Statement<M> {
-        Delete::from_untyped(self.untyped.delete()).into()
+    pub fn delete(self) -> Delete<M> {
+        Delete::from_untyped(self.untyped.delete())
     }
 }
 

--- a/crates/toasty/src/stmt/update.rs
+++ b/crates/toasty/src/stmt/update.rs
@@ -53,6 +53,11 @@ impl<M: Model> Update<M> {
     pub fn set_returning_none(&mut self) {
         self.untyped.returning = None;
     }
+
+    /// Consume this typed update and return the untyped core statement.
+    pub fn into_untyped_stmt(self) -> stmt::Statement {
+        self.untyped.into()
+    }
 }
 
 impl<M> Clone for Update<M> {

--- a/examples/hello-toasty/src/main.rs
+++ b/examples/hello-toasty/src/main.rs
@@ -105,7 +105,7 @@ async fn main() -> toasty::Result<()> {
 
     // Delete user
     let user = User::get_by_id(&mut db, &u2.id).await?;
-    user.delete(&mut db).await?;
+    user.delete().exec(&mut db).await?;
     assert!(User::get_by_id(&mut db, &u2.id).await.is_err());
 
     // Create a batch of users

--- a/examples/todo-with-cli/src/bin/app.rs
+++ b/examples/todo-with-cli/src/bin/app.rs
@@ -68,7 +68,7 @@ async fn main() -> toasty::Result<()> {
     println!("\n==> Deleting a todo...");
     let todo = Todo::get_by_id(&mut db, &todo2.id).await?;
     println!("Deleting '{}'", todo.title);
-    todo.delete(&mut db).await?;
+    todo.delete().exec(&mut db).await?;
 
     println!("\n==> Final count...");
     let todos = Todo::all().collect::<Vec<_>>(&mut db).await?;


### PR DESCRIPTION
## Changes

- **Delete statements**: Changed `delete()` to return a `Delete<M>` statement instead of executing immediately. Added `.exec()` method for execution, enabling delete statements to be used in batch operations.

- **Update statements**: Implemented `IntoStatement` trait for `Update<M>` to support batch composition alongside other statement types.

- **Batch support**: Updated `IntoStatement` implementations to ensure all sub-statements have returning clauses. Mutation statements without explicit returning now default to returning an empty record (unit type) for batch composition.

- **API changes**:
  - `Model::delete()` now returns `Delete<M>` instead of `async fn`
  - `Select<M>::delete()` now returns `Delete<M>` instead of `Statement<M>`
  - New `Delete::exec()` method for executing delete statements
  - Query filters' `.delete()` methods updated similarly

- **Tests**: Added comprehensive batch operation tests (`batch_update_delete.rs`) covering:
  - Batch updates of same model
  - Batch deletes of same model
  - Mixed update/delete operations
  - All four statement types (query, create, update, delete)
  - Instance-based deletes in batches

- **Examples**: Updated all existing code to use new `.delete().exec()` pattern