### PR TITLE
doc: add cargo fmt workflow reminder to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,10 @@ cargo clippy
 cargo fmt
 ```
 
+## Workflow
+
+Always run `cargo fmt` after finishing work on a change.
+
 ## Architecture
 
 Toasty is a Rust ORM supporting SQL (SQLite, PostgreSQL, MySQL) and NoSQL (DynamoDB) databases. It is a Cargo workspace.


### PR DESCRIPTION
## Summary
- Adds a "Workflow" section to CLAUDE.md instructing to always run `cargo fmt` after finishing work on a change

## Test plan
- N/A (documentation only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)