### PR TITLE
fix subtle cancellation safety issues

### DIFF
--- a/crates/toasty/src/transaction.rs
+++ b/crates/toasty/src/transaction.rs
@@ -74,9 +74,9 @@ impl<'db> Transaction<'db> {
         isolation: Option<IsolationLevel>,
         read_only: bool,
     ) -> Result<Transaction<'db>> {
-        // We're creating the Transaction before actually starting the transaction. If the
-        // future is cancelled while waiting on the response of the `Transaction::Start` the
-        // transaction is still rolled back.
+        // We're creating the Transaction struct before actually starting the transaction. If the
+        // future is cancelled while waiting on the response of the start command, the transaction
+        // is still rolled back.
         let tx = Transaction {
             db,
             finalized: false,
@@ -97,7 +97,7 @@ impl<'db> Transaction<'db> {
 
     /// Commit the transaction.
     pub async fn commit(mut self) -> Result<()> {
-        // Because driver operations are done in a background task, all the operations can't be
+        // Because driver operations are done in a background task, all the operations aren't
         // cancelled and will continue even if this future is dropped. Setting the finalized flag
         // to true early here makes sure that if the future is dropped we don't queue a rollback
         // command.


### PR DESCRIPTION
This pr fixes some very subtle cancellation safety issues in the `Transaction` implementation.

Not wrapping the transaction in a `Transaction` before sending the command also affected SQLx for a while (https://github.com/launchbadge/sqlx/pull/3980).

Setting the finalized flag early is because all the operations are done in a bg task and are guaranteed to be executed.