### PR TITLE
Add offset

### DIFF
--- a/crates/toasty-codegen/src/expand/query.rs
+++ b/crates/toasty-codegen/src/expand/query.rs
@@ -79,6 +79,11 @@ impl Expand<'_> {
                     self
                 }
 
+                #vis fn offset(mut self, n: usize) -> #query_struct_ident {
+                    self.stmt.offset(n);
+                    self
+                }
+
                 #include
                 #relation_methods
             }

--- a/crates/toasty-driver-integration-suite/src/tests/one_model_sort_limit.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/one_model_sort_limit.rs
@@ -107,7 +107,7 @@ pub async fn paginate(test: &mut Test) -> Result<()> {
 }
 
 #[driver_test(id(ID), requires(sql))]
-pub async fn limit(t: &mut Test) -> Result<()> {
+pub async fn limit_offset(t: &mut Test) -> Result<()> {
     #[derive(toasty::Model)]
     struct Foo {
         #[key]
@@ -137,6 +137,18 @@ pub async fn limit(t: &mut Test) -> Result<()> {
     assert_eq!(foos.len(), 7);
     for i in 0..6 {
         assert!(foos[i].order > foos[i + 1].order);
+    }
+
+    // Limit combined with offset
+    let foos: Vec<_> = Foo::all()
+        .order_by(Foo::fields().order().asc())
+        .limit(7)
+        .offset(5)
+        .collect(&mut db)
+        .await?;
+    assert_eq!(foos.len(), 7);
+    for (i, f) in foos.iter().enumerate() {
+        assert_eq!(f.order, i as i64 + 5);
     }
 
     // Limit larger than the result set returns all results

--- a/crates/toasty-sql/src/serializer/statement.rs
+++ b/crates/toasty-sql/src/serializer/statement.rs
@@ -320,9 +320,19 @@ impl ToSql for &stmt::InsertTarget {
 
 impl ToSql for &stmt::Limit {
     fn to_sql<P: Params>(self, cx: &ExprContext<'_>, f: &mut super::Formatter<'_, P>) {
-        assert!(self.offset.is_none(), "TODO; {:#?}", self);
-
         fmt!(cx, f, "LIMIT " self.limit);
+        if let Some(offset) = self.offset.as_ref() {
+            fmt!(cx, f, " " offset);
+        }
+    }
+}
+
+impl ToSql for &stmt::Offset {
+    fn to_sql<P: Params>(self, cx: &ExprContext<'_>, f: &mut super::Formatter<'_, P>) {
+        match self {
+            stmt::Offset::After(_) => panic!("Offset::After cannot be serialized to SQL, should already be lowered to a different representation"),
+            stmt::Offset::Count(count) => fmt!(cx, f, "OFFSET " count),
+        }
     }
 }
 

--- a/crates/toasty/src/engine/lower/paginate.rs
+++ b/crates/toasty/src/engine/lower/paginate.rs
@@ -19,6 +19,11 @@ impl LowerStatement<'_, '_> {
 
         let offset = match limit.offset.take() {
             Some(Offset::After(expr)) => expr,
+            Some(Offset::Count(expr)) => {
+                // Leave count-based offset intact.
+                limit.offset = Some(Offset::Count(expr));
+                return;
+            }
             _ => return,
         };
 

--- a/crates/toasty/src/stmt/select.rs
+++ b/crates/toasty/src/stmt/select.rs
@@ -1,7 +1,7 @@
 use super::{Delete, Expr, IntoSelect, Value};
 use crate::Model;
 use std::{fmt, marker::PhantomData};
-use toasty_core::stmt;
+use toasty_core::stmt::{self, Offset};
 
 pub struct Select<M> {
     /// How to filter the data source
@@ -62,6 +62,17 @@ impl<M> Select<M> {
             limit: stmt::Value::from(n as i64).into(),
             offset: None,
         });
+        self
+    }
+
+    pub fn offset(&mut self, n: usize) -> &mut Self {
+        self.untyped.limit = match self.untyped.limit.take() {
+            Some(limit) => Some(stmt::Limit {
+                limit: limit.limit,
+                offset: Some(Offset::Count(stmt::Expr::Value(Value::from(n)))),
+            }),
+            None => panic!("limit required for offset"),
+        };
         self
     }
 


### PR DESCRIPTION
Adds `OFFSET`, e.g.:
```rust
    let foos: Vec<_> = Foo::all()
        .order_by(Foo::fields().order().asc())
        .limit(7)
        .offset(5)
        .collect(&mut db)
        .await?;
```

There were also some minor engine issues to make this work.