### PR TITLE
Fix batch_load_index for nested HasMany→HasOne inserts

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/preload.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/preload.rs
@@ -968,7 +968,6 @@ pub async fn nested_has_many_then_has_one_optional(test: &mut Test) -> Result<()
 
 // ===== HasMany -> HasOne<T> (required) =====
 // User has_many Accounts, each Account has_one required Settings
-#[ignore] // TODO: nested preload panics with type mismatch for HasMany -> HasOne<T>
 #[driver_test(id(ID))]
 pub async fn nested_has_many_then_has_one_required(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]

--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -128,8 +128,9 @@ enum LoweringContext<'a> {
     /// Lowering a value row being inserted
     InsertRow(&'a stmt::Expr),
 
-    /// Lowering the returning clause of a statement.
-    Returning,
+    /// Lowering the returning clause of a statement. Optionally carries the
+    /// parent INSERT's row index when visiting a per-row returning expression.
+    Returning(Option<usize>),
 
     /// All other lowering cases
     Statement,
@@ -151,10 +152,10 @@ index_vec::define_index_type! {
 
 impl LowerStatement<'_, '_> {
     fn new_dependency(&mut self, stmt: impl Into<stmt::Statement>) -> hir::StmtId {
-        let row_index = if let LoweringContext::Insert(_, row_index) = self.cx {
-            row_index
-        } else {
-            None
+        let row_index = match self.cx {
+            LoweringContext::Insert(_, row_index) => row_index,
+            LoweringContext::Returning(row_index) => row_index,
+            _ => None,
         };
 
         let stmt_id = self.state.lower_stmt(self.expr_cx, row_index, stmt.into());
@@ -474,6 +475,18 @@ impl visit_mut::VisitMut for LowerStatement<'_, '_> {
             *i = stmt::Returning::Expr(returning);
         }
 
+        // For multi-row INSERT returning, visit each row with its row index so
+        // that sub-statements (e.g., child INSERTs for HasOne relations) capture
+        // the correct parent row index via scope_statement.
+        if matches!(&self.cx, LoweringContext::Insert(..)) {
+            if let stmt::Returning::Value(stmt::Expr::List(list)) = i {
+                for (index, item) in list.items.iter_mut().enumerate() {
+                    self.lower_returning_for_row(index).visit_expr_mut(item);
+                }
+                return;
+            }
+        }
+
         stmt::visit_mut::visit_returning_mut(&mut self.lower_returning(), i);
     }
 
@@ -761,7 +774,7 @@ impl<'a, 'b> LowerStatement<'a, 'b> {
 
     fn lower_expr_field(&self, nesting: usize, index: usize) -> stmt::Expr {
         match self.cx {
-            LoweringContext::Statement | LoweringContext::Returning => {
+            LoweringContext::Statement | LoweringContext::Returning(_) => {
                 let mapping = self.mapping_at_unwrap(nesting);
                 mapping.table_to_model.lower_expr_reference(nesting, index)
             }
@@ -1051,10 +1064,10 @@ impl<'a, 'b> LowerStatement<'a, 'b> {
     /// Plan a sub-statement that is able to reference the parent statement
     fn scope_statement(&mut self, f: impl FnOnce(&mut LowerStatement<'_, '_>)) -> hir::StmtId {
         let stmt_id = self.new_statement_info();
-        let row_index = if let LoweringContext::Insert(_, row_index) = &self.cx {
-            *row_index
-        } else {
-            None
+        let row_index = match &self.cx {
+            LoweringContext::Insert(_, row_index) => *row_index,
+            LoweringContext::Returning(row_index) => *row_index,
+            _ => None,
         };
         let scope_id = self.state.scopes.push(Scope { stmt_id, row_index });
         let mut dependencies = None;
@@ -1141,7 +1154,20 @@ impl<'a, 'b> LowerStatement<'a, 'b> {
             state: self.state,
             expr_cx: self.expr_cx,
             scope_id: self.scope_id,
-            cx: LoweringContext::Returning,
+            cx: LoweringContext::Returning(None),
+            collect_dependencies: self.collect_dependencies,
+        }
+    }
+
+    fn lower_returning_for_row<'child>(
+        &'child mut self,
+        row_index: usize,
+    ) -> LowerStatement<'child, 'b> {
+        LowerStatement {
+            state: self.state,
+            expr_cx: self.expr_cx,
+            scope_id: self.scope_id,
+            cx: LoweringContext::Returning(Some(row_index)),
             collect_dependencies: self.collect_dependencies,
         }
     }
@@ -1180,7 +1206,7 @@ impl LoweringContext<'_> {
     }
 
     fn is_returning(&self) -> bool {
-        matches!(self, LoweringContext::Returning)
+        matches!(self, LoweringContext::Returning(_))
     }
 }
 

--- a/crates/toasty/src/engine/plan/statement.rs
+++ b/crates/toasty/src/engine/plan/statement.rs
@@ -382,8 +382,13 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
                         batch_load_index.set(Some(batch_load_table_ref_index));
                     } else if let Some(row) = insert_row {
                         debug_assert!(target_stmt_info.stmt().is_insert());
-                        debug_assert!(batch_load_index.get().is_none());
-                        batch_load_index.set(Some(row));
+                        // batch_load_index may already be set during lowering
+                        // (when the parent INSERT's row index was captured via
+                        // scope_statement). In that case, the lowering value is
+                        // the correct parent row index; don't overwrite it.
+                        if batch_load_index.get().is_none() {
+                            batch_load_index.set(Some(row));
+                        }
                     } else {
                         debug_assert!(
                             batch_load_index.get().is_some(),


### PR DESCRIPTION
## Summary

Fixes a type mismatch panic that occurred when preloading nested HasMany→HasOne relationships with auto-increment IDs.

## Changes

- **Lower context tracking**: Modified `LoweringContext::Returning` to optionally carry the parent INSERT's row index, enabling proper row context propagation during multi-row INSERT returning expressions
- **Per-row returning visitor**: Added `lower_returning_for_row()` method to visit each row in multi-row INSERT returning lists with the correct row index
- **Batch load index handling**: Updated batch_load_index logic to respect values already set during lowering, preventing overwrites of correct parent row indices captured via scope_statement
- **Test cleanup**: Re-enabled `nested_has_many_then_has_one_required` test by removing the `#[ignore]` attribute

## Details

The issue occurred because nested child INSERTs in HasMany→HasOne relationships need to capture the correct parent row index. This is now properly handled by:
1. Passing row indices through the returning context
2. Visiting each row in multi-row returning expressions with its specific index
3. Preserving lowering-captured indices instead of overwriting them during planning