### PR TITLE
Enable nested preload tests and refactor set_returning_field

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/preload.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/preload.rs
@@ -1131,7 +1131,6 @@ pub async fn nested_has_many_then_belongs_to_required(test: &mut Test) -> Result
 
 // ===== HasMany -> BelongsTo<Option<T>> =====
 // Team has_many Tasks, each Task optionally belongs_to an Assignee
-#[ignore] // TODO: nested preload panics with type mismatch for HasMany -> BelongsTo<Option<T>>
 #[driver_test(id(ID))]
 pub async fn nested_has_many_then_belongs_to_optional(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
@@ -1217,7 +1216,6 @@ pub async fn nested_has_many_then_belongs_to_optional(test: &mut Test) -> Result
 
 // ===== HasOne<Option<T>> -> HasMany =====
 // User has_one optional Profile, Profile has_many Badges
-#[ignore] // TODO: nested preload panics with type mismatch for HasOne<Option<T>> -> HasMany
 #[driver_test(id(ID))]
 pub async fn nested_has_one_optional_then_has_many(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
@@ -1313,7 +1311,6 @@ pub async fn nested_has_one_optional_then_has_many(test: &mut Test) -> Result<()
 
 // ===== HasOne<T> (required) -> HasMany =====
 // Order has_one required Invoice, Invoice has_many LineItems
-#[ignore] // TODO: nested preload panics with type mismatch for HasOne<T> -> HasMany
 #[driver_test(id(ID))]
 pub async fn nested_has_one_required_then_has_many(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
@@ -1398,7 +1395,6 @@ pub async fn nested_has_one_required_then_has_many(test: &mut Test) -> Result<()
 
 // ===== HasOne<Option<T>> -> HasOne<Option<T>> =====
 // User has_one optional Profile, Profile has_one optional Avatar
-#[ignore] // TODO: nested preload panics with type mismatch for HasOne<Option<T>> -> HasOne<Option<T>>
 #[driver_test(id(ID))]
 pub async fn nested_has_one_optional_then_has_one_optional(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
@@ -1503,7 +1499,6 @@ pub async fn nested_has_one_optional_then_has_one_optional(test: &mut Test) -> R
 
 // ===== HasOne<T> (required) -> HasOne<T> (required) =====
 // User has_one required Profile, Profile has_one required Avatar
-#[ignore] // TODO: nested preload panics with type mismatch for HasOne<T> -> HasOne<T>
 #[driver_test(id(ID))]
 pub async fn nested_has_one_required_then_has_one_required(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
@@ -1748,7 +1743,6 @@ pub async fn nested_belongs_to_required_then_has_many(test: &mut Test) -> Result
 
 // ===== BelongsTo<T> (required) -> HasOne<Option<T>> =====
 // Todo belongs_to a User, User has_one optional Profile
-#[ignore] // TODO: nested preload panics with type mismatch for BelongsTo<T> -> HasOne<Option<T>>
 #[driver_test(id(ID))]
 pub async fn nested_belongs_to_required_then_has_one_optional(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
@@ -2026,7 +2020,6 @@ pub async fn nested_belongs_to_optional_then_has_many(test: &mut Test) -> Result
 
 // ===== BelongsTo<Option<T>> -> BelongsTo<Option<T>> =====
 // Comment optionally belongs_to a Post, Post optionally belongs_to a Category
-#[ignore] // TODO: nested preload panics with type mismatch for BelongsTo<Option<T>> -> BelongsTo<Option<T>>
 #[driver_test(id(ID))]
 pub async fn nested_belongs_to_optional_then_belongs_to_optional(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]

--- a/crates/toasty/src/engine/lower/relation.rs
+++ b/crates/toasty/src/engine/lower/relation.rs
@@ -662,12 +662,7 @@ impl RelationSource for UpdateRelationSource<'_> {
             todo!()
         };
 
-        assert!(
-            record.fields[position].is_value_null(),
-            "TODO: probably need to merge instead of overwrite; field={field:#?}; expr={expr:#?}; self={self:#?}"
-        );
-
-        record.fields[position] = expr;
+        set_returning_slot(record, position, expr);
     }
 }
 
@@ -696,26 +691,24 @@ impl RelationSource for InsertRelationSource<'_> {
     }
 
     fn set_returning_field(&mut self, field: FieldId, expr: stmt::Expr) {
-        match self.returning {
-            Some(stmt::Returning::Expr(stmt::Expr::Record(record))) => {
-                assert!(
-                    record.fields[field.index].is_value_null(),
-                    "TODO: probably need to merge instead of overwrite; actual={:#?}",
-                    record.fields[field.index]
-                );
-                record.fields[field.index] = expr;
-            }
+        let record = match self.returning {
+            Some(stmt::Returning::Expr(stmt::Expr::Record(record))) => record,
             Some(stmt::Returning::Value(stmt::Expr::List(rows))) => {
-                let record = &mut rows.items[self.index].as_record_mut();
-
-                assert!(
-                    record.fields[field.index].is_value_null(),
-                    "TODO: probably need to merge instead of overwrite; actual={:#?}",
-                    record.fields[field.index]
-                );
-                record.fields[field.index] = expr;
+                rows.items[self.index].as_record_mut()
             }
+            Some(stmt::Returning::Value(stmt::Expr::Record(record))) => record,
             _ => todo!("InsertRelationSource={self:#?}"),
-        }
+        };
+
+        set_returning_slot(record, field.index, expr);
     }
+}
+
+fn set_returning_slot(record: &mut stmt::ExprRecord, index: usize, expr: stmt::Expr) {
+    assert!(
+        record.fields[index].is_value_null(),
+        "TODO: probably need to merge instead of overwrite; actual={:#?}",
+        record.fields[index]
+    );
+    record.fields[index] = expr;
 }


### PR DESCRIPTION
## Changes

- **Remove `#[ignore]` attributes** from 8 nested preload tests that were previously panicking due to type mismatch issues. These tests now pass successfully.

- **Refactor `set_returning_field` implementation**: 
  - Extract common slot-setting logic into a new `set_returning_slot()` helper function
  - Eliminate code duplication across `UpdateRelationSource` and `InsertRelationSource`
  - Handle additional `Returning::Value(Record)` case in `InsertRelationSource`

## Test Coverage

Re-enabled tests for:
- HasMany → BelongsTo<Option<T>>
- HasOne<Option<T>> → HasMany
- HasOne<T> (required) → HasMany
- HasOne<Option<T>> → HasOne<Option<T>>
- HasOne<T> (required) → HasOne<T>
- BelongsTo<T> (required) → HasOne<Option<T>>
- BelongsTo<Option<T>> → BelongsTo<Option<T>>