### PR TITLE
Add batch create tests for array and vec inputs

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/batch_create_statements.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/batch_create_statements.rs
@@ -324,7 +324,7 @@ pub async fn batch_creates_from_vec(t: &mut Test) -> Result<()> {
 
     let mut db = t.setup_db(models!(User)).await;
 
-    let names = vec!["Alice", "Bob", "Carol"];
+    let names = ["Alice", "Bob", "Carol"];
     let builders: Vec<_> = names.iter().map(|n| User::create().name(*n)).collect();
 
     t.log().clear();


### PR DESCRIPTION
Cover the toasty::batch() API with array ([...; N]) and Vec<_> of create
builders, which were previously untested despite having IntoStatement
implementations.

https://claude.ai/code/session_01W4mjg8x2zWKK74hKX9AvYU