### PR TITLE
Add semantic PR validation and commit conventions documentation

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,0 +1,37 @@
+name: "Semantic PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject must not start with an uppercase letter.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,21 @@ cargo fmt
 
 Always run `cargo fmt` after finishing work on a change.
 
+## Commit and PR Conventions
+
+This repository follows the [Conventional Commits](https://www.conventionalcommits.org/) specification.
+All commit messages and PR titles must use the format:
+
+```
+type: description
+```
+
+For example: `feat: add new pattern`, `fix: resolve parsing bug`.
+
+Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.
+
+Scopes are optional. Subjects must begin with a lowercase letter.
+
 ## Architecture
 
 Toasty is a Rust ORM supporting SQL (SQLite, PostgreSQL, MySQL) and NoSQL (DynamoDB) databases. It is a Cargo workspace.


### PR DESCRIPTION
## Summary
This PR adds automated validation for pull request titles and commits using the Conventional Commits specification, along with documentation of these conventions for contributors.

## Key Changes
- **Added GitHub Actions workflow** (`.github/workflows/semantic-pr.yml`): Implements automated PR title validation using the `amannn/action-semantic-pull-request` action
  - Validates PR titles follow the `type: description` format
  - Enforces allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
  - Requires subjects to start with lowercase letters
  - Scopes are optional

- **Updated contributor guidelines** (`CLAUDE.md`): Added new "Commit and PR Conventions" section documenting:
  - Reference to Conventional Commits specification
  - Required format with examples
  - List of allowed commit types
  - Rules about scopes and subject capitalization

## Implementation Details
The semantic PR validation runs on pull request events (opened, edited, synchronize) and provides immediate feedback to contributors about PR title formatting. This ensures consistency across the repository's commit history and makes it easier to generate changelogs and track changes.

https://claude.ai/code/session_01EosQnC5wPZYyNFjcknJRbv