### PR TITLE
Add scenario! macro to reduce test model duplication

### DIFF
--- a/crates/toasty-driver-integration-suite-macros/src/driver_test.rs
+++ b/crates/toasty-driver-integration-suite-macros/src/driver_test.rs
@@ -1,7 +1,8 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, visit_mut::VisitMut, ItemFn, Type, TypePath};
+use syn::{parse_macro_input, visit_mut::VisitMut, ItemFn};
 
+use crate::id_rewriter::IdRewriter;
 use crate::parse::{BoolExpr, DriverTest, DriverTestAttr, Expansion, ExpansionList};
 
 pub fn expand(attr: TokenStream, item: TokenStream) -> TokenStream {
@@ -27,7 +28,13 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> TokenStream {
             .expansions
             .iter()
             .map(|expansion| {
-                generate_variant(&driver_test.input, expansion, &driver_test.requires, true)
+                generate_variant(
+                    &driver_test.input,
+                    expansion,
+                    &driver_test.requires,
+                    driver_test.attr.scenario.as_ref(),
+                    true,
+                )
             })
             .collect();
 
@@ -45,6 +52,7 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> TokenStream {
             &driver_test.input,
             &driver_test.expansions[0],
             &driver_test.requires,
+            driver_test.attr.scenario.as_ref(),
             false, // Don't use expansion name as function name
         );
         quote! {
@@ -59,6 +67,7 @@ fn generate_variant(
     input: &ItemFn,
     expansion: &Expansion,
     requires: &Option<BoolExpr>,
+    scenario: Option<&syn::Path>,
     use_expansion_name: bool,
 ) -> ItemFn {
     let mut variant = input.clone();
@@ -91,6 +100,21 @@ fn generate_variant(
         };
         let mut rewriter = IdRewriter::new(id_ident, target_type);
         rewriter.visit_item_fn_mut(&mut variant);
+    }
+
+    // Inject scenario use-import if specified
+    if let Some(scenario_path) = scenario {
+        let use_stmt: syn::Stmt = if let Some(ref id_variant) = expansion.id_variant {
+            let variant_ident = syn::Ident::new(id_variant.name(), proc_macro2::Span::call_site());
+            syn::parse_quote! {
+                use #scenario_path::#variant_ident::*;
+            }
+        } else {
+            syn::parse_quote! {
+                use #scenario_path::*;
+            }
+        };
+        variant.block.stmts.insert(0, use_stmt);
     }
 
     // Add capability checks at the beginning of the function if there are requires
@@ -328,37 +352,4 @@ fn rewrite_driver_test_cfg_macros(func: &mut ItemFn, expansion: &Expansion) {
 
     let mut rewriter = MacroRewriter { expansion };
     rewriter.visit_item_fn_mut(func);
-}
-
-/// Visitor that rewrites type references to a configurable target type
-struct IdRewriter {
-    /// The identifier to replace (e.g., "ID")
-    ident: String,
-    /// The target type to replace with
-    target_type: Type,
-}
-
-impl IdRewriter {
-    fn new(ident: &str, target_type: Type) -> Self {
-        Self {
-            ident: ident.to_string(),
-            target_type,
-        }
-    }
-}
-
-impl VisitMut for IdRewriter {
-    fn visit_type_mut(&mut self, ty: &mut Type) {
-        if let Type::Path(TypePath { qself: None, path }) = ty {
-            // Check if this matches the identifier we're looking for
-            if path.segments.len() == 1 && path.segments[0].ident == self.ident {
-                // Replace with target type
-                *ty = self.target_type.clone();
-                return;
-            }
-        }
-
-        // Continue visiting nested types
-        syn::visit_mut::visit_type_mut(self, ty);
-    }
 }

--- a/crates/toasty-driver-integration-suite-macros/src/id_rewriter.rs
+++ b/crates/toasty-driver-integration-suite-macros/src/id_rewriter.rs
@@ -1,0 +1,34 @@
+use syn::{visit_mut::VisitMut, Type, TypePath};
+
+/// Visitor that rewrites type references to a configurable target type
+pub(crate) struct IdRewriter {
+    /// The identifier to replace (e.g., "ID")
+    ident: String,
+    /// The target type to replace with
+    target_type: Type,
+}
+
+impl IdRewriter {
+    pub(crate) fn new(ident: &str, target_type: Type) -> Self {
+        Self {
+            ident: ident.to_string(),
+            target_type,
+        }
+    }
+}
+
+impl VisitMut for IdRewriter {
+    fn visit_type_mut(&mut self, ty: &mut Type) {
+        if let Type::Path(TypePath { qself: None, path }) = ty {
+            // Check if this matches the identifier we're looking for
+            if path.segments.len() == 1 && path.segments[0].ident == self.ident {
+                // Replace with target type
+                *ty = self.target_type.clone();
+                return;
+            }
+        }
+
+        // Continue visiting nested types
+        syn::visit_mut::visit_type_mut(self, ty);
+    }
+}

--- a/crates/toasty-driver-integration-suite-macros/src/lib.rs
+++ b/crates/toasty-driver-integration-suite-macros/src/lib.rs
@@ -1,7 +1,9 @@
 extern crate proc_macro;
 
 mod driver_test;
+mod id_rewriter;
 mod parse;
+mod scenario;
 mod test_registry;
 mod test_variants;
 
@@ -20,6 +22,11 @@ pub fn generate_test_registry(input: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn generate_driver_test_variants(input: TokenStream) -> TokenStream {
     test_variants::expand(input)
+}
+
+#[proc_macro]
+pub fn scenario(input: TokenStream) -> TokenStream {
+    scenario::expand(input)
 }
 
 /// Expression macro that evaluates to true or false based on the current driver test expansion.

--- a/crates/toasty-driver-integration-suite-macros/src/parse.rs
+++ b/crates/toasty-driver-integration-suite-macros/src/parse.rs
@@ -254,6 +254,8 @@ pub struct DriverTestAttr {
     pub matrix: Vec<String>,
     pub requires: Option<BoolExpr>,
     pub serial: bool,
+    /// Path to the scenario module (e.g., `crate::scenarios::user_todos`)
+    pub scenario: Option<syn::Path>,
     /// The original syn::Attribute
     pub ast: syn::Attribute,
 }
@@ -268,6 +270,7 @@ impl DriverTestAttr {
                 matrix: Vec::new(),
                 requires: None,
                 serial: false,
+                scenario: None,
                 ast: attr.clone(),
             })
         } else {
@@ -288,6 +291,7 @@ impl Parse for DriverTestAttr {
         let mut matrix = Vec::new();
         let mut requires = None;
         let mut serial = false;
+        let mut scenario = None;
 
         // Parse comma-separated list of attributes
         let attrs = Punctuated::<DriverTestAttrItem, Comma>::parse_terminated(input)?;
@@ -306,6 +310,9 @@ impl Parse for DriverTestAttr {
                 DriverTestAttrItem::Serial => {
                     serial = true;
                 }
+                DriverTestAttrItem::Scenario(name) => {
+                    scenario = Some(name);
+                }
             }
         }
 
@@ -317,6 +324,7 @@ impl Parse for DriverTestAttr {
             matrix,
             requires,
             serial,
+            scenario,
             ast,
         })
     }
@@ -333,6 +341,8 @@ enum DriverTestAttrItem {
     Requires(BoolExpr),
     /// serial - marks test as requiring exclusive (serial) execution
     Serial,
+    /// scenario(path) - imports a scenario module into each test variant
+    Scenario(syn::Path),
 }
 
 impl Parse for DriverTestAttrItem {
@@ -367,9 +377,16 @@ impl Parse for DriverTestAttrItem {
                 // Bare keyword, no parentheses
                 Ok(DriverTestAttrItem::Serial)
             }
+            "scenario" => {
+                // Parse scenario(path::to::module)
+                let content;
+                syn::parenthesized!(content in input);
+                let path: syn::Path = content.parse()?;
+                Ok(DriverTestAttrItem::Scenario(path))
+            }
             _ => Err(syn::Error::new_spanned(
                 name,
-                "unknown attribute, expected `id`, `matrix`, `requires`, or `serial`",
+                "unknown attribute, expected `id`, `matrix`, `requires`, `serial`, or `scenario`",
             )),
         }
     }

--- a/crates/toasty-driver-integration-suite-macros/src/scenario.rs
+++ b/crates/toasty-driver-integration-suite-macros/src/scenario.rs
@@ -1,0 +1,97 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::visit_mut::VisitMut;
+use syn::{Item, Visibility};
+
+use crate::id_rewriter::IdRewriter;
+use crate::parse::KindVariant;
+
+pub fn expand(input: TokenStream) -> TokenStream {
+    let file = syn::parse_macro_input!(input as syn::File);
+
+    // Extract optional #![id(IDENT)] from inner attributes
+    let id_ident = extract_id_ident(&file.attrs);
+    let items = file.items;
+
+    if let Some(ref id_ident) = id_ident {
+        // Generate per-variant modules
+        let variants = [KindVariant::IdU64, KindVariant::IdUuid];
+        let modules: Vec<_> = variants
+            .iter()
+            .map(|variant| {
+                let target_type: syn::Type = match variant {
+                    KindVariant::IdU64 => syn::parse_quote!(u64),
+                    KindVariant::IdUuid => syn::parse_quote!(uuid::Uuid),
+                };
+
+                let mut items = items.clone();
+
+                // Rewrite visibility to pub(crate) and fields to pub(crate)
+                for item in &mut items {
+                    make_pub_crate(item);
+                }
+
+                // Rewrite ID types
+                let mut rewriter = IdRewriter::new(id_ident, target_type);
+                for item in &mut items {
+                    rewriter.visit_item_mut(item);
+                }
+
+                let mod_name = syn::Ident::new(variant.name(), proc_macro2::Span::call_site());
+
+                quote! {
+                    pub(crate) mod #mod_name {
+                        use super::*;
+                        #(#items)*
+                    }
+                }
+            })
+            .collect();
+
+        quote! { #(#modules)* }.into()
+    } else {
+        // No ID expansion — emit items directly with pub(crate) visibility
+        let mut items = items;
+        for item in &mut items {
+            make_pub_crate(item);
+        }
+
+        quote! { #(#items)* }.into()
+    }
+}
+
+/// Extract the ID identifier from `#![id(IDENT)]` inner attributes
+fn extract_id_ident(attrs: &[syn::Attribute]) -> Option<String> {
+    for attr in attrs {
+        if attr.path().is_ident("id") {
+            let ident: syn::Ident = attr.parse_args().expect("expected #![id(IDENT)]");
+            return Some(ident.to_string());
+        }
+    }
+    None
+}
+
+/// Set item and struct field visibility to `pub(crate)`
+fn make_pub_crate(item: &mut Item) {
+    let pub_crate: Visibility = syn::parse_quote!(pub(crate));
+
+    match item {
+        Item::Struct(s) => {
+            s.vis = pub_crate.clone();
+            // Also make fields pub(crate) so tests can access them
+            for field in &mut s.fields {
+                field.vis = pub_crate.clone();
+            }
+        }
+        Item::Fn(f) => {
+            f.vis = pub_crate;
+        }
+        Item::Enum(e) => {
+            e.vis = pub_crate;
+        }
+        Item::Impl(_) => {
+            // impl blocks don't have visibility
+        }
+        _ => {}
+    }
+}

--- a/crates/toasty-driver-integration-suite-macros/src/test_registry.rs
+++ b/crates/toasty-driver-integration-suite-macros/src/test_registry.rs
@@ -222,6 +222,7 @@ fn generate_macro(structure: TestStructure) -> TokenStream {
 
     let expanded = quote! {
         #[macro_export]
+        #[allow(clippy::crate_in_macro_def)]
         macro_rules! generate_driver_tests {
             ($driver_expr:expr $(, $($t:tt)* )?) => {
                 #capability_validation

--- a/crates/toasty-driver-integration-suite/src/lib.rs
+++ b/crates/toasty-driver-integration-suite/src/lib.rs
@@ -19,6 +19,8 @@ pub use setup::Setup;
 mod test;
 pub use test::{Test, TestResult};
 
+pub mod scenarios;
+
 pub mod stmt;
 
 /// Test implementations
@@ -41,5 +43,5 @@ mod prelude {
     pub(crate) use std_util::{
         assert_err, assert_none, assert_ok, assert_unique, num::NumUtil, slice::SliceUtil,
     };
-    pub(crate) use toasty_driver_integration_suite_macros::driver_test;
+    pub(crate) use toasty_driver_integration_suite_macros::{driver_test, scenario};
 }

--- a/crates/toasty-driver-integration-suite/src/scenarios/mod.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios/mod.rs
@@ -1,0 +1,2 @@
+pub mod user_profile;
+pub mod user_todos;

--- a/crates/toasty-driver-integration-suite/src/scenarios/user_profile.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios/user_profile.rs
@@ -1,0 +1,36 @@
+use crate::prelude::*;
+
+scenario! {
+    #![id(ID)]
+
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+
+        name: String,
+
+        #[has_one]
+        profile: toasty::HasOne<Option<Profile>>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Profile {
+        #[key]
+        #[auto]
+        id: ID,
+
+        #[unique]
+        user_id: Option<ID>,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: toasty::BelongsTo<Option<User>>,
+
+        bio: String,
+    }
+
+    async fn setup(test: &mut Test) -> toasty::Db {
+        test.setup_db(models!(User, Profile)).await
+    }
+}

--- a/crates/toasty-driver-integration-suite/src/scenarios/user_todos.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios/user_todos.rs
@@ -1,0 +1,34 @@
+use crate::prelude::*;
+
+scenario! {
+    #![id(ID)]
+
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+
+        #[has_many]
+        todos: toasty::HasMany<Todo>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Todo {
+        #[key]
+        #[auto]
+        id: ID,
+
+        #[index]
+        user_id: ID,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: toasty::BelongsTo<User>,
+
+        title: String,
+    }
+
+    async fn setup(test: &mut Test) -> toasty::Db {
+        test.setup_db(models!(User, Todo)).await
+    }
+}

--- a/crates/toasty-driver-integration-suite/src/tests/has_many_crud_basic.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/has_many_crud_basic.rs
@@ -4,34 +4,9 @@
 use crate::prelude::*;
 use std::collections::HashMap;
 
-#[driver_test(id(ID))]
+#[driver_test(id(ID), scenario(crate::scenarios::user_todos))]
 pub async fn crud_user_todos(test: &mut Test) -> Result<()> {
-    #[derive(Debug, toasty::Model)]
-    struct User {
-        #[key]
-        #[auto]
-        id: ID,
-
-        #[has_many]
-        todos: toasty::HasMany<Todo>,
-    }
-
-    #[derive(Debug, toasty::Model)]
-    struct Todo {
-        #[key]
-        #[auto]
-        id: ID,
-
-        #[index]
-        user_id: ID,
-
-        #[belongs_to(key = user_id, references = id)]
-        user: toasty::BelongsTo<User>,
-
-        title: String,
-    }
-
-    let mut db = test.setup_db(models!(User, Todo)).await;
+    let mut db = setup(test).await;
 
     // Create a user
     let user = User::create().exec(&mut db).await?;
@@ -265,34 +240,9 @@ pub async fn has_many_insert_on_update(test: &mut Test) -> Result<()> {
     Ok(())
 }
 
-#[driver_test(id(ID))]
+#[driver_test(id(ID), scenario(crate::scenarios::user_todos))]
 pub async fn scoped_find_by_id(test: &mut Test) -> Result<()> {
-    #[derive(Debug, toasty::Model)]
-    struct User {
-        #[key]
-        #[auto]
-        id: ID,
-
-        #[has_many]
-        todos: toasty::HasMany<Todo>,
-    }
-
-    #[derive(Debug, toasty::Model)]
-    struct Todo {
-        #[key]
-        #[auto]
-        id: ID,
-
-        #[index]
-        user_id: ID,
-
-        #[belongs_to(key = user_id, references = id)]
-        user: toasty::BelongsTo<User>,
-
-        title: String,
-    }
-
-    let mut db = test.setup_db(models!(User, Todo)).await;
+    let mut db = setup(test).await;
 
     // Create a couple of users
     let user1 = User::create().exec(&mut db).await?;
@@ -549,35 +499,9 @@ pub async fn has_many_when_pk_is_composite(_test: &mut Test) {}
 #[driver_test(id(ID))]
 pub async fn has_many_when_fk_and_pk_are_composite(_test: &mut Test) {}
 
-#[driver_test(id(ID))]
+#[driver_test(id(ID), scenario(crate::scenarios::user_todos))]
 pub async fn belongs_to_required(test: &mut Test) {
-    #[derive(Debug, toasty::Model)]
-    struct User {
-        #[key]
-        #[auto]
-        id: ID,
-
-        #[has_many]
-        #[allow(dead_code)]
-        todos: toasty::HasMany<Todo>,
-    }
-
-    #[derive(Debug, toasty::Model)]
-    struct Todo {
-        #[key]
-        #[auto]
-        id: ID,
-
-        #[index]
-        #[allow(dead_code)]
-        user_id: ID,
-
-        #[belongs_to(key = user_id, references = id)]
-        #[allow(dead_code)]
-        user: toasty::BelongsTo<User>,
-    }
-
-    let mut db = test.setup_db(models!(User, Todo)).await;
+    let mut db = setup(test).await;
 
     assert_err!(Todo::create().exec(&mut db).await);
 }
@@ -630,34 +554,9 @@ pub async fn delete_when_belongs_to_optional(test: &mut Test) -> Result<()> {
     Ok(())
 }
 
-#[driver_test(id(ID))]
+#[driver_test(id(ID), scenario(crate::scenarios::user_todos))]
 pub async fn associate_new_user_with_todo_on_update_via_creation(test: &mut Test) -> Result<()> {
-    #[derive(Debug, toasty::Model)]
-    struct User {
-        #[key]
-        #[auto]
-        id: ID,
-
-        #[has_many]
-        todos: toasty::HasMany<Todo>,
-    }
-
-    #[derive(Debug, toasty::Model)]
-    struct Todo {
-        #[key]
-        #[auto]
-        id: ID,
-
-        #[index]
-        user_id: ID,
-
-        #[belongs_to(key = user_id, references = id)]
-        user: toasty::BelongsTo<User>,
-
-        title: String,
-    }
-
-    let mut db = test.setup_db(models!(User, Todo)).await;
+    let mut db = setup(test).await;
 
     // Create a user with a todo
     let u1 = User::create()
@@ -868,34 +767,9 @@ pub async fn assign_todo_that_already_has_user_on_update(test: &mut Test) -> Res
     Ok(())
 }
 
-#[driver_test(id(ID))]
+#[driver_test(id(ID), scenario(crate::scenarios::user_todos))]
 pub async fn assign_existing_user_to_todo(test: &mut Test) -> Result<()> {
-    #[derive(Debug, toasty::Model)]
-    struct User {
-        #[key]
-        #[auto]
-        id: ID,
-
-        #[has_many]
-        todos: toasty::HasMany<Todo>,
-    }
-
-    #[derive(Debug, toasty::Model)]
-    struct Todo {
-        #[key]
-        #[auto]
-        id: ID,
-
-        #[index]
-        user_id: ID,
-
-        #[belongs_to(key = user_id, references = id)]
-        user: toasty::BelongsTo<User>,
-
-        title: String,
-    }
-
-    let mut db = test.setup_db(models!(User, Todo)).await;
+    let mut db = setup(test).await;
 
     let mut todo = Todo::create()
         .title("hello")
@@ -925,34 +799,9 @@ pub async fn assign_existing_user_to_todo(test: &mut Test) -> Result<()> {
     Ok(())
 }
 
-#[driver_test(id(ID))]
+#[driver_test(id(ID), scenario(crate::scenarios::user_todos))]
 pub async fn assign_todo_to_user_on_update_query(test: &mut Test) -> Result<()> {
-    #[derive(Debug, toasty::Model)]
-    struct User {
-        #[key]
-        #[auto]
-        id: ID,
-
-        #[has_many]
-        todos: toasty::HasMany<Todo>,
-    }
-
-    #[derive(Debug, toasty::Model)]
-    struct Todo {
-        #[key]
-        #[auto]
-        id: ID,
-
-        #[index]
-        user_id: ID,
-
-        #[belongs_to(key = user_id, references = id)]
-        user: toasty::BelongsTo<User>,
-
-        title: String,
-    }
-
-    let mut db = test.setup_db(models!(User, Todo)).await;
+    let mut db = setup(test).await;
 
     let user = User::create().exec(&mut db).await?;
 


### PR DESCRIPTION
Introduces a new `scenario!` proc-macro that allows defining reusable test data models and setup functions that automatically expand to handle different ID types (u64 and UUID).

## Changes

- **New `scenario!` macro**: Accepts model definitions and setup functions with optional `#![id(IDENT)]` attribute to generate per-variant modules
- **ID type expansion**: Automatically generates separate modules for u64 and UUID ID variants, rewriting type references accordingly
- **Scenario integration**: Enhanced `#[driver_test]` macro to support `scenario(path)` attribute for importing scenario modules into test variants
- **Code deduplication**: Extracted `user_todos` and `user_profile` scenarios to reduce boilerplate in integration tests
- **IdRewriter refactor**: Moved `IdRewriter` to separate module for reuse across macros

## Impact

- Eliminates repetitive model definitions across multiple test functions
- Reduces test code by ~199 lines while improving maintainability
- Enables consistent test model usage across different ID type variants