### PR TITLE
feat: release the db connection

### DIFF
--- a/crates/toasty/src/db.rs
+++ b/crates/toasty/src/db.rs
@@ -99,6 +99,11 @@ impl Db {
         self.shared.engine.capability()
     }
 
+    /// Releases the connection back to the pool.
+    pub fn release_connection(&mut self) {
+        self.connection = None;
+    }
+
     /// Returns a reference to the connection pool backing this handle.
     #[doc(hidden)]
     pub fn pool(&self) -> &Pool {


### PR DESCRIPTION
When opening a `Db` with the sqlite driver in memory, the connection pool is limited to one connection. Otherwise using the `Db` only alters one connection in the pool which is not what you want. So this makes sense but can also lead to some footguns. In a hobby project I do something similar to this:
```rust
// 1. Create a Db.
let mut db = Db::builder().connect("sqlite::memory:").await?;

// 2. Use it, insert something, run migrations,...
db.push_schema().await?;

// 3. Inject the Db into the state of my axum app.
app::serve(db).await;
```
After using the `Db`, the only connection is acquired from the pool and stored in the `Db`. Because the `Db` is injected into the state, the connection is never released and the pool is always going to be empty. This leads to a subtle deadlock when trying to use the `Db`, it's waiting for a connection that is never going to be released. Currently I release the connection at startup by doing this:

```rust
let db = {
    let fresh = db.clone();
    drop(db);
    fresh
};
```
This pr introduces a `release_connection` method that returns the active connection to the pool.

While this makes it easier to fix the issue I do think this exposes a bigger problem in the sqlite driver. Potentially we should switch to the shared cache method so we can actually open multiple sqlite connections while still being in memory.

There should probably also be some documentation that states that a `Db` could hold a connection, so people don't hold onto them for too long.