### PR TITLE
fix: update IntoExpr comment to use List<Model> syntax

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/batch_nested_create.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/batch_nested_create.rs
@@ -34,7 +34,7 @@ pub async fn batch_as_nested_has_many_create(test: &mut Test) -> Result<()> {
     let mut db = test.setup_db(models!(User, Todo)).await;
 
     // Pass a tuple of create builders directly — tuples implement
-    // `IntoExpr<[Model]>` so they work as nested HasMany values.
+    // `IntoExpr<List<Model>>` so they work as nested HasMany values.
     let user = User::create()
         .name("Ann Chovey")
         .todos((


### PR DESCRIPTION
## Summary
Updated documentation comment to accurately reflect the generic type parameter used in the `IntoExpr` trait for nested HasMany values.

## Changes
- Corrected the trait bound documentation from `IntoExpr<[Model]>` to `IntoExpr<List<Model>>` in the batch nested create test comment
- This clarifies that the trait expects a `List<Model>` type parameter rather than a slice type

## Details
The comment was documenting how tuples implement `IntoExpr` to work as nested HasMany values. The correction ensures the documentation accurately represents the actual generic type being used, improving clarity for developers reading this test code.

https://claude.ai/code/session_014QjyjaGtQff2Fzq7eV16nD