### PR TITLE
refactor: rename `in_set` to `in_list`

### DIFF
--- a/crates/toasty-codegen/src/expand/embedded_enum.rs
+++ b/crates/toasty-codegen/src/expand/embedded_enum.rs
@@ -43,7 +43,7 @@ impl Expand<'_> {
     }
 
     /// Generates delegated comparison methods (`eq`, `ne`, `gt`, `ge`, `lt`,
-    /// `le`, `in_set`) that forward to `self.path()`.
+    /// `le`, `in_list`) that forward to `self.path()`.
     fn expand_comparison_methods(&self) -> TokenStream {
         let toasty = &self.toasty;
         let vis = &self.model.vis;
@@ -61,8 +61,8 @@ impl Expand<'_> {
         quote! {
             #( #methods )*
 
-            #vis fn in_set(&self, rhs: impl #toasty::stmt::IntoExpr<#toasty::List<#model_ident>>) -> #toasty::stmt::Expr<bool> {
-                self.path().in_set(rhs)
+            #vis fn in_list(&self, rhs: impl #toasty::stmt::IntoExpr<#toasty::List<#model_ident>>) -> #toasty::stmt::Expr<bool> {
+                self.path().in_list(rhs)
             }
         }
     }

--- a/crates/toasty/src/stmt/path.rs
+++ b/crates/toasty/src/stmt/path.rs
@@ -97,7 +97,7 @@ impl<T> Path<T> {
         }
     }
 
-    pub fn in_set(self, rhs: impl IntoExpr<List<T>>) -> Expr<bool> {
+    pub fn in_list(self, rhs: impl IntoExpr<List<T>>) -> Expr<bool> {
         Expr {
             untyped: stmt::Expr::in_list(self.untyped.into_stmt(), rhs.into_expr().untyped),
             _p: PhantomData,

--- a/docs/dev/src/roadmap/query-constraints.md
+++ b/docs/dev/src/roadmap/query-constraints.md
@@ -74,7 +74,7 @@ These features have core AST and SQL serialization but need user-facing APIs:
 
 **NOT IN**
 - Current: `IN` exists but no negated form
-- Needed: `ExprNotInList` or negate the `InList` expression, plus `.not_in_set()` user API
+- Needed: `ExprNotInList` or negate the `InList` expression, plus `.not_in_list()` user API
 - Files: `crates/toasty/src/stmt/path.rs`, `crates/toasty-core/src/stmt/expr.rs`
 - Use case: Exclusion lists (e.g., "exclude these IDs from results")
 
@@ -202,7 +202,7 @@ Based on the analysis above, the following groupings maximize user value:
 
 **Group 1: Expose Existing Internals**
 Items with core AST and SQL serialization that only need user-facing methods:
-- `.not_in_set()` on `Path<T>` (negate existing `InList`)
+- `.not_in_list()` on `Path<T>` (negate existing `InList`)
 
 Estimated scope: ~50 lines of user-facing API code + integration tests
 


### PR DESCRIPTION
This PR renames the `in_set` method to `in_list` across the codebase to maintain consistent naming conventions with the underlying `InList` expression type.

## Summary
The method name `in_set` was inconsistent with the internal `InList` expression type. This change standardizes the API by renaming all occurrences to `in_list`, making the public API more intuitive and aligned with the internal implementation.

## Key Changes
- Renamed `Path::in_set()` to `Path::in_list()` in `crates/toasty/src/stmt/path.rs`
- Updated embedded enum code generation to use `in_list()` instead of `in_set()` in `crates/toasty-codegen/src/expand/embedded_enum.rs`
- Updated documentation references in `docs/dev/src/roadmap/query-constraints.md` to reflect the new method name and planned `.not_in_list()` API

## Implementation Details
- The method signature and functionality remain unchanged; only the name has been updated
- All call sites have been updated to use the new method name
- Documentation has been updated to reference `.not_in_list()` for the planned negated form

https://claude.ai/code/session_01MDLc9JoDowwVNyQC1tar2H