### PR TITLE
refactor: rename terminal query method .all() to .exec()

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ let user = User::create()
 let user = User::get_by_id(&mut db, &user.id).await?;
 
 // Load and iterate the user's todos
-let todos = user.todos().all(&mut db).await?;
+let todos = user.todos().exec(&mut db).await?;
 
 for todo in &todos {
     println!("{:#?}", todo);

--- a/benches/association.rs
+++ b/benches/association.rs
@@ -141,7 +141,7 @@ fn association_benchmarks(c: &mut Criterion) {
                             let users: Vec<User> = User::all()
                                 .include(User::fields().posts())
                                 .include(User::fields().comments())
-                                .all(&mut db)
+                                .exec(&mut db)
                                 .await
                                 .unwrap();
                             black_box(users)

--- a/crates/toasty-codegen/src/expand/query.rs
+++ b/crates/toasty-codegen/src/expand/query.rs
@@ -28,7 +28,7 @@ impl Expand<'_> {
 
                 #filter_methods
 
-                #vis async fn all(self, executor: &mut dyn #toasty::Executor) -> #toasty::Result<Vec<#model_ident>> {
+                #vis async fn exec(self, executor: &mut dyn #toasty::Executor) -> #toasty::Result<Vec<#model_ident>> {
                     use #toasty::ExecutorExt;
                     executor.all(self.stmt).await
                 }

--- a/crates/toasty-codegen/src/expand/relation.rs
+++ b/crates/toasty-codegen/src/expand/relation.rs
@@ -46,7 +46,7 @@ impl Expand<'_> {
                 #filter_methods
 
                 /// Iterate all entries in the relation
-                #vis async fn all(self, executor: &mut dyn #toasty::Executor) -> #toasty::Result<Vec<#model_ident>> {
+                #vis async fn exec(self, executor: &mut dyn #toasty::Executor) -> #toasty::Result<Vec<#model_ident>> {
                     use #toasty::{ExecutorExt, IntoStatement};
                     executor.all(self.into_statement().into_query().unwrap()).await
                 }

--- a/crates/toasty-driver-integration-suite/src/tests/batch_associations.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/batch_associations.rs
@@ -42,7 +42,7 @@ pub async fn batch_two_scoped_creates_same_relation(t: &mut Test) -> Result<()> 
     assert_eq!(t1.user_id, user.id);
     assert_eq!(t2.user_id, user.id);
 
-    let all: Vec<Todo> = user.todos().all(&mut db).await?;
+    let all: Vec<Todo> = user.todos().exec(&mut db).await?;
     assert_eq!(all.len(), 2);
 
     Ok(())
@@ -129,7 +129,7 @@ pub async fn batch_scoped_update_and_delete_same_relation(t: &mut Test) -> Resul
     .exec(&mut db)
     .await?;
 
-    let remaining: Vec<Todo> = user.todos().all(&mut db).await?;
+    let remaining: Vec<Todo> = user.todos().exec(&mut db).await?;
     assert_eq!(remaining.len(), 1);
     assert_eq!(remaining[0].title, "kept");
 
@@ -187,7 +187,7 @@ pub async fn batch_scoped_all_four_crud(t: &mut Test) -> Result<()> {
     assert_eq!(created.title, "new");
 
     // Verify final state
-    let final_todos: Vec<Todo> = user.todos().all(&mut db).await?;
+    let final_todos: Vec<Todo> = user.todos().exec(&mut db).await?;
     assert_eq!(final_todos.len(), 2); // "updated" + "new", "doomed" deleted
 
     let titles: Vec<&str> = final_todos.iter().map(|t| t.title.as_str()).collect();
@@ -444,11 +444,11 @@ pub async fn batch_scoped_delete_with_root_update(t: &mut Test) -> Result<()> {
     .await?;
 
     // Todo deleted
-    let remaining: Vec<Todo> = user.todos().all(&mut db).await?;
+    let remaining: Vec<Todo> = user.todos().exec(&mut db).await?;
     assert!(remaining.is_empty());
 
     // User updated
-    let updated: Vec<User> = User::filter_by_name("Alice2").all(&mut db).await?;
+    let updated: Vec<User> = User::filter_by_name("Alice2").exec(&mut db).await?;
     assert_eq!(updated.len(), 1);
 
     Ok(())

--- a/crates/toasty-driver-integration-suite/src/tests/batch_create_statements.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/batch_create_statements.rs
@@ -47,9 +47,9 @@ pub async fn batch_two_creates_same_model(t: &mut Test) -> Result<()> {
     assert!(t.log().is_empty());
 
     // Verify both were persisted
-    let all: Vec<_> = User::filter_by_id(alice.id).all(&mut db).await?;
+    let all: Vec<_> = User::filter_by_id(alice.id).exec(&mut db).await?;
     assert_eq!(all.len(), 1);
-    let all: Vec<_> = User::filter_by_id(bob.id).all(&mut db).await?;
+    let all: Vec<_> = User::filter_by_id(bob.id).exec(&mut db).await?;
     assert_eq!(all.len(), 1);
 
     Ok(())

--- a/crates/toasty-driver-integration-suite/src/tests/batch_nested_create.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/batch_nested_create.rs
@@ -47,7 +47,7 @@ pub async fn batch_as_nested_has_many_create(test: &mut Test) -> Result<()> {
     assert_eq!(user.name, "Ann Chovey");
 
     // Verify both todos were created and linked
-    let todos: Vec<_> = user.todos().all(&mut db).await?;
+    let todos: Vec<_> = user.todos().exec(&mut db).await?;
     assert_eq_unordered!(todos.iter().map(|t| &t.title[..]), ["Make pizza", "Sleep"]);
 
     Ok(())

--- a/crates/toasty-driver-integration-suite/src/tests/batch_update_delete.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/batch_update_delete.rs
@@ -25,9 +25,9 @@ pub async fn batch_two_updates_same_model(t: &mut Test) -> Result<()> {
     .await?;
 
     // Verify updates applied
-    let alice: Vec<User> = User::filter_by_name("Alice2").all(&mut db).await?;
+    let alice: Vec<User> = User::filter_by_name("Alice2").exec(&mut db).await?;
     assert_eq!(alice.len(), 1);
-    let bob: Vec<User> = User::filter_by_name("Bob2").all(&mut db).await?;
+    let bob: Vec<User> = User::filter_by_name("Bob2").exec(&mut db).await?;
     assert_eq!(bob.len(), 1);
 
     Ok(())
@@ -59,7 +59,7 @@ pub async fn batch_two_deletes_same_model(t: &mut Test) -> Result<()> {
     .await?;
 
     // Verify deletes applied, Carol remains
-    let all: Vec<User> = User::all().all(&mut db).await?;
+    let all: Vec<User> = User::all().exec(&mut db).await?;
     assert_eq!(all.len(), 1);
     assert_eq!(all[0].name, "Carol");
 
@@ -100,11 +100,11 @@ pub async fn batch_update_and_delete(t: &mut Test) -> Result<()> {
     .await?;
 
     // User updated
-    let users: Vec<User> = User::filter_by_name("Alice2").all(&mut db).await?;
+    let users: Vec<User> = User::filter_by_name("Alice2").exec(&mut db).await?;
     assert_eq!(users.len(), 1);
 
     // Post deleted
-    let posts: Vec<Post> = Post::all().all(&mut db).await?;
+    let posts: Vec<Post> = Post::all().exec(&mut db).await?;
     assert_eq!(posts.len(), 0);
 
     Ok(())
@@ -140,15 +140,15 @@ pub async fn batch_all_four_statement_types(t: &mut Test) -> Result<()> {
     assert_eq!(created.name, "Carol");
 
     // Verify update applied
-    let alice: Vec<User> = User::filter_by_name("Alice2").all(&mut db).await?;
+    let alice: Vec<User> = User::filter_by_name("Alice2").exec(&mut db).await?;
     assert_eq!(alice.len(), 1);
 
     // Verify delete applied
-    let bob: Vec<User> = User::filter_by_name("Bob").all(&mut db).await?;
+    let bob: Vec<User> = User::filter_by_name("Bob").exec(&mut db).await?;
     assert_eq!(bob.len(), 0);
 
     // Carol was created
-    let carol: Vec<User> = User::filter_by_name("Carol").all(&mut db).await?;
+    let carol: Vec<User> = User::filter_by_name("Carol").exec(&mut db).await?;
     assert_eq!(carol.len(), 1);
 
     Ok(())
@@ -174,7 +174,7 @@ pub async fn batch_instance_delete(t: &mut Test) -> Result<()> {
         .exec(&mut db)
         .await?;
 
-    let all: Vec<User> = User::all().all(&mut db).await?;
+    let all: Vec<User> = User::all().exec(&mut db).await?;
     assert_eq!(all.len(), 0);
 
     Ok(())

--- a/crates/toasty-driver-integration-suite/src/tests/belongs_to_self_referential.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/belongs_to_self_referential.rs
@@ -63,7 +63,7 @@ pub async fn crud_person_self_referential(t: &mut Test) -> Result<()> {
     };
 
     // Load children from parent
-    let children: Vec<_> = p1.children().all(&mut db).await?;
+    let children: Vec<_> = p1.children().exec(&mut db).await?;
     assert(&children);
 
     // Try preloading this time

--- a/crates/toasty-driver-integration-suite/src/tests/connection_per_clone.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/connection_per_clone.rs
@@ -60,7 +60,7 @@ pub async fn clone_acquires_separate_connection(t: &mut Test) -> Result<()> {
 
     // The original handle still works fine.
     let item = Item::create().exec(&mut db).await?;
-    let found = Item::filter_by_id(item.id).all(&mut db).await?;
+    let found = Item::filter_by_id(item.id).exec(&mut db).await?;
     assert_eq!(found.len(), 1);
 
     Ok(())

--- a/crates/toasty-driver-integration-suite/src/tests/create_macro.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/create_macro.rs
@@ -186,7 +186,7 @@ pub async fn create_macro_nested_association(test: &mut Test) -> Result<()> {
 
     assert_eq!(user.name, "Carl");
 
-    let todos: Vec<_> = user.todos().all(&mut db).await?;
+    let todos: Vec<_> = user.todos().exec(&mut db).await?;
     assert_eq!(todos.len(), 1);
     assert_eq!(todos[0].title, "get something done");
 
@@ -234,7 +234,7 @@ pub async fn create_macro_nested_multiple(test: &mut Test) -> Result<()> {
 
     assert_eq!(user.name, "Carl");
 
-    let mut todos: Vec<_> = user.todos().all(&mut db).await?;
+    let mut todos: Vec<_> = user.todos().exec(&mut db).await?;
     assert_eq!(todos.len(), 2);
 
     todos.sort_by(|a, b| a.title.cmp(&b.title));
@@ -354,11 +354,11 @@ pub async fn create_macro_deeply_nested(test: &mut Test) -> Result<()> {
 
     assert_eq!(user.name, "Carl");
 
-    let todos: Vec<_> = user.todos().all(&mut db).await?;
+    let todos: Vec<_> = user.todos().exec(&mut db).await?;
     assert_eq!(todos.len(), 1);
     assert_eq!(todos[0].title, "get something done");
 
-    let mut tags: Vec<_> = todos[0].tags().all(&mut db).await?;
+    let mut tags: Vec<_> = todos[0].tags().exec(&mut db).await?;
     tags.sort_by(|a, b| a.name.cmp(&b.name));
     assert_eq!(tags.len(), 2);
     assert_eq!(tags[0].name, "urgent");

--- a/crates/toasty-driver-integration-suite/src/tests/embedded_enum_index.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embedded_enum_index.rs
@@ -131,7 +131,7 @@ pub async fn embedded_enum_unique_index_enforced(test: &mut Test) -> Result<()> 
             .email()
             .matches(|e| e.address().eq("alice@example.com")),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_struct!(users, [_ { name: "Alice", .. }]);

--- a/crates/toasty-driver-integration-suite/src/tests/embedded_enum_unit.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embedded_enum_unit.rs
@@ -163,7 +163,7 @@ pub async fn filter_by_enum_variant(t: &mut Test) -> Result<()> {
 
     // Filter: only Active tasks (discriminant = 2)
     let active = Task::filter(Task::fields().status().eq(Status::Active))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
     assert_eq!(active.len(), 2);
     {
@@ -187,7 +187,7 @@ pub async fn filter_by_enum_variant(t: &mut Test) -> Result<()> {
 
     // Filter: only Pending tasks (discriminant = 1)
     let pending = Task::filter(Task::fields().status().eq(Status::Pending))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
     assert_eq!(pending.len(), 1);
     assert_eq!(pending[0].name, "Task A");
@@ -212,7 +212,7 @@ pub async fn filter_by_enum_variant(t: &mut Test) -> Result<()> {
 
     // Filter: only Done tasks (discriminant = 3)
     let done = Task::filter(Task::fields().status().eq(Status::Done))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
     assert_eq!(done.len(), 1);
     assert_eq!(done[0].name, "Task D");

--- a/crates/toasty-driver-integration-suite/src/tests/embedded_struct.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embedded_struct.rs
@@ -329,7 +329,7 @@ pub async fn query_embedded_struct_fields(t: &mut Test) -> Result<()> {
     let mut all_users = Vec::new();
     for country in ["USA", "CAN"] {
         let mut users = User::filter(User::fields().country().eq(country))
-            .all(&mut db)
+            .exec(&mut db)
             .await?;
         all_users.append(&mut users);
     }
@@ -343,7 +343,7 @@ pub async fn query_embedded_struct_fields(t: &mut Test) -> Result<()> {
             .eq("USA")
             .and(User::fields().address().city().eq("Seattle")),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq!(seattle_users.len(), 2);
@@ -358,7 +358,7 @@ pub async fn query_embedded_struct_fields(t: &mut Test) -> Result<()> {
             .eq("CAN")
             .and(User::fields().address().city().eq("Vancouver")),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq!(vancouver_users.len(), 2);
@@ -370,7 +370,7 @@ pub async fn query_embedded_struct_fields(t: &mut Test) -> Result<()> {
             .eq("USA")
             .and(User::fields().address().zip().eq("98101")),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq!(user_98101.len(), 1);
@@ -417,25 +417,25 @@ pub async fn query_embedded_fields_comparison_ops(t: &mut Test) -> Result<()> {
 
     // Test gt: score > 80 should return Alice (100) and Bob (85)
     let high_scorers = Player::filter(Player::fields().stats().score().gt(80))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
     assert_eq!(high_scorers.len(), 2);
 
     // Test le: score <= 55 should return Diana (55) and Eve (40)
     let low_scorers = Player::filter(Player::fields().stats().score().le(55))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
     assert_eq!(low_scorers.len(), 2);
 
     // Test ne: score != 70 excludes only Charlie
     let not_charlie = Player::filter(Player::fields().stats().score().ne(70))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
     assert_eq!(not_charlie.len(), 4);
 
     // Test ge: score >= 70 should return Alice, Bob, Charlie
     let mid_to_high = Player::filter(Player::fields().stats().score().ge(70))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
     assert_eq!(mid_to_high.len(), 3);
     Ok(())
@@ -487,7 +487,7 @@ pub async fn query_embedded_multiple_fields(t: &mut Test) -> Result<()> {
             .eq(10)
             .and(Location::fields().coords().y().eq(20)),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq!(matching.len(), 2);
@@ -505,7 +505,7 @@ pub async fn query_embedded_multiple_fields(t: &mut Test) -> Result<()> {
             .and(Location::fields().coords().y().eq(20))
             .and(Location::fields().coords().z().eq(0)),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq!(exact_match.len(), 1);
@@ -571,19 +571,19 @@ pub async fn update_with_embedded_field_filter(t: &mut Test) -> Result<()> {
 
     // Doc A should be updated (was v1 draft, now v2 draft)
     let doc_a = Document::filter(Document::fields().title().eq("Doc A"))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
     assert_eq!(doc_a[0].meta.version, 2);
 
     // Doc B should be unchanged (was v2 draft, still v2 draft)
     let doc_b = Document::filter(Document::fields().title().eq("Doc B"))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
     assert_eq!(doc_b[0].meta.version, 2);
 
     // Doc C should be unchanged (was v1 published, still v1 published - wrong status)
     let doc_c = Document::filter(Document::fields().title().eq("Doc C"))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
     assert_eq!(doc_c[0].meta.version, 1);
     Ok(())

--- a/crates/toasty-driver-integration-suite/src/tests/embedded_struct_index.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embedded_struct_index.rs
@@ -121,7 +121,7 @@ pub async fn embedded_struct_unique_index_enforced(test: &mut Test) -> Result<()
 
     // Filter by the indexed embedded field
     let users = User::filter(User::fields().contact().email().eq("alice@example.com"))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert_eq!(users.len(), 1);

--- a/crates/toasty-driver-integration-suite/src/tests/filter_data_enum.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/filter_data_enum.rs
@@ -43,7 +43,7 @@ pub async fn filter_data_enum(t: &mut Test) -> Result<()> {
     let emails = User::filter(User::fields().contact().eq(ContactInfo::Email {
         address: "alice@example.com".to_string(),
     }))
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq!(emails.len(), 1);
@@ -100,13 +100,13 @@ pub async fn filter_data_enum_by_variant(t: &mut Test) -> Result<()> {
         .await?;
 
     let emails = User::filter(User::fields().contact().is_email())
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert_eq!(emails.len(), 2);
 
     let phones = User::filter(User::fields().contact().is_phone())
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert_eq!(phones.len(), 1);
@@ -165,18 +165,18 @@ pub async fn filter_unit_enum_by_variant(t: &mut Test) -> Result<()> {
         .await?;
 
     let active = Task::filter(Task::fields().status().is_active())
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
     assert_eq!(active.len(), 2);
 
     let pending = Task::filter(Task::fields().status().is_pending())
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
     assert_eq!(pending.len(), 1);
     assert_eq!(pending[0].name, "A");
 
     let done = Task::filter(Task::fields().status().is_done())
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
     assert_eq!(done.len(), 1);
     assert_eq!(done[0].name, "D");
@@ -234,7 +234,7 @@ pub async fn filter_enum_variant_with_partition_key(t: &mut Test) -> Result<()> 
             .eq("alice")
             .and(Task::fields().status().is_active()),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq!(active.len(), 2);
@@ -245,7 +245,7 @@ pub async fn filter_enum_variant_with_partition_key(t: &mut Test) -> Result<()> 
             .eq("alice")
             .and(Task::fields().status().is_done()),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq!(done.len(), 1);
@@ -258,7 +258,7 @@ pub async fn filter_enum_variant_with_partition_key(t: &mut Test) -> Result<()> 
             .eq("bob")
             .and(Task::fields().status().is_active()),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq!(bob_active.len(), 1);

--- a/crates/toasty-driver-integration-suite/src/tests/filter_data_enum_variant_field.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/filter_data_enum_variant_field.rs
@@ -55,7 +55,7 @@ pub async fn filter_by_variant_field(t: &mut Test) -> Result<()> {
             .email()
             .matches(|e| e.address().eq("alice@example.com")),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq!(results.len(), 1);
@@ -68,7 +68,7 @@ pub async fn filter_by_variant_field(t: &mut Test) -> Result<()> {
             .phone()
             .matches(|e| e.number().eq("555-1234")),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq!(results.len(), 1);
@@ -81,7 +81,7 @@ pub async fn filter_by_variant_field(t: &mut Test) -> Result<()> {
             .email()
             .matches(|e| e.address().eq("nobody@example.com")),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq!(results.len(), 0);
@@ -149,7 +149,7 @@ pub async fn filter_variant_field_with_partition_key(t: &mut Test) -> Result<()>
                 .matches(|e| e.address().eq("alice@example.com")),
         ),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq!(results.len(), 1);

--- a/crates/toasty-driver-integration-suite/src/tests/has_many_batch_create.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/has_many_batch_create.rs
@@ -41,7 +41,7 @@ pub async fn user_batch_create_todos_one_level_basic_fk(test: &mut Test) -> Resu
     assert_eq!(user.name, "Ann Chovey");
 
     // There are associated TODOs
-    let todos: Vec<_> = user.todos().all(&mut db).await?;
+    let todos: Vec<_> = user.todos().exec(&mut db).await?;
     assert_eq!(1, todos.len());
     assert_eq!("Make pizza", todos[0].title);
 
@@ -113,7 +113,7 @@ pub async fn user_batch_create_todos_two_levels_basic_fk(test: &mut Test) -> Res
     assert_eq!(user.name, "Ann Chovey");
 
     // There are associated TODOs
-    let todos: Vec<_> = user.todos().all(&mut db).await?;
+    let todos: Vec<_> = user.todos().exec(&mut db).await?;
     assert_eq!(1, todos.len());
     assert_eq!("Make pizza", todos[0].title);
 
@@ -142,7 +142,7 @@ pub async fn user_batch_create_todos_two_levels_basic_fk(test: &mut Test) -> Res
         .await?;
 
     // There are associated TODOs
-    let todos: Vec<_> = user.todos().all(&mut db).await?;
+    let todos: Vec<_> = user.todos().exec(&mut db).await?;
     assert_eq_unordered!(
         todos.iter().map(|todo| &todo.title[..]),
         ["do something", "do something else"]
@@ -159,7 +159,7 @@ pub async fn user_batch_create_todos_two_levels_basic_fk(test: &mut Test) -> Res
         ["things", "other things"]
     );
 
-    let todos: Vec<_> = category.todos().all(&mut db).await?;
+    let todos: Vec<_> = category.todos().exec(&mut db).await?;
     assert_eq!(1, todos.len());
     Ok(())
 }
@@ -226,7 +226,7 @@ pub async fn user_batch_create_todos_set_category_by_value(test: &mut Test) -> R
     assert_eq!(user.name, "John Doe");
 
     // There are associated TODOs
-    let todos: Vec<_> = user.todos().all(&mut db).await?;
+    let todos: Vec<_> = user.todos().exec(&mut db).await?;
     assert_eq_unordered!(
         todos.iter().map(|todo| &todo.title[..]),
         ["Pizza", "Hamburger"]
@@ -236,7 +236,7 @@ pub async fn user_batch_create_todos_set_category_by_value(test: &mut Test) -> R
         assert_eq!(todo.category_id, category.id);
     }
 
-    let todos: Vec<_> = category.todos().all(&mut db).await?;
+    let todos: Vec<_> = category.todos().exec(&mut db).await?;
     assert_eq_unordered!(
         todos.iter().map(|todo| &todo.title[..]),
         ["Pizza", "Hamburger"]
@@ -304,7 +304,7 @@ pub async fn user_batch_create_todos_with_optional_field(test: &mut Test) -> Res
     assert_eq!(user.name, "Ann Chovey");
 
     // Verify both todos were created
-    let todos: Vec<_> = user.todos().all(&mut db).await?;
+    let todos: Vec<_> = user.todos().exec(&mut db).await?;
     assert_eq!(2, todos.len());
 
     let mut titles: Vec<_> = todos.iter().map(|t| &t.title[..]).collect();
@@ -360,7 +360,7 @@ pub async fn user_batch_create_two_todos_simple(test: &mut Test) -> Result<()> {
     assert_eq!(user.name, "Ann Chovey");
 
     // There should be 2 associated TODOs
-    let todos: Vec<_> = user.todos().all(&mut db).await?;
+    let todos: Vec<_> = user.todos().exec(&mut db).await?;
     assert_eq!(2, todos.len());
 
     // Verify the titles

--- a/crates/toasty-driver-integration-suite/src/tests/has_many_crud_basic.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/has_many_crud_basic.rs
@@ -12,7 +12,7 @@ pub async fn crud_user_todos(test: &mut Test) -> Result<()> {
     let user = User::create().exec(&mut db).await?;
 
     // No TODOs
-    assert_eq!(0, user.todos().all(&mut db).await?.len());
+    assert_eq!(0, user.todos().exec(&mut db).await?.len());
 
     // Create a Todo associated with the user
     let todo = user
@@ -23,13 +23,13 @@ pub async fn crud_user_todos(test: &mut Test) -> Result<()> {
         .await?;
 
     // Find the todo by ID
-    let list = Todo::filter_by_id(todo.id).all(&mut db).await?;
+    let list = Todo::filter_by_id(todo.id).exec(&mut db).await?;
 
     assert_eq!(1, list.len());
     assert_eq!(todo.id, list[0].id);
 
     // Find the TODO by user ID
-    let list = Todo::filter_by_user_id(user.id).all(&mut db).await?;
+    let list = Todo::filter_by_user_id(user.id).exec(&mut db).await?;
 
     assert_eq!(1, list.len());
     assert_eq!(todo.id, list[0].id);
@@ -63,7 +63,7 @@ pub async fn crud_user_todos(test: &mut Test) -> Result<()> {
     }
 
     // Load all TODOs
-    let list = user.todos().all(&mut db).await?;
+    let list = user.todos().exec(&mut db).await?;
 
     assert_eq!(6, list.len());
 
@@ -75,7 +75,7 @@ pub async fn crud_user_todos(test: &mut Test) -> Result<()> {
     }
 
     // Find all TODOs by user (using the belongs_to queries)
-    let list = Todo::filter_by_user_id(user.id).all(&mut db).await?;
+    let list = Todo::filter_by_user_id(user.id).exec(&mut db).await?;
     assert_eq!(6, list.len());
 
     let by_id: HashMap<_, _> = list.into_iter().map(|todo| (todo.id, todo)).collect();
@@ -90,7 +90,7 @@ pub async fn crud_user_todos(test: &mut Test) -> Result<()> {
     let user2 = User::create().exec(&mut db).await?;
 
     // No TODOs associated with `user2`
-    assert_eq!(0, user2.todos().all(&mut db).await?.len());
+    assert_eq!(0, user2.todos().exec(&mut db).await?.len());
 
     // Create a TODO for user2
     let u2_todo = user2
@@ -101,7 +101,7 @@ pub async fn crud_user_todos(test: &mut Test) -> Result<()> {
         .await?;
 
     {
-        let u1_todos = user.todos().all(&mut db).await?;
+        let u1_todos = user.todos().exec(&mut db).await?;
 
         for todo in u1_todos {
             assert_ne!(u2_todo.id, todo.id);
@@ -196,7 +196,7 @@ pub async fn has_many_insert_on_update(test: &mut Test) -> Result<()> {
 
     // Create a user, no TODOs
     let mut user = User::create().name("Alice").exec(&mut db).await?;
-    assert!(user.todos().all(&mut db).await?.is_empty());
+    assert!(user.todos().exec(&mut db).await?.is_empty());
 
     // Update the user and create a todo in a batch
     user.update()
@@ -206,7 +206,7 @@ pub async fn has_many_insert_on_update(test: &mut Test) -> Result<()> {
         .await?;
 
     assert_eq!("Bob", user.name);
-    let todos: Vec<_> = user.todos().all(&mut db).await?;
+    let todos: Vec<_> = user.todos().exec(&mut db).await?;
     assert_eq!(1, todos.len());
     assert_eq!(todos[0].title, "change name");
     Ok(())
@@ -299,7 +299,7 @@ pub async fn has_many_when_fk_is_composite(test: &mut Test) -> Result<()> {
     let user = User::create().exec(&mut db).await?;
 
     // No TODOs
-    assert_eq!(0, user.todos().all(&mut db).await?.len());
+    assert_eq!(0, user.todos().exec(&mut db).await?.len());
 
     // Create a Todo associated with the user
     let todo = user
@@ -311,14 +311,14 @@ pub async fn has_many_when_fk_is_composite(test: &mut Test) -> Result<()> {
 
     // Find the todo by ID
     let list = Todo::filter_by_user_id_and_id(user.id, todo.id)
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert_eq!(1, list.len());
     assert_eq!(todo.id, list[0].id);
 
     // Find the TODO by user ID
-    let list = Todo::filter_by_user_id(user.id).all(&mut db).await?;
+    let list = Todo::filter_by_user_id(user.id).exec(&mut db).await?;
 
     assert_eq!(1, list.len());
     assert_eq!(todo.id, list[0].id);
@@ -348,7 +348,7 @@ pub async fn has_many_when_fk_is_composite(test: &mut Test) -> Result<()> {
     }
 
     // Load all TODOs
-    let list = user.todos().all(&mut db).await?;
+    let list = user.todos().exec(&mut db).await?;
 
     assert_eq!(6, list.len());
 
@@ -360,7 +360,7 @@ pub async fn has_many_when_fk_is_composite(test: &mut Test) -> Result<()> {
     }
 
     // Find all TODOs by user (using the belongs_to queries)
-    let list = Todo::filter_by_user_id(user.id).all(&mut db).await?;
+    let list = Todo::filter_by_user_id(user.id).exec(&mut db).await?;
     assert_eq!(6, list.len());
 
     let by_id: HashMap<_, _> = list.into_iter().map(|todo| (todo.id, todo)).collect();
@@ -375,7 +375,7 @@ pub async fn has_many_when_fk_is_composite(test: &mut Test) -> Result<()> {
     let user2 = User::create().exec(&mut db).await?;
 
     // No TODOs associated with `user2`
-    assert_eq!(0, user2.todos().all(&mut db).await?.len());
+    assert_eq!(0, user2.todos().exec(&mut db).await?.len());
 
     // Create a TODO for user2
     let u2_todo = user2
@@ -385,7 +385,7 @@ pub async fn has_many_when_fk_is_composite(test: &mut Test) -> Result<()> {
         .exec(&mut db)
         .await?;
 
-    let u1_todos = user.todos().all(&mut db).await?;
+    let u1_todos = user.todos().exec(&mut db).await?;
 
     for todo in u1_todos {
         assert_ne!(u2_todo.id, todo.id);
@@ -511,7 +511,7 @@ pub async fn associate_new_user_with_todo_on_update_via_creation(test: &mut Test
         .await?;
 
     // Get the todo
-    let todos: Vec<_> = u1.todos().all(&mut db).await?;
+    let todos: Vec<_> = u1.todos().exec(&mut db).await?;
     assert_eq!(1, todos.len());
     let mut todo = todos.into_iter().next().unwrap();
 
@@ -552,7 +552,7 @@ pub async fn associate_new_user_with_todo_on_update_query_via_creation(
     let u1 = User::create().todo(Todo::create()).exec(&mut db).await?;
 
     // Get the todo
-    let todos: Vec<_> = u1.todos().all(&mut db).await?;
+    let todos: Vec<_> = u1.todos().exec(&mut db).await?;
     assert_eq!(1, todos.len());
     let todo = todos.into_iter().next().unwrap();
 
@@ -598,7 +598,7 @@ pub async fn update_user_with_null_todo_is_err(test: &mut Test) -> Result<()> {
     let u1 = User::create().todo(Todo::create()).exec(&mut db).await?;
 
     // Get the todo
-    let todos: Vec<_> = u1.todos().all(&mut db).await?;
+    let todos: Vec<_> = u1.todos().exec(&mut db).await?;
     assert_eq!(1, todos.len());
     let todo = todos.into_iter().next().unwrap();
 
@@ -652,11 +652,11 @@ pub async fn assign_todo_that_already_has_user_on_create(test: &mut Test) -> Res
     assert_eq!(u2.id, todo_reload.user_id);
 
     // First user has no todos
-    let todos: Vec<_> = u1.todos().all(&mut db).await?;
+    let todos: Vec<_> = u1.todos().exec(&mut db).await?;
     assert_eq!(0, todos.len());
 
     // Second user has the todo
-    let todos: Vec<_> = u2.todos().all(&mut db).await?;
+    let todos: Vec<_> = u2.todos().exec(&mut db).await?;
     assert_eq!(1, todos.len());
     assert_eq!(todo.id, todos[0].id);
     Ok(())
@@ -703,11 +703,11 @@ pub async fn assign_todo_that_already_has_user_on_update(test: &mut Test) -> Res
     assert_eq!(u2.id, todo_reload.user_id);
 
     // First user has no todos
-    let todos: Vec<_> = u1.todos().all(&mut db).await?;
+    let todos: Vec<_> = u1.todos().exec(&mut db).await?;
     assert_eq!(0, todos.len());
 
     // Second user has the todo
-    let todos: Vec<_> = u2.todos().all(&mut db).await?;
+    let todos: Vec<_> = u2.todos().exec(&mut db).await?;
     assert_eq!(1, todos.len());
     assert_eq!(todo.id, todos[0].id);
     Ok(())
@@ -735,11 +735,11 @@ pub async fn assign_existing_user_to_todo(test: &mut Test) -> Result<()> {
     assert_eq!(u2.id, todo_reload.user_id);
 
     // First user has no todos
-    let todos: Vec<_> = u1.todos().all(&mut db).await?;
+    let todos: Vec<_> = u1.todos().exec(&mut db).await?;
     assert_eq!(0, todos.len());
 
     // Second user has the todo
-    let todos: Vec<_> = u2.todos().all(&mut db).await?;
+    let todos: Vec<_> = u2.todos().exec(&mut db).await?;
     assert_eq!(1, todos.len());
     assert_eq!(todo.id, todos[0].id);
     Ok(())
@@ -757,7 +757,7 @@ pub async fn assign_todo_to_user_on_update_query(test: &mut Test) -> Result<()> 
         .exec(&mut db)
         .await?;
 
-    let todos: Vec<_> = user.todos().all(&mut db).await?;
+    let todos: Vec<_> = user.todos().exec(&mut db).await?;
     assert_eq!(1, todos.len());
     assert_eq!("hello", todos[0].title);
     Ok(())

--- a/crates/toasty-driver-integration-suite/src/tests/has_many_crud_multi_relations.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/has_many_crud_multi_relations.rs
@@ -56,7 +56,7 @@ pub async fn crud_user_todos_categories(test: &mut Test) -> Result<()> {
     let user = User::create().name("Ann Chovey").exec(&mut db).await?;
 
     // No TODOs
-    assert!(user.todos().all(&mut db).await?.is_empty());
+    assert!(user.todos().exec(&mut db).await?.is_empty());
 
     // Create a category
     let category = Category::create().name("Food").exec(&mut db).await?;
@@ -95,9 +95,9 @@ pub async fn crud_user_todos_categories(test: &mut Test) -> Result<()> {
     let expect: HashMap<_, _> = todos.into_iter().map(|todo| (todo.id, todo)).collect();
 
     let lists = [
-        category.todos().all(&mut db).await?,
-        user.todos().all(&mut db).await?,
-        Todo::filter_by_user_id(user.id).all(&mut db).await?,
+        category.todos().exec(&mut db).await?,
+        user.todos().exec(&mut db).await?,
+        Todo::filter_by_user_id(user.id).exec(&mut db).await?,
     ];
 
     for list in lists {
@@ -154,20 +154,20 @@ pub async fn crud_user_todos_categories(test: &mut Test) -> Result<()> {
     let list = category
         .todos()
         .query(Todo::fields().user().eq(&user))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
     check_todo_list(&mut db, &expect, list).await?;
 
     let list = user
         .todos()
         .query(Todo::fields().category().eq(&category))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
     check_todo_list(&mut db, &expect, list).await?;
 
     let list = Todo::filter_by_user_id(user.id)
         .filter(Todo::fields().category().eq(&category))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
     check_todo_list(&mut db, &expect, list).await
 }

--- a/crates/toasty-driver-integration-suite/src/tests/has_many_filter_on_association.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/has_many_filter_on_association.rs
@@ -79,7 +79,7 @@ pub async fn filter_parent_by_child_field(test: &mut Test) -> Result<()> {
             .todos()
             .any(Todo::fields().complete().eq(false)),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq_unordered!(users.iter().map(|u| &u.name[..]), ["Alice", "Carol"]);
@@ -90,7 +90,7 @@ pub async fn filter_parent_by_child_field(test: &mut Test) -> Result<()> {
             .todos()
             .any(Todo::fields().complete().eq(true)),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq_unordered!(users.iter().map(|u| &u.name[..]), ["Bob", "Carol"]);
@@ -141,7 +141,7 @@ pub async fn filter_parent_no_matching_children(test: &mut Test) -> Result<()> {
 
     // No todos with priority > 5 exist
     let users: Vec<_> = User::filter(User::fields().todos().any(Todo::fields().priority().gt(5)))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert!(users.is_empty());

--- a/crates/toasty-driver-integration-suite/src/tests/has_many_link_unlink.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/has_many_link_unlink.rs
@@ -36,13 +36,13 @@ pub async fn remove_add_single_relation_option_belongs_to(test: &mut Test) -> Re
         .exec(&mut db)
         .await?;
 
-    let todos: Vec<_> = user.todos().all(&mut db).await?;
+    let todos: Vec<_> = user.todos().exec(&mut db).await?;
     assert_eq!(2, todos.len());
 
     // Remove a todo from the list.
     user.todos().remove(&mut db, &todos[0]).await?;
 
-    let todos_reloaded: Vec<_> = user.todos().all(&mut db).await?;
+    let todos_reloaded: Vec<_> = user.todos().exec(&mut db).await?;
     assert_eq!(1, todos_reloaded.len());
     assert_eq!(todos[1].id, todos_reloaded[0].id);
 
@@ -56,7 +56,7 @@ pub async fn remove_add_single_relation_option_belongs_to(test: &mut Test) -> Re
     // Create a second user w/ a TODO. We will ensure that unlinking *only*
     // unlinks records currently associated with the base model.
     let u2 = User::create().todo(Todo::create()).exec(&mut db).await?;
-    let u2_todos = u2.todos().all(&mut db).await?;
+    let u2_todos = u2.todos().exec(&mut db).await?;
 
     // Try unlinking u2's todo via user. This should fail
     assert_err!(user.todos().remove(&mut db, &u2_todos[0]).await);
@@ -69,7 +69,7 @@ pub async fn remove_add_single_relation_option_belongs_to(test: &mut Test) -> Re
     user.todos().insert(&mut db, &todos[0]).await?;
 
     // The TODO is in the association again
-    let todos_reloaded: Vec<_> = user.todos().all(&mut db).await?;
+    let todos_reloaded: Vec<_> = user.todos().exec(&mut db).await?;
     assert!(todos_reloaded.iter().any(|t| t.id == todos[0].id));
     assert_ok!(user.todos().get_by_id(&mut db, todos[0].id).await);
     Ok(())
@@ -112,7 +112,7 @@ pub async fn add_remove_single_relation_required_belongs_to(test: &mut Test) -> 
 
     let ids = vec![t1.id, t2.id, t3.id];
 
-    let todos_reloaded: Vec<_> = user.todos().all(&mut db).await?;
+    let todos_reloaded: Vec<_> = user.todos().exec(&mut db).await?;
     assert_eq!(todos_reloaded.len(), 3);
 
     for id in ids {
@@ -126,7 +126,7 @@ pub async fn add_remove_single_relation_required_belongs_to(test: &mut Test) -> 
     assert_err!(Todo::get_by_id(&mut db, todos_reloaded[0].id).await);
 
     // Rest of the todos exist
-    let todos_reloaded: Vec<_> = user.todos().all(&mut db).await?;
+    let todos_reloaded: Vec<_> = user.todos().exec(&mut db).await?;
     assert_eq!(todos_reloaded.len(), 2);
     Ok(())
 }
@@ -169,10 +169,10 @@ pub async fn reassign_relation_required_belongs_to(test: &mut Test) -> Result<()
     u2.todos().insert(&mut db, &t1).await?;
 
     // The TODO is no longer associated with user 1
-    assert!(u1.todos().all(&mut db).await?.is_empty());
+    assert!(u1.todos().exec(&mut db).await?.is_empty());
 
     // The TODO is assiated with user 2
-    let todos = u2.todos().all(&mut db).await?;
+    let todos = u2.todos().exec(&mut db).await?;
     assert_eq!(1, todos.len());
     assert_eq!(t1.id, todos[0].id);
     Ok(())
@@ -218,7 +218,7 @@ pub async fn add_remove_multiple_relation_option_belongs_to(test: &mut Test) -> 
     // Associate the todos with the user
     user.todos().insert(&mut db, &[t1, t2, t3]).await?;
 
-    let todos_reloaded: Vec<_> = user.todos().all(&mut db).await?;
+    let todos_reloaded: Vec<_> = user.todos().exec(&mut db).await?;
     assert_eq!(todos_reloaded.len(), 3);
 
     for id in ids {

--- a/crates/toasty-driver-integration-suite/src/tests/has_many_n_1.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/has_many_n_1.rs
@@ -63,7 +63,7 @@ pub async fn hello_world(test: &mut Test) -> Result<()> {
         .exec(&mut db)
         .await?;
 
-    let todos = user.todos().all(&mut db).await?;
+    let todos = user.todos().exec(&mut db).await?;
 
     assert_eq!(3, todos.len());
     Ok(())

--- a/crates/toasty-driver-integration-suite/src/tests/has_many_scoped_query.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/has_many_scoped_query.rs
@@ -74,7 +74,7 @@ pub async fn scoped_query_eq(test: &mut Test) -> Result<()> {
     let todos = u1
         .todos()
         .query(Todo::fields().order().eq(0))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert_eq!(1, todos.len());
@@ -86,7 +86,7 @@ pub async fn scoped_query_eq(test: &mut Test) -> Result<()> {
     let todos = u2
         .todos()
         .query(Todo::fields().order().eq(0))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert_eq!(1, todos.len());
@@ -107,7 +107,7 @@ pub async fn scoped_query_eq(test: &mut Test) -> Result<()> {
     let todos = u1
         .todos()
         .query(Todo::fields().order().eq(0))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     for todo in todos {
@@ -122,7 +122,7 @@ pub async fn scoped_query_eq(test: &mut Test) -> Result<()> {
     let todos = u2
         .todos()
         .query(Todo::fields().order().eq(1))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert!(todos.is_empty());
@@ -178,7 +178,7 @@ pub async fn scoped_query_gt(test: &mut Test) -> Result<()> {
     let todos: Vec<_> = user
         .todos()
         .query(Todo::fields().order().ne(2))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert_eq_unordered!(
@@ -194,7 +194,7 @@ pub async fn scoped_query_gt(test: &mut Test) -> Result<()> {
     let todos: Vec<_> = user
         .todos()
         .query(Todo::fields().order().gt(2))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert_eq_unordered!(
@@ -206,7 +206,7 @@ pub async fn scoped_query_gt(test: &mut Test) -> Result<()> {
     let todos: Vec<_> = user
         .todos()
         .query(Todo::fields().order().ge(2))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert_eq_unordered!(
@@ -218,7 +218,7 @@ pub async fn scoped_query_gt(test: &mut Test) -> Result<()> {
     let todos: Vec<_> = user
         .todos()
         .query(Todo::fields().order().lt(2))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert_eq_unordered!(
@@ -230,7 +230,7 @@ pub async fn scoped_query_gt(test: &mut Test) -> Result<()> {
     let todos: Vec<_> = user
         .todos()
         .query(Todo::fields().order().le(2))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert_eq_unordered!(

--- a/crates/toasty-driver-integration-suite/src/tests/jiff.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/jiff.rs
@@ -473,7 +473,7 @@ pub async fn order_by_timestamp(test: &mut Test) -> Result<(), BoxError> {
 
     let asc: Vec<_> = Foo::all()
         .order_by(Foo::fields().val().asc())
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert_eq!(asc.len(), 3);
@@ -482,7 +482,7 @@ pub async fn order_by_timestamp(test: &mut Test) -> Result<(), BoxError> {
 
     let desc: Vec<_> = Foo::all()
         .order_by(Foo::fields().val().desc())
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert_eq!(desc.len(), 3);
@@ -517,12 +517,12 @@ pub async fn filter_by_timestamp(test: &mut Test) -> Result<(), BoxError> {
     Event::create().at(ts2).name("b").exec(&mut db).await?;
     Event::create().at(ts3).name("c").exec(&mut db).await?;
 
-    let results = Event::filter_by_at(ts2).all(&mut db).await?;
+    let results = Event::filter_by_at(ts2).exec(&mut db).await?;
     assert_struct!(results, [{ name: "b", at: == ts2 }]);
 
     // No match
     let results = Event::filter_by_at(Timestamp::from_second(0)?)
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
     assert!(results.is_empty());
 

--- a/crates/toasty-driver-integration-suite/src/tests/one_model_batch_create.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/one_model_batch_create.rs
@@ -52,7 +52,7 @@ pub async fn batch_create_one(test: &mut Test) -> Result<()> {
         assert!(test.log().is_empty());
     }
 
-    let reloaded: Vec<_> = Todo::filter_by_id(res[0].id).all(&mut db).await?;
+    let reloaded: Vec<_> = Todo::filter_by_id(res[0].id).exec(&mut db).await?;
     assert_eq!(1, reloaded.len());
     assert_eq!(reloaded[0].id, res[0].id);
     Ok(())
@@ -90,7 +90,7 @@ pub async fn batch_create_many(test: &mut Test) -> Result<()> {
     }
 
     for todo in &res {
-        let reloaded: Vec<_> = Todo::filter_by_id(todo.id).all(&mut db).await?;
+        let reloaded: Vec<_> = Todo::filter_by_id(todo.id).exec(&mut db).await?;
         assert_eq!(1, reloaded.len());
         assert_eq!(reloaded[0].id, todo.id);
     }
@@ -121,7 +121,7 @@ pub async fn batch_create_fails_if_any_record_missing_fields(test: &mut Test) ->
     assert!(res.is_empty());
 
     let users: Vec<_> = User::filter_by_email("me@carllerche.com")
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert!(users.is_empty());
@@ -227,7 +227,7 @@ pub async fn batch_create_unique_violation_rolls_back(t: &mut Test) -> Result<()
     assert!(t.log().is_empty());
 
     // Only the seeded user remains
-    let users = User::all().all(&mut db).await?;
+    let users = User::all().exec(&mut db).await?;
     assert_eq!(1, users.len());
 
     Ok(())

--- a/crates/toasty-driver-integration-suite/src/tests/one_model_composite_key.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/one_model_composite_key.rs
@@ -30,7 +30,7 @@ pub async fn batch_get_by_key(test: &mut Test) -> Result<()> {
         (&keys[1].0, &keys[1].1),
         (&keys[2].0, &keys[2].1),
     ])
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq!(3, foos.len());

--- a/crates/toasty-driver-integration-suite/src/tests/one_model_crud.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/one_model_crud.rs
@@ -21,7 +21,7 @@ pub async fn crud_no_fields(t: &mut Test) -> Result<()> {
     let created = Foo::create().exec(&mut db).await?;
 
     // Find Foo
-    let read = Foo::filter_by_id(created.id).all(&mut db).await?;
+    let read = Foo::filter_by_id(created.id).exec(&mut db).await?;
 
     assert_eq!(1, read.len());
     assert_eq!(created.id, read[0].id);
@@ -39,7 +39,7 @@ pub async fn crud_no_fields(t: &mut Test) -> Result<()> {
     assert_unique!(ids);
 
     for id in &ids {
-        let read = Foo::filter_by_id(id).all(&mut db).await?;
+        let read = Foo::filter_by_id(id).exec(&mut db).await?;
 
         assert_eq!(1, read.len());
         assert_eq!(*id, read[0].id);
@@ -94,7 +94,7 @@ pub async fn crud_one_string(test: &mut Test) -> Result<()> {
     assert_eq!(created.val, "hello world");
 
     // Find Foo
-    let read = Foo::filter_by_id(created.id).all(&mut db).await?;
+    let read = Foo::filter_by_id(created.id).exec(&mut db).await?;
 
     assert_eq!(1, read.len());
     assert_eq!(created.id, read[0].id);
@@ -115,7 +115,7 @@ pub async fn crud_one_string(test: &mut Test) -> Result<()> {
     assert_unique!(ids);
 
     for (i, id) in ids.iter().enumerate() {
-        let read = Foo::filter_by_id(id).all(&mut db).await?;
+        let read = Foo::filter_by_id(id).exec(&mut db).await?;
 
         assert_eq!(1, read.len());
         assert_eq!(*id, read[0].id);
@@ -469,7 +469,7 @@ pub async fn batch_get_by_id(test: &mut Test) -> Result<()> {
     }
 
     let items: Vec<_> = Foo::filter_by_id_batch([&keys[0], &keys[1], &keys[2]])
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert_eq!(3, items.len());
@@ -497,7 +497,7 @@ pub async fn empty_batch_get_by_id(test: &mut Test) -> Result<()> {
         ids.push(item.id);
     }
 
-    let items: Vec<_> = Foo::filter_by_id_batch(&[] as &[ID]).all(&mut db).await?;
+    let items: Vec<_> = Foo::filter_by_id_batch(&[] as &[ID]).exec(&mut db).await?;
 
     assert_eq!(0, items.len());
     Ok(())

--- a/crates/toasty-driver-integration-suite/src/tests/one_model_option_filter.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/one_model_option_filter.rs
@@ -34,7 +34,7 @@ pub async fn filter_option_is_none(test: &mut Test) -> Result<()> {
 
     // Filter for users with no bio (IS NULL)
     let users = User::filter(User::fields().bio().is_none())
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert_eq!(1, users.len());
@@ -75,7 +75,7 @@ pub async fn filter_option_is_some(test: &mut Test) -> Result<()> {
 
     // Filter for users with a bio (IS NOT NULL)
     let users = User::filter(User::fields().bio().is_some())
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert_eq!(2, users.len());
@@ -129,7 +129,7 @@ pub async fn filter_option_combined_with_other_filters(test: &mut Test) -> Resul
             .is_some()
             .and(User::fields().age().gt(30)),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq!(1, users.len());
@@ -142,7 +142,7 @@ pub async fn filter_option_combined_with_other_filters(test: &mut Test) -> Resul
             .is_none()
             .and(User::fields().age().eq(25)),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq!(1, users.len());
@@ -200,7 +200,7 @@ pub async fn filter_option_multiple_nullable_fields(test: &mut Test) -> Result<(
             .is_some()
             .and(Article::fields().summary().is_none()),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq!(1, articles.len());
@@ -213,7 +213,7 @@ pub async fn filter_option_multiple_nullable_fields(test: &mut Test) -> Result<(
             .is_none()
             .and(Article::fields().summary().is_none()),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq!(1, articles.len());
@@ -278,7 +278,7 @@ pub async fn filter_option_with_partition_key(test: &mut Test) -> Result<()> {
             .eq("Electronics")
             .and(Product::fields().description().is_none()),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq!(1, products.len());
@@ -291,7 +291,7 @@ pub async fn filter_option_with_partition_key(test: &mut Test) -> Result<()> {
             .eq("Electronics")
             .and(Product::fields().description().is_some()),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq!(2, products.len());
@@ -306,7 +306,7 @@ pub async fn filter_option_with_partition_key(test: &mut Test) -> Result<()> {
             .eq("Books")
             .and(Product::fields().description().is_none()),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq!(1, products.len());

--- a/crates/toasty-driver-integration-suite/src/tests/one_model_query.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/one_model_query.rs
@@ -31,7 +31,7 @@ pub async fn query_index_eq(test: &mut Test) -> Result<()> {
         User::create().name(name).email(email).exec(&mut db).await?;
     }
 
-    let users = User::filter_by_name("one").all(&mut db).await?;
+    let users = User::filter_by_name("one").exec(&mut db).await?;
 
     assert_eq!(1, users.len());
     assert_eq!("one", users[0].name);
@@ -44,7 +44,7 @@ pub async fn query_index_eq(test: &mut Test) -> Result<()> {
         .exec(&mut db)
         .await?;
 
-    let mut users = User::filter_by_name("one").all(&mut db).await?;
+    let mut users = User::filter_by_name("one").exec(&mut db).await?;
 
     users.sort_by_key(|u| u.email.clone());
 
@@ -100,7 +100,7 @@ pub async fn query_partition_key_string_eq(test: &mut Test) -> Result<()> {
 
     // Query on the partition key only
     let teams = Team::filter(Team::fields().league().eq("EPL"))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     let mut names = teams.iter().map(|team| &team.name).collect::<Vec<_>>();
@@ -118,7 +118,7 @@ pub async fn query_partition_key_string_eq(test: &mut Test) -> Result<()> {
             .eq("MLS")
             .and(Team::fields().name().eq("Portland Timbers")),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     let mut names = teams.iter().map(|team| &team.name).collect::<Vec<_>>();
@@ -133,7 +133,7 @@ pub async fn query_partition_key_string_eq(test: &mut Test) -> Result<()> {
             .eq("MLS")
             .and(Team::fields().founded().eq(2009)),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     let mut names = teams.iter().map(|team| &team.name).collect::<Vec<_>>();
@@ -149,7 +149,7 @@ pub async fn query_partition_key_string_eq(test: &mut Test) -> Result<()> {
             .and(Team::fields().founded().eq(2009))
             .and(Team::fields().name().eq("Portland Timbers")),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq!(1, teams.len());
@@ -168,7 +168,7 @@ pub async fn query_partition_key_string_eq(test: &mut Test) -> Result<()> {
             .and(Team::fields().founded().eq(2009))
             .and(Team::fields().name().eq("LA Galaxy")),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert!(teams.is_empty());
@@ -219,7 +219,7 @@ pub async fn query_local_key_cmp(test: &mut Test) -> Result<()> {
 
     let events: Vec<_> = Event::filter_by_kind("info")
         .filter(Event::fields().timestamp().ne(10))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert_eq_unordered!(
@@ -229,7 +229,7 @@ pub async fn query_local_key_cmp(test: &mut Test) -> Result<()> {
 
     let events: Vec<_> = Event::filter_by_kind("info")
         .filter(Event::fields().timestamp().gt(10))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert_eq_unordered!(
@@ -239,7 +239,7 @@ pub async fn query_local_key_cmp(test: &mut Test) -> Result<()> {
 
     let events: Vec<_> = Event::filter_by_kind("info")
         .filter(Event::fields().timestamp().ge(10))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert_eq_unordered!(
@@ -249,7 +249,7 @@ pub async fn query_local_key_cmp(test: &mut Test) -> Result<()> {
 
     let events: Vec<_> = Event::filter_by_kind("info")
         .filter(Event::fields().timestamp().lt(10))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert_eq_unordered!(
@@ -259,7 +259,7 @@ pub async fn query_local_key_cmp(test: &mut Test) -> Result<()> {
 
     let events: Vec<_> = Event::filter_by_kind("info")
         .filter(Event::fields().timestamp().le(10))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert_eq_unordered!(
@@ -302,7 +302,7 @@ pub async fn query_or_basic(test: &mut Test) -> Result<()> {
             .eq("Alice")
             .or(User::fields().age().eq(35)),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await;
 
     if test.capability().sql {
@@ -384,7 +384,7 @@ pub async fn query_or_multiple(test: &mut Test) -> Result<()> {
             .or(User::fields().age().eq(35))
             .or(User::fields().age().eq(40)),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await;
 
     if test.capability().sql {
@@ -447,7 +447,7 @@ pub async fn query_or_and_combined(test: &mut Test) -> Result<()> {
             .or(User::fields().age().eq(35))
             .and(User::fields().active().eq(true)),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await;
 
     if test.capability().sql {
@@ -515,7 +515,7 @@ pub async fn query_or_with_index(test: &mut Test) -> Result<()> {
                 .or(Player::fields().position().eq("Goalkeeper")),
         ),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq!(2, players.len());
@@ -533,7 +533,7 @@ pub async fn query_or_with_index(test: &mut Test) -> Result<()> {
                 .or(Player::fields().number().eq(9)),
         ),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq!(3, players.len());
@@ -585,7 +585,7 @@ pub async fn query_or_on_partition_key(test: &mut Test) -> Result<()> {
             .eq("Timbers")
             .or(Player::fields().team().eq("Sounders")),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq!(4, players.len());
@@ -648,7 +648,7 @@ pub async fn query_or_on_composite_pk(test: &mut Test) -> Result<()> {
                 .eq("Sounders")
                 .and(Player::fields().name().eq("Clint Dempsey"))),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq!(2, players.len());
@@ -707,7 +707,7 @@ pub async fn query_or_with_comparisons(test: &mut Test) -> Result<()> {
                 .or(Player::fields().number().lt(2)),
         ),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq!(2, players.len());
@@ -763,7 +763,7 @@ pub async fn query_arbitrary_constraint(test: &mut Test) -> Result<()> {
     }
 
     let events: Vec<_> = Event::filter(Event::fields().timestamp().gt(12))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert_eq_unordered!(
@@ -777,7 +777,7 @@ pub async fn query_arbitrary_constraint(test: &mut Test) -> Result<()> {
             .gt(12)
             .and(Event::fields().kind().ne("info")),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert!(events.iter().all(|event| event.kind != "info"));
@@ -793,7 +793,7 @@ pub async fn query_arbitrary_constraint(test: &mut Test) -> Result<()> {
             .eq("info")
             .and(Event::fields().timestamp().ne(10)),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq_unordered!(
@@ -807,7 +807,7 @@ pub async fn query_arbitrary_constraint(test: &mut Test) -> Result<()> {
             .eq("info")
             .and(Event::fields().timestamp().gt(10)),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq_unordered!(
@@ -821,7 +821,7 @@ pub async fn query_arbitrary_constraint(test: &mut Test) -> Result<()> {
             .eq("info")
             .and(Event::fields().timestamp().ge(10)),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq_unordered!(
@@ -835,7 +835,7 @@ pub async fn query_arbitrary_constraint(test: &mut Test) -> Result<()> {
             .eq("info")
             .and(Event::fields().timestamp().lt(10)),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq_unordered!(
@@ -849,7 +849,7 @@ pub async fn query_arbitrary_constraint(test: &mut Test) -> Result<()> {
             .eq("info")
             .and(Event::fields().timestamp().le(10)),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq_unordered!(
@@ -885,7 +885,7 @@ pub async fn query_not_basic(test: &mut Test) -> Result<()> {
 
     // Query with NOT condition: NOT (name = "Alice")
     let result = User::filter(User::fields().name().eq("Alice").not())
-        .all(&mut db)
+        .exec(&mut db)
         .await;
 
     if test.capability().sql {
@@ -948,7 +948,7 @@ pub async fn query_not_and_combined(test: &mut Test) -> Result<()> {
             .eq(true)
             .and(User::fields().age().eq(25).not()),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await;
 
     if test.capability().sql {
@@ -994,7 +994,7 @@ pub async fn query_not_or_combined(test: &mut Test) -> Result<()> {
             .or(User::fields().name().eq("Bob"))
             .not(),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await;
 
     if test.capability().sql {
@@ -1059,7 +1059,7 @@ pub async fn query_not_with_index(test: &mut Test) -> Result<()> {
             .eq("Timbers")
             .and(Player::fields().position().eq("Midfielder").not()),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq!(2, players.len());
@@ -1076,7 +1076,7 @@ pub async fn query_not_with_index(test: &mut Test) -> Result<()> {
             .eq("Timbers")
             .and(Player::fields().number().gt(8).not()),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq!(3, players.len());
@@ -1128,7 +1128,7 @@ pub async fn query_not_operator_syntax(test: &mut Test) -> Result<()> {
             .eq("Timbers")
             .and(!Player::fields().position().eq("Midfielder")),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     assert_eq!(2, players.len());
@@ -1145,7 +1145,7 @@ pub async fn query_not_operator_syntax(test: &mut Test) -> Result<()> {
                 .or(Player::fields().position().eq("Goalkeeper"))),
         ),
     )
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 
     // Excludes Diego Chara (21), Fanendo Adi (9), Adam Kwarasey (Goalkeeper)

--- a/crates/toasty-driver-integration-suite/src/tests/one_model_sort_limit.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/one_model_sort_limit.rs
@@ -23,7 +23,7 @@ pub async fn sort_asc(test: &mut Test) -> Result<()> {
 
     let foos_asc: Vec<_> = Foo::all()
         .order_by(Foo::fields().order().asc())
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert_eq!(foos_asc.len(), 100);
@@ -34,7 +34,7 @@ pub async fn sort_asc(test: &mut Test) -> Result<()> {
 
     let foos_desc: Vec<_> = Foo::all()
         .order_by(Foo::fields().order().desc())
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert_eq!(foos_desc.len(), 100);
@@ -66,7 +66,7 @@ pub async fn paginate(test: &mut Test) -> Result<()> {
     let foos: Page<_> = Foo::all()
         .order_by(Foo::fields().order().desc())
         .paginate(10)
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert_eq!(foos.len(), 10);
@@ -78,7 +78,7 @@ pub async fn paginate(test: &mut Test) -> Result<()> {
         .order_by(Foo::fields().order().desc())
         .paginate(10)
         .after(90)
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert_eq!(foos.len(), 10);
@@ -125,14 +125,14 @@ pub async fn limit_offset(t: &mut Test) -> Result<()> {
     }
 
     // Basic limit without ordering
-    let foos: Vec<_> = Foo::all().limit(5).all(&mut db).await?;
+    let foos: Vec<_> = Foo::all().limit(5).exec(&mut db).await?;
     assert_eq!(foos.len(), 5);
 
     // Limit combined with ordering
     let foos: Vec<_> = Foo::all()
         .order_by(Foo::fields().order().desc())
         .limit(7)
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
     assert_eq!(foos.len(), 7);
     for i in 0..6 {
@@ -144,7 +144,7 @@ pub async fn limit_offset(t: &mut Test) -> Result<()> {
         .order_by(Foo::fields().order().asc())
         .limit(7)
         .offset(5)
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
     assert_eq!(foos.len(), 7);
     for (i, f) in foos.iter().enumerate() {
@@ -152,7 +152,7 @@ pub async fn limit_offset(t: &mut Test) -> Result<()> {
     }
 
     // Limit larger than the result set returns all results
-    let foos: Vec<_> = Foo::all().limit(100).all(&mut db).await?;
+    let foos: Vec<_> = Foo::all().limit(100).exec(&mut db).await?;
     assert_eq!(foos.len(), 20);
 
     Ok(())

--- a/crates/toasty-driver-integration-suite/src/tests/preload.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/preload.rs
@@ -516,7 +516,7 @@ pub async fn preload_on_empty_table(test: &mut Test) -> Result<()> {
     // Query with include on empty table - should return empty result, not SQL error
     let users: Vec<User> = User::all()
         .include(User::fields().todos())
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert_eq!(0, users.len());
@@ -560,7 +560,7 @@ pub async fn preload_on_empty_query(test: &mut Test) -> Result<()> {
     // Query with include on empty table - should return empty result, not SQL error
     let users: Vec<User> = User::filter_by_name("foo")
         .include(User::fields().todos())
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     assert_eq!(0, users.len());

--- a/crates/toasty-driver-integration-suite/src/tests/tx_atomic_stmt.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/tx_atomic_stmt.rs
@@ -56,7 +56,7 @@ pub async fn multi_op_create_wraps_in_transaction(t: &mut Test) -> Result<()> {
     );
     assert!(t.log().is_empty());
 
-    let todos = user.todos().all(&mut db).await?;
+    let todos = user.todos().exec(&mut db).await?;
     assert_eq!(1, todos.len());
 
     Ok(())
@@ -157,7 +157,7 @@ pub async fn create_with_has_many_rolls_back_on_failure(t: &mut Test) -> Result<
     assert!(t.log().is_empty());
 
     // No orphaned user — count unchanged from pre-seed
-    let users = User::all().all(&mut db).await?;
+    let users = User::all().exec(&mut db).await?;
     assert_eq!(1, users.len());
 
     Ok(())
@@ -229,7 +229,7 @@ pub async fn create_with_has_one_rolls_back_on_failure(t: &mut Test) -> Result<(
     assert!(t.log().is_empty());
 
     // No orphaned user — count unchanged from pre-seed
-    let users = User::all().all(&mut db).await?;
+    let users = User::all().exec(&mut db).await?;
     assert_eq!(1, users.len());
 
     Ok(())
@@ -304,7 +304,7 @@ pub async fn update_with_new_association_rolls_back_on_failure(t: &mut Test) -> 
     assert!(t.log().is_empty());
 
     // INSERT was rolled back — no orphaned todo
-    let todos = user.todos().all(&mut db).await?;
+    let todos = user.todos().exec(&mut db).await?;
     assert!(todos.is_empty());
 
     Ok(())
@@ -344,7 +344,7 @@ pub async fn rmw_uses_savepoints(t: &mut Test) -> Result<()> {
     let mut db = t.setup_db(models!(User, Todo)).await;
 
     let user = User::create().todo(Todo::create()).exec(&mut db).await?;
-    let todos: Vec<_> = user.todos().all(&mut db).await?;
+    let todos: Vec<_> = user.todos().exec(&mut db).await?;
 
     t.log().clear();
     user.todos().remove(&mut db, &todos[0]).await?;
@@ -405,7 +405,7 @@ pub async fn rmw_condition_failure_issues_rollback_to_savepoint(t: &mut Test) ->
 
     let user1 = User::create().exec(&mut db).await?;
     let user2 = User::create().todo(Todo::create()).exec(&mut db).await?;
-    let u2_todos: Vec<_> = user2.todos().all(&mut db).await?;
+    let u2_todos: Vec<_> = user2.todos().exec(&mut db).await?;
 
     t.log().clear();
     // Remove u2's todo via user1 — condition (user_id = user1.id) won't match

--- a/crates/toasty-driver-integration-suite/src/tests/tx_interactive.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/tx_interactive.rs
@@ -22,7 +22,7 @@ pub async fn commit_persists_data(t: &mut Test) -> Result<()> {
     User::create().name("Alice").exec(&mut tx).await?;
     tx.commit().await?;
 
-    let users = User::all().all(&mut db).await?;
+    let users = User::all().exec(&mut db).await?;
     assert_eq!(users.len(), 1);
     assert_eq!(users[0].name, "Alice");
 
@@ -46,7 +46,7 @@ pub async fn rollback_discards_data(t: &mut Test) -> Result<()> {
     User::create().name("Ghost").exec(&mut tx).await?;
     tx.rollback().await?;
 
-    let users = User::all().all(&mut db).await?;
+    let users = User::all().exec(&mut db).await?;
     assert!(users.is_empty());
 
     Ok(())
@@ -71,7 +71,7 @@ pub async fn drop_without_finalize_rolls_back(t: &mut Test) -> Result<()> {
         // tx is dropped here without commit/rollback
     }
 
-    let users = User::all().all(&mut db).await?;
+    let users = User::all().exec(&mut db).await?;
     assert!(users.is_empty());
 
     Ok(())
@@ -96,7 +96,7 @@ pub async fn multiple_ops_in_transaction(t: &mut Test) -> Result<()> {
     User::create().name("Carol").exec(&mut tx).await?;
     tx.commit().await?;
 
-    let users = User::all().all(&mut db).await?;
+    let users = User::all().exec(&mut db).await?;
     assert_eq!(users.len(), 3);
 
     Ok(())
@@ -119,7 +119,7 @@ pub async fn read_your_writes(t: &mut Test) -> Result<()> {
     let mut tx = db.transaction().await?;
     User::create().name("Alice").exec(&mut tx).await?;
 
-    let users = User::all().all(&mut tx).await?;
+    let users = User::all().exec(&mut tx).await?;
     assert_eq!(users.len(), 1);
     assert_eq!(users[0].name, "Alice");
 
@@ -304,7 +304,7 @@ pub async fn nested_commit_both(t: &mut Test) -> Result<()> {
 
     tx.commit().await?;
 
-    let users = User::all().all(&mut db).await?;
+    let users = User::all().exec(&mut db).await?;
     assert_eq!(users.len(), 2);
 
     Ok(())
@@ -335,7 +335,7 @@ pub async fn nested_rollback_inner(t: &mut Test) -> Result<()> {
 
     tx.commit().await?;
 
-    let users = User::all().all(&mut db).await?;
+    let users = User::all().exec(&mut db).await?;
     assert_eq!(users.len(), 1);
     assert_eq!(users[0].name, "Alice");
 
@@ -367,7 +367,7 @@ pub async fn nested_rollback_outer(t: &mut Test) -> Result<()> {
 
     tx.rollback().await?;
 
-    let users = User::all().all(&mut db).await?;
+    let users = User::all().exec(&mut db).await?;
     assert!(users.is_empty());
 
     Ok(())
@@ -398,7 +398,7 @@ pub async fn nested_drop_rolls_back_savepoint(t: &mut Test) -> Result<()> {
 
     tx.commit().await?;
 
-    let users = User::all().all(&mut db).await?;
+    let users = User::all().exec(&mut db).await?;
     assert_eq!(users.len(), 1);
     assert_eq!(users[0].name, "Alice");
 
@@ -546,7 +546,7 @@ pub async fn two_sequential_nested_transactions(t: &mut Test) -> Result<()> {
 
     tx.commit().await?;
 
-    let users = User::all().all(&mut db).await?;
+    let users = User::all().exec(&mut db).await?;
     assert_eq!(users.len(), 1);
     assert_eq!(users[0].name, "Alice");
 
@@ -626,7 +626,7 @@ pub async fn multi_op_inside_tx_uses_savepoints(t: &mut Test) -> Result<()> {
     assert!(t.log().is_empty());
 
     // Verify the data landed
-    let todos = user.todos().all(&mut db).await?;
+    let todos = user.todos().exec(&mut db).await?;
     assert_eq!(todos.len(), 1);
     assert_eq!(todos[0].title, "task");
 

--- a/crates/toasty/src/page.rs
+++ b/crates/toasty/src/page.rs
@@ -68,7 +68,7 @@ impl<M: Load> Page<M> {
             Some(cursor) => Ok(Some(
                 Paginate::from(self.query.clone())
                     .after(cursor.clone())
-                    .all(executor)
+                    .exec(executor)
                     .await?,
             )),
             None => Ok(None),
@@ -96,7 +96,7 @@ impl<M: Load> Page<M> {
             Some(cursor) => Ok(Some(
                 Paginate::from(self.query.clone())
                     .before(cursor.clone())
-                    .all(executor)
+                    .exec(executor)
                     .await?,
             )),
             None => Ok(None),

--- a/crates/toasty/src/stmt/paginate.rs
+++ b/crates/toasty/src/stmt/paginate.rs
@@ -60,7 +60,7 @@ impl<M> Paginate<M> {
 }
 
 impl<M: Load> Paginate<M> {
-    pub async fn all(mut self, executor: &mut dyn Executor) -> Result<crate::Page<M::Output>> {
+    pub async fn exec(mut self, executor: &mut dyn Executor) -> Result<crate::Page<M::Output>> {
         // Extract the limit from the query to determine page size
         let page_size = match &self.query.untyped.limit {
             Some(stmt::Limit {

--- a/docs/guide/plan.md
+++ b/docs/guide/plan.md
@@ -120,11 +120,11 @@ Each chapter introduces models incrementally. Chapter 1 starts with just `User`.
 #### 13. Relationships: HasMany
 - `#[has_many]` on the parent model
 - The `HasMany<Post>` type
-- Querying children: `user.posts().all(&mut db).await?`
+- Querying children: `user.posts().exec(&mut db).await?`
 - Creating through the relation: `user.posts().create().title("...").exec(&mut db).await?`
 - Linking/unlinking: `.insert()` and `.remove()`
 - Scoped queries: `user.posts().query(filter)`
-- **What gets generated**: `Many` struct with `.all()`, `.create()`, `.insert()`, `.remove()`, `.query()`, `.collect()`
+- **What gets generated**: `Many` struct with `.exec()`, `.create()`, `.insert()`, `.remove()`, `.query()`, `.collect()`
 
 #### 14. Relationships: HasOne
 - `#[has_one]` for single-child relations

--- a/docs/guide/src/keys-and-auto-generation.md
+++ b/docs/guide/src/keys-and-auto-generation.md
@@ -348,7 +348,7 @@ let todo = Todo::get_by_user_id_and_id(
 
 // Get all todos for a user
 let todos = Todo::filter_by_user_id(&1)
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 # Ok(())
 # }

--- a/docs/guide/src/querying-records.md
+++ b/docs/guide/src/querying-records.md
@@ -46,7 +46,7 @@ generates `get_by_code()`. Composite keys generate combined names like
 #     email: String,
 # }
 # async fn __example(mut db: toasty::Db) -> toasty::Result<()> {
-let users = User::all().all(&mut db).await?;
+let users = User::all().exec(&mut db).await?;
 
 for user in &users {
     println!("{}: {}", user.id, user.name);
@@ -60,7 +60,7 @@ for user in &users {
 Queries returned by `all()`, `filter()`, and `filter_by_*()` are not executed
 until you call a terminal method. Toasty provides three terminal methods:
 
-### `.all()` — collect all results
+### `.exec()` — collect all results
 
 Returns all matching records as a `Vec`:
 
@@ -76,7 +76,7 @@ Returns all matching records as a `Vec`:
 #     email: String,
 # }
 # async fn __example(mut db: toasty::Db) -> toasty::Result<()> {
-let users: Vec<User> = User::all().all(&mut db).await?;
+let users: Vec<User> = User::all().exec(&mut db).await?;
 # Ok(())
 # }
 ```
@@ -181,7 +181,7 @@ chapter covers this in detail. Here is a quick example:
 # }
 # async fn __example(mut db: toasty::Db) -> toasty::Result<()> {
 let users = User::filter(User::fields().name().eq("Alice"))
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 # Ok(())
 # }
@@ -194,7 +194,7 @@ You can chain `.filter()` on an existing query to add more conditions:
 ```rust,ignore
 let users = User::filter_by_name("Alice")
     .filter(User::fields().age().gt(25))
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 ```
 
@@ -218,7 +218,7 @@ fetches multiple records by key in a single query:
 # }
 # async fn __example(mut db: toasty::Db) -> toasty::Result<()> {
 let users = User::filter_by_id_batch([&1, &2, &3])
-    .all(&mut db)
+    .exec(&mut db)
     .await?;
 # Ok(())
 # }
@@ -244,6 +244,6 @@ Query builders support these terminal methods:
 
 | Method | Returns |
 |---|---|
-| `.all(&mut db)` | `Result<Vec<User>>` |
+| `.exec(&mut db)` | `Result<Vec<User>>` |
 | `.first(&mut db)` | `Result<Option<User>>` |
 | `.get(&mut db)` | `Result<User>` |

--- a/examples/composite-key/src/main.rs
+++ b/examples/composite-key/src/main.rs
@@ -75,7 +75,7 @@ async fn main() -> toasty::Result<()> {
     let todos = user
         .todos()
         .query(Todo::fields().order().eq(1))
-        .all(&mut db)
+        .exec(&mut db)
         .await?;
 
     for todo in todos {

--- a/examples/hello-toasty/src/main.rs
+++ b/examples/hello-toasty/src/main.rs
@@ -95,7 +95,7 @@ async fn main() -> toasty::Result<()> {
 
     println!("CREATED = {todo:#?}");
 
-    let todos = u2.todos().all(&mut db).await?;
+    let todos = u2.todos().exec(&mut db).await?;
 
     for todo in todos {
         println!("TODO; title={:?}", todo.title);
@@ -130,12 +130,12 @@ async fn main() -> toasty::Result<()> {
         .await?;
 
     // Get the last todo so we can unlink it
-    let todos = user.todos().all(&mut db).await?;
+    let todos = user.todos().exec(&mut db).await?;
     let len = todos.len();
 
     user.todos().remove(&mut db, todos.last().unwrap()).await?;
 
-    assert_eq!(len - 1, user.todos().all(&mut db).await?.len());
+    assert_eq!(len - 1, user.todos().exec(&mut db).await?.len());
 
     println!(">>> DONE <<<");
 

--- a/examples/todo-with-cli/src/bin/app.rs
+++ b/examples/todo-with-cli/src/bin/app.rs
@@ -47,12 +47,12 @@ async fn main() -> toasty::Result<()> {
     println!("Created {} todos", 3);
 
     println!("\n==> Listing all users and their todos...");
-    let users = User::all().all(&mut db).await?;
+    let users = User::all().exec(&mut db).await?;
 
     for user in users {
         println!("\nUser: {} ({})", user.name, user.email);
 
-        let todos = user.todos().all(&mut db).await?;
+        let todos = user.todos().exec(&mut db).await?;
         for todo in todos {
             let status = if todo.completed { "✓" } else { " " };
             println!("  [{}] {}", status, todo.title);
@@ -70,7 +70,7 @@ async fn main() -> toasty::Result<()> {
     todo.delete().exec(&mut db).await?;
 
     println!("\n==> Final count...");
-    let todos = Todo::all().all(&mut db).await?;
+    let todos = Todo::all().exec(&mut db).await?;
     println!("Total todos remaining: {}", todos.len());
 
     println!("\n>>> Application completed successfully! <<<");


### PR DESCRIPTION
This PR renames the query terminal method from `.all()` to `.exec()` across the codebase for improved clarity and consistency.

## Summary
The `.all()` method, which executes a query and returns all matching results as a `Vec`, has been renamed to `.exec()`. This change applies to:
- Direct model queries (e.g., `User::all().exec(&mut db)`)
- Filtered queries (e.g., `User::filter(...).exec(&mut db)`)
- Relation queries (e.g., `user.todos().exec(&mut db)`)
- Paginated queries (e.g., `Foo::all().paginate(10).exec(&mut db)`)

## Key Changes
- **Query codegen**: Updated `crates/toasty-codegen/src/expand/query.rs` to generate `exec()` instead of `all()`
- **Relation codegen**: Updated `crates/toasty-codegen/src/expand/relation.rs` to generate `exec()` for relation queries
- **Pagination**: Renamed `Paginate::all()` to `Paginate::exec()` in `crates/toasty/src/stmt/paginate.rs`
- **Page helper**: Updated `Page::next()` to call `.exec()` instead of `.all()`
- **Integration tests**: Updated 40+ test files to use `.exec()` instead of `.all()`
- **Examples**: Updated example applications and benchmarks
- **Documentation**: Updated guide and README to reflect the new method name

## Rationale
The new name `.exec()` better conveys that the method executes the query, while `.all()` could be confused with other collection methods. This naming is more consistent with common database abstraction patterns.

https://claude.ai/code/session_01FHcY7zPRChFoSvFhet8fxw