### PR TITLE
chore: remove unsafe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ members = [
     "benches",
 ]
 
+[workspace.lints.rust]
+unsafe_code = "deny"
+
 [workspace.dependencies]
 # Toasty crates
 toasty = { path = "crates/toasty" }

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -34,3 +34,6 @@ tests = { version = "0.1.0", path = "../tests" }
 name = "association"
 path = "association.rs"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/std-util/Cargo.toml
+++ b/crates/std-util/Cargo.toml
@@ -9,3 +9,6 @@ edition = "2021"
 heck.workspace = true
 pluralizer.workspace = true
 rand.workspace = true
+
+[lints]
+workspace = true

--- a/crates/toasty-cli/Cargo.toml
+++ b/crates/toasty-cli/Cargo.toml
@@ -18,3 +18,6 @@ serde.workspace = true
 toml.workspace = true
 toml_edit = { workspace = true, features = ["serde"] }
 url.workspace = true
+
+[lints]
+workspace = true

--- a/crates/toasty-codegen/Cargo.toml
+++ b/crates/toasty-codegen/Cargo.toml
@@ -10,3 +10,6 @@ proc-macro2.workspace = true
 quote.workspace = true
 std-util.workspace = true
 syn.workspace = true
+
+[lints]
+workspace = true

--- a/crates/toasty-core/Cargo.toml
+++ b/crates/toasty-core/Cargo.toml
@@ -28,3 +28,6 @@ serde = ["dep:serde", "bit-set/serde"]
 [dev-dependencies]
 jiff.workspace = true
 pretty_assertions.workspace = true
+
+[lints]
+workspace = true

--- a/crates/toasty-driver-dynamodb/Cargo.toml
+++ b/crates/toasty-driver-dynamodb/Cargo.toml
@@ -13,3 +13,6 @@ serde_json.workspace = true
 tracing.workspace = true
 url.workspace = true
 uuid.workspace = true
+
+[lints]
+workspace = true

--- a/crates/toasty-driver-integration-suite-macros/Cargo.toml
+++ b/crates/toasty-driver-integration-suite-macros/Cargo.toml
@@ -11,3 +11,6 @@ proc-macro = true
 proc-macro2.workspace = true
 quote.workspace = true
 syn = { workspace = true, features = ["visit", "visit-mut"] }
+
+[lints]
+workspace = true

--- a/crates/toasty-driver-integration-suite/Cargo.toml
+++ b/crates/toasty-driver-integration-suite/Cargo.toml
@@ -19,3 +19,6 @@ toasty-driver-integration-suite-macros.workspace = true
 tokio.workspace = true
 std-util.workspace = true
 uuid.workspace = true
+
+[lints]
+workspace = true

--- a/crates/toasty-driver-mysql/Cargo.toml
+++ b/crates/toasty-driver-mysql/Cargo.toml
@@ -18,3 +18,6 @@ mysql_async.workspace = true
 tokio.workspace = true
 url.workspace = true
 uuid.workspace = true
+
+[lints]
+workspace = true

--- a/crates/toasty-driver-postgresql/Cargo.toml
+++ b/crates/toasty-driver-postgresql/Cargo.toml
@@ -21,3 +21,6 @@ tokio.workspace = true
 tokio-postgres.workspace = true
 uuid.workspace = true
 url.workspace = true
+
+[lints]
+workspace = true

--- a/crates/toasty-driver-sqlite/Cargo.toml
+++ b/crates/toasty-driver-sqlite/Cargo.toml
@@ -13,3 +13,5 @@ serde_json.workspace = true
 url.workspace = true
 uuid.workspace = true
 
+[lints]
+workspace = true

--- a/crates/toasty-macros/Cargo.toml
+++ b/crates/toasty-macros/Cargo.toml
@@ -14,3 +14,6 @@ toasty-codegen.workspace = true
 proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true
+
+[lints]
+workspace = true

--- a/crates/toasty-sql/Cargo.toml
+++ b/crates/toasty-sql/Cargo.toml
@@ -6,3 +6,6 @@ publish = false
 
 [dependencies]
 toasty-core.workspace = true
+
+[lints]
+workspace = true

--- a/crates/toasty/Cargo.toml
+++ b/crates/toasty/Cargo.toml
@@ -59,3 +59,6 @@ url.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true
+
+[lints]
+workspace = true

--- a/crates/toasty/src/model/field.rs
+++ b/crates/toasty/src/model/field.rs
@@ -45,13 +45,9 @@ pub trait Field: Sized {
         _stmt: &'a mut stmt::Update,
         _projection: stmt::Projection,
     ) -> Self::UpdateBuilder<'a> {
-        // Default implementation assumes UpdateBuilder = ()
-        // Embedded types must override this method
-        unsafe {
-            // For (), this is safe. For other types, this would be UB,
-            // but those types must override this method.
-            std::mem::transmute_copy(&())
-        }
+        // Embedded types must override this method.
+        // For primitive types (where UpdateBuilder = ()), this is never called.
+        panic!("make_update_builder must be overridden")
     }
 
     /// Returns the app-level field type for this primitive.

--- a/examples/composite-key/Cargo.toml
+++ b/examples/composite-key/Cargo.toml
@@ -14,3 +14,6 @@ sqlite = [ "toasty/sqlite" ]
 toasty.workspace = true
 tokio.workspace = true
 uuid.workspace = true
+
+[lints]
+workspace = true

--- a/examples/hello-toasty/Cargo.toml
+++ b/examples/hello-toasty/Cargo.toml
@@ -20,3 +20,6 @@ uuid.workspace = true
 toasty-driver-dynamodb = { path = "../../crates/toasty-driver-dynamodb", optional = true }
 aws-config = { workspace = true, optional = true }
 aws-sdk-dynamodb = { workspace = true, optional = true }
+
+[lints]
+workspace = true

--- a/examples/todo-with-cli/Cargo.toml
+++ b/examples/todo-with-cli/Cargo.toml
@@ -26,3 +26,6 @@ path = "src/bin/app.rs"
 [[bin]]
 name = "todo-cli"
 path = "src/bin/cli.rs"
+
+[lints]
+workspace = true

--- a/examples/user-has-one-profile/Cargo.toml
+++ b/examples/user-has-one-profile/Cargo.toml
@@ -15,3 +15,6 @@ sqlite = ["toasty/sqlite"]
 toasty.workspace = true
 tokio.workspace = true
 uuid.workspace = true
+
+[lints]
+workspace = true

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -54,3 +54,6 @@ url.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
+
+[lints]
+workspace = true

--- a/tests/src/db_test.rs
+++ b/tests/src/db_test.rs
@@ -14,7 +14,7 @@ use toasty_core::stmt;
 /// 3. Keep the existing test API unchanged
 /// 4. Always log driver operations for debugging
 pub struct DbTest {
-    runtime: tokio::runtime::Runtime,
+    runtime: Option<tokio::runtime::Runtime>,
     setup: Option<Box<dyn Setup>>,
     exec_log: ExecLog,
 }
@@ -28,7 +28,7 @@ impl DbTest {
             .expect("Failed to create Tokio runtime");
 
         Self {
-            runtime,
+            runtime: Some(runtime),
             setup: Some(setup),
             exec_log: ExecLog::new(Arc::new(Mutex::new(Vec::new()))),
         }
@@ -99,14 +99,9 @@ impl DbTest {
             &'a mut DbTest,
         ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + 'a>>,
     {
-        // Use unsafe to get a mutable reference to self inside the closure
-        // This is safe because we control the runtime and know there's no aliasing
-        let self_ptr = self as *mut DbTest;
-
-        self.runtime.block_on(async {
-            let self_mut = unsafe { &mut *self_ptr };
-            test_fn(self_mut).await;
-        });
+        let rt = self.runtime.take().expect("runtime already taken");
+        rt.block_on(test_fn(self));
+        self.runtime = Some(rt);
     }
 }
 
@@ -114,7 +109,11 @@ impl Drop for DbTest {
     fn drop(&mut self) {
         // If setup is still present, clean it up
         if let Some(setup) = self.setup.take() {
-            self.runtime.block_on(async {
+            let rt = self
+                .runtime
+                .take()
+                .expect("runtime not available during cleanup");
+            rt.block_on(async {
                 let _ = setup.cleanup_my_tables().await;
             });
         }


### PR DESCRIPTION
This pr removes all unsafe calls and adds the `unsafe_code = "deny"` lint to all the crates in the workspace.