### PR TITLE
refactor: disambiguate single vs batch Insert at the type level

### DIFF
--- a/crates/toasty-codegen/src/expand/create.rs
+++ b/crates/toasty-codegen/src/expand/create.rs
@@ -65,7 +65,7 @@ impl Expand<'_> {
 
             impl #toasty::IntoExpr<#toasty::List<#model_ident>> for #create_struct_ident {
                 fn into_expr(self) -> #toasty::stmt::Expr<#toasty::List<#model_ident>> {
-                    self.stmt.into_list_expr()
+                    self.stmt.into_list().into_list_expr()
                 }
 
                 fn by_ref(&self) -> #toasty::stmt::Expr<#toasty::List<#model_ident>> {

--- a/crates/toasty/src/batch/create.rs
+++ b/crates/toasty/src/batch/create.rs
@@ -16,12 +16,7 @@ impl<M: Model> CreateMany<M> {
     }
 
     pub fn item(mut self, item: impl stmt::IntoInsert<Model = M>) -> Self {
-        let stmt = item.into_insert();
-        assert!(
-            stmt.untyped.source.single,
-            "BUG: insert statement should have `single` flag set"
-        );
-        self.stmts.push(stmt);
+        self.stmts.push(item.into_insert());
         self
     }
 
@@ -30,12 +25,7 @@ impl<M: Model> CreateMany<M> {
     /// after setting the desired fields.
     pub fn with_item(mut self, f: impl FnOnce(M::Create) -> M::Create) -> Self {
         let create = f(M::Create::default());
-        let stmt = create.into_insert();
-        assert!(
-            stmt.untyped.source.single,
-            "BUG: insert statement should have `single` flag set"
-        );
-        self.stmts.push(stmt);
+        self.stmts.push(create.into_insert());
         self
     }
 
@@ -50,30 +40,24 @@ impl<M: Model> CreateMany<M> {
             >()));
         }
         let mut stmts = self.stmts.into_iter();
-        let mut merged = stmts.next().unwrap();
+        let mut merged = stmts.next().unwrap().into_list();
         for stmt in stmts {
             merged.merge(stmt);
         }
-        // Clear the single flag so the engine handles multi-row inserts correctly.
-        merged.untyped.source.single = false;
         merged.into_list_expr()
     }
 
     pub async fn exec(self, executor: &mut dyn Executor) -> Result<Vec<M>> {
-        // If there are no records to create, then return an empty vec
         if self.stmts.is_empty() {
             return Ok(vec![]);
         }
 
-        // TODO: improve
         let mut stmts = self.stmts.into_iter();
-        let mut merged = stmts.next().unwrap();
+        let mut merged = stmts.next().unwrap().into_list();
 
         for stmt in stmts {
             merged.merge(stmt);
         }
-
-        merged.untyped.source.single = false;
 
         let mut records = executor.exec(merged.into()).await?;
         let mut result = Vec::new();

--- a/crates/toasty/src/executor_ext.rs
+++ b/crates/toasty/src/executor_ext.rs
@@ -101,13 +101,10 @@ pub trait ExecutorExt: Executor {
     #[doc(hidden)]
     fn exec_insert_one<M: Model>(
         &mut self,
-        mut stmt: stmt::Insert<M>,
+        stmt: stmt::Insert<M>,
     ) -> impl Future<Output = Result<M>> {
         async move {
-            // TODO: HAX
-            stmt.untyped.source.single = false;
-
-            let mut records = self.exec(stmt.into()).await?;
+            let mut records = self.exec(stmt.into_list().into()).await?;
 
             match records.next().await {
                 Some(Ok(value)) => M::load(value),

--- a/crates/toasty/src/stmt/insert.rs
+++ b/crates/toasty/src/stmt/insert.rs
@@ -8,6 +8,15 @@ pub struct Insert<M> {
     _p: PhantomData<M>,
 }
 
+impl<M> Insert<M> {
+    pub const fn from_untyped(untyped: stmt::Insert) -> Self {
+        Self {
+            untyped,
+            _p: PhantomData,
+        }
+    }
+}
+
 impl<M: Model> Insert<M> {
     /// Create an insertion statement that inserts an empty record
     /// (fields without #[auto] as `Expr::Value(Value::Null)`, #[auto] fields as `Expr::Default`).
@@ -37,13 +46,6 @@ impl<M: Model> Insert<M> {
         }
     }
 
-    pub const fn from_untyped(untyped: stmt::Insert) -> Self {
-        Self {
-            untyped,
-            _p: PhantomData,
-        }
-    }
-
     /// Set the scope of the insert.
     pub fn set_scope<S>(&mut self, scope: S)
     where
@@ -59,7 +61,6 @@ impl<M: Model> Insert<M> {
 
     /// Extend the expression for `field` with the given expression
     pub fn insert(&mut self, field: usize, expr: impl Into<stmt::Expr>) {
-        // self.expr_mut(field).push(expr);
         let target = self.expr_mut(field);
 
         match target {
@@ -93,8 +94,13 @@ impl<M: Model> Insert<M> {
         }
     }
 
-    pub(crate) fn merge(&mut self, stmt: Self) {
-        self.untyped.merge(stmt.untyped);
+    /// Convert this single-record insert into a batch insert.
+    pub fn into_list(mut self) -> Insert<List<M>> {
+        self.untyped.source.single = false;
+        Insert {
+            untyped: self.untyped,
+            _p: PhantomData,
+        }
     }
 
     fn expr_mut(&mut self, field: usize) -> &mut stmt::Expr {
@@ -105,6 +111,13 @@ impl<M: Model> Insert<M> {
     fn current_mut(&mut self) -> &mut stmt::ExprRecord {
         let values = self.untyped.source.body.as_values_mut();
         values.rows.last_mut().unwrap().as_record_mut()
+    }
+}
+
+impl<M: Model> Insert<List<M>> {
+    /// Merge another single insert into this batch.
+    pub(crate) fn merge(&mut self, stmt: Insert<M>) {
+        self.untyped.merge(stmt.untyped);
     }
 
     pub fn into_list_expr(self) -> Expr<List<M>> {


### PR DESCRIPTION
## Summary
- `Insert<M>` now always represents a single-record insert; `Insert<List<M>>` represents a batch insert
- Added `into_list()` on `Insert<M>` to convert single → batch, moving `merge()` and `into_list_expr()` to only be available on `Insert<List<M>>`
- Removed manual `source.single = false` mutations and runtime assertions in favor of type-level guarantees

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes
- [x] `cargo fmt` applied