### PR TITLE
refactor: update code generation to use toasty::core namespace paths

### DIFF
--- a/crates/toasty-codegen/src/expand.rs
+++ b/crates/toasty-codegen/src/expand.rs
@@ -88,8 +88,8 @@ pub(super) fn embedded_model(model: &Model) -> TokenStream {
         #embedded_model_impls
 
         impl #toasty::Register for #model_ident {
-            fn id() -> #toasty::ModelId {
-                static ID: std::sync::OnceLock<#toasty::ModelId> = std::sync::OnceLock::new();
+            fn id() -> #toasty::core::schema::app::ModelId {
+                static ID: std::sync::OnceLock<#toasty::core::schema::app::ModelId> = std::sync::OnceLock::new();
                 *ID.get_or_init(|| #toasty::generate_unique_id())
             }
 
@@ -104,15 +104,15 @@ pub(super) fn embedded_model(model: &Model) -> TokenStream {
 
             const NULLABLE: bool = false;
 
-            fn ty() -> #toasty::Type {
-                #toasty::Type::Model(<Self as #toasty::Register>::id())
+            fn ty() -> #toasty::core::stmt::Type {
+                #toasty::core::stmt::Type::Model(<Self as #toasty::Register>::id())
             }
 
-            fn load(value: #toasty::Value) -> #toasty::Result<Self> {
+            fn load(value: #toasty::core::stmt::Value) -> #toasty::Result<Self> {
                 #load_body
             }
 
-            fn reload(&mut self, value: #toasty::Value) -> #toasty::Result<()> {
+            fn reload(&mut self, value: #toasty::core::stmt::Value) -> #toasty::Result<()> {
                 #reload_body
             }
 
@@ -128,10 +128,10 @@ pub(super) fn embedded_model(model: &Model) -> TokenStream {
             }
 
             fn field_ty(
-                _storage_ty: Option<#toasty::schema::db::Type>,
-            ) -> #toasty::schema::app::FieldTy {
-                #toasty::schema::app::FieldTy::Embedded(
-                    #toasty::schema::app::Embedded {
+                _storage_ty: Option<#toasty::core::schema::db::Type>,
+            ) -> #toasty::core::schema::app::FieldTy {
+                #toasty::core::schema::app::FieldTy::Embedded(
+                    #toasty::core::schema::app::Embedded {
                         target: <Self as #toasty::Register>::id(),
                         expr_ty: Self::ty(),
                     }
@@ -178,19 +178,19 @@ pub(super) fn embedded_enum(model: &Model) -> TokenStream {
         #enum_field_struct
 
         impl #toasty::Register for #model_ident {
-            fn id() -> #toasty::ModelId {
-                static ID: std::sync::OnceLock<#toasty::ModelId> = std::sync::OnceLock::new();
+            fn id() -> #toasty::core::schema::app::ModelId {
+                static ID: std::sync::OnceLock<#toasty::core::schema::app::ModelId> = std::sync::OnceLock::new();
                 *ID.get_or_init(|| #toasty::generate_unique_id())
             }
 
-            fn schema() -> #toasty::schema::app::Model {
+            fn schema() -> #toasty::core::schema::app::Model {
                 let id = Self::id();
-                #toasty::schema::app::Model::EmbeddedEnum(
-                    #toasty::schema::app::EmbeddedEnum {
+                #toasty::core::schema::app::Model::EmbeddedEnum(
+                    #toasty::core::schema::app::EmbeddedEnum {
                         id,
                         name: #name,
-                        discriminant: #toasty::schema::app::FieldPrimitive {
-                            ty: #toasty::Type::I64,
+                        discriminant: #toasty::core::schema::app::FieldPrimitive {
+                            ty: #toasty::core::stmt::Type::I64,
                             storage_ty: ::std::option::Option::None,
                             serialize: ::std::option::Option::None,
                         },
@@ -208,24 +208,24 @@ pub(super) fn embedded_enum(model: &Model) -> TokenStream {
             type FieldAccessor<__Origin> = #field_struct_ident<__Origin>;
             type UpdateBuilder<'a> = ();
 
-            fn ty() -> #toasty::Type {
+            fn ty() -> #toasty::core::stmt::Type {
                 #ty_expr
             }
 
-            fn load(value: #toasty::Value) -> #toasty::Result<Self> {
+            fn load(value: #toasty::core::stmt::Value) -> #toasty::Result<Self> {
                 match value {
-                    #toasty::Value::I64(d) => match d {
+                    #toasty::core::stmt::Value::I64(d) => match d {
                         #( #unit_load_arms )*
                         _ => Err(#toasty::Error::type_conversion(
-                            #toasty::Value::I64(d),
+                            #toasty::core::stmt::Value::I64(d),
                             stringify!(#model_ident),
                         )),
                     },
-                    #toasty::Value::Record(mut record) => match record[0].take() {
-                        #toasty::Value::I64(d) => match d {
+                    #toasty::core::stmt::Value::Record(mut record) => match record[0].take() {
+                        #toasty::core::stmt::Value::I64(d) => match d {
                             #( #data_load_arms )*
                             _ => Err(#toasty::Error::type_conversion(
-                                #toasty::Value::I64(d),
+                                #toasty::core::stmt::Value::I64(d),
                                 stringify!(#model_ident),
                             )),
                         },
@@ -243,10 +243,10 @@ pub(super) fn embedded_enum(model: &Model) -> TokenStream {
             }
 
             fn field_ty(
-                _storage_ty: Option<#toasty::schema::db::Type>,
-            ) -> #toasty::schema::app::FieldTy {
-                #toasty::schema::app::FieldTy::Embedded(
-                    #toasty::schema::app::Embedded {
+                _storage_ty: Option<#toasty::core::schema::db::Type>,
+            ) -> #toasty::core::schema::app::FieldTy {
+                #toasty::core::schema::app::FieldTy::Embedded(
+                    #toasty::core::schema::app::Embedded {
                         target: <Self as #toasty::Register>::id(),
                         expr_ty: Self::ty(),
                     }

--- a/crates/toasty-codegen/src/expand/create.rs
+++ b/crates/toasty-codegen/src/expand/create.rs
@@ -207,7 +207,7 @@ impl Expand<'_> {
                                             self.stmt.set(#index_tokenized, <String as #toasty::IntoExpr<String>>::into_expr(json));
                                         }
                                         None => {
-                                            self.stmt.set(#index_tokenized, #toasty::stmt::Expr::<String>::from_untyped(#toasty::core::stmt::Expr::Value(#toasty::Value::Null)));
+                                            self.stmt.set(#index_tokenized, #toasty::stmt::Expr::<String>::from_untyped(#toasty::core::stmt::Expr::Value(#toasty::core::stmt::Value::Null)));
                                         }
                                     }
                                     self

--- a/crates/toasty-codegen/src/expand/embedded_enum.rs
+++ b/crates/toasty-codegen/src/expand/embedded_enum.rs
@@ -217,7 +217,7 @@ impl Expand<'_> {
                 let variant_name = schema::expand_name(toasty, &variant.name);
                 let discriminant = variant.attrs.discriminant;
                 quote! {
-                    #toasty::schema::app::EnumVariant {
+                    #toasty::core::schema::app::EnumVariant {
                         name: #variant_name,
                         discriminant: #discriminant,
                     }
@@ -241,12 +241,12 @@ impl Expand<'_> {
                 let variant_index = field.variant.expect("enum field must have variant");
                 let variant_idx = util::int(variant_index);
                 quote! {
-                    #toasty::schema::app::Field {
-                        id: #toasty::schema::app::FieldId {
+                    #toasty::core::schema::app::Field {
+                        id: #toasty::core::schema::app::FieldId {
                             model: id,
                             index: #index,
                         },
-                        name: #toasty::schema::app::FieldName {
+                        name: #toasty::core::schema::app::FieldName {
                             app_name: #app_name.to_string(),
                             storage_name: None,
                         },
@@ -408,9 +408,9 @@ impl Expand<'_> {
     pub(super) fn expand_enum_primitive_ty(&self) -> TokenStream {
         let toasty = &self.toasty;
         if self.expand_enum_has_data_variants() {
-            quote! { #toasty::Type::Model(<Self as #toasty::Register>::id()) }
+            quote! { #toasty::core::stmt::Type::Model(<Self as #toasty::Register>::id()) }
         } else {
-            quote! { #toasty::Type::I64 }
+            quote! { #toasty::core::stmt::Type::I64 }
         }
     }
 }

--- a/crates/toasty-codegen/src/expand/fields.rs
+++ b/crates/toasty-codegen/src/expand/fields.rs
@@ -104,11 +104,11 @@ impl Expand<'_> {
                 let field_name = field.name.ident.to_string();
                 let field_offset = util::int(offset);
 
-                quote!( #field_name => #toasty::FieldId { model: Self::id(), index: #field_offset }, )
+                quote!( #field_name => #toasty::core::schema::app::FieldId { model: Self::id(), index: #field_offset }, )
             });
 
         quote! {
-            fn field_name_to_id(name: &str) -> #toasty::FieldId {
+            fn field_name_to_id(name: &str) -> #toasty::core::schema::app::FieldId {
                 use #toasty::{Model, Register};
 
                 match name {

--- a/crates/toasty-codegen/src/expand/model.rs
+++ b/crates/toasty-codegen/src/expand/model.rs
@@ -73,8 +73,8 @@ impl Expand<'_> {
             }
 
             impl #toasty::Register for #model_ident {
-                fn id() -> #toasty::ModelId {
-                    static ID: std::sync::OnceLock<#toasty::ModelId> = std::sync::OnceLock::new();
+                fn id() -> #toasty::core::schema::app::ModelId {
+                    static ID: std::sync::OnceLock<#toasty::core::schema::app::ModelId> = std::sync::OnceLock::new();
                     *ID.get_or_init(|| #toasty::generate_unique_id())
                 }
 
@@ -83,7 +83,7 @@ impl Expand<'_> {
 
             impl #toasty::Load for #model_ident {
                 type Output = Self;
-                fn load(value: #toasty::Value) -> #toasty::Result<Self> {
+                fn load(value: #toasty::core::stmt::Value) -> #toasty::Result<Self> {
                     #load_body
                 }
             }
@@ -328,7 +328,7 @@ impl Expand<'_> {
 
         quote! {
             match value {
-                #toasty::Value::Record(mut record) => {
+                #toasty::core::stmt::Value::Record(mut record) => {
                     Ok(#model_ident {
                         #( #field_loads )*
                     })
@@ -387,7 +387,7 @@ impl Expand<'_> {
 
         quote! {
             match value {
-                #toasty::Value::SparseRecord(sparse) => {
+                #toasty::core::stmt::Value::SparseRecord(sparse) => {
                     for (field, value) in sparse.into_iter() {
                         match field {
                             #( #reload_arms )*

--- a/crates/toasty-codegen/src/expand/schema.rs
+++ b/crates/toasty-codegen/src/expand/schema.rs
@@ -18,8 +18,8 @@ impl Expand<'_> {
             ModelKind::Root(_) => {
                 let primary_key = self.expand_primary_key();
                 quote! {
-                    #toasty::schema::app::Model::Root(
-                        #toasty::schema::app::ModelRoot {
+                    #toasty::core::schema::app::Model::Root(
+                        #toasty::core::schema::app::ModelRoot {
                             id,
                             name: #name,
                             fields: #fields,
@@ -32,8 +32,8 @@ impl Expand<'_> {
             }
             ModelKind::EmbeddedStruct(_) => {
                 quote! {
-                    #toasty::schema::app::Model::EmbeddedStruct(
-                        #toasty::schema::app::EmbeddedStruct {
+                    #toasty::core::schema::app::Model::EmbeddedStruct(
+                        #toasty::core::schema::app::EmbeddedStruct {
                             id,
                             name: #name,
                             fields: #fields,
@@ -48,7 +48,7 @@ impl Expand<'_> {
         };
 
         quote! {
-            fn schema() -> #toasty::schema::app::Model {
+            fn schema() -> #toasty::core::schema::app::Model {
                 let id = #model_ident::id();
 
                 #model
@@ -72,7 +72,7 @@ impl Expand<'_> {
                     None => quote! { None },
                 };
                 quote! {
-                    #toasty::schema::app::FieldName {
+                    #toasty::core::schema::app::FieldName {
                         app_name: #app_name.to_string(),
                         storage_name: #storage_name,
                     }
@@ -93,15 +93,15 @@ impl Expand<'_> {
                         Some(SerializeAttr { format, nullable: serialize_nullable }) => {
                             let serialize_format = match format {
                                 SerializeFormat::Json => {
-                                    quote!(Some(#toasty::schema::app::SerializeFormat::Json))
+                                    quote!(Some(#toasty::core::schema::app::SerializeFormat::Json))
                                 }
                             };
                             let nullable_lit = *serialize_nullable;
 
                             nullable = quote!(#nullable_lit);
-                            field_ty = quote!(#toasty::schema::app::FieldTy::Primitive(
-                                #toasty::schema::app::FieldPrimitive {
-                                    ty: #toasty::Type::String,
+                            field_ty = quote!(#toasty::core::schema::app::FieldTy::Primitive(
+                                #toasty::core::schema::app::FieldPrimitive {
+                                    ty: #toasty::core::stmt::Type::String,
                                     storage_ty: #storage_ty,
                                     serialize: #serialize_format,
                                 }
@@ -121,8 +121,8 @@ impl Expand<'_> {
                         let target = fk_field.target.to_string();
 
                         quote! {
-                            #toasty::schema::app::ForeignKeyField {
-                                source: #toasty::schema::app::FieldId {
+                            #toasty::core::schema::app::ForeignKeyField {
+                                source: #toasty::core::schema::app::FieldId {
                                     model: #model_ident::id(),
                                     index: #source,
                                 },
@@ -132,12 +132,12 @@ impl Expand<'_> {
                     });
 
                     nullable = quote!(<#ty as #toasty::Relation>::nullable());
-                    field_ty = quote!(#toasty::schema::app::FieldTy::BelongsTo(#toasty::schema::app::BelongsTo {
+                    field_ty = quote!(#toasty::core::schema::app::FieldTy::BelongsTo(#toasty::core::schema::app::BelongsTo {
                         target:  <#ty as #toasty::Relation>::Model::id(),
-                        expr_ty: #toasty::Type::Model(<#ty as #toasty::Relation>::Model::id()),
+                        expr_ty: #toasty::core::stmt::Type::Model(<#ty as #toasty::Relation>::Model::id()),
                         // The pair is populated at runtime.
                         pair: None,
-                        foreign_key: #toasty::schema::app::ForeignKey {
+                        foreign_key: #toasty::core::schema::app::ForeignKey {
                             fields: vec![ #( #fk_fields ),* ],
                         },
                     }));
@@ -147,13 +147,13 @@ impl Expand<'_> {
                     let singular_name = expand_name(toasty, &rel.singular);
 
                     nullable = quote!(<#ty as #toasty::Relation>::nullable());
-                    field_ty = quote!(#toasty::schema::app::FieldTy::HasMany(#toasty::schema::app::HasMany {
+                    field_ty = quote!(#toasty::core::schema::app::FieldTy::HasMany(#toasty::core::schema::app::HasMany {
                         target: <#ty as #toasty::Relation>::Model::id(),
-                        expr_ty: #toasty::Type::List(Box::new(#toasty::Type::Model(<#ty as #toasty::Relation>::Model::id()))),
+                        expr_ty: #toasty::core::stmt::Type::List(Box::new(#toasty::core::stmt::Type::Model(<#ty as #toasty::Relation>::Model::id()))),
                         singular: #singular_name,
                         // The pair is populated at runtime.
-                        pair: #toasty::schema::app::FieldId {
-                            model: #toasty::schema::app::ModelId(usize::MAX),
+                        pair: #toasty::core::schema::app::FieldId {
+                            model: #toasty::core::schema::app::ModelId(usize::MAX),
                             index: usize::MAX,
                         },
                     }));
@@ -162,12 +162,12 @@ impl Expand<'_> {
                     let ty = &rel.ty;
 
                     nullable = quote!(<#ty as #toasty::Relation>::nullable());
-                    field_ty = quote!(#toasty::schema::app::FieldTy::HasOne(#toasty::schema::app::HasOne {
+                    field_ty = quote!(#toasty::core::schema::app::FieldTy::HasOne(#toasty::core::schema::app::HasOne {
                         target: <#ty as #toasty::Relation>::Model::id(),
-                        expr_ty: #toasty::Type::Model(<#ty as #toasty::Relation>::Model::id()),
+                        expr_ty: #toasty::core::stmt::Type::Model(<#ty as #toasty::Relation>::Model::id()),
                         // The pair is populated at runtime.
-                        pair: #toasty::schema::app::FieldId {
-                            model: #toasty::schema::app::ModelId(usize::MAX),
+                        pair: #toasty::core::schema::app::FieldId {
+                            model: #toasty::core::schema::app::ModelId(usize::MAX),
                             index: usize::MAX,
                         },
                     }));
@@ -188,16 +188,16 @@ impl Expand<'_> {
 
                             quote! { Some(<#ty as #toasty::Auto>::STRATEGY) }
                          }
-                        AutoStrategy::Uuid(UuidVersion::V4) => quote! { Some(#toasty::schema::app::AutoStrategy::Uuid(#toasty::schema::app::UuidVersion::V4)) },
-                        AutoStrategy::Uuid(UuidVersion::V7) => quote! { Some(#toasty::schema::app::AutoStrategy::Uuid(#toasty::schema::app::UuidVersion::V4)) },
-                        AutoStrategy::Increment => quote! { Some(#toasty::schema::app::AutoStrategy::Increment) },
+                        AutoStrategy::Uuid(UuidVersion::V4) => quote! { Some(#toasty::core::schema::app::AutoStrategy::Uuid(#toasty::core::schema::app::UuidVersion::V4)) },
+                        AutoStrategy::Uuid(UuidVersion::V7) => quote! { Some(#toasty::core::schema::app::AutoStrategy::Uuid(#toasty::core::schema::app::UuidVersion::V4)) },
+                        AutoStrategy::Increment => quote! { Some(#toasty::core::schema::app::AutoStrategy::Increment) },
                     }
                 }
             };
 
             quote! {
-                #toasty::schema::app::Field {
-                    id: #toasty::schema::app::FieldId {
+                #toasty::core::schema::app::Field {
+                    id: #toasty::core::schema::app::FieldId {
                         model: #model_ident::id(),
                         index: #index_tokenized,
                     },
@@ -232,7 +232,7 @@ impl Expand<'_> {
                 let field_tokenized = util::int(*field);
 
                 quote! {
-                    #toasty::schema::app::FieldId {
+                    #toasty::core::schema::app::FieldId {
                         model: id,
                         index: #field_tokenized,
                     }
@@ -241,9 +241,9 @@ impl Expand<'_> {
             .collect::<Vec<_>>();
 
         quote! {
-            #toasty::schema::app::PrimaryKey {
+            #toasty::core::schema::app::PrimaryKey {
                 fields: vec![ #( #fields ),* ],
-                index: #toasty::schema::app::IndexId {
+                index: #toasty::core::schema::app::IndexId {
                     model: id,
                     index: 0,
                 },
@@ -269,25 +269,27 @@ impl Expand<'_> {
                 let fields = model_index.fields.iter().map(|index_field| {
                     let field_tokenized = util::int(index_field.field);
                     let scope = match &index_field.scope {
-                        IndexScope::Partition => quote!(#toasty::schema::db::IndexScope::Partition),
-                        IndexScope::Local => quote!(#toasty::schema::db::IndexScope::Local),
+                        IndexScope::Partition => {
+                            quote!(#toasty::core::schema::db::IndexScope::Partition)
+                        }
+                        IndexScope::Local => quote!(#toasty::core::schema::db::IndexScope::Local),
                     };
 
                     quote! {
-                        #toasty::schema::app::IndexField {
-                            field: #toasty::schema::app::FieldId {
+                        #toasty::core::schema::app::IndexField {
+                            field: #toasty::core::schema::app::FieldId {
                                 model: id,
                                 index: #field_tokenized,
                             },
-                            op: #toasty::schema::db::IndexOp::Eq,
+                            op: #toasty::core::schema::db::IndexOp::Eq,
                             scope: #scope,
                         }
                     }
                 });
 
                 quote! {
-                    #toasty::schema::app::Index {
-                        id: #toasty::schema::app::IndexId {
+                    #toasty::core::schema::app::Index {
+                        id: #toasty::core::schema::app::IndexId {
                             model: id,
                             index: #index_tokenized,
                         },
@@ -320,7 +322,7 @@ pub(super) fn expand_name(toasty: &TokenStream, name: &Name) -> TokenStream {
     });
 
     quote! {
-        #toasty::schema::Name {
+        #toasty::core::schema::Name {
             parts: vec![#( #parts ),*],
         }
     }

--- a/crates/toasty-codegen/src/expand/update.rs
+++ b/crates/toasty-codegen/src/expand/update.rs
@@ -130,7 +130,7 @@ impl Expand<'_> {
                                     #stmt_method.set(projection, <String as #toasty::IntoExpr<String>>::into_expr(json));
                                 }
                                 None => {
-                                    #stmt_method.set(projection, #toasty::stmt::Expr::<String>::from_untyped(#toasty::core::stmt::Expr::Value(#toasty::Value::Null)));
+                                    #stmt_method.set(projection, #toasty::stmt::Expr::<String>::from_untyped(#toasty::core::stmt::Expr::Value(#toasty::core::stmt::Value::Null)));
                                 }
                             }
                             self
@@ -241,7 +241,7 @@ impl Expand<'_> {
 
             // Implement ApplyUpdate for &mut Model to enable reloading
             impl #toasty::ApplyUpdate for &mut #model_ident {
-                fn apply_result(self, mut values: ::std::vec::Vec<#toasty::Value>) -> #toasty::Result<()> {
+                fn apply_result(self, mut values: ::std::vec::Vec<#toasty::core::stmt::Value>) -> #toasty::Result<()> {
                     let value = values.into_iter()
                         .next()
                         .ok_or_else(|| #toasty::Error::record_not_found("update returned no results"))?;
@@ -337,7 +337,7 @@ impl Expand<'_> {
         let reload_arms = self.expand_reload_match_arms();
 
         quote! {
-            #vis fn reload(&mut self, value: #toasty::Value) -> #toasty::Result<()> {
+            #vis fn reload(&mut self, value: #toasty::core::stmt::Value) -> #toasty::Result<()> {
                 use #toasty::Field;
                 for (field, value) in value.into_sparse_record().into_iter() {
                     match field {

--- a/crates/toasty-codegen/src/schema/column.rs
+++ b/crates/toasty-codegen/src/schema/column.rs
@@ -191,32 +191,34 @@ impl syn::parse::Parse for ColumnType {
 }
 
 impl ColumnType {
-    /// Expand to a fully qualified `#toasty::schema::db::Type::...` token stream.
+    /// Expand to a fully qualified `#toasty::core::schema::db::Type::...` token stream.
     pub(crate) fn expand_with(
         &self,
         toasty: &proc_macro2::TokenStream,
     ) -> proc_macro2::TokenStream {
         match self {
-            Self::Boolean => quote! { #toasty::schema::db::Type::Boolean },
-            Self::Integer(size) => quote! { #toasty::schema::db::Type::Integer(#size) },
+            Self::Boolean => quote! { #toasty::core::schema::db::Type::Boolean },
+            Self::Integer(size) => quote! { #toasty::core::schema::db::Type::Integer(#size) },
             Self::UnsignedInteger(size) => {
-                quote! { #toasty::schema::db::Type::UnsignedInteger(#size) }
+                quote! { #toasty::core::schema::db::Type::UnsignedInteger(#size) }
             }
-            Self::Text => quote! { #toasty::schema::db::Type::Text },
-            Self::VarChar(size) => quote! { #toasty::schema::db::Type::VarChar(#size) },
-            Self::Numeric(None) => quote! { #toasty::schema::db::Type::Numeric(None) },
+            Self::Text => quote! { #toasty::core::schema::db::Type::Text },
+            Self::VarChar(size) => quote! { #toasty::core::schema::db::Type::VarChar(#size) },
+            Self::Numeric(None) => quote! { #toasty::core::schema::db::Type::Numeric(None) },
             Self::Numeric(Some((precision, scale))) => {
-                quote! { #toasty::schema::db::Type::Numeric(Some((#precision, #scale))) }
+                quote! { #toasty::core::schema::db::Type::Numeric(Some((#precision, #scale))) }
             }
-            Self::Binary(size) => quote! { #toasty::schema::db::Type::Binary(#size) },
-            Self::Blob => quote! { #toasty::schema::db::Type::Blob },
+            Self::Binary(size) => quote! { #toasty::core::schema::db::Type::Binary(#size) },
+            Self::Blob => quote! { #toasty::core::schema::db::Type::Blob },
             Self::Timestamp(precision) => {
-                quote! { #toasty::schema::db::Type::Timestamp(#precision) }
+                quote! { #toasty::core::schema::db::Type::Timestamp(#precision) }
             }
-            Self::Date => quote! { #toasty::schema::db::Type::Date },
-            Self::Time(precision) => quote! { #toasty::schema::db::Type::Time(#precision) },
-            Self::DateTime(precision) => quote! { #toasty::schema::db::Type::DateTime(#precision) },
-            Self::Custom(custom) => quote! { #toasty::schema::db::Type::Custom(#custom) },
+            Self::Date => quote! { #toasty::core::schema::db::Type::Date },
+            Self::Time(precision) => quote! { #toasty::core::schema::db::Type::Time(#precision) },
+            Self::DateTime(precision) => {
+                quote! { #toasty::core::schema::db::Type::DateTime(#precision) }
+            }
+            Self::Custom(custom) => quote! { #toasty::core::schema::db::Type::Custom(#custom) },
         }
     }
 }

--- a/crates/toasty/src/lib.rs
+++ b/crates/toasty/src/lib.rs
@@ -62,14 +62,6 @@ pub mod codegen_support {
     pub use std::{convert::Into, default::Default, option::Option};
 
     pub use toasty_core as core;
-    pub use toasty_core::{
-        driver,
-        schema::{
-            self,
-            app::{FieldId, ModelId},
-        },
-        stmt::{Type, Value, ValueRecord, ValueStream},
-    };
 }
 
 pub mod driver {


### PR DESCRIPTION
## Summary
This PR updates the code generation in toasty-codegen to use fully qualified paths through the `toasty::core` namespace instead of re-exporting types at the top level. This change aligns with a refactoring of the toasty crate structure where schema, statement, and driver types are now accessed through `toasty::core` rather than directly from `toasty`.

## Key Changes

- **Schema types**: Updated all references from `#toasty::schema::*` to `#toasty::core::schema::*` across schema generation, embedded models, and embedded enums
- **Statement types**: Updated all references from `#toasty::Type` and `#toasty::Value` to `#toasty::core::stmt::Type` and `#toasty::core::stmt::Value` respectively
- **Model IDs**: Changed `#toasty::ModelId` to `#toasty::core::schema::app::ModelId` in Register trait implementations
- **Field IDs**: Updated `#toasty::FieldId` to `#toasty::core::schema::app::FieldId` in field name mapping
- **Removed re-exports**: Cleaned up the `codegen_support` module in `toasty/src/lib.rs` to remove the re-exported types that are now accessed through `toasty::core`

## Implementation Details

The changes affect multiple code generation modules:
- `expand/schema.rs`: Primary schema generation for models, fields, indexes, and relationships
- `expand.rs`: Embedded model and enum trait implementations
- `expand/model.rs`: Model registration and loading implementations
- `expand/update.rs` and `expand/create.rs`: Statement building and value handling
- `expand/fields.rs`: Field name to ID mapping
- `schema/column.rs`: Database column type expansion

All generated code now uses the fully qualified `toasty::core::*` paths, making the module structure explicit and reducing reliance on re-exports.

https://claude.ai/code/session_01UB41o4hGpCmsByzYAgnJqp