### PR TITLE
refactor: replace wildcard import with explicit imports in schema module

### DIFF
--- a/crates/toasty/src/schema.rs
+++ b/crates/toasty/src/schema.rs
@@ -1,6 +1,6 @@
 use crate::Result;
 
-pub use toasty_core::schema::*;
+pub use toasty_core::schema::{app, db, mapping};
 
 pub fn from_macro(models: &[app::Model]) -> Result<app::Schema> {
     app::Schema::from_macro(models)


### PR DESCRIPTION
## Summary
Changed the schema module to use explicit imports instead of a wildcard import from `toasty_core::schema`.

## Key Changes
- Replaced `pub use toasty_core::schema::*;` with explicit imports: `pub use toasty_core::schema::{app, db, mapping};`
- This makes the public API of the schema module more explicit and maintainable

## Implementation Details
The change maintains the same public interface by explicitly re-exporting the three modules (`app`, `db`, and `mapping`) that were previously available through the wildcard import. This improves code clarity by making it obvious which items from `toasty_core::schema` are being exposed publicly, rather than implicitly exporting everything.

https://claude.ai/code/session_015WZ5BuQvasU6AaRNmwpJPn