### PR TITLE
chore: skip github pages deploy on forks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.repository == 'tokio-rs/toasty'
     name: Build docs
     runs-on: ubuntu-latest
     steps:
@@ -61,6 +62,7 @@ jobs:
           path: _site
 
   deploy:
+    if: github.repository == 'tokio-rs/toasty'
     name: Deploy to GitHub Pages
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
While pushing to my own fork, the docs workflow keeps failing when it tries to push to github pages. This pr limits the scope of the workflow to this (tokio-rs/toasty) repo.