### PR TITLE
fix: build issues on main (assert_struct version)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ toasty-driver-integration-suite = { path = "crates/toasty-driver-integration-sui
 toasty-driver-integration-suite-macros = { path = "crates/toasty-driver-integration-suite-macros" }
 
 # Other crates
-assert-struct = "0.4.0"
+assert-struct = "0.4.1"
 async-recursion = "1.1.1"
 async-stream = "0.3.6"
 async-trait = "0.1.83"


### PR DESCRIPTION
Main branch doesn't build for me at the moment, bumping `assert_struct`'s version to 0.4.1 solves the issue