### PR TITLE
docs: document sorting, limits, and pagination features

### DIFF
--- a/docs/guide/src/sorting-limits-and-pagination.md
+++ b/docs/guide/src/sorting-limits-and-pagination.md
@@ -137,7 +137,10 @@ let items = Item::all()
 Limit and offset work for simple cases, but cursor-based pagination (below) is a
 better fit for paging through large result sets. Offset-based pagination gets
 slower as the offset increases because the database still reads and discards the
-skipped rows.
+skipped rows. It can also produce inconsistent results when rows are inserted or
+deleted between page fetches. See Markus Winand's
+["No Offset"](https://use-the-index-luke.com/no-offset) for an in-depth
+explanation.
 
 ## Cursor-based pagination
 


### PR DESCRIPTION
This PR completes the documentation for sorting, limits, and pagination functionality in the query API.

## Summary
Replaced the placeholder text in the sorting, limits, and pagination guide with comprehensive documentation covering all related query methods and patterns.

## Key changes
- **Sorting with `order_by`**: Added examples showing ascending/descending sort with `.asc()` and `.desc()`, including usage with filters
- **Limiting results**: Documented `.limit(n)` with examples of getting top/bottom N records
- **Offset-based pagination**: Explained `.offset(n)` with a note about cursor-based pagination being preferable for large datasets
- **Cursor-based pagination**: Comprehensive coverage of `.paginate()` including:
  - Basic usage and `Page` type
  - Navigation with `.next()` and `.prev()` methods
  - Checking for more pages with `.has_next()` and `.has_prev()`
  - Pattern for walking all pages
  - Starting from a cursor position with `.after()`
- **Method summary**: Added reference tables for query builder methods and `Page` methods

All examples include proper Rust code blocks with necessary imports and async context.

https://claude.ai/code/session_01VPqc6CCnyQzu9XFFv5XsMc