### PR TITLE
ci: remove --document-private-items flag from Rust API docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
         run: mdbook build docs/dev
 
       - name: Build Rust API docs
-        run: cargo doc --workspace --no-deps --document-private-items
+        run: cargo doc --workspace --no-deps
         env:
           TOASTY_GUIDE_URL: ../../guide/
 


### PR DESCRIPTION
## Summary
This change removes the `--document-private-items` flag from the Rust API documentation build step in the CI workflow.

## Changes
- Removed `--document-private-items` flag from the `cargo doc` command in the docs workflow
- The documentation build now only generates docs for public API items by default

## Details
The `--document-private-items` flag was generating documentation for private items in the codebase. By removing this flag, the generated API documentation will only include public items, which is the standard behavior and reduces documentation clutter while focusing on the public API surface that users should interact with.

https://claude.ai/code/session_013w6Q9P1GumSjexygJpSMSP