### PR TITLE
refactor: remove unused IntoExpr implementation for List types

### DIFF
--- a/crates/toasty-codegen/src/expand/create.rs
+++ b/crates/toasty-codegen/src/expand/create.rs
@@ -63,16 +63,6 @@ impl Expand<'_> {
                 }
             }
 
-            impl #toasty::IntoExpr<#toasty::List<#model_ident>> for #create_struct_ident {
-                fn into_expr(self) -> #toasty::stmt::Expr<#toasty::List<#model_ident>> {
-                    self.stmt.into_list_expr()
-                }
-
-                fn by_ref(&self) -> #toasty::stmt::Expr<#toasty::List<#model_ident>> {
-                    todo!()
-                }
-            }
-
             impl Default for #create_struct_ident {
                 fn default() -> #create_struct_ident {
                     let mut s = #create_struct_ident {


### PR DESCRIPTION
## Summary
Removed an unused `IntoExpr<List<T>>` trait implementation from the create struct code generation that was not being utilized.

## Changes
- Deleted the `IntoExpr<List<#model_ident>>` trait implementation for `#create_struct_ident`
  - Removed `into_expr()` method that delegated to `self.stmt.into_list_expr()`
  - Removed `by_ref()` method that was stubbed with `todo!()`

## Details
This implementation appears to have been dead code, as evidenced by the `todo!()` placeholder in the `by_ref()` method, suggesting it was never completed or used. Removing it simplifies the generated code without affecting functionality.

https://claude.ai/code/session_01NAqNCTMRC3gZysHE6wd9gp