### PR TITLE
refactor: remove unused union query functionality

### DIFF
--- a/crates/toasty-core/src/stmt/query.rs
+++ b/crates/toasty-core/src/stmt/query.rs
@@ -2,7 +2,7 @@ use super::{
     Delete, ExprSet, Limit, Node, OrderBy, Path, Returning, Select, Source, Statement, Update,
     UpdateTarget, Values, Visit, VisitMut, With,
 };
-use crate::stmt::{self, ExprSetOp, Filter, SetOp};
+use crate::stmt::{self, Filter};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Query {
@@ -116,25 +116,6 @@ impl Query {
 
     pub fn add_filter(&mut self, filter: impl Into<Filter>) {
         self.body.as_select_mut_unwrap().add_filter(filter);
-    }
-
-    pub fn add_union(&mut self, other: impl Into<Self>) {
-        let rhs = other.into();
-
-        match (&mut self.body, rhs.body) {
-            (ExprSet::SetOp(_), ExprSet::SetOp(_)) => todo!(),
-            (ExprSet::SetOp(lhs), rhs) if lhs.is_union() => {
-                lhs.operands.push(rhs);
-            }
-            (_, ExprSet::SetOp(_)) => todo!(),
-            (me, rhs) => {
-                let lhs = std::mem::take(me);
-                *me = ExprSet::SetOp(ExprSetOp {
-                    op: SetOp::Union,
-                    operands: vec![lhs, rhs],
-                });
-            }
-        }
     }
 
     pub fn include(&mut self, path: impl Into<Path>) {

--- a/crates/toasty/src/stmt/query.rs
+++ b/crates/toasty/src/stmt/query.rs
@@ -42,11 +42,6 @@ impl<M> Query<M> {
         self
     }
 
-    pub fn union(mut self, other: Self) -> Self {
-        self.untyped.add_union(other.untyped);
-        self
-    }
-
     pub fn include(&mut self, path: impl Into<stmt::Path>) -> &mut Self {
         self.untyped.include(path.into());
         self


### PR DESCRIPTION
This PR removes the `union` query building functionality from both the core and typed query APIs.

## Summary
The `add_union` method and its associated `union` wrapper have been removed from the query builder interface. This includes cleanup of unused imports (`ExprSetOp` and `SetOp`) that were only used by the union implementation.

## Changes
- Removed `add_union()` method from `crates/toasty-core/src/stmt/query.rs` that handled combining queries with UNION operations
- Removed `union()` method from `crates/toasty/src/stmt/query.rs` that provided the typed API wrapper
- Removed unused imports `ExprSetOp` and `SetOp` from the core query module

## Notes
The union implementation was incomplete (contained `todo!()` placeholders for certain cases), suggesting this functionality was either not fully implemented or is being deferred for future work.

https://claude.ai/code/session_01Tc9iMuYHVKpppky8UeXn93