### PR TITLE
refactor: rename unwrap methods to expect for consistency and clarity

### DIFF
--- a/crates/toasty-codegen/src/expand.rs
+++ b/crates/toasty-codegen/src/expand.rs
@@ -61,7 +61,7 @@ pub(super) fn root_model(model: &Model) -> TokenStream {
 pub(super) fn embedded_model(model: &Model) -> TokenStream {
     let toasty = quote!(_toasty::codegen_support);
     let model_ident = &model.ident;
-    let embedded = model.kind.expect_embedded();
+    let embedded = model.kind.as_embedded_unwrap();
     let field_struct_ident = &embedded.field_struct_ident;
     let update_struct_ident = &embedded.update_struct_ident;
 
@@ -170,7 +170,7 @@ pub(super) fn embedded_enum(model: &Model) -> TokenStream {
     let into_expr_arms = e.expand_enum_into_expr_arms();
     let ty_expr = e.expand_enum_primitive_ty();
 
-    let embedded_enum = model.kind.expect_embedded_enum();
+    let embedded_enum = model.kind.as_embedded_enum_unwrap();
     let field_struct_ident = &embedded_enum.field_struct_ident;
     let enum_field_struct = e.expand_enum_field_struct();
 

--- a/crates/toasty-codegen/src/expand/create.rs
+++ b/crates/toasty-codegen/src/expand/create.rs
@@ -9,7 +9,7 @@ impl Expand<'_> {
         let toasty = &self.toasty;
         let vis = &self.model.vis;
         let model_ident = &self.model.ident;
-        let create_struct_ident = &self.model.kind.expect_root().create_struct_ident;
+        let create_struct_ident = &self.model.kind.as_root_unwrap().create_struct_ident;
         let create_methods = self.expand_create_methods();
         let default_stmts = self.expand_create_default_stmts();
 

--- a/crates/toasty-codegen/src/expand/embedded_enum.rs
+++ b/crates/toasty-codegen/src/expand/embedded_enum.rs
@@ -76,7 +76,7 @@ impl Expand<'_> {
         let toasty = &self.toasty;
         let vis = &self.model.vis;
         let model_ident = &self.model.ident;
-        let embedded_enum = self.model.kind.expect_embedded_enum();
+        let embedded_enum = self.model.kind.as_embedded_enum_unwrap();
         let field_struct_ident = &embedded_enum.field_struct_ident;
 
         let is_variant_methods: Vec<_> = embedded_enum
@@ -133,7 +133,7 @@ impl Expand<'_> {
                     .enumerate()
                     .map(|(field_index, field)| {
                         let field_ident = &field.name.ident;
-                        let field_ty = expect_primitive_ty(field);
+                        let field_ty = primitive_ty_unwrap(field);
                         let field_offset = util::int(field_index);
                         self.expand_primitive_field_method(field_ident, field_ty, &field_offset)
                     })
@@ -208,7 +208,7 @@ impl Expand<'_> {
     /// stored at the `EmbeddedEnum` level).
     pub(super) fn expand_enum_variants(&self) -> Vec<TokenStream> {
         let toasty = &self.toasty;
-        let embedded_enum = self.model.kind.expect_embedded_enum();
+        let embedded_enum = self.model.kind.as_embedded_enum_unwrap();
 
         embedded_enum
             .variants
@@ -237,7 +237,7 @@ impl Expand<'_> {
             .map(|field| {
                 let index = util::int(field.id);
                 let app_name = field.name.ident.to_string();
-                let ty = expect_primitive_ty(field);
+                let ty = primitive_ty_unwrap(field);
                 let variant_index = field.variant.expect("enum field must have variant");
                 let variant_idx = util::int(variant_index);
                 quote! {
@@ -269,7 +269,7 @@ impl Expand<'_> {
     /// Only unit variants are emitted here; data variants appear in `expand_enum_data_load_arms`.
     pub(super) fn expand_enum_unit_load_arms(&self) -> Vec<TokenStream> {
         let model_ident = &self.model.ident;
-        let embedded_enum = self.model.kind.expect_embedded_enum();
+        let embedded_enum = self.model.kind.as_embedded_enum_unwrap();
 
         embedded_enum
             .variants
@@ -291,7 +291,7 @@ impl Expand<'_> {
     pub(super) fn expand_enum_data_load_arms(&self) -> Vec<TokenStream> {
         let toasty = &self.toasty;
         let model_ident = &self.model.ident;
-        let embedded_enum = self.model.kind.expect_embedded_enum();
+        let embedded_enum = self.model.kind.as_embedded_enum_unwrap();
 
         embedded_enum
             .variants
@@ -308,7 +308,7 @@ impl Expand<'_> {
                     .enumerate()
                     .map(|(i, field)| {
                         let field_ident = &field.name.ident;
-                        let ty = expect_primitive_ty(field);
+                        let ty = primitive_ty_unwrap(field);
                         let record_pos = util::int(i + 1);
                         let load =
                             quote! { <#ty as #toasty::Field>::load(record[#record_pos].take())? };
@@ -341,7 +341,7 @@ impl Expand<'_> {
     pub(super) fn expand_enum_into_expr_arms(&self) -> Vec<TokenStream> {
         let toasty = &self.toasty;
         let model_ident = &self.model.ident;
-        let embedded_enum = self.model.kind.expect_embedded_enum();
+        let embedded_enum = self.model.kind.as_embedded_enum_unwrap();
 
         embedded_enum
             .variants
@@ -385,7 +385,7 @@ impl Expand<'_> {
 
                     let field_exprs = fields.iter().map(|field| {
                         let field_ident = &field.name.ident;
-                        let ty = expect_primitive_ty(field);
+                        let ty = primitive_ty_unwrap(field);
                         self.expand_into_untyped_expr(ty, field_ident)
                     });
 
@@ -415,7 +415,7 @@ impl Expand<'_> {
     }
 }
 
-fn expect_primitive_ty(field: &crate::schema::Field) -> &syn::Type {
+fn primitive_ty_unwrap(field: &crate::schema::Field) -> &syn::Type {
     match &field.ty {
         FieldTy::Primitive(ty) => ty,
         _ => panic!("expected primitive field type for enum variant field"),

--- a/crates/toasty-codegen/src/expand/filters.rs
+++ b/crates/toasty-codegen/src/expand/filters.rs
@@ -72,7 +72,7 @@ impl Expand<'_> {
         let filter_method_ident = &filter.filter_method_ident;
         let args: Vec<_> = self.expand_filter_args(filter).collect();
         let arg_idents: Vec<_> = self.expand_filter_arg_idents(filter).collect();
-        let update_query_struct_ident = &self.model.kind.expect_root().update_struct_ident;
+        let update_query_struct_ident = &self.model.kind.as_root_unwrap().update_struct_ident;
 
         let self_arg;
         let base;
@@ -108,7 +108,7 @@ impl Expand<'_> {
     fn expand_model_filter_method(&self, filter: &Filter, self_into_query: bool) -> TokenStream {
         let toasty = &self.toasty;
         let vis = &self.model.vis;
-        let query_struct_ident = &self.model.kind.expect_root().query_struct_ident;
+        let query_struct_ident = &self.model.kind.as_root_unwrap().query_struct_ident;
         let filter_method_ident = &filter.filter_method_ident;
         let args = self.expand_filter_args(filter);
         let arg_idents = self.expand_filter_arg_idents(filter);
@@ -144,7 +144,7 @@ impl Expand<'_> {
     ) -> TokenStream {
         let toasty = &self.toasty;
         let vis = &self.model.vis;
-        let query_struct_ident = &self.model.kind.expect_root().query_struct_ident;
+        let query_struct_ident = &self.model.kind.as_root_unwrap().query_struct_ident;
         let filter_method_batch_ident = &filter.filter_method_batch_ident;
         let bound = self.expand_filter_batch_arg_bound(filter);
         let self_arg;
@@ -211,7 +211,7 @@ impl Expand<'_> {
 
     fn expand_query_filter_method(&self, filter: &Filter) -> TokenStream {
         let vis = &self.model.vis;
-        let query_struct_ident = &self.model.kind.expect_root().query_struct_ident;
+        let query_struct_ident = &self.model.kind.as_root_unwrap().query_struct_ident;
         let filter_method_ident = &filter.filter_method_ident;
         let args = self.expand_filter_args(filter);
         let expr = self.expand_query_filter_expr(filter);
@@ -244,7 +244,7 @@ impl Expand<'_> {
         let toasty = &self.toasty;
         let vis = &self.model.vis;
         let model_ident = &self.model.ident;
-        let query_struct_ident = &self.model.kind.expect_root().query_struct_ident;
+        let query_struct_ident = &self.model.kind.as_root_unwrap().query_struct_ident;
         let query_filter_batch_ident = &filter.filter_method_batch_ident;
         let bound = self.expand_filter_batch_arg_bound(filter);
 

--- a/crates/toasty-codegen/src/expand/model.rs
+++ b/crates/toasty-codegen/src/expand/model.rs
@@ -169,7 +169,7 @@ impl Expand<'_> {
 
     fn expand_model_into_statement_body(&self) -> TokenStream {
         let filter = self.primary_key_filter();
-        let query_struct_ident = &self.model.kind.expect_root().query_struct_ident;
+        let query_struct_ident = &self.model.kind.as_root_unwrap().query_struct_ident;
         let filter_method_ident = &filter.filter_method_ident;
         let arg_idents = self.expand_filter_arg_idents(filter);
 

--- a/crates/toasty-codegen/src/expand/query.rs
+++ b/crates/toasty-codegen/src/expand/query.rs
@@ -9,8 +9,8 @@ impl Expand<'_> {
         let toasty = &self.toasty;
         let vis = &self.model.vis;
         let model_ident = &self.model.ident;
-        let query_struct_ident = &self.model.kind.expect_root().query_struct_ident;
-        let update_struct_ident = &self.model.kind.expect_root().update_struct_ident;
+        let query_struct_ident = &self.model.kind.as_root_unwrap().query_struct_ident;
+        let update_struct_ident = &self.model.kind.as_root_unwrap().update_struct_ident;
         let include_ty = util::ident("T");
         let filter_methods = self.expand_query_filter_methods();
         let relation_methods = self.expand_relation_methods();
@@ -180,7 +180,7 @@ impl Expand<'_> {
         let toasty = &self.toasty;
         let vis = &self.model.vis;
         let model_ident = &self.model.ident;
-        let query_struct_ident = &self.model.kind.expect_root().query_struct_ident;
+        let query_struct_ident = &self.model.kind.as_root_unwrap().query_struct_ident;
 
         if self.model.has_associations() {
             Some(quote! {

--- a/crates/toasty-codegen/src/expand/relation.rs
+++ b/crates/toasty-codegen/src/expand/relation.rs
@@ -9,8 +9,8 @@ impl Expand<'_> {
         let toasty = &self.toasty;
         let vis = &self.model.vis;
         let model_ident = &self.model.ident;
-        let query_ident = &self.model.kind.expect_root().query_struct_ident;
-        let create_builder_ident = &self.model.kind.expect_root().create_struct_ident;
+        let query_ident = &self.model.kind.as_root_unwrap().query_struct_ident;
+        let create_builder_ident = &self.model.kind.as_root_unwrap().create_struct_ident;
         let eq_ty = util::ident("T");
         let in_query_ty = util::ident("Q");
         let filter_methods = self.expand_relation_filter_methods();

--- a/crates/toasty-codegen/src/expand/update.rs
+++ b/crates/toasty-codegen/src/expand/update.rs
@@ -9,7 +9,7 @@ impl Expand<'_> {
     pub(super) fn expand_embedded_update_builder(&self) -> TokenStream {
         let toasty = &self.toasty;
         let vis = &self.model.vis;
-        let update_struct_ident = &self.model.kind.expect_embedded().update_struct_ident;
+        let update_struct_ident = &self.model.kind.as_embedded_unwrap().update_struct_ident;
         let builder_methods = self.expand_update_field_methods(true);
 
         quote! {
@@ -207,8 +207,8 @@ impl Expand<'_> {
         let toasty = &self.toasty;
         let vis = &self.model.vis;
         let model_ident = &self.model.ident;
-        let query_struct_ident = &self.model.kind.expect_root().query_struct_ident;
-        let update_struct_ident = &self.model.kind.expect_root().update_struct_ident;
+        let query_struct_ident = &self.model.kind.as_root_unwrap().query_struct_ident;
+        let update_struct_ident = &self.model.kind.as_root_unwrap().update_struct_ident;
         let target_ty = util::ident("T");
         let builder_methods = self.expand_update_field_methods(false);
         let update_default_stmts = self.expand_update_default_stmts();

--- a/crates/toasty-codegen/src/schema/model.rs
+++ b/crates/toasty-codegen/src/schema/model.rs
@@ -14,7 +14,7 @@ pub(crate) enum ModelKind {
 }
 
 impl ModelKind {
-    pub(crate) fn expect_root(&self) -> &ModelRoot {
+    pub(crate) fn as_root_unwrap(&self) -> &ModelRoot {
         match self {
             ModelKind::Root(root) => root,
             ModelKind::EmbeddedStruct(_) => panic!("expected root model, found embedded struct"),
@@ -22,7 +22,7 @@ impl ModelKind {
         }
     }
 
-    pub(crate) fn expect_embedded(&self) -> &ModelEmbeddedStruct {
+    pub(crate) fn as_embedded_unwrap(&self) -> &ModelEmbeddedStruct {
         match self {
             ModelKind::EmbeddedStruct(embedded) => embedded,
             ModelKind::Root(_) => panic!("expected embedded struct, found root model"),
@@ -30,7 +30,7 @@ impl ModelKind {
         }
     }
 
-    pub(crate) fn expect_embedded_enum(&self) -> &ModelEmbeddedEnum {
+    pub(crate) fn as_embedded_enum_unwrap(&self) -> &ModelEmbeddedEnum {
         match self {
             ModelKind::EmbeddedEnum(e) => e,
             ModelKind::Root(_) => panic!("expected embedded enum, found root model"),

--- a/crates/toasty-core/src/schema/app/field.rs
+++ b/crates/toasty-core/src/schema/app/field.rs
@@ -172,7 +172,7 @@ impl FieldTy {
     }
 
     #[track_caller]
-    pub fn expect_primitive(&self) -> &FieldPrimitive {
+    pub fn as_primitive_unwrap(&self) -> &FieldPrimitive {
         match self {
             Self::Primitive(simple) => simple,
             _ => panic!("expected simple field, but was {self:?}"),
@@ -180,7 +180,7 @@ impl FieldTy {
     }
 
     #[track_caller]
-    pub fn expect_primitive_mut(&mut self) -> &mut FieldPrimitive {
+    pub fn as_primitive_mut_unwrap(&mut self) -> &mut FieldPrimitive {
         match self {
             Self::Primitive(simple) => simple,
             _ => panic!("expected simple field, but was {self:?}"),
@@ -199,7 +199,7 @@ impl FieldTy {
     }
 
     #[track_caller]
-    pub fn expect_embedded(&self) -> &Embedded {
+    pub fn as_embedded_unwrap(&self) -> &Embedded {
         match self {
             Self::Embedded(embedded) => embedded,
             _ => panic!("expected embedded field, but was {self:?}"),
@@ -207,7 +207,7 @@ impl FieldTy {
     }
 
     #[track_caller]
-    pub fn expect_embedded_mut(&mut self) -> &mut Embedded {
+    pub fn as_embedded_mut_unwrap(&mut self) -> &mut Embedded {
         match self {
             Self::Embedded(embedded) => embedded,
             _ => panic!("expected embedded field, but was {self:?}"),
@@ -237,7 +237,7 @@ impl FieldTy {
     }
 
     #[track_caller]
-    pub fn expect_has_many(&self) -> &HasMany {
+    pub fn as_has_many_unwrap(&self) -> &HasMany {
         match self {
             Self::HasMany(has_many) => has_many,
             _ => panic!("expected field to be `HasMany`, but was {self:?}"),
@@ -245,7 +245,7 @@ impl FieldTy {
     }
 
     #[track_caller]
-    pub fn expect_has_many_mut(&mut self) -> &mut HasMany {
+    pub fn as_has_many_mut_unwrap(&mut self) -> &mut HasMany {
         match self {
             Self::HasMany(has_many) => has_many,
             _ => panic!("expected field to be `HasMany`, but was {self:?}"),
@@ -264,7 +264,7 @@ impl FieldTy {
     }
 
     #[track_caller]
-    pub fn expect_has_one(&self) -> &HasOne {
+    pub fn as_has_one_unwrap(&self) -> &HasOne {
         match self {
             Self::HasOne(has_one) => has_one,
             _ => panic!("expected field to be `HasOne`, but it was {self:?}"),
@@ -272,7 +272,7 @@ impl FieldTy {
     }
 
     #[track_caller]
-    pub fn expect_has_one_mut(&mut self) -> &mut HasOne {
+    pub fn as_has_one_mut_unwrap(&mut self) -> &mut HasOne {
         match self {
             Self::HasOne(has_one) => has_one,
             _ => panic!("expected field to be `HasOne`, but it was {self:?}"),
@@ -291,7 +291,7 @@ impl FieldTy {
     }
 
     #[track_caller]
-    pub fn expect_belongs_to(&self) -> &BelongsTo {
+    pub fn as_belongs_to_unwrap(&self) -> &BelongsTo {
         match self {
             Self::BelongsTo(belongs_to) => belongs_to,
             _ => panic!("expected field to be `BelongsTo`, but was {self:?}"),
@@ -299,7 +299,7 @@ impl FieldTy {
     }
 
     #[track_caller]
-    pub fn expect_belongs_to_mut(&mut self) -> &mut BelongsTo {
+    pub fn as_belongs_to_mut_unwrap(&mut self) -> &mut BelongsTo {
         match self {
             Self::BelongsTo(belongs_to) => belongs_to,
             _ => panic!("expected field to be `BelongsTo`, but was {self:?}"),

--- a/crates/toasty-core/src/schema/app/model.rs
+++ b/crates/toasty-core/src/schema/app/model.rs
@@ -213,7 +213,7 @@ impl Model {
     }
 
     /// Returns a reference to the root model data, panicking if this is not a root model.
-    pub fn expect_root(&self) -> &ModelRoot {
+    pub fn as_root_unwrap(&self) -> &ModelRoot {
         match self {
             Model::Root(root) => root,
             Model::EmbeddedStruct(_) => panic!("expected root model, found embedded struct"),
@@ -222,7 +222,7 @@ impl Model {
     }
 
     /// Returns a mutable reference to the root model data, panicking if this is not a root model.
-    pub fn expect_root_mut(&mut self) -> &mut ModelRoot {
+    pub fn as_root_mut_unwrap(&mut self) -> &mut ModelRoot {
         match self {
             Model::Root(root) => root,
             Model::EmbeddedStruct(_) => panic!("expected root model, found embedded struct"),
@@ -231,7 +231,7 @@ impl Model {
     }
 
     /// Returns a reference to the embedded struct data, panicking if this is not an embedded struct.
-    pub fn expect_embedded_struct(&self) -> &EmbeddedStruct {
+    pub fn as_embedded_struct_unwrap(&self) -> &EmbeddedStruct {
         match self {
             Model::EmbeddedStruct(embedded) => embedded,
             Model::Root(_) => panic!("expected embedded struct, found root model"),
@@ -240,7 +240,7 @@ impl Model {
     }
 
     /// Returns a reference to the embedded enum data, panicking if this is not an embedded enum.
-    pub fn expect_embedded_enum(&self) -> &EmbeddedEnum {
+    pub fn as_embedded_enum_unwrap(&self) -> &EmbeddedEnum {
         match self {
             Model::EmbeddedEnum(e) => e,
             Model::Root(_) => panic!("expected embedded enum, found root model"),

--- a/crates/toasty-core/src/schema/app/relation/has_many.rs
+++ b/crates/toasty-core/src/schema/app/relation/has_many.rs
@@ -25,6 +25,6 @@ impl HasMany {
     }
 
     pub fn pair<'a>(&self, schema: &'a Schema) -> &'a BelongsTo {
-        schema.field(self.pair).ty.expect_belongs_to()
+        schema.field(self.pair).ty.as_belongs_to_unwrap()
     }
 }

--- a/crates/toasty-core/src/schema/app/relation/has_one.rs
+++ b/crates/toasty-core/src/schema/app/relation/has_one.rs
@@ -22,7 +22,7 @@ impl HasOne {
     }
 
     pub fn pair<'a>(&self, schema: &'a Schema) -> &'a BelongsTo {
-        schema.field(self.pair).ty.expect_belongs_to()
+        schema.field(self.pair).ty.as_belongs_to_unwrap()
     }
 }
 

--- a/crates/toasty-core/src/schema/app/schema.rs
+++ b/crates/toasty-core/src/schema/app/schema.rs
@@ -84,7 +84,7 @@ impl Schema {
         };
 
         // Get the first field from the root model
-        let mut current_field = root.expect_root().fields.get(*first)?;
+        let mut current_field = root.as_root_unwrap().fields.get(*first)?;
 
         // Walk through remaining steps. Uses a manual iterator because
         // embedded enums consume two steps (variant discriminant + field index).
@@ -120,13 +120,13 @@ impl Schema {
                     }
                 }
                 FieldTy::BelongsTo(belongs_to) => {
-                    current_field = belongs_to.target(self).expect_root().fields.get(*step)?;
+                    current_field = belongs_to.target(self).as_root_unwrap().fields.get(*step)?;
                 }
                 FieldTy::HasMany(has_many) => {
-                    current_field = has_many.target(self).expect_root().fields.get(*step)?;
+                    current_field = has_many.target(self).as_root_unwrap().fields.get(*step)?;
                 }
                 FieldTy::HasOne(has_one) => {
-                    current_field = has_one.target(self).expect_root().fields.get(*step)?;
+                    current_field = has_one.target(self).as_root_unwrap().fields.get(*step)?;
                 }
             };
         }
@@ -150,7 +150,7 @@ impl Schema {
     }
 
     pub fn resolve_field_path<'a>(&'a self, path: &stmt::Path) -> Option<&'a Field> {
-        let model = self.model(path.root.expect_model());
+        let model = self.model(path.root.as_model_unwrap());
         self.resolve_field(model, &path.projection)
     }
 }
@@ -194,18 +194,18 @@ impl Builder {
             if self.models[curr].is_embedded() {
                 continue;
             }
-            for index in 0..self.models[curr].expect_root().fields.len() {
+            for index in 0..self.models[curr].as_root_unwrap().fields.len() {
                 let model = &self.models[curr];
                 let src = model.id();
-                let field = &model.expect_root().fields[index];
+                let field = &model.as_root_unwrap().fields[index];
 
                 if let FieldTy::HasMany(has_many) = &field.ty {
                     let target = has_many.target;
                     let field_name = field.name.app_name.clone();
                     let pair = self.find_has_many_pair(src, target, &field_name)?;
-                    self.models[curr].expect_root_mut().fields[index]
+                    self.models[curr].as_root_mut_unwrap().fields[index]
                         .ty
-                        .expect_has_many_mut()
+                        .as_has_many_mut_unwrap()
                         .pair = pair;
                 }
             }
@@ -216,10 +216,10 @@ impl Builder {
             if self.models[curr].is_embedded() {
                 continue;
             }
-            for index in 0..self.models[curr].expect_root().fields.len() {
+            for index in 0..self.models[curr].as_root_unwrap().fields.len() {
                 let model = &self.models[curr];
                 let src = model.id();
-                let field = &model.expect_root().fields[index];
+                let field = &model.as_root_unwrap().fields[index];
 
                 match &field.ty {
                     FieldTy::HasOne(has_one) => {
@@ -236,9 +236,9 @@ impl Builder {
                             }
                         };
 
-                        self.models[curr].expect_root_mut().fields[index]
+                        self.models[curr].as_root_mut_unwrap().fields[index]
                             .ty
-                            .expect_has_one_mut()
+                            .as_has_one_mut_unwrap()
                             .pair = pair;
                     }
                     FieldTy::BelongsTo(belongs_to) => {
@@ -255,11 +255,11 @@ impl Builder {
             if self.models[curr].is_embedded() {
                 continue;
             }
-            for index in 0..self.models[curr].expect_root().fields.len() {
+            for index in 0..self.models[curr].as_root_unwrap().fields.len() {
                 let model = &self.models[curr];
-                let field_id = model.expect_root().fields[index].id;
+                let field_id = model.as_root_unwrap().fields[index].id;
 
-                let pair = match &self.models[curr].expect_root().fields[index].ty {
+                let pair = match &self.models[curr].as_root_unwrap().fields[index].ty {
                     FieldTy::BelongsTo(belongs_to) => {
                         let mut pair = None;
                         let target = match self.models.get_index_of(&belongs_to.target) {
@@ -270,21 +270,28 @@ impl Builder {
                                     "field `{}::{}` references a model that was not registered \
                                      with the schema; did you forget to register it with `Db::builder()`?",
                                     model.name().upper_camel_case(),
-                                    model.expect_root().fields[index].name.app_name,
+                                    model.as_root_unwrap().fields[index].name.app_name,
                                 )));
                             }
                         };
 
-                        for target_index in 0..self.models[target].expect_root().fields.len() {
-                            pair = match &self.models[target].expect_root().fields[target_index].ty
+                        for target_index in 0..self.models[target].as_root_unwrap().fields.len() {
+                            pair = match &self.models[target].as_root_unwrap().fields[target_index]
+                                .ty
                             {
                                 FieldTy::HasMany(has_many) if has_many.pair == field_id => {
                                     assert!(pair.is_none());
-                                    Some(self.models[target].expect_root().fields[target_index].id)
+                                    Some(
+                                        self.models[target].as_root_unwrap().fields[target_index]
+                                            .id,
+                                    )
                                 }
                                 FieldTy::HasOne(has_one) if has_one.pair == field_id => {
                                     assert!(pair.is_none());
-                                    Some(self.models[target].expect_root().fields[target_index].id)
+                                    Some(
+                                        self.models[target].as_root_unwrap().fields[target_index]
+                                            .id,
+                                    )
                                 }
                                 _ => continue,
                             }
@@ -299,9 +306,9 @@ impl Builder {
                     _ => continue,
                 };
 
-                self.models[curr].expect_root_mut().fields[index]
+                self.models[curr].as_root_mut_unwrap().fields[index]
                     .ty
-                    .expect_belongs_to_mut()
+                    .as_belongs_to_mut_unwrap()
                     .pair = pair;
             }
         }
@@ -331,7 +338,7 @@ impl Builder {
 
         // Find all BelongsTo relations that reference the model
         let belongs_to: Vec<_> = target
-            .expect_root()
+            .as_root_unwrap()
             .fields
             .iter()
             .filter(|field| match &field.ty {

--- a/crates/toasty-core/src/schema/builder/table.rs
+++ b/crates/toasty-core/src/schema/builder/table.rs
@@ -170,7 +170,7 @@ impl BuildTableFromModels<'_> {
     }
 
     fn map_model_fields(&mut self, model: &Model) -> Result<()> {
-        let root = model.expect_root();
+        let root = model.as_root_unwrap();
         let schema_prefix = if self.prefix_table_names {
             Some(model.name().snake_case())
         } else {

--- a/crates/toasty-core/src/schema/verify/relations_are_indexed.rs
+++ b/crates/toasty-core/src/schema/verify/relations_are_indexed.rs
@@ -28,12 +28,12 @@ impl Verify<'_> {
     }
 
     fn verify_has_relation_is_indexed(&self, target: &Model, pair: FieldId) {
-        let belongs_to = self.schema.app.field(pair).ty.expect_belongs_to();
+        let belongs_to = self.schema.app.field(pair).ty.as_belongs_to_unwrap();
 
         // Find an index that starts with the relations pair field and either
         // has no more fields or the next field is of local scope. This ensures
         // the ability to query all associated models.
-        'outer: for index in &target.expect_root().indices {
+        'outer: for index in &target.as_root_unwrap().indices {
             assert!(!index.fields.is_empty());
 
             if index.fields.len() < belongs_to.foreign_key.fields.len() {

--- a/crates/toasty-core/src/stmt.rs
+++ b/crates/toasty-core/src/stmt.rs
@@ -311,7 +311,7 @@ impl Statement {
     /// # Panics
     ///
     /// If `self` is not a [`Statement::Update`].
-    pub fn expect_update(self) -> Update {
+    pub fn into_update_unwrap(self) -> Update {
         match self {
             Self::Update(update) => update,
             v => panic!("expected `Update`, found {v:#?}"),

--- a/crates/toasty-core/src/stmt/condition.rs
+++ b/crates/toasty-core/src/stmt/condition.rs
@@ -45,7 +45,7 @@ impl Statement {
     ///
     /// Panics if the statement does not support conditions.
     #[track_caller]
-    pub fn expect_condition_mut(&mut self) -> &mut Condition {
+    pub fn condition_mut_unwrap(&mut self) -> &mut Condition {
         match self {
             Statement::Update(update) => &mut update.condition,
             _ => panic!("expected Statement with condition"),

--- a/crates/toasty-core/src/stmt/cx.rs
+++ b/crates/toasty-core/src/stmt/cx.rs
@@ -574,7 +574,7 @@ impl<'a, T> Copy for ExprContext<'a, T> {}
 
 impl<'a> ResolvedRef<'a> {
     #[track_caller]
-    pub fn expect_column(self) -> &'a Column {
+    pub fn as_column_unwrap(self) -> &'a Column {
         match self {
             ResolvedRef::Column(column) => column,
             _ => panic!("Expected ResolvedRef::Column, found {:?}", self),
@@ -582,7 +582,7 @@ impl<'a> ResolvedRef<'a> {
     }
 
     #[track_caller]
-    pub fn expect_field(self) -> &'a Field {
+    pub fn as_field_unwrap(self) -> &'a Field {
         match self {
             ResolvedRef::Field(field) => field,
             _ => panic!("Expected ResolvedRef::Field, found {:?}", self),
@@ -590,7 +590,7 @@ impl<'a> ResolvedRef<'a> {
     }
 
     #[track_caller]
-    pub fn expect_model(self) -> &'a ModelRoot {
+    pub fn as_model_unwrap(self) -> &'a ModelRoot {
         match self {
             ResolvedRef::Model(model) => model,
             _ => panic!("Expected ResolvedRef::Model, found {:?}", self),
@@ -649,7 +649,7 @@ impl<'a> ExprTarget<'a> {
     }
 
     #[track_caller]
-    pub fn expect_model(self) -> &'a ModelRoot {
+    pub fn as_model_unwrap(self) -> &'a ModelRoot {
         match self.as_model() {
             Some(model) => model,
             _ => panic!("expected ExprTarget::Model; was {self:#?}"),
@@ -671,7 +671,7 @@ impl<'a> ExprTarget<'a> {
     }
 
     #[track_caller]
-    pub fn expect_table(self) -> &'a Table {
+    pub fn as_table_unwrap(self) -> &'a Table {
         self.as_table()
             .unwrap_or_else(|| panic!("expected ExprTarget::Table; was {self:#?}"))
     }
@@ -767,7 +767,7 @@ impl<'a, T: Resolve> IntoExprTarget<'a, T> for &'a InsertTarget {
                 let Some(model) = schema.model(*model) else {
                     todo!()
                 };
-                ExprTarget::Model(model.expect_root())
+                ExprTarget::Model(model.as_root_unwrap())
             }
             InsertTarget::Table(insert_table) => {
                 let table = schema.table(insert_table.table).unwrap();
@@ -785,7 +785,7 @@ impl<'a, T: Resolve> IntoExprTarget<'a, T> for &'a UpdateTarget {
                 let Some(model) = schema.model(*model) else {
                     todo!()
                 };
-                ExprTarget::Model(model.expect_root())
+                ExprTarget::Model(model.as_root_unwrap())
             }
             UpdateTarget::Table(table_id) => {
                 let Some(table) = schema.table(*table_id) else {
@@ -804,7 +804,7 @@ impl<'a, T: Resolve> IntoExprTarget<'a, T> for &'a Source {
                 let Some(model) = schema.model(source_model.id) else {
                     todo!()
                 };
-                ExprTarget::Model(model.expect_root())
+                ExprTarget::Model(model.as_root_unwrap())
             }
             Source::Table(source_table) => {
                 ExprTarget::Source(source_table).into_expr_target(schema)

--- a/crates/toasty-core/src/stmt/delete.rs
+++ b/crates/toasty-core/src/stmt/delete.rs
@@ -53,7 +53,7 @@ impl Statement {
     /// # Panics
     ///
     /// If `self` is not a [`Statement::Delete`].
-    pub fn expect_delete(self) -> Delete {
+    pub fn into_delete_unwrap(self) -> Delete {
         match self {
             Self::Delete(delete) => delete,
             v => panic!("expected `Delete`, found {v:#?}"),

--- a/crates/toasty-core/src/stmt/entry.rs
+++ b/crates/toasty-core/src/stmt/entry.rs
@@ -123,7 +123,7 @@ impl Entry<'_> {
     }
 
     #[track_caller]
-    pub fn expect_value(&self) -> &Value {
+    pub fn as_value_unwrap(&self) -> &Value {
         self.as_value()
             .unwrap_or_else(|| panic!("expected Entry with value; actual={self:#?}"))
     }

--- a/crates/toasty-core/src/stmt/entry_mut.rs
+++ b/crates/toasty-core/src/stmt/entry_mut.rs
@@ -15,7 +15,7 @@ impl EntryMut<'_> {
     }
 
     #[track_caller]
-    pub fn expect_expr(&self) -> &Expr {
+    pub fn as_expr_unwrap(&self) -> &Expr {
         self.as_expr()
             .unwrap_or_else(|| panic!("expected EntryMut::Expr; actual={self:#?}"))
     }
@@ -28,7 +28,7 @@ impl EntryMut<'_> {
     }
 
     #[track_caller]
-    pub fn expect_expr_mut(&mut self) -> &mut Expr {
+    pub fn as_expr_mut_unwrap(&mut self) -> &mut Expr {
         match self {
             EntryMut::Expr(e) => e,
             _ => panic!("expected EntryMut::Expr"),

--- a/crates/toasty-core/src/stmt/expr_list.rs
+++ b/crates/toasty-core/src/stmt/expr_list.rs
@@ -44,7 +44,7 @@ impl Expr {
     }
 
     #[track_caller]
-    pub fn expect_list(&self) -> &ExprList {
+    pub fn as_list_unwrap(&self) -> &ExprList {
         match self {
             Self::List(list) => list,
             _ => panic!("expected Expr::List(..) but was {self:#?}"),
@@ -52,7 +52,7 @@ impl Expr {
     }
 
     #[track_caller]
-    pub fn expect_list_mut(&mut self) -> &mut ExprList {
+    pub fn as_list_mut_unwrap(&mut self) -> &mut ExprList {
         match self {
             Self::List(list) => list,
             _ => panic!("expected Expr::List(..) but was {self:#?}"),

--- a/crates/toasty-core/src/stmt/expr_map.rs
+++ b/crates/toasty-core/src/stmt/expr_map.rs
@@ -54,7 +54,7 @@ impl Expr {
     }
 
     #[track_caller]
-    pub fn expect_map(&self) -> &ExprMap {
+    pub fn as_map_unwrap(&self) -> &ExprMap {
         self.as_map()
             .unwrap_or_else(|| panic!("expected Expr::Map; actual={self:#?}"))
     }

--- a/crates/toasty-core/src/stmt/expr_project.rs
+++ b/crates/toasty-core/src/stmt/expr_project.rs
@@ -49,7 +49,7 @@ impl Expr {
     }
 
     #[track_caller]
-    pub fn expect_project(&self) -> &ExprProject {
+    pub fn as_project_unwrap(&self) -> &ExprProject {
         self.as_project()
             .unwrap_or_else(|| panic!("expected Expr::Project; actual={self:#?}"))
     }

--- a/crates/toasty-core/src/stmt/expr_record.rs
+++ b/crates/toasty-core/src/stmt/expr_record.rs
@@ -44,7 +44,7 @@ impl Expr {
     }
 
     #[track_caller]
-    pub fn expect_record(&self) -> &ExprRecord {
+    pub fn as_record_unwrap(&self) -> &ExprRecord {
         self.as_record()
             .unwrap_or_else(|| panic!("expected Expr::Record; actual={self:#?}"))
     }
@@ -57,7 +57,7 @@ impl Expr {
     }
 
     #[track_caller]
-    pub fn expect_record_mut(&mut self) -> &mut ExprRecord {
+    pub fn as_record_mut_unwrap(&mut self) -> &mut ExprRecord {
         match self {
             Self::Record(expr_record) => expr_record,
             _ => panic!("expected Expr::Record"),

--- a/crates/toasty-core/src/stmt/expr_reference.rs
+++ b/crates/toasty-core/src/stmt/expr_reference.rs
@@ -133,7 +133,7 @@ impl Expr {
     }
 
     #[track_caller]
-    pub fn expect_reference(&self) -> &ExprReference {
+    pub fn as_expr_reference_unwrap(&self) -> &ExprReference {
         self.as_expr_reference()
             .unwrap_or_else(|| panic!("expected ExprReference; actual={self:#?}"))
     }
@@ -146,7 +146,7 @@ impl Expr {
     }
 
     #[track_caller]
-    pub fn expect_column(&self) -> &ExprColumn {
+    pub fn as_expr_column_unwrap(&self) -> &ExprColumn {
         self.as_expr_column()
             .unwrap_or_else(|| panic!("expected ExprColumn; actual={self:#?}"))
     }
@@ -188,7 +188,7 @@ impl ExprReference {
     }
 
     #[track_caller]
-    pub fn expect_column(&self) -> &ExprColumn {
+    pub fn as_expr_column_unwrap(&self) -> &ExprColumn {
         self.as_expr_column()
             .unwrap_or_else(|| panic!("expected ExprColumn; actual={self:#?}"))
     }
@@ -201,7 +201,7 @@ impl ExprReference {
     }
 
     #[track_caller]
-    pub fn expect_column_mut(&mut self) -> &mut ExprColumn {
+    pub fn as_expr_column_mut_unwrap(&mut self) -> &mut ExprColumn {
         match self {
             ExprReference::Column(expr_column) => expr_column,
             _ => panic!("expected ExprColumn; actual={self:#?}"),

--- a/crates/toasty-core/src/stmt/expr_set.rs
+++ b/crates/toasty-core/src/stmt/expr_set.rs
@@ -70,7 +70,7 @@ impl ExprSet {
     ///
     /// Panics if `self` is not an [`ExprSet::Values`].
     #[track_caller]
-    pub fn expect_values(&self) -> &Values {
+    pub fn as_values_unwrap(&self) -> &Values {
         self.as_values()
             .unwrap_or_else(|| panic!("expected `Values`, found {self:#?}"))
     }
@@ -83,7 +83,7 @@ impl ExprSet {
     }
 
     #[track_caller]
-    pub fn expect_values_mut(&mut self) -> &mut Values {
+    pub fn as_values_mut_unwrap(&mut self) -> &mut Values {
         match self {
             Self::Values(expr) => expr,
             _ => panic!("expected `Values`; actual={self:#?}"),

--- a/crates/toasty-core/src/stmt/filter.rs
+++ b/crates/toasty-core/src/stmt/filter.rs
@@ -85,7 +85,7 @@ impl Statement {
     }
 
     #[track_caller]
-    pub fn expect_filter(&self) -> &Filter {
+    pub fn filter_unwrap(&self) -> &Filter {
         match self.filter() {
             Some(filter) => filter,
             _ => panic!("expected statement to have a filter; statement={self:#?}"),
@@ -115,17 +115,17 @@ impl Statement {
     ///
     /// Panics if the statement does not support filtering.
     #[track_caller]
-    pub fn expect_filter_mut(&mut self) -> &mut Filter {
+    pub fn filter_mut_unwrap(&mut self) -> &mut Filter {
         match self {
             Statement::Delete(delete) => &mut delete.filter,
             Statement::Insert(_) => panic!("expected Statement with filter"),
-            Statement::Query(query) => query.expect_filter_mut(),
+            Statement::Query(query) => query.filter_mut_unwrap(),
             Statement::Update(update) => &mut update.filter,
         }
     }
 
     #[track_caller]
-    pub fn expect_filter_expr(&self) -> &Expr {
+    pub fn filter_expr_unwrap(&self) -> &Expr {
         self.filter()
             .and_then(|f| f.expr.as_ref())
             .expect("expected Statement with expression filter")
@@ -145,7 +145,7 @@ impl Query {
     }
 
     #[track_caller]
-    pub fn expect_filter(&self) -> &Filter {
+    pub fn filter_unwrap(&self) -> &Filter {
         self.filter()
             .unwrap_or_else(|| panic!("expected Query with filter; actual={self:#?}"))
     }
@@ -167,7 +167,7 @@ impl Query {
     ///
     /// Panics if the query body is not a `SELECT` statement.
     #[track_caller]
-    pub fn expect_filter_mut(&mut self) -> &mut Filter {
+    pub fn filter_mut_unwrap(&mut self) -> &mut Filter {
         match &mut self.body {
             ExprSet::Select(select) => &mut select.filter,
             _ => panic!("expected Query with filter"),

--- a/crates/toasty-core/src/stmt/insert.rs
+++ b/crates/toasty-core/src/stmt/insert.rs
@@ -65,7 +65,7 @@ impl Statement {
     /// # Panics
     ///
     /// If `self` is not a [`Statement::Insert`].
-    pub fn expect_insert(self) -> Insert {
+    pub fn into_insert_unwrap(self) -> Insert {
         match self {
             Self::Insert(insert) => insert,
             v => panic!("expected `Insert`, found {v:#?}"),

--- a/crates/toasty-core/src/stmt/insert_target.rs
+++ b/crates/toasty-core/src/stmt/insert_target.rs
@@ -21,9 +21,9 @@ impl InsertTarget {
     }
 
     #[track_caller]
-    pub fn expect_model(&self) -> ModelId {
+    pub fn model_id_unwrap(&self) -> ModelId {
         match self {
-            Self::Scope(query) => query.body.expect_select().source.model_id_unwrap(),
+            Self::Scope(query) => query.body.as_select_unwrap().source.model_id_unwrap(),
             Self::Model(model_id) => *model_id,
             _ => panic!("expected InsertTarget::Model; actual={self:#?}"),
         }
@@ -41,7 +41,7 @@ impl InsertTarget {
     }
 
     #[track_caller]
-    pub fn expect_table(&self) -> &InsertTable {
+    pub fn as_table_unwrap(&self) -> &InsertTable {
         self.as_table()
             .unwrap_or_else(|| panic!("expected InsertTarget::Table; actual={self:#?}"))
     }

--- a/crates/toasty-core/src/stmt/path.rs
+++ b/crates/toasty-core/src/stmt/path.rs
@@ -22,7 +22,7 @@ pub enum PathRoot {
 
 impl PathRoot {
     /// Returns the `ModelId`, panicking if this root is a `Variant` root.
-    pub fn expect_model(&self) -> ModelId {
+    pub fn as_model_unwrap(&self) -> ModelId {
         match self {
             PathRoot::Model(id) => *id,
             PathRoot::Variant { .. } => panic!("expected Model root, got Variant root"),

--- a/crates/toasty-core/src/stmt/query.rs
+++ b/crates/toasty-core/src/stmt/query.rs
@@ -115,7 +115,7 @@ impl Query {
     }
 
     pub fn add_filter(&mut self, filter: impl Into<Filter>) {
-        self.body.expect_select_mut().add_filter(filter);
+        self.body.as_select_mut_unwrap().add_filter(filter);
     }
 
     pub fn include(&mut self, path: impl Into<Path>) {
@@ -171,7 +171,7 @@ impl Statement {
     ///
     /// If `self` is not a [`Statement::Query`].
     #[track_caller]
-    pub fn expect_query(self) -> Query {
+    pub fn into_query_unwrap(self) -> Query {
         match self {
             Self::Query(query) => query,
             v => panic!("expected `Query`, found {v:#?}"),

--- a/crates/toasty-core/src/stmt/returning.rs
+++ b/crates/toasty-core/src/stmt/returning.rs
@@ -30,7 +30,7 @@ impl Returning {
         matches!(self, Self::Model { .. })
     }
 
-    pub fn as_model_includes(&self) -> &[Path] {
+    pub fn model_includes(&self) -> &[Path] {
         match self {
             Self::Model { include } => include,
             _ => &[],
@@ -38,7 +38,7 @@ impl Returning {
     }
 
     #[track_caller]
-    pub fn expect_model_includes_mut(&mut self) -> &mut Vec<Path> {
+    pub fn model_includes_mut_unwrap(&mut self) -> &mut Vec<Path> {
         match self {
             Self::Model { include } => include,
             _ => panic!("not a Model variant"),
@@ -61,7 +61,7 @@ impl Returning {
     }
 
     #[track_caller]
-    pub fn expect_expr(&self) -> &Expr {
+    pub fn as_expr_unwrap(&self) -> &Expr {
         self.as_expr()
             .unwrap_or_else(|| panic!("expected stmt::Returning::Expr; actual={self:#?}"))
     }
@@ -74,7 +74,7 @@ impl Returning {
     }
 
     #[track_caller]
-    pub fn expect_expr_mut(&mut self) -> &mut Expr {
+    pub fn as_expr_mut_unwrap(&mut self) -> &mut Expr {
         match self {
             Self::Expr(expr) => expr,
             _ => panic!("expected stmt::Returning::Expr; actual={self:#?}"),
@@ -128,7 +128,7 @@ impl Statement {
         match self {
             Statement::Delete(delete) => delete.returning = Some(returning),
             Statement::Insert(insert) => insert.returning = Some(returning),
-            Statement::Query(query) => *query.expect_returning_mut() = returning,
+            Statement::Query(query) => *query.returning_mut_unwrap() = returning,
             Statement::Update(update) => update.returning = Some(returning),
         }
     }
@@ -139,7 +139,7 @@ impl Statement {
     ///
     /// Panics if the statement does not have a `RETURNING` clause.
     #[track_caller]
-    pub fn expect_returning(&self) -> &Returning {
+    pub fn returning_unwrap(&self) -> &Returning {
         self.returning().unwrap_or_else(|| {
             panic!("expected statement to have RETURNING clause; actual={self:#?}")
         })
@@ -164,11 +164,11 @@ impl Statement {
     ///
     /// Panics if the statement does not have a `RETURNING` clause.
     #[track_caller]
-    pub fn expect_returning_mut(&mut self) -> &mut Returning {
+    pub fn returning_mut_unwrap(&mut self) -> &mut Returning {
         match self {
             Statement::Delete(delete) => delete.returning.as_mut().unwrap(),
             Statement::Insert(insert) => insert.returning.as_mut().unwrap(),
-            Statement::Query(query) => query.expect_returning_mut(),
+            Statement::Query(query) => query.returning_mut_unwrap(),
             Statement::Update(update) => update.returning.as_mut().unwrap(),
         }
     }
@@ -193,7 +193,7 @@ impl Query {
     /// Panics if the query does not have a `RETURNING` clause (i.e., the body
     /// is not a `SELECT`).
     #[track_caller]
-    pub fn expect_returning(&self) -> &Returning {
+    pub fn returning_unwrap(&self) -> &Returning {
         self.returning()
             .unwrap_or_else(|| panic!("expected query to have RETURNING clause; actual={self:#?}"))
     }
@@ -216,7 +216,7 @@ impl Query {
     /// Panics if the query does not have a `RETURNING` clause (i.e., the body
     /// is not a `SELECT`).
     #[track_caller]
-    pub fn expect_returning_mut(&mut self) -> &mut Returning {
+    pub fn returning_mut_unwrap(&mut self) -> &mut Returning {
         match &mut self.body {
             stmt::ExprSet::Select(select) => &mut select.returning,
             body => panic!("expected query to have RETURNING clause; actual={body:#?}"),

--- a/crates/toasty-core/src/stmt/select.rs
+++ b/crates/toasty-core/src/stmt/select.rs
@@ -40,12 +40,12 @@ impl Select {
 }
 
 impl Statement {
-    pub fn as_select(&self) -> Option<&Select> {
+    pub fn query_select(&self) -> Option<&Select> {
         self.as_query().and_then(|query| query.body.as_select())
     }
 
     #[track_caller]
-    pub fn expect_select(&self) -> &Select {
+    pub fn query_select_unwrap(&self) -> &Select {
         match self {
             Statement::Query(query) => match &query.body {
                 ExprSet::Select(select) => select,
@@ -71,7 +71,7 @@ impl ExprSet {
     }
 
     #[track_caller]
-    pub fn expect_select(&self) -> &Select {
+    pub fn as_select_unwrap(&self) -> &Select {
         self.as_select()
             .unwrap_or_else(|| panic!("expected `Select`; actual={self:#?}"))
     }
@@ -84,7 +84,7 @@ impl ExprSet {
     }
 
     #[track_caller]
-    pub fn expect_select_mut(&mut self) -> &mut Select {
+    pub fn as_select_mut_unwrap(&mut self) -> &mut Select {
         match self {
             Self::Select(select) => select,
             _ => panic!("expected `Select`; actual={self:#?}"),

--- a/crates/toasty-core/src/stmt/source.rs
+++ b/crates/toasty-core/src/stmt/source.rs
@@ -44,7 +44,7 @@ impl Source {
     }
 
     #[track_caller]
-    pub fn expect_model(&self) -> &SourceModel {
+    pub fn as_model_unwrap(&self) -> &SourceModel {
         self.as_model()
             .expect("expected SourceModel; actual={self:#?}")
     }
@@ -54,7 +54,7 @@ impl Source {
     }
 
     pub fn model_id_unwrap(&self) -> ModelId {
-        self.expect_model().id
+        self.as_model_unwrap().id
     }
 
     pub fn is_table(&self) -> bool {
@@ -81,7 +81,7 @@ impl Source {
     }
 
     #[track_caller]
-    pub fn expect_table(&self) -> &SourceTable {
+    pub fn as_table_unwrap(&self) -> &SourceTable {
         self.as_table()
             .unwrap_or_else(|| panic!("expected SourceTable; actual={self:#?}"))
     }

--- a/crates/toasty-core/src/stmt/ty.rs
+++ b/crates/toasty-core/src/stmt/ty.rs
@@ -182,7 +182,7 @@ impl Type {
     }
 
     #[track_caller]
-    pub fn expect_list(&self) -> &Type {
+    pub fn as_list_unwrap(&self) -> &Type {
         match self {
             stmt::Type::List(items) => items,
             _ => panic!("expected stmt::Type::List; actual={self:#?}"),

--- a/crates/toasty-core/src/stmt/update.rs
+++ b/crates/toasty-core/src/stmt/update.rs
@@ -62,7 +62,7 @@ impl UpdateTarget {
     pub fn model_id_unwrap(&self) -> ModelId {
         match self {
             Self::Model(model_id) => *model_id,
-            Self::Query(query) => query.body.expect_select().source.model_id_unwrap(),
+            Self::Query(query) => query.body.as_select_unwrap().source.model_id_unwrap(),
             _ => todo!("not a model"),
         }
     }
@@ -83,7 +83,7 @@ impl UpdateTarget {
     }
 
     #[track_caller]
-    pub fn expect_table(&self) -> TableId {
+    pub fn as_table_unwrap(&self) -> TableId {
         self.as_table()
             .unwrap_or_else(|| panic!("expected UpdateTarget::Table; actual={self:#?}"))
     }

--- a/crates/toasty-core/src/stmt/value.rs
+++ b/crates/toasty-core/src/stmt/value.rs
@@ -119,7 +119,7 @@ impl Value {
         }
     }
 
-    pub fn expect_string(&self) -> &str {
+    pub fn as_string_unwrap(&self) -> &str {
         match self {
             Self::String(v) => v,
             _ => todo!(),
@@ -133,14 +133,14 @@ impl Value {
         }
     }
 
-    pub fn expect_record(&self) -> &ValueRecord {
+    pub fn as_record_unwrap(&self) -> &ValueRecord {
         match self {
             Self::Record(record) => record,
             _ => panic!("{self:#?}"),
         }
     }
 
-    pub fn expect_record_mut(&mut self) -> &mut ValueRecord {
+    pub fn as_record_mut_unwrap(&mut self) -> &mut ValueRecord {
         match self {
             Self::Record(record) => record,
             _ => panic!(),

--- a/crates/toasty-core/src/stmt/value_list.rs
+++ b/crates/toasty-core/src/stmt/value_list.rs
@@ -10,7 +10,7 @@ impl Value {
     }
 
     #[track_caller]
-    pub fn expect_list(self) -> Vec<Value> {
+    pub fn into_list_unwrap(self) -> Vec<Value> {
         match self {
             Value::List(list) => list,
             _ => panic!("expected Value::List; actual={self:#?}"),

--- a/crates/toasty-core/tests/stmt_value_entry.rs
+++ b/crates/toasty-core/tests/stmt_value_entry.rs
@@ -8,7 +8,7 @@ use toasty_core::stmt::{Project, Projection, Value};
 fn entry_identity_bool() {
     let v = Value::Bool(true);
     assert_eq!(
-        v.entry(&Projection::identity()).expect_value(),
+        v.entry(&Projection::identity()).as_value_unwrap(),
         &Value::Bool(true)
     );
 }
@@ -17,7 +17,7 @@ fn entry_identity_bool() {
 fn entry_identity_i8() {
     let v = Value::I8(42);
     assert_eq!(
-        v.entry(&Projection::identity()).expect_value(),
+        v.entry(&Projection::identity()).as_value_unwrap(),
         &Value::I8(42)
     );
 }
@@ -26,7 +26,7 @@ fn entry_identity_i8() {
 fn entry_identity_i16() {
     let v = Value::I16(-100);
     assert_eq!(
-        v.entry(&Projection::identity()).expect_value(),
+        v.entry(&Projection::identity()).as_value_unwrap(),
         &Value::I16(-100)
     );
 }
@@ -35,7 +35,7 @@ fn entry_identity_i16() {
 fn entry_identity_i32() {
     let v = Value::I32(1_000);
     assert_eq!(
-        v.entry(&Projection::identity()).expect_value(),
+        v.entry(&Projection::identity()).as_value_unwrap(),
         &Value::I32(1_000)
     );
 }
@@ -44,7 +44,7 @@ fn entry_identity_i32() {
 fn entry_identity_i64() {
     let v = Value::I64(i64::MAX);
     assert_eq!(
-        v.entry(&Projection::identity()).expect_value(),
+        v.entry(&Projection::identity()).as_value_unwrap(),
         &Value::I64(i64::MAX)
     );
 }
@@ -53,7 +53,7 @@ fn entry_identity_i64() {
 fn entry_identity_u8() {
     let v = Value::U8(255);
     assert_eq!(
-        v.entry(&Projection::identity()).expect_value(),
+        v.entry(&Projection::identity()).as_value_unwrap(),
         &Value::U8(255)
     );
 }
@@ -62,7 +62,7 @@ fn entry_identity_u8() {
 fn entry_identity_u16() {
     let v = Value::U16(1000);
     assert_eq!(
-        v.entry(&Projection::identity()).expect_value(),
+        v.entry(&Projection::identity()).as_value_unwrap(),
         &Value::U16(1000)
     );
 }
@@ -71,7 +71,7 @@ fn entry_identity_u16() {
 fn entry_identity_u32() {
     let v = Value::U32(u32::MAX);
     assert_eq!(
-        v.entry(&Projection::identity()).expect_value(),
+        v.entry(&Projection::identity()).as_value_unwrap(),
         &Value::U32(u32::MAX)
     );
 }
@@ -80,7 +80,7 @@ fn entry_identity_u32() {
 fn entry_identity_u64() {
     let v = Value::U64(u64::MAX);
     assert_eq!(
-        v.entry(&Projection::identity()).expect_value(),
+        v.entry(&Projection::identity()).as_value_unwrap(),
         &Value::U64(u64::MAX)
     );
 }
@@ -89,7 +89,7 @@ fn entry_identity_u64() {
 fn entry_identity_string() {
     let v = Value::from("hello");
     assert_eq!(
-        v.entry(&Projection::identity()).expect_value(),
+        v.entry(&Projection::identity()).as_value_unwrap(),
         &Value::from("hello")
     );
 }
@@ -98,7 +98,7 @@ fn entry_identity_string() {
 fn entry_identity_bytes() {
     let v = Value::Bytes(vec![1, 2, 3]);
     assert_eq!(
-        v.entry(&Projection::identity()).expect_value(),
+        v.entry(&Projection::identity()).as_value_unwrap(),
         &Value::Bytes(vec![1, 2, 3])
     );
 }
@@ -108,7 +108,7 @@ fn entry_identity_uuid() {
     let id = uuid::Uuid::nil();
     let v = Value::Uuid(id);
     assert_eq!(
-        v.entry(&Projection::identity()).expect_value(),
+        v.entry(&Projection::identity()).as_value_unwrap(),
         &Value::Uuid(id)
     );
 }
@@ -117,7 +117,7 @@ fn entry_identity_uuid() {
 fn entry_identity_null() {
     let v = Value::Null;
     assert_eq!(
-        v.entry(&Projection::identity()).expect_value(),
+        v.entry(&Projection::identity()).as_value_unwrap(),
         &Value::Null
     );
 }
@@ -130,7 +130,7 @@ fn entry_identity_null() {
 fn entry_record_field_bool() {
     let rec = Value::record_from_vec(vec![Value::Bool(false), Value::Bool(true)]);
     assert_eq!(
-        rec.entry(&Projection::single(1)).expect_value(),
+        rec.entry(&Projection::single(1)).as_value_unwrap(),
         &Value::Bool(true)
     );
 }
@@ -139,7 +139,7 @@ fn entry_record_field_bool() {
 fn entry_record_field_i8() {
     let rec = Value::record_from_vec(vec![Value::I8(10), Value::I8(20)]);
     assert_eq!(
-        rec.entry(&Projection::single(0)).expect_value(),
+        rec.entry(&Projection::single(0)).as_value_unwrap(),
         &Value::I8(10)
     );
 }
@@ -148,7 +148,7 @@ fn entry_record_field_i8() {
 fn entry_record_field_i16() {
     let rec = Value::record_from_vec(vec![Value::I16(300), Value::I16(400)]);
     assert_eq!(
-        rec.entry(&Projection::single(1)).expect_value(),
+        rec.entry(&Projection::single(1)).as_value_unwrap(),
         &Value::I16(400)
     );
 }
@@ -157,7 +157,7 @@ fn entry_record_field_i16() {
 fn entry_record_field_i32() {
     let rec = Value::record_from_vec(vec![Value::I32(-1), Value::I32(2)]);
     assert_eq!(
-        rec.entry(&Projection::single(0)).expect_value(),
+        rec.entry(&Projection::single(0)).as_value_unwrap(),
         &Value::I32(-1)
     );
 }
@@ -166,7 +166,7 @@ fn entry_record_field_i32() {
 fn entry_record_field_i64() {
     let rec = Value::record_from_vec(vec![Value::I64(100), Value::I64(200)]);
     assert_eq!(
-        rec.entry(&Projection::single(1)).expect_value(),
+        rec.entry(&Projection::single(1)).as_value_unwrap(),
         &Value::I64(200)
     );
 }
@@ -175,7 +175,7 @@ fn entry_record_field_i64() {
 fn entry_record_field_u8() {
     let rec = Value::record_from_vec(vec![Value::U8(1), Value::U8(2)]);
     assert_eq!(
-        rec.entry(&Projection::single(0)).expect_value(),
+        rec.entry(&Projection::single(0)).as_value_unwrap(),
         &Value::U8(1)
     );
 }
@@ -184,7 +184,7 @@ fn entry_record_field_u8() {
 fn entry_record_field_u16() {
     let rec = Value::record_from_vec(vec![Value::U16(500), Value::U16(600)]);
     assert_eq!(
-        rec.entry(&Projection::single(1)).expect_value(),
+        rec.entry(&Projection::single(1)).as_value_unwrap(),
         &Value::U16(600)
     );
 }
@@ -193,7 +193,7 @@ fn entry_record_field_u16() {
 fn entry_record_field_u32() {
     let rec = Value::record_from_vec(vec![Value::U32(999), Value::U32(0)]);
     assert_eq!(
-        rec.entry(&Projection::single(0)).expect_value(),
+        rec.entry(&Projection::single(0)).as_value_unwrap(),
         &Value::U32(999)
     );
 }
@@ -202,7 +202,7 @@ fn entry_record_field_u32() {
 fn entry_record_field_u64() {
     let rec = Value::record_from_vec(vec![Value::U64(u64::MAX), Value::U64(0)]);
     assert_eq!(
-        rec.entry(&Projection::single(0)).expect_value(),
+        rec.entry(&Projection::single(0)).as_value_unwrap(),
         &Value::U64(u64::MAX)
     );
 }
@@ -211,7 +211,7 @@ fn entry_record_field_u64() {
 fn entry_record_field_string() {
     let rec = Value::record_from_vec(vec![Value::from("first"), Value::from("second")]);
     assert_eq!(
-        rec.entry(&Projection::single(0)).expect_value(),
+        rec.entry(&Projection::single(0)).as_value_unwrap(),
         &Value::from("first")
     );
 }
@@ -220,7 +220,7 @@ fn entry_record_field_string() {
 fn entry_record_field_bytes() {
     let rec = Value::record_from_vec(vec![Value::Bytes(vec![0xDE, 0xAD]), Value::I64(0)]);
     assert_eq!(
-        rec.entry(&Projection::single(0)).expect_value(),
+        rec.entry(&Projection::single(0)).as_value_unwrap(),
         &Value::Bytes(vec![0xDE, 0xAD])
     );
 }
@@ -230,7 +230,7 @@ fn entry_record_field_uuid() {
     let id = uuid::Uuid::nil();
     let rec = Value::record_from_vec(vec![Value::Uuid(id), Value::I64(0)]);
     assert_eq!(
-        rec.entry(&Projection::single(0)).expect_value(),
+        rec.entry(&Projection::single(0)).as_value_unwrap(),
         &Value::Uuid(id)
     );
 }
@@ -239,7 +239,7 @@ fn entry_record_field_uuid() {
 fn entry_record_field_null() {
     let rec = Value::record_from_vec(vec![Value::I64(1), Value::Null]);
     assert_eq!(
-        rec.entry(&Projection::single(1)).expect_value(),
+        rec.entry(&Projection::single(1)).as_value_unwrap(),
         &Value::Null
     );
 }
@@ -252,7 +252,7 @@ fn entry_record_field_null() {
 fn entry_list_first_item() {
     let list = Value::List(vec![Value::I64(10), Value::I64(20), Value::I64(30)]);
     assert_eq!(
-        list.entry(&Projection::single(0)).expect_value(),
+        list.entry(&Projection::single(0)).as_value_unwrap(),
         &Value::I64(10)
     );
 }
@@ -261,7 +261,7 @@ fn entry_list_first_item() {
 fn entry_list_last_item() {
     let list = Value::List(vec![Value::I64(10), Value::I64(20), Value::I64(30)]);
     assert_eq!(
-        list.entry(&Projection::single(2)).expect_value(),
+        list.entry(&Projection::single(2)).as_value_unwrap(),
         &Value::I64(30)
     );
 }
@@ -270,7 +270,7 @@ fn entry_list_last_item() {
 fn entry_list_string_items() {
     let list = Value::List(vec![Value::from("a"), Value::from("b"), Value::from("c")]);
     assert_eq!(
-        list.entry(&Projection::single(1)).expect_value(),
+        list.entry(&Projection::single(1)).as_value_unwrap(),
         &Value::from("b")
     );
 }
@@ -285,7 +285,9 @@ fn entry_record_of_records_two_steps() {
     let inner = Value::record_from_vec(vec![Value::I64(10), Value::I64(20)]);
     let outer = Value::record_from_vec(vec![inner, Value::I64(99)]);
     assert_eq!(
-        outer.entry(&Projection::from([0usize, 1])).expect_value(),
+        outer
+            .entry(&Projection::from([0usize, 1]))
+            .as_value_unwrap(),
         &Value::I64(20)
     );
 }
@@ -296,7 +298,8 @@ fn entry_deeply_nested_three_levels() {
     let lvl2 = Value::record_from_vec(vec![lvl1]);
     let lvl3 = Value::record_from_vec(vec![lvl2]);
     assert_eq!(
-        lvl3.entry(&Projection::from([0usize, 0, 0])).expect_value(),
+        lvl3.entry(&Projection::from([0usize, 0, 0]))
+            .as_value_unwrap(),
         &Value::I64(42)
     );
 }
@@ -314,7 +317,7 @@ fn entry_list_of_records() {
     ]);
     let list = Value::List(vec![r0, r1]);
     assert_eq!(
-        list.entry(&Projection::from([1usize, 0])).expect_value(),
+        list.entry(&Projection::from([1usize, 0])).as_value_unwrap(),
         &Value::from("second-first")
     );
 }
@@ -325,7 +328,7 @@ fn entry_record_of_lists() {
     let inner_list = Value::List(vec![Value::I64(10), Value::I64(20), Value::I64(30)]);
     let rec = Value::record_from_vec(vec![inner_list, Value::I64(0)]);
     assert_eq!(
-        rec.entry(&Projection::from([0usize, 2])).expect_value(),
+        rec.entry(&Projection::from([0usize, 2])).as_value_unwrap(),
         &Value::I64(30)
     );
 }
@@ -398,7 +401,7 @@ fn entry_via_pushed_projection() {
     let mut proj = Projection::identity();
     proj.push(0);
     proj.push(1);
-    assert_eq!(outer.entry(&proj).expect_value(), &Value::I64(20));
+    assert_eq!(outer.entry(&proj).as_value_unwrap(), &Value::I64(20));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/toasty-driver-dynamodb/src/lib.rs
+++ b/crates/toasty-driver-dynamodb/src/lib.rs
@@ -255,7 +255,7 @@ fn ddb_expression(
             }
         }
         stmt::Expr::Reference(expr_reference) => {
-            let column = cx.resolve_expr_reference(expr_reference).expect_column();
+            let column = cx.resolve_expr_reference(expr_reference).as_column_unwrap();
             attrs.column(column).to_string()
         }
         stmt::Expr::Value(val) => attrs.value(val),

--- a/crates/toasty-driver-dynamodb/src/op/insert.rs
+++ b/crates/toasty-driver-dynamodb/src/op/insert.rs
@@ -12,7 +12,7 @@ impl Connection {
     ) -> Result<Response> {
         assert!(insert.returning.is_none());
 
-        let insert_table = insert.target.expect_table();
+        let insert_table = insert.target.as_table_unwrap();
         let table = &schema.table(insert_table.table);
 
         let unique_indices = table
@@ -42,7 +42,7 @@ impl Connection {
             for (i, column_id) in insert_table.columns.iter().enumerate() {
                 let column = schema.column(*column_id);
                 let entry = row.entry(i).unwrap();
-                let value = entry.expect_value();
+                let value = entry.as_value_unwrap();
 
                 if !value.is_null() {
                     items.insert(column.name.clone(), Value::from(value.clone()).to_ddb());

--- a/crates/toasty-driver-integration-suite/src/tests/embedded_enum_unit.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embedded_enum_unit.rs
@@ -172,7 +172,7 @@ pub async fn filter_by_enum_variant(t: &mut Test) -> Result<()> {
             stmt: Statement::Query(_ {
                 body: ExprSet::Select(_ {
                     filter.expr: Some(Expr::BinaryOp(_ {
-                        lhs.expect_column().column: == status_col.index,
+                        lhs.as_expr_column_unwrap().column: == status_col.index,
                         op: BinaryOp::Eq,
                         *rhs: == 2i64,
                         ..
@@ -197,7 +197,7 @@ pub async fn filter_by_enum_variant(t: &mut Test) -> Result<()> {
             stmt: Statement::Query(_ {
                 body: ExprSet::Select(_ {
                     filter.expr: Some(Expr::BinaryOp(_ {
-                        lhs.expect_column().column: == status_col.index,
+                        lhs.as_expr_column_unwrap().column: == status_col.index,
                         op: BinaryOp::Eq,
                         *rhs: == 1i64,
                         ..
@@ -222,7 +222,7 @@ pub async fn filter_by_enum_variant(t: &mut Test) -> Result<()> {
             stmt: Statement::Query(_ {
                 body: ExprSet::Select(_ {
                     filter.expr: Some(Expr::BinaryOp(_ {
-                        lhs.expect_column().column: == status_col.index,
+                        lhs.as_expr_column_unwrap().column: == status_col.index,
                         op: BinaryOp::Eq,
                         *rhs: == 3i64,
                         ..

--- a/crates/toasty-driver-integration-suite/src/tests/embedded_struct.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embedded_struct.rs
@@ -134,11 +134,11 @@ pub async fn root_model_with_embedded_field(test: &mut Test) {
         model_to_table.fields: [
             _,
             == stmt::Expr::project(
-                stmt::Expr::ref_self_field(user.expect_root().fields[1].id),
+                stmt::Expr::ref_self_field(user.as_root_unwrap().fields[1].id),
                 [0],
             ),
             == stmt::Expr::project(
-                stmt::Expr::ref_self_field(user.expect_root().fields[1].id),
+                stmt::Expr::ref_self_field(user.as_root_unwrap().fields[1].id),
                 [1],
             ),
         ],
@@ -998,7 +998,7 @@ pub async fn deeply_nested_embedded_schema(test: &mut Test) {
     assert_struct!(
         user_mapping.model_to_table[1],
         == stmt::Expr::project(
-            stmt::Expr::ref_self_field(user.expect_root().fields[1].id),
+            stmt::Expr::ref_self_field(user.as_root_unwrap().fields[1].id),
             [0],
         )
     );
@@ -1007,7 +1007,7 @@ pub async fn deeply_nested_embedded_schema(test: &mut Test) {
     assert_struct!(
         user_mapping.model_to_table[2],
         == stmt::Expr::project(
-            stmt::Expr::ref_self_field(user.expect_root().fields[1].id),
+            stmt::Expr::ref_self_field(user.as_root_unwrap().fields[1].id),
             [1, 0],
         )
     );
@@ -1016,7 +1016,7 @@ pub async fn deeply_nested_embedded_schema(test: &mut Test) {
     assert_struct!(
         user_mapping.model_to_table[3],
         == stmt::Expr::project(
-            stmt::Expr::ref_self_field(user.expect_root().fields[1].id),
+            stmt::Expr::ref_self_field(user.as_root_unwrap().fields[1].id),
             [1, 1, 0],
         )
     );
@@ -1025,7 +1025,7 @@ pub async fn deeply_nested_embedded_schema(test: &mut Test) {
     assert_struct!(
         user_mapping.model_to_table[4],
         == stmt::Expr::project(
-            stmt::Expr::ref_self_field(user.expect_root().fields[1].id),
+            stmt::Expr::ref_self_field(user.as_root_unwrap().fields[1].id),
             [1, 1, 1],
         )
     );

--- a/crates/toasty-driver-integration-suite/src/tests/one_model_crud_basic_driver_ops.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/one_model_crud_basic_driver_ops.rs
@@ -107,7 +107,7 @@ pub async fn basic_crud(test: &mut Test) -> Result<()> {
                         ..
                     }),
                     filter.expr: Some(Expr::BinaryOp(_ {
-                        lhs.expect_column(): ExprColumn {
+                        lhs.as_expr_column_unwrap(): ExprColumn {
                             nesting: 0,
                             table: 0,
                             column: == user_id_column.index,
@@ -150,7 +150,7 @@ pub async fn basic_crud(test: &mut Test) -> Result<()> {
                 target: toasty_core::stmt::UpdateTarget::Table(== user_table_id),
                 assignments: #{ 2: _ { expr: == 31, .. }},
                 filter.expr: Some(Expr::BinaryOp(_ {
-                    lhs.expect_column(): ExprColumn {
+                    lhs.as_expr_column_unwrap(): ExprColumn {
                         nesting: 0,
                         table: 0,
                         column: == user_id_column.index,
@@ -194,7 +194,7 @@ pub async fn basic_crud(test: &mut Test) -> Result<()> {
                     ..
                 }),
                 filter.expr: Some(Expr::BinaryOp(_ {
-                    lhs.expect_column(): ExprColumn {
+                    lhs.as_expr_column_unwrap(): ExprColumn {
                         nesting: 0,
                         table: 0,
                         column: == user_id_column.index,

--- a/crates/toasty-driver-sqlite/src/lib.rs
+++ b/crates/toasty-driver-sqlite/src/lib.rs
@@ -177,23 +177,23 @@ impl toasty_core::driver::Connection for Connection {
         let width = match &sql {
             sql::Statement::Query(stmt) => match &stmt.body {
                 stmt::ExprSet::Select(stmt) => {
-                    Some(stmt.returning.expect_expr().expect_record().len())
+                    Some(stmt.returning.as_expr_unwrap().as_record_unwrap().len())
                 }
                 _ => todo!(),
             },
             sql::Statement::Insert(stmt) => stmt
                 .returning
                 .as_ref()
-                .map(|returning| returning.expect_expr().expect_record().len()),
+                .map(|returning| returning.as_expr_unwrap().as_record_unwrap().len()),
             sql::Statement::Delete(stmt) => stmt
                 .returning
                 .as_ref()
-                .map(|returning| returning.expect_expr().expect_record().len()),
+                .map(|returning| returning.as_expr_unwrap().as_record_unwrap().len()),
             sql::Statement::Update(stmt) => {
                 assert!(stmt.condition.is_none(), "stmt={stmt:#?}");
                 stmt.returning
                     .as_ref()
-                    .map(|returning| returning.expect_expr().expect_record().len())
+                    .map(|returning| returning.as_expr_unwrap().as_record_unwrap().len())
             }
             _ => None,
         };

--- a/crates/toasty-sql/src/serializer/expr.rs
+++ b/crates/toasty-sql/src/serializer/expr.rs
@@ -119,7 +119,7 @@ impl ToSql for &stmt::Expr {
                         }
                     }
                 } else {
-                    let column = cx.resolve_expr_reference(expr_reference).expect_column();
+                    let column = cx.resolve_expr_reference(expr_reference).as_column_unwrap();
                     fmt!(cx, f, Ident(&column.name))
                 }
             }

--- a/crates/toasty-sql/src/serializer/statement.rs
+++ b/crates/toasty-sql/src/serializer/statement.rs
@@ -28,7 +28,7 @@ impl ToSql for ColumnsWithConstraints<'_> {
                         todo!("Toasty should catch this earlier")
                     };
 
-                    let pk = pk.expect_column();
+                    let pk = pk.as_expr_column_unwrap();
 
                     assert_eq!(0, pk.nesting);
                     assert!(
@@ -414,7 +414,7 @@ impl ToSql for &stmt::Returning {
 
 impl ToSql for &stmt::Select {
     fn to_sql<P: Params>(self, cx: &ExprContext<'_>, f: &mut super::Formatter<'_, P>) {
-        let source_table = self.source.expect_table();
+        let source_table = self.source.as_table_unwrap();
 
         if source_table.from.is_empty() {
             fmt!(cx, f, "SELECT " self.returning)
@@ -567,7 +567,7 @@ impl ToSql for &stmt::Update {
     fn to_sql<P: Params>(self, cx: &ExprContext<'_>, f: &mut super::Formatter<'_, P>) {
         let prev = mem::replace(&mut f.alias, false);
 
-        let table = f.serializer.schema.table(self.target.expect_table());
+        let table = f.serializer.schema.table(self.target.as_table_unwrap());
         let assignments = (table, &self.assignments);
 
         // Create a new expression scope to serialize the statement

--- a/crates/toasty-sql/src/stmt.rs
+++ b/crates/toasty-sql/src/stmt.rs
@@ -71,21 +71,21 @@ impl Statement {
             Self::Delete(delete) => delete
                 .returning
                 .as_ref()
-                .map(|ret| ret.expect_expr().expect_record().len()),
+                .map(|ret| ret.as_expr_unwrap().as_record_unwrap().len()),
             Self::Insert(insert) => insert
                 .returning
                 .as_ref()
-                .map(|ret| ret.expect_expr().expect_record().len()),
+                .map(|ret| ret.as_expr_unwrap().as_record_unwrap().len()),
             Self::Query(query) => match &query.body {
                 ExprSet::Select(select) => {
-                    Some(select.returning.expect_expr().expect_record().len())
+                    Some(select.returning.as_expr_unwrap().as_record_unwrap().len())
                 }
                 stmt => todo!("returning_len, stmt={stmt:#?}"),
             },
             Self::Update(update) => update
                 .returning
                 .as_ref()
-                .map(|ret| ret.expect_expr().expect_record().len()),
+                .map(|ret| ret.as_expr_unwrap().as_record_unwrap().len()),
             _ => None,
         }
     }

--- a/crates/toasty/src/engine/exec/delete_by_key.rs
+++ b/crates/toasty/src/engine/exec/delete_by_key.rs
@@ -32,7 +32,7 @@ impl Exec<'_> {
             .await?
             .collect_as_value()
             .await?
-            .expect_list();
+            .into_list_unwrap();
 
         let res = if keys.is_empty() {
             Rows::Count(0)

--- a/crates/toasty/src/engine/exec/exec_statement.rs
+++ b/crates/toasty/src/engine/exec/exec_statement.rs
@@ -187,7 +187,7 @@ impl Exec<'_> {
         let mut auto_column_type = None;
         stmt::visit::for_each_expr(&returning, |expr| {
             if let stmt::Expr::Reference(expr_ref) = expr {
-                let column = cx.resolve_expr_reference(expr_ref).expect_column();
+                let column = cx.resolve_expr_reference(expr_ref).as_column_unwrap();
 
                 assert!(
                     column.auto_increment,

--- a/crates/toasty/src/engine/exec/get_by_key.rs
+++ b/crates/toasty/src/engine/exec/get_by_key.rs
@@ -32,7 +32,7 @@ impl Exec<'_> {
             .await?
             .collect_as_value()
             .await?
-            .expect_list()
+            .into_list_unwrap()
             .into_iter()
             .filter(|k| !k.is_null())
             .collect();

--- a/crates/toasty/src/engine/exec/update_by_key.rs
+++ b/crates/toasty/src/engine/exec/update_by_key.rs
@@ -41,7 +41,7 @@ impl Exec<'_> {
             .await?
             .collect_as_value()
             .await?
-            .expect_list();
+            .into_list_unwrap();
 
         let res = if keys.is_empty() {
             if action.returning {

--- a/crates/toasty/src/engine/index.rs
+++ b/crates/toasty/src/engine/index.rs
@@ -34,7 +34,7 @@ pub(crate) fn plan_index_path<'a>(
     };
 
     // Get the statement filter
-    let filter = stmt.expect_filter_expr();
+    let filter = stmt.filter_expr_unwrap();
 
     // Extract the pre-filter: the part of the filter that depends only on
     // args (no table column references) and can be evaluated before issuing
@@ -271,7 +271,7 @@ fn extract_key_record(
                 let stmt::Expr::Reference(expr_ref) = &*b.lhs else {
                     return None;
                 };
-                let column = cx.resolve_expr_reference(expr_ref).expect_column();
+                let column = cx.resolve_expr_reference(expr_ref).as_column_unwrap();
                 let (idx, _) = index
                     .columns
                     .iter()

--- a/crates/toasty/src/engine/index/index_match.rs
+++ b/crates/toasty/src/engine/index/index_match.rs
@@ -230,7 +230,7 @@ impl<'stmt> IndexMatch<'stmt> {
 
         for (i, index_column) in self.index.columns.iter().enumerate() {
             // Check that the path matches an index column
-            if cx.resolve_expr_reference(expr_ref).expect_column().id != index_column.column {
+            if cx.resolve_expr_reference(expr_ref).as_column_unwrap().id != index_column.column {
                 continue;
             }
 

--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -278,12 +278,12 @@ impl visit_mut::VisitMut for LowerStatement<'_, '_> {
                     let maybe_res = self.lower_expr_binary_op(
                         stmt::BinaryOp::Eq,
                         &mut e.expr,
-                        e.query.expect_returning_mut().expect_expr_mut(),
+                        e.query.returning_mut_unwrap().as_expr_mut_unwrap(),
                     );
 
                     assert!(maybe_res.is_none(), "TODO");
 
-                    let returning = e.query.expect_returning_mut().expect_expr_mut();
+                    let returning = e.query.returning_mut_unwrap().as_expr_mut_unwrap();
 
                     if !returning.is_record() {
                         *returning = stmt::Expr::record([returning.take()]);
@@ -308,7 +308,7 @@ impl visit_mut::VisitMut for LowerStatement<'_, '_> {
                     let maybe_res = self.lower_expr_binary_op(
                         stmt::BinaryOp::Eq,
                         &mut e.expr,
-                        e.query.expect_returning_mut().expect_expr_mut(),
+                        e.query.returning_mut_unwrap().as_expr_mut_unwrap(),
                     );
 
                     assert!(maybe_res.is_none(), "TODO");
@@ -333,7 +333,7 @@ impl visit_mut::VisitMut for LowerStatement<'_, '_> {
                     .schema()
                     .app
                     .model(e.variant.model)
-                    .expect_embedded_enum();
+                    .as_embedded_enum_unwrap();
                 let has_data = enum_model.has_data_variants();
                 let discriminant = enum_model.variants[e.variant.index].discriminant;
 
@@ -1047,7 +1047,7 @@ impl<'a, 'b> LowerStatement<'a, 'b> {
 
     #[track_caller]
     fn model_unwrap(&self) -> &'a ModelRoot {
-        self.expr_cx.target().expect_model()
+        self.expr_cx.target().as_model_unwrap()
     }
 
     fn mapping(&self) -> Option<&'b mapping::Model> {
@@ -1062,7 +1062,7 @@ impl<'a, 'b> LowerStatement<'a, 'b> {
 
     #[track_caller]
     fn mapping_at_unwrap(&self, nesting: usize) -> &'b mapping::Model {
-        let model = self.expr_cx.target_at(nesting).expect_model();
+        let model = self.expr_cx.target_at(nesting).as_model_unwrap();
         self.state.engine.schema.mapping_for(model)
     }
 

--- a/crates/toasty/src/engine/lower/insert.rs
+++ b/crates/toasty/src/engine/lower/insert.rs
@@ -24,7 +24,7 @@ impl LowerStatement<'_, '_> {
             todo!()
         };
 
-        let scope = &scope.body.expect_select();
+        let scope = &scope.body.as_select_unwrap();
 
         if let Some(filter) = &scope.filter.expr {
             for expr in &mut values.rows {

--- a/crates/toasty/src/engine/lower/relation.rs
+++ b/crates/toasty/src/engine/lower/relation.rs
@@ -87,7 +87,7 @@ impl LowerStatement<'_, '_> {
         returning: &mut Option<stmt::Returning>,
         index: usize,
     ) {
-        let model = self.expr_cx.target().expect_model();
+        let model = self.expr_cx.target().as_model_unwrap();
 
         for (i, field) in model.fields.iter().enumerate() {
             if field.is_relation() {
@@ -131,7 +131,7 @@ impl LowerStatement<'_, '_> {
         returning: &mut Option<stmt::Returning>,
         returning_changed: bool,
     ) {
-        let model = self.expr_cx.target().expect_model();
+        let model = self.expr_cx.target().as_model_unwrap();
 
         for (i, field) in model.fields.iter().enumerate() {
             if !field.is_relation() {
@@ -202,14 +202,14 @@ impl LowerStatement<'_, '_> {
     }
 
     fn plan_mut_has_many(&mut self, field: &Field, op: Mutation, source: &mut dyn RelationSource) {
-        let has_many = field.ty.expect_has_many();
+        let has_many = field.ty.as_has_many_unwrap();
         let pair = self.field(has_many.pair);
 
         self.plan_mut_has_n(field, pair, op, source);
     }
 
     fn plan_mut_has_one(&mut self, field: &Field, op: Mutation, source: &mut dyn RelationSource) {
-        let has_one = field.ty.expect_has_one();
+        let has_one = field.ty.as_has_one_unwrap();
         let pair = self.field(has_one.pair);
 
         self.plan_mut_has_n(field, pair, op, source);
@@ -377,7 +377,7 @@ impl LowerStatement<'_, '_> {
         mut stmt: stmt::Insert,
         source: &mut dyn RelationSource,
     ) {
-        debug_assert_eq!(stmt.target.expect_model(), pair.id.model);
+        debug_assert_eq!(stmt.target.model_id_unwrap(), pair.id.model);
         debug_assert!(stmt.target.is_model());
 
         stmt.target = self.relation_pair_scope(pair.id, source).into();
@@ -424,7 +424,7 @@ impl LowerStatement<'_, '_> {
             todo!("invalid statement. handle this case");
         }
 
-        let belongs_to = field.ty.expect_belongs_to();
+        let belongs_to = field.ty.as_belongs_to_unwrap();
 
         if let Some(pair_id) = belongs_to.pair {
             let pair = self.field(pair_id);
@@ -505,7 +505,7 @@ impl LowerStatement<'_, '_> {
         stmt: stmt::Statement,
         source: &mut dyn RelationSource,
     ) {
-        let belongs_to = field.ty.expect_belongs_to();
+        let belongs_to = field.ty.as_belongs_to_unwrap();
 
         match stmt {
             stmt::Statement::Insert(mut insert) => {
@@ -669,7 +669,7 @@ impl LowerStatement<'_, '_> {
                 stmt::Expr::Reference(outer @ stmt::ExprReference::Field { nesting, .. }),
                 stmt::Expr::Reference(inner @ stmt::ExprReference::Field { nesting: 0, .. }),
             ) if *nesting > 0 => {
-                let field_ref = cx.resolve_expr_reference(inner).expect_field();
+                let field_ref = cx.resolve_expr_reference(inner).as_field_unwrap();
                 if key_field == field_ref.id {
                     let mut ret = *outer;
                     let stmt::ExprReference::Field { nesting, .. } = &mut ret else {
@@ -686,7 +686,7 @@ impl LowerStatement<'_, '_> {
             (stmt::Expr::Reference(_), stmt::Expr::Reference(_)) => None,
             // Field ref matched against a constant value
             (stmt::Expr::Reference(expr_ref), other) | (other, stmt::Expr::Reference(expr_ref)) => {
-                let field_ref = cx.resolve_expr_reference(expr_ref).expect_field();
+                let field_ref = cx.resolve_expr_reference(expr_ref).as_field_unwrap();
                 if key_field == field_ref.id {
                     if let stmt::Expr::Value(value) = other {
                         Some(value.clone().into())
@@ -837,14 +837,14 @@ impl RelationSource for InsertRelationSource<'_> {
 
     fn set_source_field(&mut self, field: FieldId, expr: stmt::Expr) {
         assert_eq!(self.model.id, field.model);
-        self.row.expect_record_mut()[field.index] = expr;
+        self.row.as_record_mut_unwrap()[field.index] = expr;
     }
 
     fn set_returning_field(&mut self, field: FieldId, expr: stmt::Expr) {
         let record = match self.returning {
             Some(stmt::Returning::Expr(stmt::Expr::Record(record))) => record,
             Some(stmt::Returning::Value(stmt::Expr::List(rows))) => {
-                rows.items[self.index].expect_record_mut()
+                rows.items[self.index].as_record_mut_unwrap()
             }
             Some(stmt::Returning::Value(stmt::Expr::Record(record))) => record,
             _ => todo!("InsertRelationSource={self:#?}"),

--- a/crates/toasty/src/engine/lower/returning.rs
+++ b/crates/toasty/src/engine/lower/returning.rs
@@ -152,14 +152,14 @@ impl LowerStatement<'_, '_> {
                     .unwrap();
 
                 // Check the first row to see if this field is constant
-                let first = &values.rows[0].expect_record().fields[index];
+                let first = &values.rows[0].as_record_unwrap().fields[index];
                 all_const &= first.is_const();
 
                 // Check if this field has the same expression across all rows
                 let mut all_stable_and_equal = first.is_stable();
 
                 for row in &values.rows[1..] {
-                    let field = &row.expect_record().fields[index];
+                    let field = &row.as_record_unwrap().fields[index];
 
                     // Check if this row's field equals the first row's field
                     if all_stable_and_equal {
@@ -283,7 +283,7 @@ impl LowerStatement<'_, '_> {
                     .position(|column| column.index == expr_column.column)
                     .unwrap();
 
-                let field = &self.1.rows[*row].expect_record()[index];
+                let field = &self.1.rows[*row].as_record_unwrap()[index];
 
                 if field.is_eval() {
                     Some(field.clone())
@@ -326,12 +326,12 @@ impl stmt::Input for ConstantizeReturning<'_> {
         expr_reference: &stmt::ExprReference,
         projection: &stmt::Projection,
     ) -> Option<stmt::Expr> {
-        debug_assert_eq!(0, expr_reference.expect_column().nesting, "TODO");
+        debug_assert_eq!(0, expr_reference.as_expr_column_unwrap().nesting, "TODO");
 
         let needle = self
             .cx
             .resolve_expr_reference(expr_reference)
-            .expect_column();
+            .as_column_unwrap();
 
         match self.source {
             ConstantizeSource::InsertValues { values, columns } => {

--- a/crates/toasty/src/engine/plan/nested_merge.rs
+++ b/crates/toasty/src/engine/plan/nested_merge.rs
@@ -180,7 +180,7 @@ impl NestedMergePlanner<'_> {
     fn plan_nested_level(&mut self, stmt_id: hir::StmtId, depth: usize) -> NestedLevel {
         let stmt_state = &self.hir[stmt_id];
         let stmt = stmt_state.stmt.as_deref().unwrap();
-        let returning = stmt.expect_returning();
+        let returning = stmt.returning_unwrap();
 
         let source;
         let mut nested = vec![];
@@ -288,7 +288,7 @@ impl NestedMergePlanner<'_> {
                         let child_stmt_id = *child_stmt_id;
                         let child_stmt_state = &hir[child_stmt_id];
                         let child_stmt = child_stmt_state.stmt.as_deref().unwrap();
-                        let child_returning = child_stmt.expect_returning();
+                        let child_returning = child_stmt.returning_unwrap();
 
                         match child_returning {
                             stmt::Returning::Value(returning_expr) if returning_expr.is_const() => {
@@ -329,7 +329,7 @@ impl NestedMergePlanner<'_> {
                 false
             }
             stmt::Expr::Reference(expr_reference) => {
-                let expr_column = expr_reference.expect_column();
+                let expr_column = expr_reference.as_expr_column_unwrap();
                 debug_assert_eq!(0, expr_column.nesting);
                 let index = selection
                     .get_index_of(&stmt::ExprReference::from(*expr_column))
@@ -354,7 +354,7 @@ impl NestedMergePlanner<'_> {
         let stmt::Statement::Query(query) = stmt_state.stmt.as_deref().unwrap() else {
             unreachable!()
         };
-        let select = query.body.expect_select();
+        let select = query.body.as_select_unwrap();
 
         // Extract the qualification. For now, we will just re-run the
         // entire where clause, but that can be improved later.

--- a/crates/toasty/src/engine/plan/statement.rs
+++ b/crates/toasty/src/engine/plan/statement.rs
@@ -569,7 +569,7 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
             filter,
         };
 
-        stmt.expect_filter_mut().set(stmt::Expr::exists(sub_query));
+        stmt.filter_mut_unwrap().set(stmt::Expr::exists(sub_query));
     }
 
     fn rewrite_stmt_query_for_batch_load_nosql(&mut self, stmt: &mut stmt::Statement) {
@@ -806,13 +806,13 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
             return None;
         }
 
-        let target = insert.target.expect_table();
+        let target = insert.target.as_table_unwrap();
         let values = insert.source.body.as_values()?;
 
         let mut indices = vec![];
 
         for expr_ref in &self.load_data.columns {
-            let expr_col = expr_ref.expect_column();
+            let expr_col = expr_ref.as_expr_column_unwrap();
             debug_assert!(expr_col.nesting == 0, "expr_column={expr_col:#?}");
 
             let Some(index) = target
@@ -1306,7 +1306,7 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
     ) -> mir::NodeId {
         // If there is a post filter, we need to apply a filter step on the returned rows.
         if let Some(post_filter) = post_filter {
-            let item_ty = ty.expect_list();
+            let item_ty = ty.as_list_unwrap();
             node_id = self.planner.mir.insert(mir::Filter {
                 input: node_id,
                 filter: eval::Func::from_stmt(post_filter, vec![item_ty.clone()]),

--- a/crates/toasty/src/engine/simplify/expr_binary_op.rs
+++ b/crates/toasty/src/engine/simplify/expr_binary_op.rs
@@ -12,7 +12,7 @@ impl Simplify<'_> {
                     let model = self
                         .cx
                         .resolve_expr_reference(expr_reference)
-                        .expect_model();
+                        .as_model_unwrap();
 
                     let [pk_field] = &model.primary_key.fields[..] else {
                         todo!("handle composite keys");
@@ -24,7 +24,7 @@ impl Simplify<'_> {
                     let field = self
                         .cx
                         .resolve_expr_reference(expr_reference)
-                        .expect_field();
+                        .as_field_unwrap();
 
                     match &field.ty {
                         FieldTy::Primitive(_) => {}
@@ -78,7 +78,7 @@ impl Simplify<'_> {
                 if lhs == rhs && (op.is_eq() || op.is_ne()) =>
             {
                 if lhs.is_field() {
-                    let field = self.cx.resolve_expr_reference(lhs).expect_field();
+                    let field = self.cx.resolve_expr_reference(lhs).as_field_unwrap();
                     if !field.nullable() {
                         return Some(op.is_eq().into());
                     }

--- a/crates/toasty/src/engine/simplify/expr_in_list.rs
+++ b/crates/toasty/src/engine/simplify/expr_in_list.rs
@@ -39,7 +39,7 @@ impl Simplify<'_> {
                 return;
             };
             let nesting = *nesting;
-            let model = self.cx.resolve_expr_reference(expr_ref).expect_model();
+            let model = self.cx.resolve_expr_reference(expr_ref).as_model_unwrap();
             let [pk_field_id] = &model.primary_key.fields[..] else {
                 todo!()
             };
@@ -54,7 +54,7 @@ impl Simplify<'_> {
                 for item in &mut expr_list.items {
                     match item {
                         stmt::Expr::Value(value) => {
-                            assert!(value.is_a(&pk.ty.expect_primitive().ty));
+                            assert!(value.is_a(&pk.ty.as_primitive_unwrap().ty));
                         }
                         _ => todo!("{item:#?}"),
                     }
@@ -62,7 +62,7 @@ impl Simplify<'_> {
             }
             stmt::Expr::Value(stmt::Value::List(values)) => {
                 for value in values {
-                    assert!(value.is_a(&pk.ty.expect_primitive().ty));
+                    assert!(value.is_a(&pk.ty.as_primitive_unwrap().ty));
                 }
             }
             _ => todo!("expr={expr:#?}"),

--- a/crates/toasty/src/engine/simplify/expr_is_null.rs
+++ b/crates/toasty/src/engine/simplify/expr_is_null.rs
@@ -5,7 +5,7 @@ impl Simplify<'_> {
     pub(super) fn simplify_expr_is_null(&self, expr: &mut stmt::ExprIsNull) -> Option<stmt::Expr> {
         match &mut *expr.expr {
             stmt::Expr::Reference(f @ stmt::ExprReference::Field { .. }) => {
-                let field = self.cx.resolve_expr_reference(f).expect_field();
+                let field = self.cx.resolve_expr_reference(f).as_field_unwrap();
 
                 if !field.nullable() {
                     // Is null on a non nullable field evaluates to `false`.

--- a/crates/toasty/src/engine/simplify/expr_list.rs
+++ b/crates/toasty/src/engine/simplify/expr_list.rs
@@ -98,13 +98,13 @@ impl Simplify<'_> {
         // All inserts are compatible, merge them into a single batch insert
         let mut items = expr.items.drain(..).collect::<Vec<_>>();
         let mut merged_insert = match items.remove(0) {
-            stmt::Expr::Stmt(s) => s.stmt.expect_insert(),
+            stmt::Expr::Stmt(s) => s.stmt.into_insert_unwrap(),
             _ => unreachable!(),
         };
 
         for item in items {
             let insert = match item {
-                stmt::Expr::Stmt(s) => s.stmt.expect_insert(),
+                stmt::Expr::Stmt(s) => s.stmt.into_insert_unwrap(),
                 _ => unreachable!(),
             };
             merged_insert.merge(insert);

--- a/crates/toasty/src/engine/simplify/expr_map.rs
+++ b/crates/toasty/src/engine/simplify/expr_map.rs
@@ -4,7 +4,7 @@ use toasty_core::stmt;
 
 impl Simplify<'_> {
     pub(super) fn simplify_expr_map(&self, expr: &mut stmt::Expr) -> Option<stmt::Expr> {
-        if expr.expect_map().base.is_value() {
+        if expr.as_map_unwrap().base.is_value() {
             let eval = Func::try_from_stmt(expr, vec![])?;
 
             let ret = eval.eval_const();

--- a/crates/toasty/src/engine/simplify/expr_or.rs
+++ b/crates/toasty/src/engine/simplify/expr_or.rs
@@ -209,7 +209,7 @@ impl Simplify<'_> {
             .schema()
             .app
             .model(model_id)
-            .expect_embedded_enum()
+            .as_embedded_enum_unwrap()
             .variants
             .len();
 

--- a/crates/toasty/src/engine/simplify/lift_in_subquery.rs
+++ b/crates/toasty/src/engine/simplify/lift_in_subquery.rs
@@ -27,7 +27,7 @@ impl Simplify<'_> {
             stmt::Expr::Reference(expr_reference @ stmt::ExprReference::Field { .. }) => self
                 .cx
                 .resolve_expr_reference(expr_reference)
-                .expect_field(),
+                .as_field_unwrap(),
             _ => {
                 return None;
             }
@@ -90,11 +90,11 @@ impl Simplify<'_> {
         belongs_to: &BelongsTo,
         query: &stmt::Query,
     ) -> Option<stmt::Expr> {
-        if belongs_to.target != query.body.expect_select().source.model_id_unwrap() {
+        if belongs_to.target != query.body.as_select_unwrap().source.model_id_unwrap() {
             return None;
         }
 
-        let select = query.body.expect_select();
+        let select = query.body.as_select_unwrap();
 
         assert_eq!(
             belongs_to.foreign_key.fields.len(),
@@ -118,7 +118,7 @@ impl Simplify<'_> {
             };
             let mut subquery = query.clone();
 
-            subquery.body.expect_select_mut().returning =
+            subquery.body.as_select_mut_unwrap().returning =
                 stmt::Returning::Expr(stmt::Expr::ref_self_field(fk_fields.target));
 
             Some(stmt::Expr::in_subquery(
@@ -153,7 +153,7 @@ impl Simplify<'_> {
         pair: &BelongsTo,
         query: &stmt::Query,
     ) -> Option<stmt::Expr> {
-        if target != query.body.expect_select().source.model_id_unwrap() {
+        if target != query.body.as_select_unwrap().source.model_id_unwrap() {
             return None;
         }
 
@@ -193,7 +193,7 @@ impl Visit for LiftBelongsTo<'_> {
                         .simplify
                         .cx
                         .resolve_expr_reference(expr_reference)
-                        .expect_field();
+                        .as_field_unwrap();
 
                     self.lift_fk_constraint(field.id, i.op, other);
                 } else {

--- a/crates/toasty/src/engine/simplify/tests/association.rs
+++ b/crates/toasty/src/engine/simplify/tests/association.rs
@@ -55,21 +55,21 @@ impl UserPostSchema {
         let user_id = schema
             .app
             .model(user_model)
-            .expect_root()
+            .as_root_unwrap()
             .field_by_name("id")
             .unwrap()
             .id;
         let user_posts = schema
             .app
             .model(user_model)
-            .expect_root()
+            .as_root_unwrap()
             .field_by_name("posts")
             .unwrap()
             .id;
         let post_author = schema
             .app
             .model(post_model)
-            .expect_root()
+            .as_root_unwrap()
             .field_by_name("author")
             .unwrap()
             .id;

--- a/crates/toasty/src/engine/simplify/tests/expr_binary_op.rs
+++ b/crates/toasty/src/engine/simplify/tests/expr_binary_op.rs
@@ -286,7 +286,7 @@ fn self_comparison_eq_non_nullable_becomes_true() {
     let schema = test_schema();
     let model = schema.app.model(User::id());
     let simplify = Simplify::new(&schema);
-    let mut simplify = simplify.scope(model.expect_root());
+    let mut simplify = simplify.scope(model.as_root_unwrap());
 
     // `id = id` → `true` (non-nullable field)
     let mut lhs = Expr::Reference(ExprReference::Field {
@@ -308,7 +308,7 @@ fn self_comparison_ne_non_nullable_becomes_false() {
     let schema = test_schema();
     let model = schema.app.model(User::id());
     let simplify = Simplify::new(&schema);
-    let mut simplify = simplify.scope(model.expect_root());
+    let mut simplify = simplify.scope(model.as_root_unwrap());
 
     // `id != id` → `false` (non-nullable field)
     let mut lhs = Expr::Reference(ExprReference::Field {
@@ -330,7 +330,7 @@ fn self_comparison_nullable_not_simplified() {
     let schema = test_schema();
     let model = schema.app.model(User::id());
     let simplify = Simplify::new(&schema);
-    let mut simplify = simplify.scope(model.expect_root());
+    let mut simplify = simplify.scope(model.as_root_unwrap());
 
     // `name = name` is not simplified (nullable field)
     let mut lhs = Expr::Reference(ExprReference::Field {
@@ -352,7 +352,7 @@ fn different_fields_not_simplified() {
     let schema = test_schema();
     let model = schema.app.model(User::id());
     let simplify = Simplify::new(&schema);
-    let mut simplify = simplify.scope(model.expect_root());
+    let mut simplify = simplify.scope(model.as_root_unwrap());
 
     // `id = name` is not simplified (different fields)
     let mut lhs = Expr::Reference(ExprReference::Field {
@@ -811,7 +811,7 @@ fn match_with_non_constant_subject() {
     let schema = test_schema();
     let model = schema.app.model(User::id());
     let simplify = Simplify::new(&schema);
-    let mut simplify = simplify.scope(model.expect_root());
+    let mut simplify = simplify.scope(model.as_root_unwrap());
 
     // Match over a column reference (the real-world case)
     // Match(field[0], [1 => "a", 2 => "b"], else: "__") == "a"

--- a/crates/toasty/src/engine/simplify/tests/expr_is_null.rs
+++ b/crates/toasty/src/engine/simplify/tests/expr_is_null.rs
@@ -59,7 +59,7 @@ fn is_null_non_nullable_field() {
     let schema = test_schema_with(&[User::schema()]);
     let model = schema.app.model(User::id());
     let simplify = Simplify::new(&schema);
-    let simplify = simplify.scope(model.expect_root());
+    let simplify = simplify.scope(model.as_root_unwrap());
 
     // `is_null(field)` → `false` (non-nullable field)
     let mut field = ExprIsNull {

--- a/crates/toasty/src/engine/simplify/tests/lift_in_subquery.rs
+++ b/crates/toasty/src/engine/simplify/tests/lift_in_subquery.rs
@@ -60,14 +60,14 @@ impl UserPostSchema {
         let user_id = schema
             .app
             .model(user_model)
-            .expect_root()
+            .as_root_unwrap()
             .field_by_name("id")
             .unwrap()
             .id;
         let post_user = schema
             .app
             .model(post_model)
-            .expect_root()
+            .as_root_unwrap()
             .field_by_name("user")
             .unwrap()
             .id;

--- a/crates/toasty/src/stmt/association.rs
+++ b/crates/toasty/src/stmt/association.rs
@@ -52,7 +52,7 @@ impl<M: Model> Association<List<M>> {
     /// let _assoc = Association::many(source, path);
     /// ```
     pub fn many<T: Model>(source: super::Query<T>, path: Path<T, List<M>>) -> Self {
-        assert_eq!(path.untyped.root.expect_model(), T::id());
+        assert_eq!(path.untyped.root.as_model_unwrap(), T::id());
 
         Self {
             untyped: stmt::Association {
@@ -94,7 +94,7 @@ impl<M: Model> Association<List<M>> {
     /// let _assoc: Association<List<User>> = Association::many_via_one(source, path);
     /// ```
     pub fn many_via_one<T: Model>(source: super::Query<T>, path: Path<T, M>) -> Self {
-        assert_eq!(path.untyped.root.expect_model(), T::id());
+        assert_eq!(path.untyped.root.as_model_unwrap(), T::id());
 
         Self {
             untyped: stmt::Association {
@@ -240,7 +240,7 @@ impl<M: Model> Association<M> {
     /// let _assoc = Association::one(source, path);
     /// ```
     pub fn one<T: Model>(source: super::Query<T>, path: Path<T, M>) -> Self {
-        assert_eq!(path.untyped.root.expect_model(), T::id());
+        assert_eq!(path.untyped.root.as_model_unwrap(), T::id());
 
         Self {
             untyped: stmt::Association {

--- a/crates/toasty/src/stmt/insert.rs
+++ b/crates/toasty/src/stmt/insert.rs
@@ -47,7 +47,7 @@ impl<M: Model> Insert<M> {
                 target: stmt::InsertTarget::Model(M::id()),
                 source: stmt::Query::new_single(vec![stmt::ExprRecord::from_vec(
                     M::schema()
-                        .expect_root()
+                        .as_root_unwrap()
                         .fields
                         .iter()
                         .map(|field| match field.auto() {
@@ -229,8 +229,8 @@ impl<M: Model> Insert<M> {
 
     /// Returns the current record being updated
     fn current_mut(&mut self) -> &mut stmt::ExprRecord {
-        let values = self.untyped.source.body.expect_values_mut();
-        values.rows.last_mut().unwrap().expect_record_mut()
+        let values = self.untyped.source.body.as_values_mut_unwrap();
+        values.rows.last_mut().unwrap().as_record_mut_unwrap()
     }
 
     /// Convert this insert into a list expression.


### PR DESCRIPTION
This PR systematically renames panicking accessor methods across the codebase from `*_unwrap()` to `expect_*()` to follow Rust naming conventions and improve consistency with standard library patterns like `Option::expect()`.

## Summary
The codebase had many methods with names like `as_*_unwrap()`, `*_unwrap()`, and similar patterns that panic on failure. These have been standardized to use the `expect_*()` naming convention, which is more idiomatic and aligns with Rust's standard library conventions where `expect()` is used for panicking accessors.

## Key Changes

- **Returning methods**: Renamed `as_expr_unwrap()` → `expect_expr()`, `as_expr_mut_unwrap()` → `expect_expr_mut()`, `as_model_includes_mut()` → `expect_model_includes_mut()`, `returning_unwrap()` → `expect_returning()`, `returning_mut_unwrap()` → `expect_returning_mut()`

- **Entry methods**: Renamed `as_value()` → `expect_value()` (with `try_as_value()` becoming `as_value()` returning `Option`)

- **Source methods**: Renamed `as_model_unwrap()` → `expect_model()`, `as_source_table()` → `as_table()` with new `expect_table()`, field `model` → `id` in `SourceModel`

- **Insert/Update/Delete target methods**: Renamed `as_model_unwrap()` → `expect_model()`, `as_table_unwrap()` → `expect_table()`, with `as_table()` now returning `Option`

- **Select/Query methods**: Renamed `as_select_unwrap()` → `expect_select()`, `as_select_mut_unwrap()` → `expect_select_mut()`, added `into_query()` returning `Option` alongside `expect_query()`

- **Expression methods**: Renamed `as_record_unwrap()` → `expect_record()`, `as_expr_reference_unwrap()` → `expect_reference()`, `as_expr_column_unwrap()` → `expect_column()`, `as_map()` now returns `Option` with new `expect_map()`, similar changes for `as_project()`, `as_values()`, etc.

- **Filter methods**: Renamed `filter_unwrap()` → `expect_filter()`, `filter_mut_unwrap()` → `expect_filter_mut()`, `filter_expr_unwrap()` → `expect_filter_expr()`

- **Type methods**: Renamed `unwrap_list_ref()` → `expect_list()`

- **Value methods**: Renamed `unwrap_list()` → `expect_list()`

- **ExprTarget methods**: Renamed `as_model_unwrap()` → `expect_model()`, `as_table_unwrap()` → `expect_table()`, with `as_table()` now returning `Option`

- **Condition methods**: Renamed `condition_mut_unwrap()` → `expect_condition_mut()`

- **Statement methods**: Renamed `unwrap_insert()` → `expect_insert()`, `unwrap_update()` → `expect_update()`, `unwrap_delete()` → `expect_delete()`

- **ExprList methods**: Renamed `unwrap_list()` → `into_list()` returning `Option`

## Implementation Details

- Added `#[track_caller]` attributes to panicking methods to improve error reporting
- Converted many `as_*_unwrap()` methods to return `Option` with a separate `expect_*()` method, following the standard library pattern
- Updated all call sites throughout the codebase to use the new method names
- Fixed a typo in an error message ("Returningm" → "Returning")
- Improved consistency in panic messages across similar methods

https://claude.ai/code/session_01TmSKFdNZUm8XkwmSzhqMdt