### PR TITLE
chore: reduce debug info in dev and test profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,3 +106,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 trybuild = { version = "1.0.89", features = ["diff"] }
 url = "2.5.4"
 uuid = { version = "1.11.0", features = ["v4", "v7", "fast-rng"] }
+
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.test]
+debug = "line-tables-only"


### PR DESCRIPTION
## Summary
Reduce debug information overhead in development and test builds by using line-tables-only debug symbols instead of the default full debug info.

## Changes
- Configure `[profile.dev]` to use `debug = "line-tables-only"`
- Configure `[profile.test]` to use `debug = "line-tables-only"`

## Details
This change reduces compilation time and binary size for dev and test builds while still maintaining enough debug information for stack traces and basic debugging. Full debug symbols are typically unnecessary during development iteration and testing, making this a good trade-off for faster builds without significantly impacting debuggability.

https://claude.ai/code/session_011xDirCfgHAB5m5eFfRRrJP