### PR TITLE
refactor: remove async_trait reexport from toasty-core

### DIFF
--- a/crates/toasty-core/src/driver.rs
+++ b/crates/toasty-core/src/driver.rs
@@ -28,13 +28,12 @@ pub use response::{Response, Rows};
 pub mod operation;
 pub use operation::{IsolationLevel, Operation};
 
-use crate::{
-    async_trait,
-    schema::{
-        db::{AppliedMigration, Migration, SchemaDiff},
-        Schema,
-    },
+use crate::schema::{
+    db::{AppliedMigration, Migration, SchemaDiff},
+    Schema,
 };
+
+use async_trait::async_trait;
 
 use std::{borrow::Cow, fmt::Debug, sync::Arc};
 

--- a/crates/toasty-core/src/lib.rs
+++ b/crates/toasty-core/src/lib.rs
@@ -60,6 +60,3 @@ pub mod stmt;
 /// }
 /// ```
 pub type Result<T, E = Error> = core::result::Result<T, E>;
-
-/// Re-export of `async_trait` for use by driver implementations.
-pub use async_trait::async_trait;

--- a/crates/toasty-driver-dynamodb/Cargo.toml
+++ b/crates/toasty-driver-dynamodb/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
+async-trait.workspace = true
 toasty-core.workspace = true
 aws-config.workspace = true
 aws-sdk-dynamodb.workspace = true

--- a/crates/toasty-driver-dynamodb/src/lib.rs
+++ b/crates/toasty-driver-dynamodb/src/lib.rs
@@ -5,8 +5,8 @@ mod value;
 pub(crate) use r#type::TypeExt;
 pub(crate) use value::Value;
 
+use async_trait::async_trait;
 use toasty_core::{
-    async_trait,
     driver::{operation::Operation, Capability, Driver, Response},
     schema::db::{self, Column, ColumnId, Migration, SchemaDiff, Table},
     stmt::{self, ExprContext},

--- a/crates/toasty-driver-integration-suite/src/logging_driver.rs
+++ b/crates/toasty-driver-integration-suite/src/logging_driver.rs
@@ -1,9 +1,9 @@
+use async_trait::async_trait;
 use std::{
     borrow::Cow,
     sync::{Arc, Mutex},
 };
 use toasty_core::{
-    async_trait,
     driver::{Capability, Connection, Driver, Operation, Response, Rows},
     schema::db::{AppliedMigration, Migration, SchemaDiff},
     Result, Schema,

--- a/crates/toasty-driver-mysql/Cargo.toml
+++ b/crates/toasty-driver-mysql/Cargo.toml
@@ -9,6 +9,7 @@ bigdecimal = ["dep:bigdecimal", "toasty-core/bigdecimal"]
 jiff = ["dep:jiff", "toasty-core/jiff"]
 
 [dependencies]
+async-trait.workspace = true
 toasty-core.workspace = true
 toasty-sql.workspace = true
 rust_decimal = { workspace = true, optional = true }

--- a/crates/toasty-driver-mysql/src/lib.rs
+++ b/crates/toasty-driver-mysql/src/lib.rs
@@ -3,13 +3,13 @@
 mod value;
 pub(crate) use value::Value;
 
+use async_trait::async_trait;
 use mysql_async::{
     prelude::{Queryable, ToValue},
     Conn, OptsBuilder,
 };
 use std::{borrow::Cow, sync::Arc};
 use toasty_core::{
-    async_trait,
     driver::{Capability, Driver, Operation, Response},
     schema::db::{self, Migration, SchemaDiff, Table},
     stmt::{self, ValueRecord},

--- a/crates/toasty-driver-postgresql/Cargo.toml
+++ b/crates/toasty-driver-postgresql/Cargo.toml
@@ -9,6 +9,7 @@ bigdecimal = ["dep:bigdecimal", "toasty-core/bigdecimal"]
 jiff = ["dep:jiff", "toasty-core/jiff", "postgres-types/with-jiff-0_2"]
 
 [dependencies]
+async-trait.workspace = true
 toasty-core.workspace = true
 toasty-sql.workspace = true
 rust_decimal = { workspace = true, optional = true, features = ["db-postgres"] }

--- a/crates/toasty-driver-postgresql/src/lib.rs
+++ b/crates/toasty-driver-postgresql/src/lib.rs
@@ -4,10 +4,10 @@ mod value;
 
 pub(crate) use value::Value;
 
+use async_trait::async_trait;
 use postgres::{tls::MakeTlsConnect, types::ToSql, Socket};
 use std::{borrow::Cow, sync::Arc};
 use toasty_core::{
-    async_trait,
     driver::{Capability, Driver, Operation, Response},
     schema::db::{self, Migration, SchemaDiff, Table},
     stmt,

--- a/crates/toasty-driver-sqlite/Cargo.toml
+++ b/crates/toasty-driver-sqlite/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
+async-trait.workspace = true
 toasty-core.workspace = true
 toasty-sql.workspace = true
 rusqlite.workspace = true

--- a/crates/toasty-driver-sqlite/src/lib.rs
+++ b/crates/toasty-driver-sqlite/src/lib.rs
@@ -1,6 +1,7 @@
 mod value;
 pub(crate) use value::Value;
 
+use async_trait::async_trait;
 use rusqlite::Connection as RusqliteConnection;
 use std::{
     borrow::Cow,
@@ -8,7 +9,6 @@ use std::{
     sync::Arc,
 };
 use toasty_core::{
-    async_trait,
     driver::{
         operation::{IsolationLevel, Operation, Transaction},
         Capability, Driver, Response,
@@ -139,7 +139,7 @@ impl Connection {
     }
 }
 
-#[toasty_core::async_trait]
+#[async_trait]
 impl toasty_core::driver::Connection for Connection {
     async fn exec(&mut self, schema: &Arc<Schema>, op: Operation) -> Result<Response> {
         let (sql, ret_tys): (sql::Statement, _) = match op {

--- a/crates/toasty/Cargo.toml
+++ b/crates/toasty/Cargo.toml
@@ -31,6 +31,7 @@ serde = ["dep:serde_core", "dep:serde_json"]
 
 
 [dependencies]
+async-trait.workspace = true
 toasty-macros.workspace = true
 toasty-core.workspace = true
 

--- a/crates/toasty/src/db.rs
+++ b/crates/toasty/src/db.rs
@@ -9,8 +9,8 @@ pub use pool::*;
 use crate::{engine::Engine, Executor, Result, Transaction, TransactionBuilder};
 pub(crate) use pool::{ConnectionHandle, ConnectionOperation};
 
+use async_trait::async_trait;
 use toasty_core::{
-    async_trait,
     driver::Driver,
     stmt::{self, Value},
     Schema,

--- a/crates/toasty/src/db/connect.rs
+++ b/crates/toasty/src/db/connect.rs
@@ -1,9 +1,9 @@
 use crate::Result;
 
+use async_trait::async_trait;
 use std::borrow::Cow;
 pub use toasty_core::driver::{operation::Operation, Capability, Connection, Response};
 use toasty_core::{
-    async_trait,
     driver::Driver,
     schema::db::{Migration, SchemaDiff},
 };

--- a/crates/toasty/src/executor.rs
+++ b/crates/toasty/src/executor.rs
@@ -1,7 +1,8 @@
 use crate::{schema::Load, Result, Statement, Transaction};
 
+use async_trait::async_trait;
 use std::sync::Arc;
-use toasty_core::{async_trait, stmt::Value, Schema};
+use toasty_core::{stmt::Value, Schema};
 
 /// Anything that can execute queries — [`Db`](crate::Db) or
 /// [`Transaction`](crate::Transaction).

--- a/crates/toasty/src/transaction.rs
+++ b/crates/toasty/src/transaction.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use crate::{db::ConnectionOperation, Executor, Result};
 
+use async_trait::async_trait;
 use toasty_core::{
-    async_trait,
     driver::operation::{self, IsolationLevel},
     stmt::Value,
     Schema,

--- a/tests/src/logging_driver.rs
+++ b/tests/src/logging_driver.rs
@@ -1,9 +1,9 @@
+use async_trait::async_trait;
 use std::{
     borrow::Cow,
     sync::{Arc, Mutex},
 };
 use toasty_core::{
-    async_trait,
     driver::{Capability, Connection, Driver, Operation, Response, Rows},
     schema::db::{AppliedMigration, Migration, SchemaDiff},
     Result, Schema,


### PR DESCRIPTION
## Summary

- Remove the `pub use async_trait::async_trait` reexport from `toasty-core`
- Add `async-trait` as a direct workspace dependency to each crate that uses it (`toasty`, `toasty-driver-sqlite`, `toasty-driver-mysql`, `toasty-driver-postgresql`, `toasty-driver-dynamodb`)
- Update all imports from `toasty_core::async_trait` to `async_trait::async_trait`

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes (all 47 tests)
- [x] `cargo clippy` passes
- [x] `cargo fmt` applied

https://claude.ai/code/session_011kSuZg2iqfQzWujcM54VYq