### PR TITLE
docs: add comprehensive documentation to toasty-sql crate

### DIFF
--- a/crates/toasty-sql/src/lib.rs
+++ b/crates/toasty-sql/src/lib.rs
@@ -1,8 +1,19 @@
+#![warn(missing_docs)]
+
+//! SQL serialization for Toasty.
+//!
+//! This crate converts Toasty's statement AST into SQL strings for SQLite,
+//! PostgreSQL, and MySQL. It also generates DDL statements for schema
+//! migrations.
+
+/// Schema migration statement generation.
 pub mod migration;
 pub use migration::*;
 
+/// SQL serialization and parameter handling.
 pub mod serializer;
 pub use serializer::{Params, Serializer, TypedValue};
 
+/// SQL statement types for both DML and DDL operations.
 pub mod stmt;
 pub use stmt::Statement;

--- a/crates/toasty-sql/src/migration.rs
+++ b/crates/toasty-sql/src/migration.rs
@@ -9,6 +9,11 @@ use toasty_core::{
 
 use crate::stmt::{AlterColumnChanges, AlterTable, AlterTableAction, DropTable, Name, Statement};
 
+/// A migration step pairing a DDL [`Statement`] with the [`Schema`] it applies against.
+///
+/// Each `MigrationStatement` carries a snapshot of the schema at the point where
+/// the statement should be serialized. This is necessary because rename and
+/// recreation operations modify the schema as they go.
 pub struct MigrationStatement<'a> {
     statement: Statement,
     schema: Cow<'a, Schema>,
@@ -19,6 +24,12 @@ impl<'a> MigrationStatement<'a> {
         MigrationStatement { statement, schema }
     }
 
+    /// Generates migration statements from a [`SchemaDiff`].
+    ///
+    /// Walks the diff's table, column, and index changes and produces the
+    /// corresponding DDL statements. On databases that lack `ALTER COLUMN`
+    /// support (e.g. SQLite), column type changes trigger a full table
+    /// recreation sequence.
     pub fn from_diff(schema_diff: &'a SchemaDiff<'a>, capability: &Capability) -> Vec<Self> {
         let mut result = Vec::new();
         for table in schema_diff.tables().iter() {
@@ -249,10 +260,12 @@ impl<'a> MigrationStatement<'a> {
         }
     }
 
+    /// Returns the DDL statement for this migration step.
     pub fn statement(&self) -> &Statement {
         &self.statement
     }
 
+    /// Returns the schema snapshot this statement should be serialized against.
     pub fn schema(&self) -> &Schema {
         &self.schema
     }

--- a/crates/toasty-sql/src/serializer.rs
+++ b/crates/toasty-sql/src/serializer.rs
@@ -34,10 +34,12 @@ use toasty_core::{
     schema::db::{self, Index, Table},
 };
 
-/// Context information when serializing VALUES in an INSERT statement
+/// Context information when serializing VALUES in an INSERT statement.
 #[derive(Debug, Clone)]
 pub struct InsertContext {
+    /// The table being inserted into.
     pub table_id: db::TableId,
+    /// Columns receiving values, in order.
     pub columns: Vec<db::ColumnId>,
 }
 
@@ -73,9 +75,15 @@ struct Formatter<'a, T> {
     insert_context: Option<InsertContext>,
 }
 
+/// Expression context bound to a database-level schema.
 pub type ExprContext<'a> = toasty_core::stmt::ExprContext<'a, db::Schema>;
 
 impl<'a> Serializer<'a> {
+    /// Serializes a [`Statement`] to a SQL string, appending a trailing semicolon.
+    ///
+    /// Parameter placeholders are written in the dialect's native format
+    /// (`$1` for PostgreSQL, `?1` for SQLite, `?` for MySQL) and the
+    /// corresponding values are pushed into `params`.
     pub fn serialize(&self, stmt: &Statement, params: &mut impl Params) -> String {
         let mut ret = String::new();
 

--- a/crates/toasty-sql/src/serializer/flavor.rs
+++ b/crates/toasty-sql/src/serializer/flavor.rs
@@ -10,6 +10,7 @@ pub(super) enum Flavor {
 }
 
 impl<'a> Serializer<'a> {
+    /// Creates a serializer that emits SQLite SQL.
     pub fn sqlite(schema: &'a db::Schema) -> Self {
         Serializer {
             schema,
@@ -17,10 +18,12 @@ impl<'a> Serializer<'a> {
         }
     }
 
+    /// Returns `true` if this serializer targets SQLite.
     pub fn is_sqlite(&self) -> bool {
         matches!(self.flavor, Flavor::Sqlite)
     }
 
+    /// Creates a serializer that emits PostgreSQL SQL.
     pub fn postgresql(schema: &'a db::Schema) -> Self {
         Serializer {
             schema,
@@ -28,6 +31,7 @@ impl<'a> Serializer<'a> {
         }
     }
 
+    /// Creates a serializer that emits MySQL SQL.
     pub fn mysql(schema: &'a db::Schema) -> Self {
         Serializer {
             schema,

--- a/crates/toasty-sql/src/serializer/params.rs
+++ b/crates/toasty-sql/src/serializer/params.rs
@@ -4,15 +4,53 @@ use super::{Flavor, Formatter, ToSql};
 
 use toasty_core::stmt;
 
+/// Collects query parameter values during SQL serialization.
+///
+/// Implement this trait to control how bound parameters are stored. The
+/// serializer calls [`push`](Params::push) each time it encounters a value
+/// that should be sent as a bind parameter rather than inlined into the SQL
+/// string.
 pub trait Params {
+    /// Appends a value (with an optional type hint) and returns its [`Placeholder`].
     fn push(&mut self, param: &stmt::Value, type_hint: Option<&stmt::Type>) -> Placeholder;
 }
 
+/// A positional bind-parameter placeholder.
+///
+/// The inner `usize` is the 1-based parameter index. The serializer renders
+/// it in the target dialect's format (`$1`, `?1`, or `?`).
+///
+/// # Example
+///
+/// ```
+/// use toasty_sql::serializer::Placeholder;
+///
+/// let p = Placeholder(3);
+/// assert_eq!(p.0, 3);
+/// ```
 pub struct Placeholder(pub usize);
 
+/// A parameter value paired with an optional type hint.
+///
+/// Type hints let drivers pick the right wire format when the value alone
+/// is ambiguous (e.g. distinguishing `INTEGER` from `BIGINT`).
+///
+/// # Example
+///
+/// ```
+/// use toasty_sql::TypedValue;
+///
+/// let tv = TypedValue {
+///     value: toasty_core::stmt::Value::Null,
+///     type_hint: None,
+/// };
+/// assert!(tv.type_hint.is_none());
+/// ```
 #[derive(Debug, Clone)]
 pub struct TypedValue {
+    /// The parameter value.
     pub value: stmt::Value,
+    /// An optional type hint for the value.
     pub type_hint: Option<stmt::Type>,
 }
 

--- a/crates/toasty-sql/src/stmt.rs
+++ b/crates/toasty-sql/src/stmt.rs
@@ -42,25 +42,41 @@ pub use table_name::TableName;
 
 pub use toasty_core::stmt::*;
 
+/// A SQL statement, covering both DDL (schema changes) and DML (data manipulation).
 #[derive(Debug, Clone)]
 pub enum Statement {
+    /// Add a column to an existing table.
     AddColumn(AddColumn),
+    /// Alter properties of an existing column.
     AlterColumn(AlterColumn),
+    /// Alter an existing table (e.g. rename).
     AlterTable(AlterTable),
+    /// Copy rows from one table to another.
     CopyTable(CopyTable),
+    /// Create an index.
     CreateIndex(CreateIndex),
+    /// Create a table.
     CreateTable(CreateTable),
+    /// Drop a column from an existing table.
     DropColumn(DropColumn),
+    /// Drop a table.
     DropTable(DropTable),
+    /// Drop an index.
     DropIndex(DropIndex),
+    /// A SQLite PRAGMA statement.
     Pragma(Pragma),
+    /// A DELETE statement.
     Delete(Delete),
+    /// An INSERT statement.
     Insert(Insert),
+    /// A SELECT query.
     Query(Query),
+    /// An UPDATE statement.
     Update(Update),
 }
 
 impl Statement {
+    /// Returns `true` if this is an [`Update`] statement.
     pub fn is_update(&self) -> bool {
         matches!(self, Self::Update(_))
     }

--- a/crates/toasty-sql/src/stmt/alter_column.rs
+++ b/crates/toasty-sql/src/stmt/alter_column.rs
@@ -37,6 +37,10 @@ pub struct AlterColumnChanges {
 }
 
 impl AlterColumnChanges {
+    /// Computes the set of changes between two column definitions.
+    ///
+    /// Each field is `Some` only when the corresponding property differs
+    /// between `previous` and `next`.
     pub fn from_diff(previous: &Column, next: &Column) -> Self {
         Self {
             new_name: (previous.name != next.name).then(|| next.name.clone()),
@@ -89,6 +93,7 @@ impl AlterColumnChanges {
         result
     }
 
+    /// Returns `true` if any type-level property changed (type, nullability, or auto-increment).
     pub fn has_type_change(&self) -> bool {
         self.new_ty.is_some() || self.new_not_null.is_some() || self.new_auto_increment.is_some()
     }

--- a/crates/toasty-sql/src/stmt/column_def.rs
+++ b/crates/toasty-sql/src/stmt/column_def.rs
@@ -3,11 +3,16 @@ use toasty_core::{
     schema::db::{self, Column},
 };
 
+/// A column definition used in `CREATE TABLE` and `ADD COLUMN` statements.
 #[derive(Debug, Clone)]
 pub struct ColumnDef {
+    /// Column name.
     pub name: String,
+    /// Storage type (e.g. `INTEGER`, `TEXT`).
     pub ty: db::Type,
+    /// When `true`, the column has a `NOT NULL` constraint.
     pub not_null: bool,
+    /// When `true`, the column auto-increments.
     pub auto_increment: bool,
 }
 

--- a/crates/toasty-sql/src/stmt/create_index.rs
+++ b/crates/toasty-sql/src/stmt/create_index.rs
@@ -5,6 +5,7 @@ use toasty_core::{
     stmt,
 };
 
+/// A `CREATE INDEX` statement.
 #[derive(Debug, Clone)]
 pub struct CreateIndex {
     /// Name of the index
@@ -21,6 +22,7 @@ pub struct CreateIndex {
 }
 
 impl Statement {
+    /// Creates a `CREATE INDEX` statement from a schema [`Index`].
     pub fn create_index(index: &Index) -> Self {
         CreateIndex {
             index: index.id,

--- a/crates/toasty-sql/src/stmt/create_table.rs
+++ b/crates/toasty-sql/src/stmt/create_table.rs
@@ -6,6 +6,7 @@ use toasty_core::{
     stmt,
 };
 
+/// A `CREATE TABLE` statement.
 #[derive(Debug, Clone)]
 pub struct CreateTable {
     /// Name of the table
@@ -19,6 +20,7 @@ pub struct CreateTable {
 }
 
 impl Statement {
+    /// Creates a `CREATE TABLE` statement from a schema [`Table`].
     pub fn create_table(table: &Table, capability: &Capability) -> Self {
         CreateTable {
             table: table.id,

--- a/crates/toasty-sql/src/stmt/ident.rs
+++ b/crates/toasty-sql/src/stmt/ident.rs
@@ -1,5 +1,18 @@
 use std::fmt;
 
+/// A SQL identifier (table name, column name, etc.).
+///
+/// Wraps a string-like value. When serialized, the identifier is quoted to
+/// avoid conflicts with SQL reserved words.
+///
+/// # Example
+///
+/// ```
+/// use toasty_sql::stmt::Ident;
+///
+/// let id = Ident::from("users");
+/// assert_eq!(id.to_string(), "users");
+/// ```
 #[derive(Debug, Clone)]
 pub struct Ident<T = String>(pub T);
 

--- a/crates/toasty-sql/src/stmt/name.rs
+++ b/crates/toasty-sql/src/stmt/name.rs
@@ -1,5 +1,18 @@
 use std::fmt;
 
+/// A possibly schema-qualified SQL name (e.g. `"users"` or `"public"."users"`).
+///
+/// Stores each segment as a separate string. Single-segment names are the
+/// common case.
+///
+/// # Example
+///
+/// ```
+/// use toasty_sql::stmt::Name;
+///
+/// let name = Name::from("users");
+/// assert_eq!(name.to_string(), "users");
+/// ```
 #[derive(Debug, Clone)]
 pub struct Name(pub Vec<String>);
 

--- a/crates/toasty-sql/src/stmt/table_name.rs
+++ b/crates/toasty-sql/src/stmt/table_name.rs
@@ -1,9 +1,12 @@
 use super::ident::Ident;
 use toasty_core::schema::db::TableId;
 
+/// A reference to a table, either by schema ID or by a string identifier.
 #[derive(Debug, Clone)]
 pub enum TableName {
+    /// Reference by schema-assigned table ID.
     TableId(TableId),
+    /// Reference by a literal identifier string.
     Ident(Ident),
 }
 


### PR DESCRIPTION
## Summary

This PR adds extensive documentation to the `toasty-sql` crate, including module-level docs, public API documentation, and examples. The changes improve code clarity and enable better IDE support and documentation generation.

## Key Changes

- **Crate-level documentation**: Added `#![warn(missing_docs)]` lint and comprehensive module documentation to `lib.rs` explaining the crate's purpose (SQL serialization for Toasty across SQLite, PostgreSQL, and MySQL)

- **Core trait and type documentation**:
  - `Params` trait: Documented the parameter collection mechanism and `push` method
  - `Placeholder`: Documented 1-based parameter indexing and dialect-specific rendering
  - `TypedValue`: Documented the value/type-hint pairing and its purpose for wire format disambiguation
  - `Statement` enum: Added doc comments for all 14 statement variants (DDL and DML)

- **Migration API documentation**: 
  - `MigrationStatement`: Documented the schema snapshot pairing and its necessity for rename/recreation operations
  - `from_diff` method: Explained the diff-to-DDL generation process and SQLite table recreation behavior

- **SQL identifier types**:
  - `Ident`: Documented as a quoted SQL identifier with example usage
  - `Name`: Documented as a schema-qualified name with support for multi-segment paths

- **Statement-specific documentation**:
  - `CreateTable`, `CreateIndex`: Added factory method documentation
  - `AlterColumnChanges`: Documented the diff computation and `has_type_change` method
  - `ColumnDef`: Documented all fields (name, type, constraints)
  - `TableName`: Documented both ID-based and identifier-based references

- **Serializer API documentation**:
  - `Serializer::serialize`: Documented parameter placeholder rendering across dialects
  - Flavor constructors: Added docs for `sqlite()`, `postgresql()`, `mysql()` and `is_sqlite()` helper
  - `InsertContext`: Documented table and column tracking during INSERT serialization

## Implementation Details

All documentation follows Rust conventions with:
- Clear descriptions of purpose and behavior
- Practical examples where appropriate
- Cross-references to related types using `[`Type`]` syntax
- Consistent formatting and terminology

https://claude.ai/code/session_016iqYuG1y7jAQmwLsJSn4gz