### PR TITLE
feat: implement Create trait for ManyField and OneField relation structs

### DIFF
--- a/crates/toasty-macros/src/model/expand/relation.rs
+++ b/crates/toasty-macros/src/model/expand/relation.rs
@@ -149,6 +149,11 @@ impl Expand<'_> {
                 #many_field_association_methods
             }
 
+            impl<__Origin> #toasty::Create for ManyField<__Origin> {
+                type Item = #model_ident;
+                type Builder = #create_builder_ident;
+            }
+
             impl<__Origin> Into<#toasty::Path<__Origin, #toasty::List<#model_ident>>> for ManyField<__Origin> {
                 fn into(self) -> #toasty::Path<__Origin, #toasty::List<#model_ident>> {
                     self.path
@@ -176,6 +181,11 @@ impl Expand<'_> {
                 }
 
                 #one_field_association_methods
+            }
+
+            impl<__Origin> #toasty::Create for OneField<__Origin> {
+                type Item = #model_ident;
+                type Builder = #create_builder_ident;
             }
 
             impl<__Origin> Into<#toasty::Path<__Origin, #model_ident>> for OneField<__Origin> {


### PR DESCRIPTION
Generated relation field structs (ManyField<__Origin> and OneField<__Origin>)
now implement the Create trait, yielding the target model's create builder.
This enables e.g. User::fields().todos() to produce a Todo create builder
and Todo::fields().user() to produce a User create builder.

https://claude.ai/code/session_01SNe8U4qeGmvnejPnAWWBpu