### PR TITLE
refactor: remove driver type re-exports from toasty::db except Driver and Capability

### DIFF
--- a/crates/toasty/src/db.rs
+++ b/crates/toasty/src/db.rs
@@ -5,7 +5,7 @@ mod pool;
 mod tx;
 
 pub use builder::Builder;
-pub use connect::{Capability, Connect, Connection, Operation, Response};
+pub use connect::{Capability, Connect, Driver};
 pub use executor::Executor;
 pub use pool::{Pool, PoolConfig, PoolConnection, PoolStatus, Timeouts};
 pub use tx::{Transaction, TransactionBuilder};
@@ -16,7 +16,7 @@ use crate::{engine::Engine, Result};
 
 use async_trait::async_trait;
 use toasty_core::{
-    driver::Driver,
+    driver::{operation::Operation, Response},
     stmt::{self, Value},
     Schema,
 };

--- a/crates/toasty/src/db/connect.rs
+++ b/crates/toasty/src/db/connect.rs
@@ -2,9 +2,9 @@ use crate::Result;
 
 use async_trait::async_trait;
 use std::borrow::Cow;
-pub use toasty_core::driver::{operation::Operation, Capability, Connection, Response};
+pub use toasty_core::driver::{Capability, Driver};
 use toasty_core::{
-    driver::Driver,
+    driver::Connection,
     schema::db::{Migration, SchemaDiff},
 };
 


### PR DESCRIPTION
## Summary

- Remove re-exports of `Operation`, `Connection`, and `Response` from `toasty::db` (they are internal implementation details from `toasty_core::driver`)
- Keep only `Driver` and `Capability` as public re-exports
- Internal usages in `db.rs` now import `Operation` and `Response` directly from `toasty_core::driver`

## Test plan

- [x] `cargo build` compiles with no warnings
- [x] `cargo clippy` passes clean
- [x] `cargo test` — all tests pass
- [x] No external code was importing the removed re-exports

https://claude.ai/code/session_01KPMWX1MQRa8YjF73vGeufV