### PR TITLE
fix: bring back associated type for `Model::Create`

### DIFF
--- a/crates/toasty-macros/src/model/expand/model.rs
+++ b/crates/toasty-macros/src/model/expand/model.rs
@@ -99,6 +99,7 @@ impl Expand<'_> {
 
             impl #toasty::Model for #model_ident {
                 type Query = #query_struct_ident;
+                type Create = #create_struct_ident;
                 type Update<'a> = #update_struct_ident<&'a mut Self>;
                 type UpdateQuery = #update_struct_ident;
             }

--- a/crates/toasty/src/schema/model.rs
+++ b/crates/toasty/src/schema/model.rs
@@ -9,6 +9,9 @@ pub trait Model: Register + Load<Output = Self> + Create<Item = Self> + Sized {
     /// Query builder type for this model
     type Query;
 
+    // Create builder type for this model
+    type Create;
+
     /// Update builder type for this model
     type Update<'a>;
 


### PR DESCRIPTION
```rust
    pub fn create_email_verification(token: &str) -> <Self as Model>::Create {
        Self::create().token_nonce_hash(Self::hash_token(token, None))
    }
```
This code snipped worked before but no longer works. I assume this was accidental.