### PR TITLE
refactor: move reload from Field trait to Load trait

### DIFF
--- a/crates/toasty-macros/src/model/expand.rs
+++ b/crates/toasty-macros/src/model/expand.rs
@@ -108,6 +108,10 @@ pub(super) fn embedded_model(model: &Model) -> TokenStream {
             fn load(value: #toasty::core::stmt::Value) -> #toasty::Result<Self> {
                 #load_body
             }
+
+            fn reload(target: &mut Self, value: #toasty::core::stmt::Value) -> #toasty::Result<()> {
+                #reload_body
+            }
         }
 
         impl #toasty::ModelField for #model_ident {
@@ -126,10 +130,6 @@ pub(super) fn embedded_model(model: &Model) -> TokenStream {
         impl #toasty::Field for #model_ident {
             type FieldAccessor<__Origin> = #field_struct_ident<__Origin>;
             type UpdateBuilder<'a> = #update_struct_ident<'a>;
-
-            fn reload(&mut self, value: #toasty::core::stmt::Value) -> #toasty::Result<()> {
-                #reload_body
-            }
 
             fn make_field_accessor<__Origin>(path: #toasty::Path<__Origin, Self>) -> Self::FieldAccessor<__Origin> {
                 #field_struct_ident { path }
@@ -239,6 +239,11 @@ pub(super) fn embedded_enum(model: &Model) -> TokenStream {
                     },
                     value => Err(#toasty::Error::type_conversion(value, stringify!(#model_ident))),
                 }
+            }
+
+            fn reload(target: &mut Self, value: #toasty::core::stmt::Value) -> #toasty::Result<()> {
+                *target = Self::load(value)?;
+                Ok(())
             }
         }
 

--- a/crates/toasty-macros/src/model/expand/model.rs
+++ b/crates/toasty-macros/src/model/expand/model.rs
@@ -32,14 +32,13 @@ impl Expand<'_> {
         let into_delete_body = self.expand_model_into_delete_body();
         let into_expr_body_ref = self.expand_model_into_expr_body(true);
         let into_expr_body_val = self.expand_model_into_expr_body(false);
-        let reload_method = self.expand_reload_method();
+        let reload_trait_method = self.expand_reload_trait_method();
 
         quote! {
             impl #model_ident {
                 #model_fields
                 #filter_methods
                 #relation_methods
-                #reload_method
 
                 #vis fn create() -> #create_struct_ident {
                     #create_struct_ident::default()
@@ -90,6 +89,8 @@ impl Expand<'_> {
                 fn load(value: #toasty::core::stmt::Value) -> #toasty::Result<Self> {
                     #load_body
                 }
+
+                #reload_trait_method
             }
 
             impl #toasty::Create for #model_ident {
@@ -386,15 +387,15 @@ impl Expand<'_> {
 
                     quote! {
                         #i => {
-                            self.#field_ident = #assign;
+                            target.#field_ident = #assign;
                         }
                     }
                 }
                 FieldTy::Primitive(ty) => {
-                    quote!(#i => <#ty as #toasty::Field>::reload(&mut self.#field_ident, value)?,)
+                    quote!(#i => <#ty as #toasty::Load>::reload(&mut target.#field_ident, value)?,)
                 }
                 _ => {
-                    quote!(#i => self.#field_ident.unload(),)
+                    quote!(#i => target.#field_ident.unload(),)
                 }
             }
         });
@@ -411,7 +412,7 @@ impl Expand<'_> {
                     Ok(())
                 }
                 value => {
-                    *self = <Self as #toasty::Load>::load(value)?;
+                    *target = <Self as #toasty::Load>::load(value)?;
                     Ok(())
                 }
             }

--- a/crates/toasty-macros/src/model/expand/update.rs
+++ b/crates/toasty-macros/src/model/expand/update.rs
@@ -257,7 +257,7 @@ impl Expand<'_> {
                 }
 
                 fn apply_result(self, value: #toasty::core::stmt::Value) -> #toasty::Result<()> {
-                    self.reload(value)
+                    <#model_ident as #toasty::Load>::reload(self, value)
                 }
             }
 
@@ -349,32 +349,30 @@ impl Expand<'_> {
 
                     quote! {
                         #i => {
-                            self.#field_ident = #assign;
+                            target.#field_ident = #assign;
                         }
                     }
                 }
                 FieldTy::Primitive(ty) => {
-                    quote!(#i => <#ty as #toasty::Field>::reload(&mut self.#field_ident, value)?,)
+                    quote!(#i => <#ty as #toasty::Load>::reload(&mut target.#field_ident, value)?,)
                 }
                 _ => {
                     // Relation fields (BelongsTo, HasMany, HasOne) are unloaded on update.
                     // Embedded fields are handled above via the Primitive arm.
-                    quote!(#i => self.#field_ident.unload(),)
+                    quote!(#i => target.#field_ident.unload(),)
                 }
             }
 
         }).collect()
     }
 
-    /// Generate the body of the `reload` method for a root model.
-    pub(super) fn expand_reload_method(&self) -> TokenStream {
+    /// Generate the `Load::reload` trait method implementation for a root model.
+    pub(super) fn expand_reload_trait_method(&self) -> TokenStream {
         let toasty = &self.toasty;
-        let vis = &self.model.vis;
         let reload_arms = self.expand_reload_match_arms();
 
         quote! {
-            #vis fn reload(&mut self, value: #toasty::core::stmt::Value) -> #toasty::Result<()> {
-                use #toasty::Field;
+            fn reload(target: &mut Self, value: #toasty::core::stmt::Value) -> #toasty::Result<()> {
                 for (field, value) in value.into_sparse_record().into_iter() {
                     match field {
                         #reload_arms

--- a/crates/toasty/src/schema/field.rs
+++ b/crates/toasty/src/schema/field.rs
@@ -20,16 +20,6 @@ pub trait Field: Sized + Load<Output = Self> + ModelField {
     /// For primitives, this will be {Type}Update<'a> once implemented.
     type UpdateBuilder<'a>;
 
-    /// Reload the value in-place from a value returned by the database.
-    ///
-    /// The value may be a `SparseRecord` for partial embedded updates, in which
-    /// case only the specified fields should be updated. Embedded types must
-    /// override this method to handle partial updates correctly.
-    fn reload(&mut self, value: stmt::Value) -> Result<()> {
-        *self = Self::load(value)?;
-        Ok(())
-    }
-
     /// Build a field accessor from a path.
     /// For primitives, returns the path as-is.
     /// For embedded types, wraps the path in a Fields struct.
@@ -61,6 +51,11 @@ macro_rules! impl_field_numeric {
 
                 fn load(value: stmt::Value) -> Result<Self> {
                     value.try_into()
+                }
+
+                fn reload(target: &mut Self, value: stmt::Value) -> Result<()> {
+                    *target = Self::load(value)?;
+                    Ok(())
                 }
             }
 
@@ -101,6 +96,11 @@ impl Load for isize {
     fn load(value: stmt::Value) -> Result<Self> {
         value.try_into()
     }
+
+    fn reload(target: &mut Self, value: stmt::Value) -> Result<()> {
+        *target = Self::load(value)?;
+        Ok(())
+    }
 }
 
 impl ModelField for isize {}
@@ -123,6 +123,11 @@ impl Load for usize {
 
     fn load(value: stmt::Value) -> Result<Self> {
         value.try_into()
+    }
+
+    fn reload(target: &mut Self, value: stmt::Value) -> Result<()> {
+        *target = Self::load(value)?;
+        Ok(())
     }
 }
 
@@ -149,6 +154,11 @@ impl Load for String {
             stmt::Value::String(v) => Ok(v),
             _ => Err(toasty_core::Error::type_conversion(value, "String")),
         }
+    }
+
+    fn reload(target: &mut Self, value: stmt::Value) -> Result<()> {
+        *target = Self::load(value)?;
+        Ok(())
     }
 }
 
@@ -211,6 +221,11 @@ where
     fn load(value: stmt::Value) -> Result<Self> {
         <T::Owned as Load>::load(value).map(Cow::Owned)
     }
+
+    fn reload(target: &mut Self, value: stmt::Value) -> Result<()> {
+        *target = Self::load(value)?;
+        Ok(())
+    }
 }
 
 impl<T> ModelField for Cow<'_, T>
@@ -246,6 +261,11 @@ impl Load for uuid::Uuid {
             _ => Err(toasty_core::Error::type_conversion(value, "uuid::Uuid")),
         }
     }
+
+    fn reload(target: &mut Self, value: stmt::Value) -> Result<()> {
+        *target = Self::load(value)?;
+        Ok(())
+    }
 }
 
 impl ModelField for uuid::Uuid {}
@@ -272,6 +292,11 @@ impl Load for bool {
             _ => Err(toasty_core::Error::type_conversion(value, "bool")),
         }
     }
+
+    fn reload(target: &mut Self, value: stmt::Value) -> Result<()> {
+        *target = Self::load(value)?;
+        Ok(())
+    }
 }
 
 impl ModelField for bool {}
@@ -294,6 +319,11 @@ impl<T: Field> Load for Arc<T> {
 
     fn load(value: stmt::Value) -> Result<Self> {
         <T as Load>::load(value).map(Arc::new)
+    }
+
+    fn reload(target: &mut Self, value: stmt::Value) -> Result<()> {
+        *target = Self::load(value)?;
+        Ok(())
     }
 }
 
@@ -318,6 +348,11 @@ impl<T: Field> Load for Rc<T> {
     fn load(value: stmt::Value) -> Result<Self> {
         <T as Load>::load(value).map(Rc::new)
     }
+
+    fn reload(target: &mut Self, value: stmt::Value) -> Result<()> {
+        *target = Self::load(value)?;
+        Ok(())
+    }
 }
 
 impl<T: Field> ModelField for Rc<T> {}
@@ -340,6 +375,11 @@ impl<T: Field> Load for Box<T> {
 
     fn load(value: stmt::Value) -> Result<Self> {
         <T as Load>::load(value).map(Box::new)
+    }
+
+    fn reload(target: &mut Self, value: stmt::Value) -> Result<()> {
+        *target = Self::load(value)?;
+        Ok(())
     }
 }
 
@@ -370,6 +410,11 @@ impl Load for rust_decimal::Decimal {
                 "rust_decimal::Decimal",
             )),
         }
+    }
+
+    fn reload(target: &mut Self, value: stmt::Value) -> Result<()> {
+        *target = Self::load(value)?;
+        Ok(())
     }
 }
 
@@ -402,6 +447,11 @@ impl Load for bigdecimal::BigDecimal {
                 "bigdecimal::BigDecimal",
             )),
         }
+    }
+
+    fn reload(target: &mut Self, value: stmt::Value) -> Result<()> {
+        *target = Self::load(value)?;
+        Ok(())
     }
 }
 

--- a/crates/toasty/src/schema/field_jiff.rs
+++ b/crates/toasty/src/schema/field_jiff.rs
@@ -20,6 +20,11 @@ macro_rules! impl_jiff_field {
                     _ => Err(toasty_core::Error::type_conversion(value, $lit)),
                 }
             }
+
+            fn reload(target: &mut Self, value: Value) -> Result<()> {
+                *target = Self::load(value)?;
+                Ok(())
+            }
         }
 
         impl ModelField for $ty {}

--- a/crates/toasty/src/schema/load.rs
+++ b/crates/toasty/src/schema/load.rs
@@ -28,6 +28,23 @@ pub trait Load {
     fn load_relation(value: stmt::Value) -> Result<Self::Output, Error> {
         Self::load(value)
     }
+
+    /// Reload the value in-place from a value returned by the database.
+    ///
+    /// The value may be a `SparseRecord` for partial embedded updates, in which
+    /// case only the specified fields should be updated. Embedded types must
+    /// override this method to handle partial updates correctly.
+    ///
+    /// Takes `&mut Self::Output` rather than `&mut self` so that wrapper types
+    /// like `Option<T>` can implement reload generically regardless of whether
+    /// `T::Output == T`.
+    ///
+    /// The default implementation panics. Types that support reloading (i.e.,
+    /// types that implement [`Field`]) should override this.
+    fn reload(target: &mut Self::Output, value: stmt::Value) -> Result<(), Error> {
+        let _ = (target, value);
+        unimplemented!("reload is not supported for this type")
+    }
 }
 
 impl Load for () {
@@ -62,6 +79,11 @@ impl<T: Load<Output = T>> Load for Vec<T> {
                 .collect(),
             _ => Err(Error::type_conversion(value, "Vec<T>")),
         }
+    }
+
+    fn reload(target: &mut Self::Output, value: stmt::Value) -> Result<(), Error> {
+        *target = Self::load(value)?;
+        Ok(())
     }
 }
 

--- a/crates/toasty/src/schema/option.rs
+++ b/crates/toasty/src/schema/option.rs
@@ -41,6 +41,11 @@ impl<T: Load> Load for Option<T> {
             v => Ok(Some(T::load(v)?)),
         }
     }
+
+    fn reload(target: &mut Self::Output, value: Value) -> Result<(), crate::Error> {
+        *target = Self::load(value)?;
+        Ok(())
+    }
 }
 
 impl<T: Relation> Create for Option<T> {

--- a/tests/tests/ui/relation_has_one_requires_attr.stderr
+++ b/tests/tests/ui/relation_has_one_requires_attr.stderr
@@ -16,23 +16,6 @@ error[E0277]: the trait bound `toasty::HasOne<Option<Profile>>: toasty::schema::
           and $N others
   = note: this error originates in the derive macro `toasty::Model` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `toasty::HasOne<Option<Profile>>: toasty::schema::Field` is not satisfied
- --> tests/ui/relation_has_one_requires_attr.rs:7:14
-  |
-7 |     profile: toasty::HasOne<Option<Profile>>,
-  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `toasty::schema::Field` is not implemented for `toasty::HasOne<Option<Profile>>`
-  |
-  = help: the following other types implement trait `toasty::schema::Field`:
-            Arc<T>
-            Box<T>
-            Cow<'_, T>
-            Option<T>
-            Rc<T>
-            Vec<u8>
-            bigdecimal::BigDecimal
-            bool
-          and $N others
-
 error[E0277]: the trait bound `toasty::HasOne<Option<Profile>>: ModelField` is not satisfied
  --> tests/ui/relation_has_one_requires_attr.rs:7:14
   |
@@ -74,3 +57,20 @@ note: required by a bound in `make_field_accessor`
 ...
   |     fn make_field_accessor<Origin>(path: Path<Origin, Self>) -> Self::FieldAccessor<Origin>;
   |        ------------------- required by a bound in this associated function
+
+error[E0277]: the trait bound `toasty::HasOne<Option<Profile>>: toasty::schema::Field` is not satisfied
+ --> tests/ui/relation_has_one_requires_attr.rs:7:14
+  |
+7 |     profile: toasty::HasOne<Option<Profile>>,
+  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `toasty::schema::Field` is not implemented for `toasty::HasOne<Option<Profile>>`
+  |
+  = help: the following other types implement trait `toasty::schema::Field`:
+            Arc<T>
+            Box<T>
+            Cow<'_, T>
+            Option<T>
+            Rc<T>
+            Vec<u8>
+            bigdecimal::BigDecimal
+            bool
+          and $N others


### PR DESCRIPTION
Move the `reload` method from the `Field` trait to the `Load` trait,
where it semantically belongs alongside `load`. The method is now a
static function taking `&mut Self::Output` instead of `&mut self`,
which allows wrapper types like `Option<T>` to implement reload
generically without requiring `T::Output == T`.

- Add `reload(target: &mut Self::Output, ...)` to `Load` with a
  panicking default for types that don't support reloading
- Remove `reload` from `Field` trait entirely
- Add `reload` overrides to all `Load` impls with `Output = Self`
- Move embedded model reload from `Field` impl to `Load` impl
- Replace root model inherent `reload` method with `Load::reload`
  trait method
- Update all generated code to call `Load::reload` instead of
  `Field::reload`

https://claude.ai/code/session_01WamTbg7DWMNdrCKisvd2NJ