### PR TITLE
refactor: remove Load and ModelField supertraits from Field trait

### DIFF
--- a/crates/toasty/src/schema/field.rs
+++ b/crates/toasty/src/schema/field.rs
@@ -9,7 +9,7 @@ use crate::{
 use std::borrow::Cow;
 use toasty_core::stmt;
 
-pub trait Field: Sized + Load<Output = Self> + ModelField {
+pub trait Field: Sized {
     /// The type returned when accessing this field from a Fields struct.
     /// For primitives, this is Path<Origin, Self>.
     /// For embedded types, this is {Type}Fields<Origin>.

--- a/tests/tests/ui/relation_has_one_requires_attr.stderr
+++ b/tests/tests/ui/relation_has_one_requires_attr.stderr
@@ -33,31 +33,6 @@ error[E0277]: the trait bound `toasty::HasOne<Option<Profile>>: ModelField` is n
             bool
           and $N others
 
-error[E0277]: the trait bound `toasty::HasOne<Option<Profile>>: ModelField` is not satisfied
- --> tests/ui/relation_has_one_requires_attr.rs:7:14
-  |
-7 |     profile: toasty::HasOne<Option<Profile>>,
-  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `ModelField` is not implemented for `toasty::HasOne<Option<Profile>>`
-  |
-  = help: the following other types implement trait `ModelField`:
-            Arc<T>
-            Box<T>
-            Cow<'_, T>
-            Option<T>
-            Rc<T>
-            Vec<u8>
-            bigdecimal::BigDecimal
-            bool
-          and $N others
-note: required by a bound in `make_field_accessor`
- --> $WORKSPACE/crates/toasty/src/schema/field.rs
-  |
-  | pub trait Field: Sized + Load<Output = Self> + ModelField {
-  |                                                ^^^^^^^^^^ required by this bound in `Field::make_field_accessor`
-...
-  |     fn make_field_accessor<Origin>(path: Path<Origin, Self>) -> Self::FieldAccessor<Origin>;
-  |        ------------------- required by a bound in this associated function
-
 error[E0277]: the trait bound `toasty::HasOne<Option<Profile>>: toasty::schema::Field` is not satisfied
  --> tests/ui/relation_has_one_requires_attr.rs:7:14
   |


### PR DESCRIPTION
The Field trait no longer extends Load<Output = Self> + ModelField.
All macro-generated code already uses explicit trait qualification
(e.g., <T as Load>::load(), <T as ModelField>::field_ty()) so these
supertraits were not actually required by any generic bounds.

https://claude.ai/code/session_01DoNoKLavvyb17BFMqS9fRe