### PR TITLE
refactor: rename PoolConnection to Connection and move to db/connection.rs

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/infra_connection_per_clone.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/infra_connection_per_clone.rs
@@ -48,7 +48,7 @@ pub async fn clone_acquires_separate_connection(t: &mut Test) -> Result<()> {
     drop(db2);
 
     // The background task needs a moment to notice the channel closed and exit,
-    // which drops the PoolConnection and returns it to the pool.
+    // which drops the Connection and returns it to the pool.
     tokio::task::yield_now().await;
 
     let status = db.pool().status();

--- a/crates/toasty/src/db.rs
+++ b/crates/toasty/src/db.rs
@@ -1,13 +1,16 @@
 mod builder;
 mod connect;
+mod connection;
 mod executor;
 mod pool;
 mod tx;
 
 pub use builder::Builder;
-pub use connect::{Capability, Connect, Driver};
+pub use connect::Connect;
+pub use connection::Connection;
 pub use executor::Executor;
-pub use pool::{Pool, PoolConfig, PoolConnection, PoolStatus, Timeouts};
+pub use pool::{Pool, PoolConfig, PoolStatus, Timeouts};
+pub use toasty_core::driver::{Capability, Driver};
 pub use tx::{Transaction, TransactionBuilder};
 
 pub(crate) use pool::{ConnectionHandle, ConnectionOperation};
@@ -36,7 +39,7 @@ pub(crate) struct Shared {
 /// back to the pool.
 pub struct Db {
     shared: Arc<Shared>,
-    pub(crate) connection: Option<PoolConnection>,
+    pub(crate) connection: Option<Connection>,
 }
 
 impl Clone for Db {

--- a/crates/toasty/src/db/connect.rs
+++ b/crates/toasty/src/db/connect.rs
@@ -2,7 +2,7 @@ use crate::Result;
 
 use async_trait::async_trait;
 use std::borrow::Cow;
-pub use toasty_core::driver::{Capability, Driver};
+use toasty_core::driver::{Capability, Driver};
 use toasty_core::{
     driver::Connection,
     schema::db::{Migration, SchemaDiff},

--- a/crates/toasty/src/db/connection.rs
+++ b/crates/toasty/src/db/connection.rs
@@ -1,0 +1,15 @@
+use super::pool::{ConnectionHandle, Manager};
+
+/// A connection retrieved from a pool.
+///
+/// When dropped, the connection is returned to the pool for reuse.
+pub struct Connection {
+    pub(super) inner: deadpool::managed::Object<Manager>,
+}
+
+impl Connection {
+    /// Access the underlying connection handle.
+    pub(crate) fn handle(&self) -> &ConnectionHandle {
+        &self.inner
+    }
+}

--- a/crates/toasty/src/db/pool.rs
+++ b/crates/toasty/src/db/pool.rs
@@ -105,13 +105,13 @@ impl Pool {
     }
 
     /// Retrieves a connection from the pool.
-    pub async fn get(&self) -> crate::Result<PoolConnection> {
+    pub async fn get(&self) -> crate::Result<super::Connection> {
         let connection = self
             .inner
             .get()
             .await
             .map_err(toasty_core::Error::connection_pool)?;
-        Ok(PoolConnection { inner: connection })
+        Ok(super::Connection { inner: connection })
     }
 
     /// Returns the database driver this pool uses to create connections.
@@ -137,7 +137,7 @@ impl Pool {
     }
 }
 
-struct Manager {
+pub(super) struct Manager {
     driver: Box<dyn Driver>,
     engine: Engine,
 }
@@ -232,18 +232,4 @@ pub struct PoolStatus {
 
     /// The number of tasks waiting for a connection to become available.
     pub waiting: usize,
-}
-
-/// A connection retrieved from a pool.
-///
-/// When dropped, the connection is returned to the pool for reuse.
-pub struct PoolConnection {
-    inner: deadpool::managed::Object<Manager>,
-}
-
-impl PoolConnection {
-    /// Access the underlying connection handle.
-    pub(crate) fn handle(&self) -> &ConnectionHandle {
-        &self.inner
-    }
 }


### PR DESCRIPTION
Re-export Capability and Driver directly from toasty_core::driver
instead of passing through db::connect.

https://claude.ai/code/session_01JjSTMWKjhspA9aDXRV3BMG