### PR TITLE
feat: add Path<Origin> associated type and new_path/new_root_path methods to Model trait

### DIFF
--- a/crates/toasty-macros/src/model/expand/model.rs
+++ b/crates/toasty-macros/src/model/expand/model.rs
@@ -105,6 +105,11 @@ impl Expand<'_> {
                 type Create = #create_struct_ident;
                 type Update<'a> = #update_struct_ident<&'a mut Self>;
                 type UpdateQuery = #update_struct_ident;
+                type Path<__Origin> = #field_struct_ident<__Origin>;
+
+                fn new_path<__Origin>(path: #toasty::Path<__Origin, Self>) -> Self::Path<__Origin> {
+                    #field_struct_ident::from_path(path)
+                }
             }
 
             impl #toasty::Relation for #model_ident {

--- a/crates/toasty/src/schema/model.rs
+++ b/crates/toasty/src/schema/model.rs
@@ -1,5 +1,5 @@
 use super::{Load, Register};
-use crate::stmt::{IntoExpr, IntoInsert};
+use crate::stmt::{IntoExpr, IntoInsert, Path};
 
 /// Trait for root models that map to database tables and can be queried.
 ///
@@ -18,6 +18,17 @@ pub trait Model: Register + Load<Output = Self> + Sized {
 
     /// Update by query builder type for this model
     type UpdateQuery;
+
+    /// A typed path from `Origin` into this model.
+    type Path<Origin>;
+
+    /// Construct a model path from a [`Path`] targeting this model.
+    fn new_path<Origin>(path: Path<Origin, Self>) -> Self::Path<Origin>;
+
+    /// Construct a path rooted at this model.
+    fn new_root_path() -> Self::Path<Self> {
+        Self::new_path(Path::root())
+    }
 
     /// Return a fresh, default-initialized create builder.
     fn new_create() -> Self::Create {


### PR DESCRIPTION
These match the items by the same name on Scope, giving Model a consistent
way to construct typed paths.

https://claude.ai/code/session_01CfJQkqrvEV7HSN6AFCf43F