### PR TITLE
fix: wrap One and OptionOne query structs with correct single-result types

### DIFF
--- a/crates/toasty-macros/src/model/expand/model.rs
+++ b/crates/toasty-macros/src/model/expand/model.rs
@@ -122,12 +122,13 @@ impl Expand<'_> {
                 type One = One;
                 type OneField<__Origin> = #field_struct_ident<__Origin>;
                 type OptionOne = OptionOne;
-                type NarrowQuery = #model_ident;
 
-                fn narrow_query(
-                    query: #toasty::stmt::Query<#toasty::List<Self::Model>>,
-                ) -> #toasty::stmt::Query<Self::NarrowQuery> {
-                    query.one()
+                fn one_from_query(query: #toasty::stmt::Query<#toasty::List<Self::Model>>) -> Self::One {
+                    One::from_stmt(query.one())
+                }
+
+                fn option_one_from_query(query: #toasty::stmt::Query<#toasty::List<Self::Model>>) -> Self::OptionOne {
+                    OptionOne::from_stmt(query.first())
                 }
 
                 fn new_many_field<__Origin>(

--- a/crates/toasty-macros/src/model/expand/model.rs
+++ b/crates/toasty-macros/src/model/expand/model.rs
@@ -122,6 +122,13 @@ impl Expand<'_> {
                 type One = One;
                 type OneField<__Origin> = #field_struct_ident<__Origin>;
                 type OptionOne = OptionOne;
+                type NarrowQuery = #model_ident;
+
+                fn narrow_query(
+                    query: #toasty::stmt::Query<#toasty::List<Self::Model>>,
+                ) -> #toasty::stmt::Query<Self::NarrowQuery> {
+                    query.one()
+                }
 
                 fn new_many_field<__Origin>(
                     path: #toasty::Path<__Origin, #toasty::List<Self::Model>>,

--- a/crates/toasty-macros/src/model/expand/relation.rs
+++ b/crates/toasty-macros/src/model/expand/relation.rs
@@ -79,10 +79,6 @@ impl Expand<'_> {
                     One { stmt }
                 }
 
-                #vis fn from_list_query(stmt: #toasty::stmt::Query<#toasty::List<#model_ident>>) -> One {
-                    One::from_stmt(stmt.one())
-                }
-
                 /// Create a new associated record
                 #vis fn create(self) -> #create_builder_ident {
                     let mut builder = #create_builder_ident::default();
@@ -107,10 +103,6 @@ impl Expand<'_> {
             impl OptionOne {
                 pub fn from_stmt(stmt: #toasty::stmt::Query<#toasty::Option<#model_ident>>) -> OptionOne {
                     OptionOne { stmt }
-                }
-
-                pub fn from_list_query(stmt: #toasty::stmt::Query<#toasty::List<#model_ident>>) -> OptionOne {
-                    OptionOne::from_stmt(stmt.first())
                 }
 
                 /// Create a new associated record
@@ -193,8 +185,10 @@ impl Expand<'_> {
 
                 {
                     use #toasty::IntoStatement;
-                    <#ty as #toasty::Relation>::One::from_list_query(
-                        <#ty as #toasty::Relation>::Model::filter(#filter).into_statement().into_query().unwrap()
+                    <#ty as #toasty::Relation>::One::from_stmt(
+                        <#ty as #toasty::Relation>::narrow_query(
+                            <#ty as #toasty::Relation>::Model::filter(#filter).into_statement().into_query().unwrap()
+                        )
                     )
                 }
             }
@@ -351,11 +345,13 @@ impl Expand<'_> {
 
                 {
                     use #toasty::IntoStatement;
-                    <#ty as #toasty::Relation>::One::from_list_query(
-                        #toasty::stmt::Association::one(
-                            self.into_statement().into_query().unwrap().to_list(),
-                            Self::fields().#field_ident().into()
-                        ).into_statement().into_query().unwrap()
+                    <#ty as #toasty::Relation>::One::from_stmt(
+                        <#ty as #toasty::Relation>::narrow_query(
+                            #toasty::stmt::Association::one(
+                                self.into_statement().into_query().unwrap().to_list(),
+                                Self::fields().#field_ident().into()
+                            ).into_statement().into_query().unwrap()
+                        )
                     )
                 }
             }

--- a/crates/toasty-macros/src/model/expand/relation.rs
+++ b/crates/toasty-macros/src/model/expand/relation.rs
@@ -185,10 +185,8 @@ impl Expand<'_> {
 
                 {
                     use #toasty::IntoStatement;
-                    <#ty as #toasty::Relation>::One::from_stmt(
-                        <#ty as #toasty::Relation>::narrow_query(
-                            <#ty as #toasty::Relation>::Model::filter(#filter).into_statement().into_query().unwrap()
-                        )
+                    <#ty as #toasty::Relation>::one_from_query(
+                        <#ty as #toasty::Relation>::Model::filter(#filter).into_statement().into_query().unwrap()
                     )
                 }
             }
@@ -345,13 +343,11 @@ impl Expand<'_> {
 
                 {
                     use #toasty::IntoStatement;
-                    <#ty as #toasty::Relation>::One::from_stmt(
-                        <#ty as #toasty::Relation>::narrow_query(
-                            #toasty::stmt::Association::one(
-                                self.into_statement().into_query().unwrap().to_list(),
-                                Self::fields().#field_ident().into()
-                            ).into_statement().into_query().unwrap()
-                        )
+                    <#ty as #toasty::Relation>::one_from_query(
+                        #toasty::stmt::Association::one(
+                            self.into_statement().into_query().unwrap().to_list(),
+                            Self::fields().#field_ident().into()
+                        ).into_statement().into_query().unwrap()
                     )
                 }
             }

--- a/crates/toasty-macros/src/model/expand/relation.rs
+++ b/crates/toasty-macros/src/model/expand/relation.rs
@@ -75,8 +75,12 @@ impl Expand<'_> {
             }
 
             impl One {
-                #vis fn from_stmt(stmt: #toasty::stmt::Query<#toasty::List<#model_ident>>) -> One {
-                    One { stmt: stmt.one() }
+                #vis fn from_stmt(stmt: #toasty::stmt::Query<#model_ident>) -> One {
+                    One { stmt }
+                }
+
+                #vis fn from_list_query(stmt: #toasty::stmt::Query<#toasty::List<#model_ident>>) -> One {
+                    One::from_stmt(stmt.one())
                 }
 
                 /// Create a new associated record
@@ -101,8 +105,12 @@ impl Expand<'_> {
             }
 
             impl OptionOne {
-                pub fn from_stmt(stmt: #toasty::stmt::Query<#toasty::List<#model_ident>>) -> OptionOne {
-                    OptionOne { stmt: stmt.first() }
+                pub fn from_stmt(stmt: #toasty::stmt::Query<#toasty::Option<#model_ident>>) -> OptionOne {
+                    OptionOne { stmt }
+                }
+
+                pub fn from_list_query(stmt: #toasty::stmt::Query<#toasty::List<#model_ident>>) -> OptionOne {
+                    OptionOne::from_stmt(stmt.first())
                 }
 
                 /// Create a new associated record
@@ -185,7 +193,7 @@ impl Expand<'_> {
 
                 {
                     use #toasty::IntoStatement;
-                    <#ty as #toasty::Relation>::One::from_stmt(
+                    <#ty as #toasty::Relation>::One::from_list_query(
                         <#ty as #toasty::Relation>::Model::filter(#filter).into_statement().into_query().unwrap()
                     )
                 }
@@ -343,7 +351,7 @@ impl Expand<'_> {
 
                 {
                     use #toasty::IntoStatement;
-                    <#ty as #toasty::Relation>::One::from_stmt(
+                    <#ty as #toasty::Relation>::One::from_list_query(
                         #toasty::stmt::Association::one(
                             self.into_statement().into_query().unwrap().to_list(),
                             Self::fields().#field_ident().into()

--- a/crates/toasty-macros/src/model/expand/relation.rs
+++ b/crates/toasty-macros/src/model/expand/relation.rs
@@ -19,11 +19,11 @@ impl Expand<'_> {
             }
 
             #vis struct One {
-                stmt: #toasty::stmt::Query<#toasty::List<#model_ident>>,
+                stmt: #toasty::stmt::Query<#model_ident>,
             }
 
             #vis struct OptionOne {
-                stmt: #toasty::stmt::Query<#toasty::List<#model_ident>>,
+                stmt: #toasty::stmt::Query<#toasty::Option<#model_ident>>,
             }
 
             impl Many {
@@ -76,25 +76,25 @@ impl Expand<'_> {
 
             impl One {
                 #vis fn from_stmt(stmt: #toasty::stmt::Query<#toasty::List<#model_ident>>) -> One {
-                    One { stmt }
+                    One { stmt: stmt.one() }
                 }
 
                 /// Create a new associated record
                 #vis fn create(self) -> #create_builder_ident {
                     let mut builder = #create_builder_ident::default();
-                    builder.stmt.set_scope(self.stmt);
+                    builder.stmt.set_scope(self.stmt.to_list());
                     builder
                 }
 
                 #vis async fn exec(self, executor: &mut dyn #toasty::Executor) -> #toasty::Result<#model_ident> {
-                    self.stmt.one().exec(executor).await
+                    self.stmt.exec(executor).await
                 }
             }
 
             impl #toasty::IntoStatement for One {
-                type Returning = #toasty::List<#model_ident>;
+                type Returning = #model_ident;
 
-                fn into_statement(self) -> #toasty::Statement<#toasty::List<#model_ident>> {
+                fn into_statement(self) -> #toasty::Statement<#model_ident> {
                     use #toasty::IntoStatement;
                     self.stmt.into_statement()
                 }
@@ -102,18 +102,18 @@ impl Expand<'_> {
 
             impl OptionOne {
                 pub fn from_stmt(stmt: #toasty::stmt::Query<#toasty::List<#model_ident>>) -> OptionOne {
-                    OptionOne { stmt }
+                    OptionOne { stmt: stmt.first() }
                 }
 
                 /// Create a new associated record
                 #vis fn create(self) -> #create_builder_ident {
                     let mut builder = #create_builder_ident::default();
-                    builder.stmt.set_scope(self.stmt);
+                    builder.stmt.set_scope(self.stmt.into_rows());
                     builder
                 }
 
                 #vis async fn exec(self, executor: &mut dyn #toasty::Executor) -> #toasty::Result<#toasty::Option<#model_ident>> {
-                    self.stmt.first().exec(executor).await
+                    self.stmt.exec(executor).await
                 }
             }
         }

--- a/crates/toasty/src/schema/belongs_to.rs
+++ b/crates/toasty/src/schema/belongs_to.rs
@@ -66,12 +66,15 @@ impl<T: Relation> Relation for BelongsTo<T> {
     type One = T::One;
     type OneField<__Origin> = T::OneField<__Origin>;
     type OptionOne = T::OptionOne;
-    type NarrowQuery = T::NarrowQuery;
 
-    fn narrow_query(
+    fn one_from_query(query: crate::stmt::Query<crate::stmt::List<Self::Model>>) -> Self::One {
+        T::one_from_query(query)
+    }
+
+    fn option_one_from_query(
         query: crate::stmt::Query<crate::stmt::List<Self::Model>>,
-    ) -> crate::stmt::Query<Self::NarrowQuery> {
-        T::narrow_query(query)
+    ) -> Self::OptionOne {
+        T::option_one_from_query(query)
     }
 
     fn new_many_field<__Origin>(

--- a/crates/toasty/src/schema/belongs_to.rs
+++ b/crates/toasty/src/schema/belongs_to.rs
@@ -66,6 +66,13 @@ impl<T: Relation> Relation for BelongsTo<T> {
     type One = T::One;
     type OneField<__Origin> = T::OneField<__Origin>;
     type OptionOne = T::OptionOne;
+    type NarrowQuery = T::NarrowQuery;
+
+    fn narrow_query(
+        query: crate::stmt::Query<crate::stmt::List<Self::Model>>,
+    ) -> crate::stmt::Query<Self::NarrowQuery> {
+        T::narrow_query(query)
+    }
 
     fn new_many_field<__Origin>(
         path: crate::stmt::Path<__Origin, crate::stmt::List<Self::Model>>,

--- a/crates/toasty/src/schema/has_many.rs
+++ b/crates/toasty/src/schema/has_many.rs
@@ -79,6 +79,13 @@ impl<T: Relation> Relation for HasMany<T> {
     type One = T::One;
     type OneField<__Origin> = T::OneField<__Origin>;
     type OptionOne = T::OptionOne;
+    type NarrowQuery = T::NarrowQuery;
+
+    fn narrow_query(
+        query: crate::stmt::Query<crate::stmt::List<Self::Model>>,
+    ) -> crate::stmt::Query<Self::NarrowQuery> {
+        T::narrow_query(query)
+    }
 
     fn new_many_field<__Origin>(
         path: crate::stmt::Path<__Origin, crate::stmt::List<Self::Model>>,

--- a/crates/toasty/src/schema/has_many.rs
+++ b/crates/toasty/src/schema/has_many.rs
@@ -79,12 +79,15 @@ impl<T: Relation> Relation for HasMany<T> {
     type One = T::One;
     type OneField<__Origin> = T::OneField<__Origin>;
     type OptionOne = T::OptionOne;
-    type NarrowQuery = T::NarrowQuery;
 
-    fn narrow_query(
+    fn one_from_query(query: crate::stmt::Query<crate::stmt::List<Self::Model>>) -> Self::One {
+        T::one_from_query(query)
+    }
+
+    fn option_one_from_query(
         query: crate::stmt::Query<crate::stmt::List<Self::Model>>,
-    ) -> crate::stmt::Query<Self::NarrowQuery> {
-        T::narrow_query(query)
+    ) -> Self::OptionOne {
+        T::option_one_from_query(query)
     }
 
     fn new_many_field<__Origin>(

--- a/crates/toasty/src/schema/has_one.rs
+++ b/crates/toasty/src/schema/has_one.rs
@@ -66,6 +66,13 @@ impl<T: Relation> Relation for HasOne<T> {
     type One = T::One;
     type OneField<__Origin> = T::OneField<__Origin>;
     type OptionOne = T::OptionOne;
+    type NarrowQuery = T::NarrowQuery;
+
+    fn narrow_query(
+        query: crate::stmt::Query<crate::stmt::List<Self::Model>>,
+    ) -> crate::stmt::Query<Self::NarrowQuery> {
+        T::narrow_query(query)
+    }
 
     fn new_many_field<__Origin>(
         path: crate::stmt::Path<__Origin, crate::stmt::List<Self::Model>>,

--- a/crates/toasty/src/schema/has_one.rs
+++ b/crates/toasty/src/schema/has_one.rs
@@ -66,12 +66,15 @@ impl<T: Relation> Relation for HasOne<T> {
     type One = T::One;
     type OneField<__Origin> = T::OneField<__Origin>;
     type OptionOne = T::OptionOne;
-    type NarrowQuery = T::NarrowQuery;
 
-    fn narrow_query(
+    fn one_from_query(query: crate::stmt::Query<crate::stmt::List<Self::Model>>) -> Self::One {
+        T::one_from_query(query)
+    }
+
+    fn option_one_from_query(
         query: crate::stmt::Query<crate::stmt::List<Self::Model>>,
-    ) -> crate::stmt::Query<Self::NarrowQuery> {
-        T::narrow_query(query)
+    ) -> Self::OptionOne {
+        T::option_one_from_query(query)
     }
 
     fn new_many_field<__Origin>(

--- a/crates/toasty/src/schema/option.rs
+++ b/crates/toasty/src/schema/option.rs
@@ -1,5 +1,4 @@
 use super::{Load, Relation};
-use crate::stmt::Query;
 use toasty_core::schema::app::FieldId;
 use toasty_core::stmt::{self, Value};
 
@@ -59,10 +58,15 @@ impl<T: Relation> Relation for Option<T> {
     type One = T::OptionOne;
     type OneField<__Origin> = T::OneField<__Origin>;
     type OptionOne = T::OptionOne;
-    type NarrowQuery = Option<T::Model>;
 
-    fn narrow_query(query: Query<crate::stmt::List<Self::Model>>) -> Query<Self::NarrowQuery> {
-        query.first()
+    fn one_from_query(query: crate::stmt::Query<crate::stmt::List<Self::Model>>) -> Self::One {
+        T::option_one_from_query(query)
+    }
+
+    fn option_one_from_query(
+        query: crate::stmt::Query<crate::stmt::List<Self::Model>>,
+    ) -> Self::OptionOne {
+        T::option_one_from_query(query)
     }
 
     fn new_many_field<__Origin>(

--- a/crates/toasty/src/schema/option.rs
+++ b/crates/toasty/src/schema/option.rs
@@ -1,4 +1,5 @@
 use super::{Load, Relation};
+use crate::stmt::Query;
 use toasty_core::schema::app::FieldId;
 use toasty_core::stmt::{self, Value};
 
@@ -58,6 +59,11 @@ impl<T: Relation> Relation for Option<T> {
     type One = T::OptionOne;
     type OneField<__Origin> = T::OneField<__Origin>;
     type OptionOne = T::OptionOne;
+    type NarrowQuery = Option<T::Model>;
+
+    fn narrow_query(query: Query<crate::stmt::List<Self::Model>>) -> Query<Self::NarrowQuery> {
+        query.first()
+    }
 
     fn new_many_field<__Origin>(
         path: crate::stmt::Path<__Origin, crate::stmt::List<Self::Model>>,

--- a/crates/toasty/src/schema/relation.rs
+++ b/crates/toasty/src/schema/relation.rs
@@ -42,16 +42,15 @@ pub trait Relation: Load<Output = Self> {
     /// is nullable, making the association optional.
     type OptionOne;
 
-    /// The element type produced when narrowing a `Query<List<Model>>` to a
-    /// single-result query. For a required relation this is `Model`; for an
-    /// optional relation (`Option<Model>`) this is `Option<Model>`.
-    type NarrowQuery;
-
-    /// Narrow a list query into a single-result query.
+    /// Construct a [`One`](Self::One) from a list query.
     ///
-    /// Required relations narrow via `.one()`, optional relations via
-    /// `.first()`.
-    fn narrow_query(query: Query<List<Self::Model>>) -> Query<Self::NarrowQuery>;
+    /// Narrows via `.one()` and wraps in the `One` struct.
+    fn one_from_query(query: Query<List<Self::Model>>) -> Self::One;
+
+    /// Construct an [`OptionOne`](Self::OptionOne) from a list query.
+    ///
+    /// Narrows via `.first()` and wraps in the `OptionOne` struct.
+    fn option_one_from_query(query: Query<List<Self::Model>>) -> Self::OptionOne;
 
     /// Return a fresh, default-initialized create builder.
     fn new_create() -> Self::Create {

--- a/crates/toasty/src/schema/relation.rs
+++ b/crates/toasty/src/schema/relation.rs
@@ -1,5 +1,5 @@
 use super::{Load, Model};
-use crate::stmt::{IntoExpr, IntoInsert, List, Path};
+use crate::stmt::{IntoExpr, IntoInsert, List, Path, Query};
 
 use toasty_core::schema::app::FieldId;
 
@@ -41,6 +41,17 @@ pub trait Relation: Load<Output = Self> {
     /// The optional has-one relation wrapper type. Used when the foreign key
     /// is nullable, making the association optional.
     type OptionOne;
+
+    /// The element type produced when narrowing a `Query<List<Model>>` to a
+    /// single-result query. For a required relation this is `Model`; for an
+    /// optional relation (`Option<Model>`) this is `Option<Model>`.
+    type NarrowQuery;
+
+    /// Narrow a list query into a single-result query.
+    ///
+    /// Required relations narrow via `.one()`, optional relations via
+    /// `.first()`.
+    fn narrow_query(query: Query<List<Self::Model>>) -> Query<Self::NarrowQuery>;
 
     /// Return a fresh, default-initialized create builder.
     fn new_create() -> Self::Create {

--- a/crates/toasty/src/stmt/query.rs
+++ b/crates/toasty/src/stmt/query.rs
@@ -343,6 +343,41 @@ impl<T> Query<List<T>> {
     }
 }
 
+impl<T> Query<Option<T>> {
+    /// Widen an optional single-row query back into a list query.
+    ///
+    /// This is the inverse of [`first`](Query::first). The `Option` wrapper is
+    /// stripped: `Query<Option<T>>` becomes `Query<List<T>>`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this query is not a single-row query.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[derive(Debug, toasty::Model)]
+    /// # struct User {
+    /// #     #[key]
+    /// #     id: i64,
+    /// #     name: String,
+    /// # }
+    /// use toasty::stmt::{List, Query};
+    ///
+    /// let q: Query<Option<User>> = Query::<List<User>>::all().first();
+    /// let _list_q: Query<List<User>> = q.into_rows();
+    /// ```
+    pub fn into_rows(mut self) -> Query<List<T>> {
+        assert!(self.untyped.single, "not a single query");
+        self.untyped.single = false;
+
+        Query {
+            untyped: self.untyped,
+            _p: PhantomData,
+        }
+    }
+}
+
 fn set_first(query: &mut stmt::Query) {
     assert!(!query.single, "query is single");
     query.single = true;


### PR DESCRIPTION
One now wraps Query<Model> instead of Query<List<Model>>, and OptionOne
wraps Query<Option<Model>> instead of Query<List<Model>>. The conversion
from list queries happens inside from_stmt via .one() and .first().

Also adds Query<Option<T>>::into_rows() as the inverse of first() to
convert back to Query<List<T>> when needed (e.g., for set_scope in create).

https://claude.ai/code/session_01S16hRm6bWrp2utsfvx1str