### PR TITLE
chore: release v0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,20 +46,20 @@ unsafe_code = "deny"
 
 [workspace.dependencies]
 # Toasty crates
-toasty = { version = "0.3.0", path = "crates/toasty" }
-toasty-cli = { version = "0.3.0", path = "crates/toasty-cli" }
-toasty-core = { version = "0.3.0", path = "crates/toasty-core" }
-toasty-macros = { version = "0.3.0", path = "crates/toasty-macros" }
-toasty-sql = { version = "0.3.0", path = "crates/toasty-sql" }
+toasty = { version = "0.4.0", path = "crates/toasty" }
+toasty-cli = { version = "0.4.0", path = "crates/toasty-cli" }
+toasty-core = { version = "0.4.0", path = "crates/toasty-core" }
+toasty-macros = { version = "0.4.0", path = "crates/toasty-macros" }
+toasty-sql = { version = "0.4.0", path = "crates/toasty-sql" }
 # Driver implementations
-toasty-driver-dynamodb = { version = "0.3.0", path = "crates/toasty-driver-dynamodb" }
-toasty-driver-mysql = { version = "0.3.0", path = "crates/toasty-driver-mysql" }
-toasty-driver-postgresql = { version = "0.3.0", path = "crates/toasty-driver-postgresql" }
-toasty-driver-sqlite = { version = "0.3.0", path = "crates/toasty-driver-sqlite" }
+toasty-driver-dynamodb = { version = "0.4.0", path = "crates/toasty-driver-dynamodb" }
+toasty-driver-mysql = { version = "0.4.0", path = "crates/toasty-driver-mysql" }
+toasty-driver-postgresql = { version = "0.4.0", path = "crates/toasty-driver-postgresql" }
+toasty-driver-sqlite = { version = "0.4.0", path = "crates/toasty-driver-sqlite" }
 
 # Driver integration test suite dependencies
-toasty-driver-integration-suite = { version = "0.3.0", path = "crates/toasty-driver-integration-suite" }
-toasty-driver-integration-suite-macros = { version = "0.3.0", path = "crates/toasty-driver-integration-suite-macros" }
+toasty-driver-integration-suite = { version = "0.4.0", path = "crates/toasty-driver-integration-suite" }
+toasty-driver-integration-suite-macros = { version = "0.4.0", path = "crates/toasty-driver-integration-suite-macros" }
 
 # Other crates
 assert-struct = "0.4.2"

--- a/crates/toasty-cli/Cargo.toml
+++ b/crates/toasty-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-cli"
-version = "0.3.0"
+version = "0.4.0"
 description = "Command-line interface for Toasty schema management"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-core/CHANGELOG.md
+++ b/crates/toasty-core/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/tokio-rs/toasty/compare/toasty-core-v0.3.0...toasty-core-v0.4.0) - 2026-04-11
+
+### Added
+
+- add support for newtype embedded structs ([#634](https://github.com/tokio-rs/toasty/pull/634))
+- auto-discover related models through fields ([#635](https://github.com/tokio-rs/toasty/pull/635))
+
+### Other
+
+- make Error non_exaustive ([#636](https://github.com/tokio-rs/toasty/pull/636))
+- make FieldName::app_name optional to support unnamed fields ([#633](https://github.com/tokio-rs/toasty/pull/633))
+
 ## [0.3.0](https://github.com/tokio-rs/toasty/compare/toasty-core-v0.2.0...toasty-core-v0.3.0) - 2026-04-03
 
 ### Added

--- a/crates/toasty-core/Cargo.toml
+++ b/crates/toasty-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-core"
-version = "0.3.0"
+version = "0.4.0"
 description = "Core types, schema representations, and driver interface for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-dynamodb/CHANGELOG.md
+++ b/crates/toasty-driver-dynamodb/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-dynamodb-v0.3.0...toasty-driver-dynamodb-v0.4.0) - 2026-04-11
+
+### Added
+
+- use on-demand billing for DynamoDB table and GSI creation ([#618](https://github.com/tokio-rs/toasty/pull/618))
+- support unsigned integer primary keys in DynamoDB ([#617](https://github.com/tokio-rs/toasty/pull/617))
+
 ## [0.3.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-dynamodb-v0.2.0...toasty-driver-dynamodb-v0.3.0) - 2026-04-03
 
 ### Other

--- a/crates/toasty-driver-dynamodb/Cargo.toml
+++ b/crates/toasty-driver-dynamodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-dynamodb"
-version = "0.3.0"
+version = "0.4.0"
 description = "Amazon DynamoDB driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-integration-suite-macros/Cargo.toml
+++ b/crates/toasty-driver-integration-suite-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-integration-suite-macros"
-version = "0.3.0"
+version = "0.4.0"
 description = "Proc macros for the Toasty driver integration test suite"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-integration-suite/CHANGELOG.md
+++ b/crates/toasty-driver-integration-suite/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-v0.3.0...toasty-driver-integration-suite-v0.4.0) - 2026-04-11
+
+### Added
+
+- add field shorthand syntax support to create! macro ([#650](https://github.com/tokio-rs/toasty/pull/650))
+- support unsigned integer primary keys in DynamoDB ([#617](https://github.com/tokio-rs/toasty/pull/617))
+- add support for newtype embedded structs ([#634](https://github.com/tokio-rs/toasty/pull/634))
+- auto-discover related models through fields ([#635](https://github.com/tokio-rs/toasty/pull/635))
+- support boxed and smart pointer foreign keys in has_many relations ([#630](https://github.com/tokio-rs/toasty/pull/630))
+
+### Other
+
+- make FieldName::app_name optional to support unnamed fields ([#633](https://github.com/tokio-rs/toasty/pull/633))
+
 ## [0.3.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-v0.2.0...toasty-driver-integration-suite-v0.3.0) - 2026-04-03
 
 ### Added

--- a/crates/toasty-driver-integration-suite/Cargo.toml
+++ b/crates/toasty-driver-integration-suite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-integration-suite"
-version = "0.3.0"
+version = "0.4.0"
 description = "Integration test suite for Toasty database drivers"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-mysql/Cargo.toml
+++ b/crates/toasty-driver-mysql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-mysql"
-version = "0.3.0"
+version = "0.4.0"
 description = "MySQL driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-postgresql/CHANGELOG.md
+++ b/crates/toasty-driver-postgresql/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-postgresql-v0.3.0...toasty-driver-postgresql-v0.4.0) - 2026-04-11
+
+### Added
+
+- add opinionated support for postgres TLS using rustls ([#663](https://github.com/tokio-rs/toasty/pull/663))
+
+### Fixed
+
+- percent encoding in postgres connection strings ([#671](https://github.com/tokio-rs/toasty/pull/671))
+
 ## [0.3.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-postgresql-v0.2.0...toasty-driver-postgresql-v0.3.0) - 2026-04-03
 
 ### Other

--- a/crates/toasty-driver-postgresql/Cargo.toml
+++ b/crates/toasty-driver-postgresql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-postgresql"
-version = "0.3.0"
+version = "0.4.0"
 description = "PostgreSQL driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-sqlite/Cargo.toml
+++ b/crates/toasty-driver-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-sqlite"
-version = "0.3.0"
+version = "0.4.0"
 description = "SQLite driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-macros/CHANGELOG.md
+++ b/crates/toasty-macros/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/tokio-rs/toasty/compare/toasty-macros-v0.3.0...toasty-macros-v0.4.0) - 2026-04-11
+
+### Added
+
+- add field shorthand syntax support to create! macro ([#650](https://github.com/tokio-rs/toasty/pull/650))
+- add support for newtype embedded structs ([#634](https://github.com/tokio-rs/toasty/pull/634))
+- auto-discover related models through fields ([#635](https://github.com/tokio-rs/toasty/pull/635))
+
+### Other
+
+- fix UUID v7 auto-generation strategy code generation ([#646](https://github.com/tokio-rs/toasty/pull/646))
+- make FieldName::app_name optional to support unnamed fields ([#633](https://github.com/tokio-rs/toasty/pull/633))
+
 ## [0.3.0](https://github.com/tokio-rs/toasty/compare/toasty-macros-v0.2.0...toasty-macros-v0.3.0) - 2026-04-03
 
 ### Added

--- a/crates/toasty-macros/Cargo.toml
+++ b/crates/toasty-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-macros"
-version = "0.3.0"
+version = "0.4.0"
 description = "Derive macros for Toasty models and embeds"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-sql/Cargo.toml
+++ b/crates/toasty-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-sql"
-version = "0.3.0"
+version = "0.4.0"
 description = "SQL serialization layer for Toasty database drivers"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty/CHANGELOG.md
+++ b/crates/toasty/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/tokio-rs/toasty/compare/toasty-v0.3.0...toasty-v0.4.0) - 2026-04-11
+
+### Added
+
+- add support for newtype embedded structs ([#634](https://github.com/tokio-rs/toasty/pull/634))
+- auto-discover related models through fields ([#635](https://github.com/tokio-rs/toasty/pull/635))
+- support boxed and smart pointer foreign keys in has_many relations ([#630](https://github.com/tokio-rs/toasty/pull/630))
+
+### Other
+
+- make FieldName::app_name optional to support unnamed fields ([#633](https://github.com/tokio-rs/toasty/pull/633))
+
 ## [0.3.0](https://github.com/tokio-rs/toasty/compare/toasty-v0.2.0...toasty-v0.3.0) - 2026-04-03
 
 ### Added

--- a/crates/toasty/Cargo.toml
+++ b/crates/toasty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty"
-version = "0.3.0"
+version = "0.4.0"
 description = "An async ORM for Rust supporting SQL and NoSQL databases"
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `toasty-core`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `toasty-driver-dynamodb`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `toasty-sql`: 0.3.0 -> 0.4.0
* `toasty-driver-mysql`: 0.3.0 -> 0.4.0
* `toasty-driver-postgresql`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `toasty-driver-sqlite`: 0.3.0 -> 0.4.0
* `toasty-macros`: 0.3.0 -> 0.4.0
* `toasty`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `toasty-cli`: 0.3.0 -> 0.4.0
* `toasty-driver-integration-suite-macros`: 0.3.0 -> 0.4.0
* `toasty-driver-integration-suite`: 0.3.0 -> 0.4.0 (✓ API compatible changes)

### ⚠ `toasty-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field FieldName.app in /tmp/.tmp9uYwU1/toasty/crates/toasty-core/src/schema/app/field.rs:107
  field FieldName.storage in /tmp/.tmp9uYwU1/toasty/crates/toasty-core/src/schema/app/field.rs:110
  field FieldStruct.id in /tmp/.tmp9uYwU1/toasty/crates/toasty-core/src/schema/mapping/field.rs:201

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field app_name of struct FieldName, previously in file /tmp/.tmpVmIEX3/toasty-core/src/schema/app/field.rs:105
  field storage_name of struct FieldName, previously in file /tmp/.tmpVmIEX3/toasty-core/src/schema/app/field.rs:108
```

### ⚠ `toasty-driver-postgresql` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type PostgreSQL is no longer UnwindSafe, in /tmp/.tmp9uYwU1/toasty/crates/toasty-driver-postgresql/src/lib.rs:48
  type PostgreSQL is no longer RefUnwindSafe, in /tmp/.tmp9uYwU1/toasty/crates/toasty-driver-postgresql/src/lib.rs:48
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `toasty-core`

<blockquote>

## [0.4.0](https://github.com/tokio-rs/toasty/compare/toasty-core-v0.3.0...toasty-core-v0.4.0) - 2026-04-11

### Added

- add support for newtype embedded structs ([#634](https://github.com/tokio-rs/toasty/pull/634))
- auto-discover related models through fields ([#635](https://github.com/tokio-rs/toasty/pull/635))

### Other

- make Error non_exaustive ([#636](https://github.com/tokio-rs/toasty/pull/636))
- make FieldName::app_name optional to support unnamed fields ([#633](https://github.com/tokio-rs/toasty/pull/633))
</blockquote>

## `toasty-driver-dynamodb`

<blockquote>

## [0.4.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-dynamodb-v0.3.0...toasty-driver-dynamodb-v0.4.0) - 2026-04-11

### Added

- use on-demand billing for DynamoDB table and GSI creation ([#618](https://github.com/tokio-rs/toasty/pull/618))
- support unsigned integer primary keys in DynamoDB ([#617](https://github.com/tokio-rs/toasty/pull/617))
</blockquote>

## `toasty-sql`

<blockquote>

## [0.3.0](https://github.com/tokio-rs/toasty/compare/toasty-sql-v0.2.0...toasty-sql-v0.3.0) - 2026-04-03

### Other

- push pagination handling into engine ([#610](https://github.com/tokio-rs/toasty/pull/610))
- add badges to README ([#606](https://github.com/tokio-rs/toasty/pull/606))
- update README examples to use create! macro syntax ([#603](https://github.com/tokio-rs/toasty/pull/603))
</blockquote>

## `toasty-driver-mysql`

<blockquote>

## [0.3.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-mysql-v0.2.0...toasty-driver-mysql-v0.3.0) - 2026-04-03

### Other

- signature change on Connection trait ([#626](https://github.com/tokio-rs/toasty/pull/626))
- push pagination handling into engine ([#610](https://github.com/tokio-rs/toasty/pull/610))
- add badges to README ([#606](https://github.com/tokio-rs/toasty/pull/606))
- update README examples to use create! macro syntax ([#603](https://github.com/tokio-rs/toasty/pull/603))
</blockquote>

## `toasty-driver-postgresql`

<blockquote>

## [0.4.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-postgresql-v0.3.0...toasty-driver-postgresql-v0.4.0) - 2026-04-11

### Added

- add opinionated support for postgres TLS using rustls ([#663](https://github.com/tokio-rs/toasty/pull/663))

### Fixed

- percent encoding in postgres connection strings ([#671](https://github.com/tokio-rs/toasty/pull/671))
</blockquote>

## `toasty-driver-sqlite`

<blockquote>

## [0.3.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-sqlite-v0.2.0...toasty-driver-sqlite-v0.3.0) - 2026-04-03

### Other

- signature change on Connection trait ([#626](https://github.com/tokio-rs/toasty/pull/626))
- push pagination handling into engine ([#610](https://github.com/tokio-rs/toasty/pull/610))
- add badges to README ([#606](https://github.com/tokio-rs/toasty/pull/606))
- update README examples to use create! macro syntax ([#603](https://github.com/tokio-rs/toasty/pull/603))
</blockquote>

## `toasty-macros`

<blockquote>

## [0.4.0](https://github.com/tokio-rs/toasty/compare/toasty-macros-v0.3.0...toasty-macros-v0.4.0) - 2026-04-11

### Added

- add field shorthand syntax support to create! macro ([#650](https://github.com/tokio-rs/toasty/pull/650))
- add support for newtype embedded structs ([#634](https://github.com/tokio-rs/toasty/pull/634))
- auto-discover related models through fields ([#635](https://github.com/tokio-rs/toasty/pull/635))

### Other

- fix UUID v7 auto-generation strategy code generation ([#646](https://github.com/tokio-rs/toasty/pull/646))
- make FieldName::app_name optional to support unnamed fields ([#633](https://github.com/tokio-rs/toasty/pull/633))
</blockquote>

## `toasty`

<blockquote>

## [0.4.0](https://github.com/tokio-rs/toasty/compare/toasty-v0.3.0...toasty-v0.4.0) - 2026-04-11

### Added

- add support for newtype embedded structs ([#634](https://github.com/tokio-rs/toasty/pull/634))
- auto-discover related models through fields ([#635](https://github.com/tokio-rs/toasty/pull/635))
- support boxed and smart pointer foreign keys in has_many relations ([#630](https://github.com/tokio-rs/toasty/pull/630))

### Other

- make FieldName::app_name optional to support unnamed fields ([#633](https://github.com/tokio-rs/toasty/pull/633))
</blockquote>

## `toasty-cli`

<blockquote>

## [0.3.0](https://github.com/tokio-rs/toasty/compare/toasty-cli-v0.2.0...toasty-cli-v0.3.0) - 2026-04-03

### Other

- signature change on Connection trait ([#626](https://github.com/tokio-rs/toasty/pull/626))
- add badges to README ([#606](https://github.com/tokio-rs/toasty/pull/606))
- update README examples to use create! macro syntax ([#603](https://github.com/tokio-rs/toasty/pull/603))
</blockquote>

## `toasty-driver-integration-suite-macros`

<blockquote>

## [0.3.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-macros-v0.2.0...toasty-driver-integration-suite-macros-v0.3.0) - 2026-04-03

### Other

- add badges to README ([#606](https://github.com/tokio-rs/toasty/pull/606))
- update README examples to use create! macro syntax ([#603](https://github.com/tokio-rs/toasty/pull/603))
</blockquote>

## `toasty-driver-integration-suite`

<blockquote>

## [0.4.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-v0.3.0...toasty-driver-integration-suite-v0.4.0) - 2026-04-11

### Added

- add field shorthand syntax support to create! macro ([#650](https://github.com/tokio-rs/toasty/pull/650))
- support unsigned integer primary keys in DynamoDB ([#617](https://github.com/tokio-rs/toasty/pull/617))
- add support for newtype embedded structs ([#634](https://github.com/tokio-rs/toasty/pull/634))
- auto-discover related models through fields ([#635](https://github.com/tokio-rs/toasty/pull/635))
- support boxed and smart pointer foreign keys in has_many relations ([#630](https://github.com/tokio-rs/toasty/pull/630))

### Other

- make FieldName::app_name optional to support unnamed fields ([#633](https://github.com/tokio-rs/toasty/pull/633))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).