### PR TITLE
feat: add opinionated support for postgres TLS using rustls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,12 +107,23 @@ jobs:
             options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
         env:
             TOASTY_CONNECTION_URL: postgresql://toasty:toasty@localhost/toasty
+            TOASTY_TEST_POSTGRES_TLS_URL: postgresql://toasty:toasty@localhost:5433/toasty
         steps:
         - uses: actions/checkout@v4
         - uses: dtolnay/rust-toolchain@stable
         - uses: Swatinem/rust-cache@v2
           with:
             save-if: ${{ github.ref == 'refs/heads/main' }}
+        - name: Generate TLS certificates
+          run: mkdir -p tests/tls/certs && tests/tls/generate-certs.sh
+        - name: Start TLS PostgreSQL
+          run: docker compose up -d postgresql-tls
+        - name: Wait for TLS PostgreSQL
+          run: |
+            for i in $(seq 1 30); do
+              docker compose exec postgresql-tls pg_isready -U toasty && break
+              sleep 1
+            done
         - name: cargo test
           run: cargo test --workspace --no-default-features --features postgresql
         - name: cargo run --bin example-hello-toasty

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 docs/guide/book/
 docs/dev/book/
 .idea
+tests/tls/certs/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ rustls = { version = "0.23", default-features = false }
 const-oid = { version = "0.9.6", default-features = false, features = ["db"] }
 sha2 = { version = "0.11", default-features = false }
 x509-cert = { version = "0.2.5", default-features = false, features = ["std"] }
+rustls-platform-verifier = "0.6"
 tokio-stream = { version = "0.1.18", default-features = false }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,11 @@ tempfile = "3.27"
 proptest = "1"
 tokio = { version = "1.50", features = ["full"] }
 tokio-postgres = "0.7.17"
+tokio-rustls = { version = "0.26", default-features = false }
+rustls = { version = "0.23", default-features = false }
+const-oid = { version = "0.9.6", default-features = false, features = ["db"] }
+sha2 = { version = "0.11", default-features = false }
+x509-cert = { version = "0.2.5", default-features = false, features = ["std"] }
 tokio-stream = { version = "0.1.18", default-features = false }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,6 @@ mysql_async = { version = "0.36.2", default-features = false, features = [
 ] }
 pulldown-cmark = { version = "0.13", default-features = false }
 pluralizer = "0.5.0"
-postgres = "0.19.13"
 postgres-types = { version = "0.2.13", features = ["with-uuid-1", "array-impls"] }
 pretty_assertions = "1.4.1"
 proc-macro2 = "1.0.106"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ sha2 = { version = "0.11", default-features = false }
 x509-cert = { version = "0.2.5", default-features = false, features = ["std"] }
 rustls-platform-verifier = "0.6"
 rustls-pemfile = "2"
+rustls-webpki = { version = "0.103", default-features = false, features = ["alloc", "std"] }
 tokio-stream = { version = "0.1.18", default-features = false }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,11 +105,12 @@ proptest = "1"
 tokio = { version = "1.50", features = ["full"] }
 tokio-postgres = "0.7.17"
 tokio-rustls = { version = "0.26", default-features = false }
-rustls = { version = "0.23", default-features = false }
+rustls = { version = "0.23", default-features = false, features = ["std", "ring"] }
 const-oid = { version = "0.9.6", default-features = false, features = ["db"] }
 sha2 = { version = "0.11", default-features = false }
 x509-cert = { version = "0.2.5", default-features = false, features = ["std"] }
 rustls-platform-verifier = "0.6"
+rustls-pemfile = "2"
 tokio-stream = { version = "0.1.18", default-features = false }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,6 +10,7 @@
 #
 # TOASTY_TEST_MYSQL_URL = "mysql://toasty:toasty@localhost:3306/toasty"
 # TOASTY_TEST_POSTGRES_URL = "postgresql://toasty:toasty@localhost:5432/toasty"
+# TOASTY_TEST_POSTGRES_TLS_URL = "postgresql://toasty:toasty@localhost:5433/toasty"
 # TOASTY_TEST_DYNAMODB_URL = "dynamodb://localhost:8000"
 #
 # # DynamoDB specific environment variables
@@ -49,6 +50,39 @@ services:
       POSTGRES_DB: toasty
     ports:
       - "5432:5432"
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "toasty"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  postgresql-tls:
+    image: postgres:17
+    environment:
+      POSTGRES_USER: toasty
+      POSTGRES_PASSWORD: toasty
+      POSTGRES_DB: toasty
+      POSTGRES_INITDB_ARGS: --auth-host=scram-sha-256
+      POSTGRES_HOST_AUTH_METHOD: scram-sha-256
+    ports:
+      - "5433:5432"
+    volumes:
+      - ./tests/tls/certs:/certs:ro
+      - ./tests/tls/pg_hba.conf:/etc/pg_hba.conf:ro
+      - ./tests/tls/setup-ssl.sh:/usr/local/bin/setup-ssl.sh:ro
+    entrypoint: ["/usr/local/bin/setup-ssl.sh"]
+    command:
+      - postgres
+      - -c
+      - ssl=on
+      - -c
+      - ssl_cert_file=/var/lib/postgresql/server.crt
+      - -c
+      - ssl_key_file=/var/lib/postgresql/server.key
+      - -c
+      - ssl_ca_file=/var/lib/postgresql/ca.crt
+      - -c
+      - hba_file=/var/lib/postgresql/pg_hba.conf
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "toasty"]
       interval: 10s

--- a/crates/toasty-driver-postgresql/Cargo.toml
+++ b/crates/toasty-driver-postgresql/Cargo.toml
@@ -21,6 +21,7 @@ tls = [
     "dep:const-oid",
     "dep:sha2",
     "dep:x509-cert",
+    "dep:rustls-platform-verifier",
 ]
 rust_decimal = ["dep:rust_decimal", "toasty-core/rust_decimal"]
 bigdecimal = ["dep:bigdecimal", "toasty-core/bigdecimal"]
@@ -45,6 +46,7 @@ tokio-rustls = { workspace = true, optional = true }
 const-oid = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
 x509-cert = { workspace = true, optional = true }
+rustls-platform-verifier = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/crates/toasty-driver-postgresql/Cargo.toml
+++ b/crates/toasty-driver-postgresql/Cargo.toml
@@ -14,6 +14,14 @@ readme.workspace = true
 documentation = "https://docs.rs/toasty-driver-postgresql"
 
 [features]
+default = ["tls"]
+tls = [
+    "dep:rustls",
+    "dep:tokio-rustls",
+    "dep:const-oid",
+    "dep:sha2",
+    "dep:x509-cert",
+]
 rust_decimal = ["dep:rust_decimal", "toasty-core/rust_decimal"]
 bigdecimal = ["dep:bigdecimal", "toasty-core/bigdecimal"]
 jiff = ["dep:jiff", "toasty-core/jiff", "postgres-types/with-jiff-0_2"]
@@ -32,6 +40,11 @@ tokio.workspace = true
 tokio-postgres.workspace = true
 uuid.workspace = true
 url.workspace = true
+rustls = { workspace = true, optional = true }
+tokio-rustls = { workspace = true, optional = true }
+const-oid = { workspace = true, optional = true }
+sha2 = { workspace = true, optional = true }
+x509-cert = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/crates/toasty-driver-postgresql/Cargo.toml
+++ b/crates/toasty-driver-postgresql/Cargo.toml
@@ -22,6 +22,7 @@ tls = [
     "dep:sha2",
     "dep:x509-cert",
     "dep:rustls-platform-verifier",
+    "dep:rustls-pemfile",
 ]
 rust_decimal = ["dep:rust_decimal", "toasty-core/rust_decimal"]
 bigdecimal = ["dep:bigdecimal", "toasty-core/bigdecimal"]
@@ -47,6 +48,7 @@ const-oid = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
 x509-cert = { workspace = true, optional = true }
 rustls-platform-verifier = { workspace = true, optional = true }
+rustls-pemfile = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/crates/toasty-driver-postgresql/Cargo.toml
+++ b/crates/toasty-driver-postgresql/Cargo.toml
@@ -23,6 +23,7 @@ tls = [
     "dep:x509-cert",
     "dep:rustls-platform-verifier",
     "dep:rustls-pemfile",
+    "dep:rustls-webpki",
 ]
 rust_decimal = ["dep:rust_decimal", "toasty-core/rust_decimal"]
 bigdecimal = ["dep:bigdecimal", "toasty-core/bigdecimal"]
@@ -49,6 +50,7 @@ sha2 = { workspace = true, optional = true }
 x509-cert = { workspace = true, optional = true }
 rustls-platform-verifier = { workspace = true, optional = true }
 rustls-pemfile = { workspace = true, optional = true }
+rustls-webpki = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/crates/toasty-driver-postgresql/Cargo.toml
+++ b/crates/toasty-driver-postgresql/Cargo.toml
@@ -26,7 +26,6 @@ rust_decimal = { workspace = true, optional = true, features = ["db-postgres"] }
 bigdecimal = { workspace = true, optional = true }
 jiff = { workspace = true, optional = true }
 lru.workspace = true
-postgres.workspace = true
 tracing.workspace = true
 postgres-types.workspace = true
 tokio.workspace = true

--- a/crates/toasty-driver-postgresql/src/lib.rs
+++ b/crates/toasty-driver-postgresql/src/lib.rs
@@ -12,6 +12,8 @@
 //! ```
 
 mod statement_cache;
+#[cfg(feature = "tls")]
+mod tls;
 mod r#type;
 mod value;
 

--- a/crates/toasty-driver-postgresql/src/lib.rs
+++ b/crates/toasty-driver-postgresql/src/lib.rs
@@ -18,7 +18,6 @@ mod value;
 pub(crate) use value::Value;
 
 use async_trait::async_trait;
-use postgres::{Socket, tls::MakeTlsConnect, types::ToSql};
 use std::{borrow::Cow, sync::Arc};
 use toasty_core::{
     Result, Schema,
@@ -28,7 +27,7 @@ use toasty_core::{
     stmt::ValueRecord,
 };
 use toasty_sql::{self as sql, TypedValue};
-use tokio_postgres::{Client, Config};
+use tokio_postgres::{Client, Config, Socket, tls::MakeTlsConnect, types::ToSql};
 use url::Url;
 
 use crate::{statement_cache::StatementCache, r#type::TypeExt};

--- a/crates/toasty-driver-postgresql/src/lib.rs
+++ b/crates/toasty-driver-postgresql/src/lib.rs
@@ -47,6 +47,8 @@ use crate::{statement_cache::StatementCache, r#type::TypeExt};
 pub struct PostgreSQL {
     url: String,
     config: Config,
+    #[cfg(feature = "tls")]
+    tls: Option<tls::MakeRustlsConnect>,
 }
 
 impl PostgreSQL {
@@ -92,10 +94,76 @@ impl PostgreSQL {
             config.password(password);
         }
 
+        for (key, value) in url.query_pairs() {
+            match key.as_ref() {
+                "sslmode" => {
+                    let mode = match value.as_ref() {
+                        "disable" => tokio_postgres::config::SslMode::Disable,
+                        "prefer" => tokio_postgres::config::SslMode::Prefer,
+                        "require" | "verify-ca" | "verify-full" => {
+                            tokio_postgres::config::SslMode::Require
+                        }
+                        other => {
+                            return Err(toasty_core::Error::invalid_connection_url(format!(
+                                "unsupported sslmode: {other}"
+                            )));
+                        }
+                    };
+                    config.ssl_mode(mode);
+                }
+                "channel_binding" => {
+                    let cb = match value.as_ref() {
+                        "disable" => tokio_postgres::config::ChannelBinding::Disable,
+                        "prefer" => tokio_postgres::config::ChannelBinding::Prefer,
+                        "require" => tokio_postgres::config::ChannelBinding::Require,
+                        other => {
+                            return Err(toasty_core::Error::invalid_connection_url(format!(
+                                "unsupported channel_binding: {other}"
+                            )));
+                        }
+                    };
+                    config.channel_binding(cb);
+                }
+                "sslnegotiation" => {
+                    let neg = match value.as_ref() {
+                        "postgres" => tokio_postgres::config::SslNegotiation::Postgres,
+                        "direct" => tokio_postgres::config::SslNegotiation::Direct,
+                        other => {
+                            return Err(toasty_core::Error::invalid_connection_url(format!(
+                                "unsupported sslnegotiation: {other}"
+                            )));
+                        }
+                    };
+                    config.ssl_negotiation(neg);
+                }
+                _ => {}
+            }
+        }
+
+        #[cfg(feature = "tls")]
+        let tls = if config.get_ssl_mode() != tokio_postgres::config::SslMode::Disable {
+            use rustls_platform_verifier::ConfigVerifierExt;
+            let rustls_config = rustls::ClientConfig::with_platform_verifier()
+                .map_err(toasty_core::Error::driver_operation_failed)?;
+            Some(tls::MakeRustlsConnect::new(rustls_config))
+        } else {
+            None
+        };
+
         Ok(Self {
             url: url_str,
             config,
+            #[cfg(feature = "tls")]
+            tls,
         })
+    }
+
+    async fn connect_with_config(&self, config: Config) -> Result<Connection> {
+        #[cfg(feature = "tls")]
+        if let Some(ref tls) = self.tls {
+            return Connection::connect(config, tls.clone()).await;
+        }
+        Connection::connect(config, tokio_postgres::NoTls).await
     }
 }
 
@@ -111,7 +179,7 @@ impl Driver for PostgreSQL {
 
     async fn connect(&self) -> toasty_core::Result<Box<dyn toasty_core::driver::Connection>> {
         Ok(Box::new(
-            Connection::connect(self.config.clone(), tokio_postgres::NoTls).await?,
+            self.connect_with_config(self.config.clone()).await?,
         ))
     }
 
@@ -150,7 +218,7 @@ impl Driver for PostgreSQL {
         let connect = |dbname: &str| {
             let mut config = self.config.clone();
             config.dbname(dbname);
-            Connection::connect(config, tokio_postgres::NoTls)
+            self.connect_with_config(config)
         };
 
         // Step 1: Connect to the target DB and create a temp DB

--- a/crates/toasty-driver-postgresql/src/lib.rs
+++ b/crates/toasty-driver-postgresql/src/lib.rs
@@ -95,104 +95,16 @@ impl PostgreSQL {
         }
 
         #[cfg(feature = "tls")]
-        let mut sslmode = tls::SslVerifyMode::Prefer;
-        #[cfg(feature = "tls")]
-        let mut sslrootcert: Option<String> = None;
-        #[cfg(feature = "tls")]
-        let mut sslcert: Option<String> = None;
-        #[cfg(feature = "tls")]
-        let mut sslkey: Option<String> = None;
+        let tls = tls::configure_tls(&url, &mut config)?;
 
+        #[cfg(not(feature = "tls"))]
         for (key, value) in url.query_pairs() {
-            match key.as_ref() {
-                #[cfg(feature = "tls")]
-                "sslmode" => {
-                    sslmode = match value.as_ref() {
-                        "disable" => tls::SslVerifyMode::Disable,
-                        "prefer" => tls::SslVerifyMode::Prefer,
-                        "require" => tls::SslVerifyMode::Require,
-                        "verify-ca" => tls::SslVerifyMode::VerifyCa,
-                        "verify-full" => tls::SslVerifyMode::VerifyFull,
-                        other => {
-                            return Err(toasty_core::Error::invalid_connection_url(format!(
-                                "unsupported sslmode: {other}"
-                            )));
-                        }
-                    };
-                }
-                #[cfg(not(feature = "tls"))]
-                "sslmode" => {
-                    if value.as_ref() != "disable" {
-                        return Err(toasty_core::Error::invalid_connection_url(
-                            "TLS not available: compile with the `tls` feature",
-                        ));
-                    }
-                }
-                #[cfg(feature = "tls")]
-                "sslrootcert" => {
-                    sslrootcert = Some(value.into_owned());
-                }
-                #[cfg(feature = "tls")]
-                "sslcert" => {
-                    sslcert = Some(value.into_owned());
-                }
-                #[cfg(feature = "tls")]
-                "sslkey" => {
-                    sslkey = Some(value.into_owned());
-                }
-                "channel_binding" => {
-                    let cb = match value.as_ref() {
-                        "disable" => tokio_postgres::config::ChannelBinding::Disable,
-                        "prefer" => tokio_postgres::config::ChannelBinding::Prefer,
-                        "require" => tokio_postgres::config::ChannelBinding::Require,
-                        other => {
-                            return Err(toasty_core::Error::invalid_connection_url(format!(
-                                "unsupported channel_binding: {other}"
-                            )));
-                        }
-                    };
-                    config.channel_binding(cb);
-                }
-                "sslnegotiation" => {
-                    let neg = match value.as_ref() {
-                        "postgres" => tokio_postgres::config::SslNegotiation::Postgres,
-                        "direct" => tokio_postgres::config::SslNegotiation::Direct,
-                        other => {
-                            return Err(toasty_core::Error::invalid_connection_url(format!(
-                                "unsupported sslnegotiation: {other}"
-                            )));
-                        }
-                    };
-                    config.ssl_negotiation(neg);
-                }
-                _ => {}
+            if key == "sslmode" && value != "disable" {
+                return Err(toasty_core::Error::invalid_connection_url(
+                    "TLS not available: compile with the `tls` feature",
+                ));
             }
         }
-
-        #[cfg(feature = "tls")]
-        {
-            let tp_ssl_mode = match sslmode {
-                tls::SslVerifyMode::Disable => tokio_postgres::config::SslMode::Disable,
-                tls::SslVerifyMode::Prefer => tokio_postgres::config::SslMode::Prefer,
-                tls::SslVerifyMode::Require
-                | tls::SslVerifyMode::VerifyCa
-                | tls::SslVerifyMode::VerifyFull => tokio_postgres::config::SslMode::Require,
-            };
-            config.ssl_mode(tp_ssl_mode);
-        }
-
-        #[cfg(feature = "tls")]
-        let tls = if sslmode != tls::SslVerifyMode::Disable {
-            let rustls_config = tls::build_client_config(
-                sslmode,
-                sslrootcert.as_deref(),
-                sslcert.as_deref(),
-                sslkey.as_deref(),
-            )?;
-            Some(tls::MakeRustlsConnect::new(rustls_config))
-        } else {
-            None
-        };
 
         Ok(Self {
             url: url_str,

--- a/crates/toasty-driver-postgresql/src/lib.rs
+++ b/crates/toasty-driver-postgresql/src/lib.rs
@@ -94,22 +94,51 @@ impl PostgreSQL {
             config.password(password);
         }
 
+        #[cfg(feature = "tls")]
+        let mut sslmode = tls::SslVerifyMode::Prefer;
+        #[cfg(feature = "tls")]
+        let mut sslrootcert: Option<String> = None;
+        #[cfg(feature = "tls")]
+        let mut sslcert: Option<String> = None;
+        #[cfg(feature = "tls")]
+        let mut sslkey: Option<String> = None;
+
         for (key, value) in url.query_pairs() {
             match key.as_ref() {
+                #[cfg(feature = "tls")]
                 "sslmode" => {
-                    let mode = match value.as_ref() {
-                        "disable" => tokio_postgres::config::SslMode::Disable,
-                        "prefer" => tokio_postgres::config::SslMode::Prefer,
-                        "require" | "verify-ca" | "verify-full" => {
-                            tokio_postgres::config::SslMode::Require
-                        }
+                    sslmode = match value.as_ref() {
+                        "disable" => tls::SslVerifyMode::Disable,
+                        "prefer" => tls::SslVerifyMode::Prefer,
+                        "require" => tls::SslVerifyMode::Require,
+                        "verify-ca" => tls::SslVerifyMode::VerifyCa,
+                        "verify-full" => tls::SslVerifyMode::VerifyFull,
                         other => {
                             return Err(toasty_core::Error::invalid_connection_url(format!(
                                 "unsupported sslmode: {other}"
                             )));
                         }
                     };
-                    config.ssl_mode(mode);
+                }
+                #[cfg(not(feature = "tls"))]
+                "sslmode" => {
+                    if value.as_ref() != "disable" {
+                        return Err(toasty_core::Error::invalid_connection_url(
+                            "TLS not available: compile with the `tls` feature",
+                        ));
+                    }
+                }
+                #[cfg(feature = "tls")]
+                "sslrootcert" => {
+                    sslrootcert = Some(value.into_owned());
+                }
+                #[cfg(feature = "tls")]
+                "sslcert" => {
+                    sslcert = Some(value.into_owned());
+                }
+                #[cfg(feature = "tls")]
+                "sslkey" => {
+                    sslkey = Some(value.into_owned());
                 }
                 "channel_binding" => {
                     let cb = match value.as_ref() {
@@ -141,10 +170,25 @@ impl PostgreSQL {
         }
 
         #[cfg(feature = "tls")]
-        let tls = if config.get_ssl_mode() != tokio_postgres::config::SslMode::Disable {
-            use rustls_platform_verifier::ConfigVerifierExt;
-            let rustls_config = rustls::ClientConfig::with_platform_verifier()
-                .map_err(toasty_core::Error::driver_operation_failed)?;
+        {
+            let tp_ssl_mode = match sslmode {
+                tls::SslVerifyMode::Disable => tokio_postgres::config::SslMode::Disable,
+                tls::SslVerifyMode::Prefer => tokio_postgres::config::SslMode::Prefer,
+                tls::SslVerifyMode::Require
+                | tls::SslVerifyMode::VerifyCa
+                | tls::SslVerifyMode::VerifyFull => tokio_postgres::config::SslMode::Require,
+            };
+            config.ssl_mode(tp_ssl_mode);
+        }
+
+        #[cfg(feature = "tls")]
+        let tls = if sslmode != tls::SslVerifyMode::Disable {
+            let rustls_config = tls::build_client_config(
+                sslmode,
+                sslrootcert.as_deref(),
+                sslcert.as_deref(),
+                sslkey.as_deref(),
+            )?;
             Some(tls::MakeRustlsConnect::new(rustls_config))
         } else {
             None

--- a/crates/toasty-driver-postgresql/src/statement_cache.rs
+++ b/crates/toasty-driver-postgresql/src/statement_cache.rs
@@ -1,9 +1,9 @@
 use std::borrow::Cow;
 
 use lru::LruCache;
-use postgres::{Error, Statement};
 use postgres_types::Type;
 use tokio_postgres::Client;
+use tokio_postgres::{Error, Statement};
 
 #[derive(Debug, Clone)]
 pub struct StatementCache {

--- a/crates/toasty-driver-postgresql/src/tls/config.rs
+++ b/crates/toasty-driver-postgresql/src/tls/config.rs
@@ -1,7 +1,7 @@
-use std::{fmt, sync::Arc};
+use std::sync::Arc;
 
 use rustls::{
-    ClientConfig, DigitallySignedStruct, Error, RootCertStore, SignatureScheme,
+    ClientConfig, DigitallySignedStruct, Error, OtherError, RootCertStore, SignatureScheme,
     client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
     crypto::CryptoProvider,
     pki_types::{CertificateDer, ServerName, UnixTime},
@@ -62,44 +62,37 @@ pub(crate) fn build_client_config(
 
         SslVerifyMode::Prefer | SslVerifyMode::Require => {
             if let Some(roots) = roots {
-                let webpki = rustls::client::WebPkiServerVerifier::builder_with_provider(
-                    Arc::new(roots),
-                    provider.clone(),
-                )
-                .build()
-                .map_err(toasty_core::Error::driver_operation_failed)?;
-                Arc::new(CaOnlyVerifier(webpki))
+                Arc::new(CaOnlyVerifier {
+                    roots: Arc::new(roots),
+                    provider: provider.clone(),
+                })
             } else {
                 Arc::new(NoVerification(provider.clone()))
             }
         }
 
         SslVerifyMode::VerifyCa => {
-            if let Some(roots) = roots {
-                let webpki = rustls::client::WebPkiServerVerifier::builder_with_provider(
-                    Arc::new(roots),
-                    provider.clone(),
-                )
-                .build()
-                .map_err(toasty_core::Error::driver_operation_failed)?;
-                Arc::new(CaOnlyVerifier(webpki))
-            } else {
-                let platform = platform_verifier(&provider)?;
-                Arc::new(CaOnlyVerifier(platform))
-            }
+            let roots = roots.ok_or_else(|| {
+                toasty_core::Error::invalid_connection_url("sslmode=verify-ca requires sslrootcert")
+            })?;
+            Arc::new(CaOnlyVerifier {
+                roots: Arc::new(roots),
+                provider: provider.clone(),
+            })
         }
 
         SslVerifyMode::VerifyFull => {
-            if let Some(roots) = roots {
-                rustls::client::WebPkiServerVerifier::builder_with_provider(
-                    Arc::new(roots),
-                    provider.clone(),
+            let roots = roots.ok_or_else(|| {
+                toasty_core::Error::invalid_connection_url(
+                    "sslmode=verify-full requires sslrootcert (use sslrootcert=system for OS trust store)",
                 )
-                .build()
-                .map_err(toasty_core::Error::driver_operation_failed)?
-            } else {
-                platform_verifier(&provider)?
-            }
+            })?;
+            rustls::client::WebPkiServerVerifier::builder_with_provider(
+                Arc::new(roots),
+                provider.clone(),
+            )
+            .build()
+            .map_err(toasty_core::Error::driver_operation_failed)?
         }
     };
 
@@ -164,13 +157,16 @@ impl ServerCertVerifier for NoVerification {
 
 /// Verifies the server certificate chain against trusted roots but does NOT
 /// check that the server hostname matches the certificate.
+///
+/// Uses `webpki::EndEntityCert::verify_for_usage()` directly rather than
+/// delegating to `WebPkiServerVerifier` and suppressing hostname errors,
+/// which would rely on rustls's internal validation ordering.
+///
 /// Used for sslmode=verify-ca and sslmode=require with sslrootcert.
-struct CaOnlyVerifier(Arc<dyn ServerCertVerifier>);
-
-impl fmt::Debug for CaOnlyVerifier {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("CaOnlyVerifier").finish()
-    }
+#[derive(Debug)]
+struct CaOnlyVerifier {
+    roots: Arc<RootCertStore>,
+    provider: Arc<CryptoProvider>,
 }
 
 impl ServerCertVerifier for CaOnlyVerifier {
@@ -178,20 +174,22 @@ impl ServerCertVerifier for CaOnlyVerifier {
         &self,
         end_entity: &CertificateDer<'_>,
         intermediates: &[CertificateDer<'_>],
-        server_name: &ServerName<'_>,
-        ocsp_response: &[u8],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
         now: UnixTime,
     ) -> Result<ServerCertVerified, Error> {
-        match self
-            .0
-            .verify_server_cert(end_entity, intermediates, server_name, ocsp_response, now)
-        {
-            Ok(v) => Ok(v),
-            Err(Error::InvalidCertificate(rustls::CertificateError::NotValidForName)) => {
-                Ok(ServerCertVerified::assertion())
-            }
-            Err(e) => Err(e),
-        }
+        let cert = webpki::EndEntityCert::try_from(end_entity).map_err(pki_error)?;
+        cert.verify_for_usage(
+            self.provider.signature_verification_algorithms.all,
+            &self.roots.roots,
+            intermediates,
+            now,
+            webpki::KeyUsage::server_auth(),
+            None,
+            None,
+        )
+        .map_err(pki_error)?;
+        Ok(ServerCertVerified::assertion())
     }
 
     fn verify_tls12_signature(
@@ -200,7 +198,12 @@ impl ServerCertVerifier for CaOnlyVerifier {
         cert: &CertificateDer<'_>,
         dss: &DigitallySignedStruct,
     ) -> Result<HandshakeSignatureValid, Error> {
-        self.0.verify_tls12_signature(message, cert, dss)
+        rustls::crypto::verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &self.provider.signature_verification_algorithms,
+        )
     }
 
     fn verify_tls13_signature(
@@ -209,11 +212,41 @@ impl ServerCertVerifier for CaOnlyVerifier {
         cert: &CertificateDer<'_>,
         dss: &DigitallySignedStruct,
     ) -> Result<HandshakeSignatureValid, Error> {
-        self.0.verify_tls13_signature(message, cert, dss)
+        rustls::crypto::verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &self.provider.signature_verification_algorithms,
+        )
     }
 
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        self.0.supported_verify_schemes()
+        self.provider
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
+fn pki_error(e: webpki::Error) -> Error {
+    use rustls::CertificateError;
+    use webpki::Error::*;
+    match e {
+        BadDer | BadDerTime | TrailingData(_) => CertificateError::BadEncoding.into(),
+        CertNotValidYet { time, not_before } => {
+            CertificateError::NotValidYetContext { time, not_before }.into()
+        }
+        CertExpired { time, not_after } => {
+            CertificateError::ExpiredContext { time, not_after }.into()
+        }
+        InvalidCertValidity => CertificateError::Expired.into(),
+        UnknownIssuer => CertificateError::UnknownIssuer.into(),
+        CertRevoked => CertificateError::Revoked.into(),
+        InvalidSignatureForPublicKey => CertificateError::BadSignature.into(),
+        #[allow(deprecated)]
+        UnsupportedSignatureAlgorithm | UnsupportedSignatureAlgorithmForPublicKey => {
+            CertificateError::UnsupportedSignatureAlgorithm.into()
+        }
+        _ => CertificateError::Other(OtherError(Arc::new(e))).into(),
     }
 }
 

--- a/crates/toasty-driver-postgresql/src/tls/config.rs
+++ b/crates/toasty-driver-postgresql/src/tls/config.rs
@@ -1,0 +1,306 @@
+use std::{fmt, sync::Arc};
+
+use rustls::{
+    ClientConfig, DigitallySignedStruct, Error, RootCertStore, SignatureScheme,
+    client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
+    crypto::CryptoProvider,
+    pki_types::{CertificateDer, ServerName, UnixTime},
+};
+
+/// SSL verification mode parsed from the connection URL.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SslVerifyMode {
+    Disable,
+    Prefer,
+    Require,
+    VerifyCa,
+    VerifyFull,
+}
+
+pub(crate) fn build_client_config(
+    mode: SslVerifyMode,
+    sslrootcert: Option<&str>,
+    sslcert: Option<&str>,
+    sslkey: Option<&str>,
+) -> Result<ClientConfig, toasty_core::Error> {
+    let provider = match CryptoProvider::get_default() {
+        Some(p) => p.clone(),
+        None => {
+            let provider = rustls::crypto::ring::default_provider();
+            let _ = provider.install_default();
+            CryptoProvider::get_default()
+                .expect("just installed")
+                .clone()
+        }
+    };
+
+    let client_auth = load_client_auth(sslcert, sslkey)?;
+
+    // sslrootcert=system -> platform verifier, enforce verify-full
+    if sslrootcert == Some("system") {
+        if mode != SslVerifyMode::VerifyFull {
+            return Err(toasty_core::Error::invalid_connection_url(
+                "sslrootcert=system requires sslmode=verify-full",
+            ));
+        }
+        let verifier = platform_verifier(&provider)?;
+        let builder = ClientConfig::builder_with_provider(provider)
+            .with_safe_default_protocol_versions()
+            .map_err(toasty_core::Error::driver_operation_failed)?
+            .dangerous()
+            .with_custom_certificate_verifier(verifier);
+        return apply_client_auth(builder, client_auth);
+    }
+
+    let roots = match sslrootcert {
+        Some(path) => Some(load_root_certs(path)?),
+        None => None,
+    };
+
+    let verifier: Arc<dyn ServerCertVerifier> = match mode {
+        SslVerifyMode::Disable => unreachable!("TLS should not be built for sslmode=disable"),
+
+        SslVerifyMode::Prefer | SslVerifyMode::Require => {
+            if let Some(roots) = roots {
+                let webpki = rustls::client::WebPkiServerVerifier::builder_with_provider(
+                    Arc::new(roots),
+                    provider.clone(),
+                )
+                .build()
+                .map_err(toasty_core::Error::driver_operation_failed)?;
+                Arc::new(CaOnlyVerifier(webpki))
+            } else {
+                Arc::new(NoVerification(provider.clone()))
+            }
+        }
+
+        SslVerifyMode::VerifyCa => {
+            if let Some(roots) = roots {
+                let webpki = rustls::client::WebPkiServerVerifier::builder_with_provider(
+                    Arc::new(roots),
+                    provider.clone(),
+                )
+                .build()
+                .map_err(toasty_core::Error::driver_operation_failed)?;
+                Arc::new(CaOnlyVerifier(webpki))
+            } else {
+                let platform = platform_verifier(&provider)?;
+                Arc::new(CaOnlyVerifier(platform))
+            }
+        }
+
+        SslVerifyMode::VerifyFull => {
+            if let Some(roots) = roots {
+                rustls::client::WebPkiServerVerifier::builder_with_provider(
+                    Arc::new(roots),
+                    provider.clone(),
+                )
+                .build()
+                .map_err(toasty_core::Error::driver_operation_failed)?
+            } else {
+                platform_verifier(&provider)?
+            }
+        }
+    };
+
+    let builder = ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(toasty_core::Error::driver_operation_failed)?
+        .dangerous()
+        .with_custom_certificate_verifier(verifier);
+
+    apply_client_auth(builder, client_auth)
+}
+
+/// Accepts any server certificate (encryption only, no verification).
+/// Used for sslmode=require/prefer without sslrootcert.
+#[derive(Debug)]
+struct NoVerification(Arc<CryptoProvider>);
+
+impl ServerCertVerifier for NoVerification {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, Error> {
+        rustls::crypto::verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &self.0.signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, Error> {
+        rustls::crypto::verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &self.0.signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.0.signature_verification_algorithms.supported_schemes()
+    }
+}
+
+/// Verifies the server certificate chain against trusted roots but does NOT
+/// check that the server hostname matches the certificate.
+/// Used for sslmode=verify-ca and sslmode=require with sslrootcert.
+struct CaOnlyVerifier(Arc<dyn ServerCertVerifier>);
+
+impl fmt::Debug for CaOnlyVerifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CaOnlyVerifier").finish()
+    }
+}
+
+impl ServerCertVerifier for CaOnlyVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        intermediates: &[CertificateDer<'_>],
+        server_name: &ServerName<'_>,
+        ocsp_response: &[u8],
+        now: UnixTime,
+    ) -> Result<ServerCertVerified, Error> {
+        match self
+            .0
+            .verify_server_cert(end_entity, intermediates, server_name, ocsp_response, now)
+        {
+            Ok(v) => Ok(v),
+            Err(Error::InvalidCertificate(rustls::CertificateError::NotValidForName)) => {
+                Ok(ServerCertVerified::assertion())
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, Error> {
+        self.0.verify_tls12_signature(message, cert, dss)
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, Error> {
+        self.0.verify_tls13_signature(message, cert, dss)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.0.supported_verify_schemes()
+    }
+}
+
+type ClientAuthData = (
+    Vec<CertificateDer<'static>>,
+    rustls::pki_types::PrivateKeyDer<'static>,
+);
+
+fn load_client_auth(
+    sslcert: Option<&str>,
+    sslkey: Option<&str>,
+) -> Result<Option<ClientAuthData>, toasty_core::Error> {
+    match (sslcert, sslkey) {
+        (Some(cert_path), Some(key_path)) => {
+            let cert_data =
+                std::fs::read(cert_path).map_err(toasty_core::Error::driver_operation_failed)?;
+            let certs: Vec<CertificateDer<'static>> =
+                rustls_pemfile::certs(&mut cert_data.as_slice())
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(toasty_core::Error::driver_operation_failed)?;
+            if certs.is_empty() {
+                return Err(toasty_core::Error::invalid_connection_url(format!(
+                    "no certificates found in sslcert file: {cert_path}"
+                )));
+            }
+
+            let key_data =
+                std::fs::read(key_path).map_err(toasty_core::Error::driver_operation_failed)?;
+            let key = rustls_pemfile::private_key(&mut key_data.as_slice())
+                .map_err(toasty_core::Error::driver_operation_failed)?
+                .ok_or_else(|| {
+                    toasty_core::Error::invalid_connection_url(format!(
+                        "no private key found in sslkey file: {key_path}"
+                    ))
+                })?;
+
+            Ok(Some((certs, key)))
+        }
+        (None, None) => Ok(None),
+        (Some(_), None) => Err(toasty_core::Error::invalid_connection_url(
+            "sslcert specified without sslkey",
+        )),
+        (None, Some(_)) => Err(toasty_core::Error::invalid_connection_url(
+            "sslkey specified without sslcert",
+        )),
+    }
+}
+
+fn apply_client_auth(
+    builder: rustls::ConfigBuilder<ClientConfig, rustls::client::WantsClientCert>,
+    client_auth: Option<ClientAuthData>,
+) -> Result<ClientConfig, toasty_core::Error> {
+    match client_auth {
+        Some((certs, key)) => builder
+            .with_client_auth_cert(certs, key)
+            .map_err(toasty_core::Error::driver_operation_failed),
+        None => Ok(builder.with_no_client_auth()),
+    }
+}
+
+fn platform_verifier(
+    provider: &Arc<CryptoProvider>,
+) -> Result<Arc<dyn ServerCertVerifier>, toasty_core::Error> {
+    Ok(Arc::new(
+        rustls_platform_verifier::Verifier::new(provider.clone())
+            .map_err(toasty_core::Error::driver_operation_failed)?,
+    ))
+}
+
+fn load_root_certs(path: &str) -> Result<RootCertStore, toasty_core::Error> {
+    let pem_data = std::fs::read(path).map_err(toasty_core::Error::driver_operation_failed)?;
+    let certs: Vec<CertificateDer<'static>> = rustls_pemfile::certs(&mut pem_data.as_slice())
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(toasty_core::Error::driver_operation_failed)?;
+
+    let mut store = RootCertStore::empty();
+    for cert in certs {
+        store
+            .add(cert)
+            .map_err(toasty_core::Error::driver_operation_failed)?;
+    }
+
+    if store.is_empty() {
+        return Err(toasty_core::Error::invalid_connection_url(format!(
+            "no certificates found in sslrootcert file: {path}"
+        )));
+    }
+
+    Ok(store)
+}

--- a/crates/toasty-driver-postgresql/src/tls/config.rs
+++ b/crates/toasty-driver-postgresql/src/tls/config.rs
@@ -60,23 +60,17 @@ pub(crate) fn build_client_config(
     let verifier: Arc<dyn ServerCertVerifier> = match mode {
         SslVerifyMode::Disable => unreachable!("TLS should not be built for sslmode=disable"),
 
-        SslVerifyMode::Prefer | SslVerifyMode::Require => {
-            if let Some(roots) = roots {
-                Arc::new(CaOnlyVerifier {
-                    roots: Arc::new(roots),
-                    provider: provider.clone(),
-                })
-            } else {
-                Arc::new(NoVerification(provider.clone()))
-            }
-        }
+        SslVerifyMode::Prefer | SslVerifyMode::Require => Arc::new(CaOnlyVerifier {
+            roots: roots.map(Arc::new),
+            provider: provider.clone(),
+        }),
 
         SslVerifyMode::VerifyCa => {
             let roots = roots.ok_or_else(|| {
                 toasty_core::Error::invalid_connection_url("sslmode=verify-ca requires sslrootcert")
             })?;
             Arc::new(CaOnlyVerifier {
-                roots: Arc::new(roots),
+                roots: Some(Arc::new(roots)),
                 provider: provider.clone(),
             })
         }
@@ -105,67 +99,18 @@ pub(crate) fn build_client_config(
     apply_client_auth(builder, client_auth)
 }
 
-/// Accepts any server certificate (encryption only, no verification).
-/// Used for sslmode=require/prefer without sslrootcert.
-#[derive(Debug)]
-struct NoVerification(Arc<CryptoProvider>);
-
-impl ServerCertVerifier for NoVerification {
-    fn verify_server_cert(
-        &self,
-        _end_entity: &CertificateDer<'_>,
-        _intermediates: &[CertificateDer<'_>],
-        _server_name: &ServerName<'_>,
-        _ocsp_response: &[u8],
-        _now: UnixTime,
-    ) -> Result<ServerCertVerified, Error> {
-        Ok(ServerCertVerified::assertion())
-    }
-
-    fn verify_tls12_signature(
-        &self,
-        message: &[u8],
-        cert: &CertificateDer<'_>,
-        dss: &DigitallySignedStruct,
-    ) -> Result<HandshakeSignatureValid, Error> {
-        rustls::crypto::verify_tls12_signature(
-            message,
-            cert,
-            dss,
-            &self.0.signature_verification_algorithms,
-        )
-    }
-
-    fn verify_tls13_signature(
-        &self,
-        message: &[u8],
-        cert: &CertificateDer<'_>,
-        dss: &DigitallySignedStruct,
-    ) -> Result<HandshakeSignatureValid, Error> {
-        rustls::crypto::verify_tls13_signature(
-            message,
-            cert,
-            dss,
-            &self.0.signature_verification_algorithms,
-        )
-    }
-
-    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        self.0.signature_verification_algorithms.supported_schemes()
-    }
-}
-
 /// Verifies the server certificate chain against trusted roots but does NOT
 /// check that the server hostname matches the certificate.
 ///
-/// Uses `webpki::EndEntityCert::verify_for_usage()` directly rather than
-/// delegating to `WebPkiServerVerifier` and suppressing hostname errors,
-/// which would rely on rustls's internal validation ordering.
+/// When `roots` is `None`, accepts any certificate (encryption only).
+/// When `roots` is `Some`, uses `webpki::EndEntityCert::verify_for_usage()`
+/// directly to validate the chain without hostname checking.
 ///
-/// Used for sslmode=verify-ca and sslmode=require with sslrootcert.
+/// Used for sslmode=prefer/require (with optional sslrootcert) and
+/// sslmode=verify-ca (requires sslrootcert).
 #[derive(Debug)]
 struct CaOnlyVerifier {
-    roots: Arc<RootCertStore>,
+    roots: Option<Arc<RootCertStore>>,
     provider: Arc<CryptoProvider>,
 }
 
@@ -178,17 +123,19 @@ impl ServerCertVerifier for CaOnlyVerifier {
         _ocsp_response: &[u8],
         now: UnixTime,
     ) -> Result<ServerCertVerified, Error> {
-        let cert = webpki::EndEntityCert::try_from(end_entity).map_err(pki_error)?;
-        cert.verify_for_usage(
-            self.provider.signature_verification_algorithms.all,
-            &self.roots.roots,
-            intermediates,
-            now,
-            webpki::KeyUsage::server_auth(),
-            None,
-            None,
-        )
-        .map_err(pki_error)?;
+        if let Some(roots) = &self.roots {
+            let cert = webpki::EndEntityCert::try_from(end_entity).map_err(pki_error)?;
+            cert.verify_for_usage(
+                self.provider.signature_verification_algorithms.all,
+                &roots.roots,
+                intermediates,
+                now,
+                webpki::KeyUsage::server_auth(),
+                None,
+                None,
+            )
+            .map_err(pki_error)?;
+        }
         Ok(ServerCertVerified::assertion())
     }
 

--- a/crates/toasty-driver-postgresql/src/tls/config.rs
+++ b/crates/toasty-driver-postgresql/src/tls/config.rs
@@ -7,7 +7,13 @@ use rustls::{
     pki_types::{CertificateDer, ServerName, UnixTime},
 };
 
-/// SSL verification mode parsed from the connection URL.
+/// SSL verification mode parsed from the `sslmode` query parameter.
+///
+/// Matches libpq's modes, with one notable difference: libpq falls back to
+/// `~/.postgresql/root.crt` (or the system CA file) when `sslrootcert` is
+/// not specified for `verify-ca` / `verify-full`. We don't implement that
+/// file lookup, so both modes require an explicit `sslrootcert` parameter.
+/// Use `sslrootcert=system` for the OS trust store with `verify-full`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SslVerifyMode {
     Disable,

--- a/crates/toasty-driver-postgresql/src/tls/connect.rs
+++ b/crates/toasty-driver-postgresql/src/tls/connect.rs
@@ -28,6 +28,9 @@
 // - Removed test module
 // - Removed module-level doc include
 // - Adjusted lint attributes to match workspace conventions
+// - Fixed channel binding hash selection: explicitly match known OIDs
+//   and return None for unsupported algorithms (e.g. Ed25519) instead
+//   of incorrectly using SHA-512
 
 use std::{convert::TryFrom, sync::Arc};
 
@@ -42,13 +45,10 @@ use std::{
     task::{Context, Poll},
 };
 
-use const_oid::db::{
-    rfc5912::{
-        ECDSA_WITH_SHA_256, ECDSA_WITH_SHA_384, ID_SHA_1, ID_SHA_256, ID_SHA_384, ID_SHA_512,
-        SHA_1_WITH_RSA_ENCRYPTION, SHA_256_WITH_RSA_ENCRYPTION, SHA_384_WITH_RSA_ENCRYPTION,
-        SHA_512_WITH_RSA_ENCRYPTION,
-    },
-    rfc8410::ID_ED_25519,
+use const_oid::db::rfc5912::{
+    ECDSA_WITH_SHA_256, ECDSA_WITH_SHA_384, ID_SHA_1, ID_SHA_256, ID_SHA_384, ID_SHA_512,
+    SHA_1_WITH_RSA_ENCRYPTION, SHA_256_WITH_RSA_ENCRYPTION, SHA_384_WITH_RSA_ENCRYPTION,
+    SHA_512_WITH_RSA_ENCRYPTION,
 };
 use sha2::{Digest, Sha256, Sha384, Sha512};
 use tokio::io::ReadBuf;
@@ -105,22 +105,38 @@ where
             Some(certs) if !certs.is_empty() => Certificate::from_der(&certs[0])
                 .ok()
                 .and_then(|cert| {
-                    let hash: Vec<u8> = match cert.signature_algorithm.oid {
-                        // SHA1 is upgraded to SHA256 per https://datatracker.ietf.org/doc/html/rfc5929#section-4.1
+                    // tls-server-end-point channel binding (RFC 5929 §4.1):
+                    // hash the certificate using the digest from its signature
+                    // algorithm, upgrading MD5/SHA-1 to SHA-256.
+                    //
+                    // For algorithms with no associated digest (Ed25519, ML-DSA,
+                    // etc.) RFC 5929 leaves channel binding undefined. Both
+                    // libpq and the PostgreSQL server error out in this case
+                    // ("could not find digest for NID UNDEF"). We return None
+                    // to disable channel binding, matching libpq. See the
+                    // pgsql-hackers thread "Channel binding for post-quantum
+                    // cryptography" (Oct 2025) for ongoing discussion.
+                    match cert.signature_algorithm.oid {
                         ID_SHA_1
                         | ID_SHA_256
                         | SHA_1_WITH_RSA_ENCRYPTION
                         | SHA_256_WITH_RSA_ENCRYPTION
-                        | ECDSA_WITH_SHA_256 => Sha256::digest(certs[0].as_ref()).to_vec(),
+                        | ECDSA_WITH_SHA_256 => Some(Sha256::digest(certs[0].as_ref()).to_vec()),
                         ID_SHA_384 | SHA_384_WITH_RSA_ENCRYPTION | ECDSA_WITH_SHA_384 => {
-                            Sha384::digest(certs[0].as_ref()).to_vec()
+                            Some(Sha384::digest(certs[0].as_ref()).to_vec())
                         }
-                        ID_SHA_512 | SHA_512_WITH_RSA_ENCRYPTION | ID_ED_25519 => {
-                            Sha512::digest(certs[0].as_ref()).to_vec()
+                        ID_SHA_512 | SHA_512_WITH_RSA_ENCRYPTION => {
+                            Some(Sha512::digest(certs[0].as_ref()).to_vec())
                         }
-                        _ => return None,
-                    };
-                    Some(hash)
+                        oid => {
+                            tracing::warn!(
+                                %oid,
+                                "server certificate uses unsupported signature algorithm for \
+                                 tls-server-end-point channel binding; channel binding disabled"
+                            );
+                            None
+                        }
+                    }
                 })
                 .map_or_else(ChannelBinding::none, |hash| {
                     ChannelBinding::tls_server_end_point(hash)

--- a/crates/toasty-driver-postgresql/src/tls/connect.rs
+++ b/crates/toasty-driver-postgresql/src/tls/connect.rs
@@ -1,0 +1,200 @@
+// Vendored from tokio-postgres-rustls
+// https://github.com/jbg/tokio-postgres-rustls/commit/4326f72863ff8f205a71773a5f8b8467e8cd699a
+//
+// MIT License
+//
+// Copyright (c) 2019 Jasper Hugo
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// Changes from upstream:
+// - Replaced ring::digest with sha2::{Sha256, Sha384, Sha512}
+// - Removed test module
+// - Removed module-level doc include
+// - Adjusted lint attributes to match workspace conventions
+
+use std::{convert::TryFrom, sync::Arc};
+
+use rustls::{ClientConfig, pki_types::ServerName};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_postgres::tls::MakeTlsConnect;
+
+use std::{
+    future::Future,
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use const_oid::db::{
+    rfc5912::{
+        ECDSA_WITH_SHA_256, ECDSA_WITH_SHA_384, ID_SHA_1, ID_SHA_256, ID_SHA_384, ID_SHA_512,
+        SHA_1_WITH_RSA_ENCRYPTION, SHA_256_WITH_RSA_ENCRYPTION, SHA_384_WITH_RSA_ENCRYPTION,
+        SHA_512_WITH_RSA_ENCRYPTION,
+    },
+    rfc8410::ID_ED_25519,
+};
+use sha2::{Digest, Sha256, Sha384, Sha512};
+use tokio::io::ReadBuf;
+use tokio_postgres::tls::{ChannelBinding, TlsConnect};
+use tokio_rustls::{TlsConnector, client::TlsStream};
+use x509_cert::{Certificate, der::Decode};
+
+pub(crate) struct TlsConnectFuture<S> {
+    inner: tokio_rustls::Connect<S>,
+}
+
+impl<S> Future for TlsConnectFuture<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    type Output = io::Result<RustlsStream<S>>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.inner).poll(cx).map_ok(RustlsStream)
+    }
+}
+
+pub(crate) struct RustlsConnect(RustlsConnectData);
+
+pub(crate) struct RustlsConnectData {
+    hostname: ServerName<'static>,
+    connector: TlsConnector,
+}
+
+impl<S> TlsConnect<S> for RustlsConnect
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    type Stream = RustlsStream<S>;
+    type Error = io::Error;
+    type Future = TlsConnectFuture<S>;
+
+    fn connect(self, stream: S) -> Self::Future {
+        TlsConnectFuture {
+            inner: self.0.connector.connect(self.0.hostname, stream),
+        }
+    }
+}
+
+pub(crate) struct RustlsStream<S>(TlsStream<S>);
+
+impl<S> tokio_postgres::tls::TlsStream for RustlsStream<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    fn channel_binding(&self) -> ChannelBinding {
+        let (_, session) = self.0.get_ref();
+        match session.peer_certificates() {
+            Some(certs) if !certs.is_empty() => Certificate::from_der(&certs[0])
+                .ok()
+                .and_then(|cert| {
+                    let hash: Vec<u8> = match cert.signature_algorithm.oid {
+                        // SHA1 is upgraded to SHA256 per https://datatracker.ietf.org/doc/html/rfc5929#section-4.1
+                        ID_SHA_1
+                        | ID_SHA_256
+                        | SHA_1_WITH_RSA_ENCRYPTION
+                        | SHA_256_WITH_RSA_ENCRYPTION
+                        | ECDSA_WITH_SHA_256 => Sha256::digest(certs[0].as_ref()).to_vec(),
+                        ID_SHA_384 | SHA_384_WITH_RSA_ENCRYPTION | ECDSA_WITH_SHA_384 => {
+                            Sha384::digest(certs[0].as_ref()).to_vec()
+                        }
+                        ID_SHA_512 | SHA_512_WITH_RSA_ENCRYPTION | ID_ED_25519 => {
+                            Sha512::digest(certs[0].as_ref()).to_vec()
+                        }
+                        _ => return None,
+                    };
+                    Some(hash)
+                })
+                .map_or_else(ChannelBinding::none, |hash| {
+                    ChannelBinding::tls_server_end_point(hash)
+                }),
+            _ => ChannelBinding::none(),
+        }
+    }
+}
+
+impl<S> AsyncRead for RustlsStream<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<tokio::io::Result<()>> {
+        Pin::new(&mut self.0).poll_read(cx, buf)
+    }
+}
+
+impl<S> AsyncWrite for RustlsStream<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<tokio::io::Result<usize>> {
+        Pin::new(&mut self.0).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<tokio::io::Result<()>> {
+        Pin::new(&mut self.0).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<tokio::io::Result<()>> {
+        Pin::new(&mut self.0).poll_shutdown(cx)
+    }
+}
+
+/// A `MakeTlsConnect` implementation using `rustls`.
+#[derive(Clone)]
+pub(crate) struct MakeRustlsConnect {
+    config: Arc<ClientConfig>,
+}
+
+impl MakeRustlsConnect {
+    pub(crate) fn new(config: ClientConfig) -> Self {
+        Self {
+            config: Arc::new(config),
+        }
+    }
+}
+
+impl<S> MakeTlsConnect<S> for MakeRustlsConnect
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    type Stream = RustlsStream<S>;
+    type TlsConnect = RustlsConnect;
+    type Error = rustls::pki_types::InvalidDnsNameError;
+
+    fn make_tls_connect(&mut self, hostname: &str) -> Result<Self::TlsConnect, Self::Error> {
+        ServerName::try_from(hostname).map(|dns_name| {
+            RustlsConnect(RustlsConnectData {
+                hostname: dns_name.to_owned(),
+                connector: Arc::clone(&self.config).into(),
+            })
+        })
+    }
+}

--- a/crates/toasty-driver-postgresql/src/tls/connect.rs
+++ b/crates/toasty-driver-postgresql/src/tls/connect.rs
@@ -168,7 +168,7 @@ where
 }
 
 /// A `MakeTlsConnect` implementation using `rustls`.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct MakeRustlsConnect {
     config: Arc<ClientConfig>,
 }

--- a/crates/toasty-driver-postgresql/src/tls/mod.rs
+++ b/crates/toasty-driver-postgresql/src/tls/mod.rs
@@ -1,5 +1,93 @@
 mod config;
 mod connect;
 
-pub(crate) use config::{SslVerifyMode, build_client_config};
+use config::{SslVerifyMode, build_client_config};
 pub(crate) use connect::MakeRustlsConnect;
+
+use tokio_postgres::Config;
+use url::Url;
+
+pub(crate) fn configure_tls(
+    url: &Url,
+    config: &mut Config,
+) -> Result<Option<MakeRustlsConnect>, toasty_core::Error> {
+    let mut sslmode = SslVerifyMode::Prefer;
+    let mut sslrootcert: Option<String> = None;
+    let mut sslcert: Option<String> = None;
+    let mut sslkey: Option<String> = None;
+
+    for (key, value) in url.query_pairs() {
+        match key.as_ref() {
+            "sslmode" => {
+                sslmode = match value.as_ref() {
+                    "disable" => SslVerifyMode::Disable,
+                    "prefer" => SslVerifyMode::Prefer,
+                    "require" => SslVerifyMode::Require,
+                    "verify-ca" => SslVerifyMode::VerifyCa,
+                    "verify-full" => SslVerifyMode::VerifyFull,
+                    other => {
+                        return Err(toasty_core::Error::invalid_connection_url(format!(
+                            "unsupported sslmode: {other}"
+                        )));
+                    }
+                };
+            }
+            "sslrootcert" => {
+                sslrootcert = Some(value.into_owned());
+            }
+            "sslcert" => {
+                sslcert = Some(value.into_owned());
+            }
+            "sslkey" => {
+                sslkey = Some(value.into_owned());
+            }
+            "channel_binding" => {
+                let cb = match value.as_ref() {
+                    "disable" => tokio_postgres::config::ChannelBinding::Disable,
+                    "prefer" => tokio_postgres::config::ChannelBinding::Prefer,
+                    "require" => tokio_postgres::config::ChannelBinding::Require,
+                    other => {
+                        return Err(toasty_core::Error::invalid_connection_url(format!(
+                            "unsupported channel_binding: {other}"
+                        )));
+                    }
+                };
+                config.channel_binding(cb);
+            }
+            "sslnegotiation" => {
+                let neg = match value.as_ref() {
+                    "postgres" => tokio_postgres::config::SslNegotiation::Postgres,
+                    "direct" => tokio_postgres::config::SslNegotiation::Direct,
+                    other => {
+                        return Err(toasty_core::Error::invalid_connection_url(format!(
+                            "unsupported sslnegotiation: {other}"
+                        )));
+                    }
+                };
+                config.ssl_negotiation(neg);
+            }
+            _ => {}
+        }
+    }
+
+    let ssl_mode = match sslmode {
+        SslVerifyMode::Disable => tokio_postgres::config::SslMode::Disable,
+        SslVerifyMode::Prefer => tokio_postgres::config::SslMode::Prefer,
+        SslVerifyMode::Require | SslVerifyMode::VerifyCa | SslVerifyMode::VerifyFull => {
+            tokio_postgres::config::SslMode::Require
+        }
+    };
+    config.ssl_mode(ssl_mode);
+
+    if sslmode != SslVerifyMode::Disable {
+        let rustls_config = build_client_config(
+            sslmode,
+            sslrootcert.as_deref(),
+            sslcert.as_deref(),
+            sslkey.as_deref(),
+        )?;
+        Ok(Some(MakeRustlsConnect::new(rustls_config)))
+    } else {
+        Ok(None)
+    }
+}

--- a/crates/toasty-driver-postgresql/src/tls/mod.rs
+++ b/crates/toasty-driver-postgresql/src/tls/mod.rs
@@ -1,3 +1,5 @@
+mod config;
 mod connect;
 
+pub(crate) use config::{SslVerifyMode, build_client_config};
 pub(crate) use connect::MakeRustlsConnect;

--- a/crates/toasty-driver-postgresql/src/tls/mod.rs
+++ b/crates/toasty-driver-postgresql/src/tls/mod.rs
@@ -1,0 +1,3 @@
+mod connect;
+
+pub(crate) use connect::MakeRustlsConnect;

--- a/crates/toasty-driver-postgresql/src/type.rs
+++ b/crates/toasty-driver-postgresql/src/type.rs
@@ -1,5 +1,5 @@
-use postgres::types::Type;
 use toasty_core::stmt;
+use tokio_postgres::types::Type;
 
 pub trait TypeExt {
     /// Converts a Toasty type to a PostgreSQL type.

--- a/crates/toasty-driver-postgresql/src/value.rs
+++ b/crates/toasty-driver-postgresql/src/value.rs
@@ -1,8 +1,8 @@
-use postgres::{
+use toasty_core::stmt::{self, Value as CoreValue};
+use tokio_postgres::{
     Column, Row,
     types::{IsNull, ToSql, Type, accepts, private::BytesMut, to_sql_checked},
 };
-use toasty_core::stmt::{self, Value as CoreValue};
 
 #[derive(Debug)]
 pub struct Value(pub(crate) CoreValue);

--- a/tests/tests/postgresql_tls.rs
+++ b/tests/tests/postgresql_tls.rs
@@ -107,25 +107,65 @@ async fn verify_full() {
 async fn verify_full_hostname_mismatch() {
     use toasty_core::driver::Driver;
 
-    // Connect via 127.0.0.1 instead of localhost. The cert SAN has
-    // DNS:localhost,IP:127.0.0.1 -- but tokio-postgres resolves the host to
-    // an IP and uses it for TLS. We override the host to force a mismatch
-    // by using a hostname not in the cert.
+    // test.localtest.me resolves to 127.0.0.1 but is not in the certificate
+    // SAN (DNS:localhost,IP:127.0.0.1), so verify-full should reject it.
     let base = tls_url();
-    let url = base.replace("localhost", "127.0.0.2");
+    let url = base.replace("localhost", "test.localtest.me");
     let url = format!("{}?sslmode=verify-full&sslrootcert={}", url, ca_cert_path());
 
-    match PostgreSQL::new(&url) {
-        Ok(driver) => {
-            let result =
-                tokio::time::timeout(std::time::Duration::from_secs(5), driver.connect()).await;
-            match result {
-                Ok(Ok(_)) => panic!("expected connection to fail with hostname mismatch"),
-                Ok(Err(_)) | Err(_) => {} // TLS error or timeout, both acceptable
-            }
-        }
-        Err(_) => {} // acceptable: hostname resolution failure
-    }
+    let driver = PostgreSQL::new(&url).expect("driver creation failed");
+    let result = driver.connect().await;
+    assert!(
+        result.is_err(),
+        "expected connection to fail with hostname mismatch"
+    );
+}
+
+#[tokio::test]
+async fn verify_ca_hostname_mismatch() {
+    // test.localtest.me resolves to 127.0.0.1 but is not in the certificate
+    // SAN (DNS:localhost,IP:127.0.0.1). verify-ca should still accept this
+    // because it does not check the hostname.
+    let base = tls_url();
+    let url = base.replace("localhost", "test.localtest.me");
+    let url = format!("{}?sslmode=verify-ca&sslrootcert={}", url, ca_cert_path());
+
+    let driver = PostgreSQL::new(&url).expect("driver creation failed");
+    smoke_query(&driver).await;
+}
+
+#[tokio::test]
+async fn verify_ca_wrong_ca() {
+    use toasty_core::driver::Driver;
+
+    let wrong_ca = format!("{}/client.crt", certs_dir());
+    let url = format!("{}?sslmode=verify-ca&sslrootcert={}", tls_url(), wrong_ca);
+    let driver = PostgreSQL::new(&url).expect("driver creation failed");
+    let result = driver.connect().await;
+    assert!(
+        result.is_err(),
+        "expected verify-ca to reject certificate signed by untrusted CA"
+    );
+}
+
+#[test]
+fn verify_ca_requires_sslrootcert() {
+    let url = format!("{}?sslmode=verify-ca", tls_url());
+    let result = PostgreSQL::new(&url);
+    assert!(
+        result.is_err(),
+        "expected error when verify-ca used without sslrootcert"
+    );
+}
+
+#[test]
+fn verify_full_requires_sslrootcert() {
+    let url = format!("{}?sslmode=verify-full", tls_url());
+    let result = PostgreSQL::new(&url);
+    assert!(
+        result.is_err(),
+        "expected error when verify-full used without sslrootcert"
+    );
 }
 
 #[tokio::test]

--- a/tests/tests/postgresql_tls.rs
+++ b/tests/tests/postgresql_tls.rs
@@ -1,0 +1,47 @@
+#![cfg(feature = "postgresql")]
+
+use toasty_driver_postgresql::PostgreSQL;
+
+fn tls_url() -> String {
+    std::env::var("TOASTY_TEST_POSTGRES_TLS_URL")
+        .unwrap_or_else(|_| "postgresql://toasty:toasty@localhost:5433/toasty".to_string())
+}
+
+async fn smoke_query(driver: &PostgreSQL) {
+    use toasty_core::driver::Driver;
+    let conn = driver.connect().await.expect("connection failed");
+    drop(conn);
+}
+
+#[tokio::test]
+async fn tls_require() {
+    let url = format!("{}?sslmode=require", tls_url());
+    let driver = PostgreSQL::new(&url).expect("driver creation failed");
+    smoke_query(&driver).await;
+}
+
+#[tokio::test]
+async fn tls_prefer() {
+    let url = format!("{}?sslmode=prefer", tls_url());
+    let driver = PostgreSQL::new(&url).expect("driver creation failed");
+    smoke_query(&driver).await;
+}
+
+#[tokio::test]
+async fn tls_channel_binding() {
+    let url = format!("{}?sslmode=require&channel_binding=require", tls_url());
+    let driver = PostgreSQL::new(&url).expect("driver creation failed");
+    smoke_query(&driver).await;
+}
+
+#[tokio::test]
+async fn tls_disable_against_tls_server() {
+    let url = format!("{}?sslmode=disable", tls_url());
+    let driver = PostgreSQL::new(&url).expect("driver creation failed");
+    use toasty_core::driver::Driver;
+    let result = driver.connect().await;
+    assert!(
+        result.is_err(),
+        "expected connection to fail with sslmode=disable against TLS-only server"
+    );
+}

--- a/tests/tests/postgresql_tls.rs
+++ b/tests/tests/postgresql_tls.rs
@@ -7,6 +7,15 @@ fn tls_url() -> String {
         .unwrap_or_else(|_| "postgresql://toasty:toasty@localhost:5433/toasty".to_string())
 }
 
+fn certs_dir() -> String {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    format!("{manifest_dir}/tls/certs")
+}
+
+fn ca_cert_path() -> String {
+    format!("{}/ca.crt", certs_dir())
+}
+
 async fn smoke_query(driver: &PostgreSQL) {
     use toasty_core::driver::Driver;
     let conn = driver.connect().await.expect("connection failed");
@@ -44,4 +53,84 @@ async fn tls_disable_against_tls_server() {
         result.is_err(),
         "expected connection to fail with sslmode=disable against TLS-only server"
     );
+}
+
+#[tokio::test]
+async fn sslrootcert_require() {
+    let url = format!(
+        "{}?sslmode=require&sslrootcert={}",
+        tls_url(),
+        ca_cert_path()
+    );
+    let driver = PostgreSQL::new(&url).expect("driver creation failed");
+    smoke_query(&driver).await;
+}
+
+#[tokio::test]
+async fn sslrootcert_wrong_ca() {
+    use toasty_core::driver::Driver;
+
+    let wrong_ca = format!("{}/client.crt", certs_dir());
+
+    let url = format!("{}?sslmode=require&sslrootcert={}", tls_url(), wrong_ca);
+    let driver = PostgreSQL::new(&url).expect("driver creation failed");
+    let result = driver.connect().await;
+    assert!(
+        result.is_err(),
+        "expected connection to fail with wrong CA certificate"
+    );
+}
+
+#[tokio::test]
+async fn verify_ca() {
+    let url = format!(
+        "{}?sslmode=verify-ca&sslrootcert={}",
+        tls_url(),
+        ca_cert_path()
+    );
+    let driver = PostgreSQL::new(&url).expect("driver creation failed");
+    smoke_query(&driver).await;
+}
+
+#[tokio::test]
+async fn verify_full() {
+    let url = format!(
+        "{}?sslmode=verify-full&sslrootcert={}",
+        tls_url(),
+        ca_cert_path()
+    );
+    let driver = PostgreSQL::new(&url).expect("driver creation failed");
+    smoke_query(&driver).await;
+}
+
+#[tokio::test]
+async fn verify_full_hostname_mismatch() {
+    use toasty_core::driver::Driver;
+
+    // Connect via 127.0.0.1 instead of localhost. The cert SAN has
+    // DNS:localhost,IP:127.0.0.1 -- but tokio-postgres resolves the host to
+    // an IP and uses it for TLS. We override the host to force a mismatch
+    // by using a hostname not in the cert.
+    let base = tls_url();
+    let url = base.replace("localhost", "127.0.0.2");
+    let url = format!("{}?sslmode=verify-full&sslrootcert={}", url, ca_cert_path());
+
+    match PostgreSQL::new(&url) {
+        Ok(driver) => {
+            let result =
+                tokio::time::timeout(std::time::Duration::from_secs(5), driver.connect()).await;
+            match result {
+                Ok(Ok(_)) => panic!("expected connection to fail with hostname mismatch"),
+                Ok(Err(_)) | Err(_) => {} // TLS error or timeout, both acceptable
+            }
+        }
+        Err(_) => {} // acceptable: hostname resolution failure
+    }
+}
+
+#[tokio::test]
+async fn require_without_sslrootcert() {
+    let url = format!("{}?sslmode=require", tls_url());
+    let driver = PostgreSQL::new(&url).expect("driver creation failed");
+    smoke_query(&driver).await;
 }

--- a/tests/tests/postgresql_tls.rs
+++ b/tests/tests/postgresql_tls.rs
@@ -134,3 +134,39 @@ async fn require_without_sslrootcert() {
     let driver = PostgreSQL::new(&url).expect("driver creation failed");
     smoke_query(&driver).await;
 }
+
+#[tokio::test]
+async fn client_cert_auth() {
+    let dir = certs_dir();
+    let url = format!(
+        "{}?sslmode=verify-full&sslrootcert={}/ca.crt&sslcert={}/client.crt&sslkey={}/client.key",
+        tls_url(),
+        dir,
+        dir,
+        dir
+    );
+    let driver = PostgreSQL::new(&url).expect("driver creation failed");
+    smoke_query(&driver).await;
+}
+
+#[test]
+fn missing_sslkey() {
+    let dir = certs_dir();
+    let url = format!("{}?sslcert={}/client.crt", tls_url(), dir);
+    let result = PostgreSQL::new(&url);
+    assert!(
+        result.is_err(),
+        "expected error when sslcert set without sslkey"
+    );
+}
+
+#[test]
+fn missing_sslcert() {
+    let dir = certs_dir();
+    let url = format!("{}?sslkey={}/client.key", tls_url(), dir);
+    let result = PostgreSQL::new(&url);
+    assert!(
+        result.is_err(),
+        "expected error when sslkey set without sslcert"
+    );
+}

--- a/tests/tls/generate-certs.sh
+++ b/tests/tls/generate-certs.sh
@@ -41,7 +41,8 @@ openssl x509 -req \
     -CAkey "$DIR/ca.key" \
     -CAcreateserial \
     -days 36500 \
-    -out "$DIR/client.crt"
+    -out "$DIR/client.crt" \
+    -extfile <(printf "extendedKeyUsage=clientAuth")
 
 # Cleanup CSRs and serial files
 rm -f "$DIR"/*.csr "$DIR"/*.srl

--- a/tests/tls/generate-certs.sh
+++ b/tests/tls/generate-certs.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -euo pipefail
+
+# Generates test PKI for TLS integration tests.
+# Output goes to ./certs/ relative to this script.
+# Certs are valid for 100 years so they never expire in CI.
+
+DIR="$(cd "$(dirname "$0")/certs" && pwd)"
+
+# CA
+openssl req -new -x509 -nodes \
+    -days 36500 \
+    -keyout "$DIR/ca.key" \
+    -out "$DIR/ca.crt" \
+    -subj "/CN=Toasty Test CA"
+
+# Server cert (SAN=localhost,127.0.0.1)
+openssl req -new -nodes \
+    -keyout "$DIR/server.key" \
+    -out "$DIR/server.csr" \
+    -subj "/CN=localhost"
+
+openssl x509 -req \
+    -in "$DIR/server.csr" \
+    -CA "$DIR/ca.crt" \
+    -CAkey "$DIR/ca.key" \
+    -CAcreateserial \
+    -days 36500 \
+    -out "$DIR/server.crt" \
+    -extfile <(printf "subjectAltName=DNS:localhost,IP:127.0.0.1")
+
+# Client cert
+openssl req -new -nodes \
+    -keyout "$DIR/client.key" \
+    -out "$DIR/client.csr" \
+    -subj "/CN=toasty"
+
+openssl x509 -req \
+    -in "$DIR/client.csr" \
+    -CA "$DIR/ca.crt" \
+    -CAkey "$DIR/ca.key" \
+    -CAcreateserial \
+    -days 36500 \
+    -out "$DIR/client.crt"
+
+# Cleanup CSRs and serial files
+rm -f "$DIR"/*.csr "$DIR"/*.srl
+
+echo "Generated test certificates in $DIR"

--- a/tests/tls/pg_hba.conf
+++ b/tests/tls/pg_hba.conf
@@ -1,0 +1,3 @@
+local   all   all                 scram-sha-256
+hostssl all   all   0.0.0.0/0     scram-sha-256
+hostssl all   all   ::/0          scram-sha-256

--- a/tests/tls/setup-ssl.sh
+++ b/tests/tls/setup-ssl.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Wrapper entrypoint: copies TLS certs into place, then delegates
+# to the standard postgres docker-entrypoint.
+set -e
+
+cp /certs/server.crt /var/lib/postgresql/server.crt
+cp /certs/server.key /var/lib/postgresql/server.key
+cp /certs/ca.crt /var/lib/postgresql/ca.crt
+cp /etc/pg_hba.conf /var/lib/postgresql/pg_hba.conf
+
+chown postgres:postgres /var/lib/postgresql/server.crt \
+                        /var/lib/postgresql/server.key \
+                        /var/lib/postgresql/ca.crt \
+                        /var/lib/postgresql/pg_hba.conf
+
+chmod 600 /var/lib/postgresql/server.key
+
+exec docker-entrypoint.sh "$@"


### PR DESCRIPTION
Adds rustls-based TLS support to `toasty-driver-postgresql`, gated behind a `tls` feature (enabled by default). This enables encrypted connections and supports the full set of libpq SSL parameters: `sslmode`, `sslrootcert`, `sslcert`, `sslkey`, `channel_binding`, and `sslnegotiation`.

The `tokio-postgres-rustls` crate is vendored (from commit `4326f72`) because the upstream has not released a fix for channel binding support ([jbg/tokio-postgres-rustls#32](https://github.com/jbg/tokio-postgres-rustls/pull/32)). The vendored code replaces `ring` with `sha2` for channel binding hashes and is kept under the original MIT license with attribution.

Verification modes follow libpq semantics:
- `require` — encryption only, no certificate verification (unless `sslrootcert` is provided, in which case it behaves like `verify-ca`)
- `verify-ca` — validates the server certificate chain against `sslrootcert`
- `verify-full` — additionally verifies the server hostname
- `sslrootcert=system` — uses platform certificate store via `rustls-platform-verifier` (we can switch to `rustls-native-certs` if desired, but they recommend using platform verifier)

Includes Docker Compose test infrastructure with a TLS-enabled PostgreSQL service and self-signed certificates, covering `sslmode` variants, `sslrootcert` verification, client certificate auth, and channel binding.

fixes #660 #651 

---

Written with the assistance of claude-4.6-opus. I still want to give it another review pass before merging.