### PR TITLE
feat: multi-column composite index support

### DIFF
--- a/crates/toasty-driver-dynamodb/src/lib.rs
+++ b/crates/toasty-driver-dynamodb/src/lib.rs
@@ -269,21 +269,26 @@ fn deserialize_ddb_cursor(cursor: &stmt::Value) -> HashMap<String, AttributeValu
     ret
 }
 
-fn ddb_key_schema(partition: &Column, range: Option<&Column>) -> Vec<KeySchemaElement> {
+fn ddb_key_schema(
+    partition_columns: &[&Column],
+    range_columns: &[&Column],
+) -> Vec<KeySchemaElement> {
     let mut ks = vec![];
 
-    ks.push(
-        KeySchemaElement::builder()
-            .attribute_name(&partition.name)
-            .key_type(KeyType::Hash)
-            .build()
-            .unwrap(),
-    );
-
-    if let Some(range) = range {
+    for col in partition_columns {
         ks.push(
             KeySchemaElement::builder()
-                .attribute_name(&range.name)
+                .attribute_name(&col.name)
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        );
+    }
+
+    for col in range_columns {
+        ks.push(
+            KeySchemaElement::builder()
+                .attribute_name(&col.name)
                 .key_type(KeyType::Range)
                 .build()
                 .unwrap(),

--- a/crates/toasty-driver-dynamodb/src/op/create_table.rs
+++ b/crates/toasty-driver-dynamodb/src/op/create_table.rs
@@ -33,22 +33,23 @@ impl Connection {
         // Calculate which attributes need to be defined
         let mut defined_attributes = std::collections::HashSet::new();
 
-        let mut pk_columns = table.primary_key_columns();
+        let pk_cols: Vec<&db::Column> = table.primary_key_columns().collect();
 
-        // TODO: for now, up to 2 columns are supported as part of the PK.
         assert!(
-            pk_columns.len() >= 1 && pk_columns.len() <= 2,
+            !pk_cols.is_empty() && pk_cols.len() <= 2,
             "TABLE={table:#?}"
         );
 
-        let partition_column = pk_columns.next().unwrap();
-        defined_attributes.insert(partition_column.id);
-
-        let range_column = pk_columns.next();
-
-        if let Some(range_column) = &range_column {
-            defined_attributes.insert(range_column.id);
+        for col in &pk_cols {
+            defined_attributes.insert(col.id);
         }
+
+        let pk_partition_cols = &pk_cols[..1];
+        let pk_range_cols = if pk_cols.len() > 1 {
+            &pk_cols[1..]
+        } else {
+            &[][..]
+        };
 
         let mut gsis = vec![];
 
@@ -57,14 +58,46 @@ impl Connection {
                 continue;
             }
 
-            assert_eq!(1, index.columns.len());
-            let field = &table.column(index.columns[0].column);
-            defined_attributes.insert(field.id);
+            let partition_cols: Vec<&db::Column> = index
+                .columns
+                .iter()
+                .filter(|ic| ic.scope.is_partition())
+                .map(|ic| table.column(ic.column))
+                .collect();
+
+            let range_cols: Vec<&db::Column> = index
+                .columns
+                .iter()
+                .filter(|ic| ic.scope.is_local())
+                .map(|ic| table.column(ic.column))
+                .collect();
+
+            assert!(
+                !partition_cols.is_empty() && partition_cols.len() <= 4,
+                "GSI '{}' must have 1 to 4 partition (HASH) columns, got {}",
+                index.name,
+                partition_cols.len()
+            );
+
+            assert!(
+                range_cols.len() <= 4,
+                "GSI '{}' must have at most 4 range (RANGE) columns, got {}",
+                index.name,
+                range_cols.len()
+            );
+
+            for col in &partition_cols {
+                defined_attributes.insert(col.id);
+            }
+
+            for col in &range_cols {
+                defined_attributes.insert(col.id);
+            }
 
             gsis.push(
                 GlobalSecondaryIndex::builder()
                     .index_name(&index.name)
-                    .set_key_schema(Some(ddb_key_schema(field, None)))
+                    .set_key_schema(Some(ddb_key_schema(&partition_cols, &range_cols)))
                     .projection(
                         Projection::builder()
                             .projection_type(ProjectionType::All)
@@ -93,7 +126,7 @@ impl Connection {
             .create_table()
             .table_name(&table.name)
             .set_attribute_definitions(Some(attribute_definitions))
-            .set_key_schema(Some(ddb_key_schema(partition_column, range_column)))
+            .set_key_schema(Some(ddb_key_schema(pk_partition_cols, pk_range_cols)))
             .set_global_secondary_indexes(if gsis.is_empty() { None } else { Some(gsis) })
             .billing_mode(BillingMode::PayPerRequest)
             .send()
@@ -110,7 +143,7 @@ impl Connection {
             self.client
                 .create_table()
                 .table_name(&index.name)
-                .set_key_schema(Some(ddb_key_schema(pk, None)))
+                .set_key_schema(Some(ddb_key_schema(&[pk], &[])))
                 .attribute_definitions(
                     AttributeDefinition::builder()
                         .attribute_name(&pk.name)

--- a/crates/toasty-driver-dynamodb/src/op/create_table.rs
+++ b/crates/toasty-driver-dynamodb/src/op/create_table.rs
@@ -35,10 +35,13 @@ impl Connection {
 
         let pk_cols: Vec<&db::Column> = table.primary_key_columns().collect();
 
-        assert!(
-            !pk_cols.is_empty() && pk_cols.len() <= 2,
-            "TABLE={table:#?}"
-        );
+        if pk_cols.is_empty() || pk_cols.len() > 2 {
+            return Err(toasty_core::Error::invalid_schema(format!(
+                "table '{}' primary key must have 1 or 2 columns, got {}",
+                table.name,
+                pk_cols.len()
+            )));
+        }
 
         for col in &pk_cols {
             defined_attributes.insert(col.id);
@@ -72,19 +75,21 @@ impl Connection {
                 .map(|ic| table.column(ic.column))
                 .collect();
 
-            assert!(
-                !partition_cols.is_empty() && partition_cols.len() <= 4,
-                "GSI '{}' must have 1 to 4 partition (HASH) columns, got {}",
-                index.name,
-                partition_cols.len()
-            );
+            if partition_cols.is_empty() || partition_cols.len() > 4 {
+                return Err(toasty_core::Error::invalid_schema(format!(
+                    "GSI '{}' must have 1 to 4 partition (HASH) columns, got {}",
+                    index.name,
+                    partition_cols.len()
+                )));
+            }
 
-            assert!(
-                range_cols.len() <= 4,
-                "GSI '{}' must have at most 4 range (RANGE) columns, got {}",
-                index.name,
-                range_cols.len()
-            );
+            if range_cols.len() > 4 {
+                return Err(toasty_core::Error::invalid_schema(format!(
+                    "GSI '{}' must have at most 4 range (RANGE) columns, got {}",
+                    index.name,
+                    range_cols.len()
+                )));
+            }
 
             for col in &partition_cols {
                 defined_attributes.insert(col.id);

--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -33,6 +33,7 @@ pub mod field_auto;
 pub mod field_column_name;
 pub mod field_column_type;
 pub mod field_default_and_update;
+pub mod gsi_composite;
 pub mod infra_connection_per_clone;
 pub mod infra_missing_registrations;
 pub mod infra_reset_db;

--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -33,7 +33,7 @@ pub mod field_auto;
 pub mod field_column_name;
 pub mod field_column_type;
 pub mod field_default_and_update;
-pub mod gsi_composite;
+pub mod index_composite;
 pub mod infra_connection_per_clone;
 pub mod infra_missing_registrations;
 pub mod infra_reset_db;

--- a/crates/toasty-driver-integration-suite/src/tests/gsi_composite.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/gsi_composite.rs
@@ -17,25 +17,11 @@ pub async fn gsi_composite_query(t: &mut Test) -> Result<()> {
 
     let mut db = t.setup_db(models!(GameScore)).await;
 
-    toasty::create!(GameScore {
-        user_id: "u1",
-        game_title: "chess",
-        top_score: 100_i64
-    })
-    .exec(&mut db)
-    .await?;
-    toasty::create!(GameScore {
-        user_id: "u2",
-        game_title: "chess",
-        top_score: 200_i64
-    })
-    .exec(&mut db)
-    .await?;
-    toasty::create!(GameScore {
-        user_id: "u1",
-        game_title: "go",
-        top_score: 50_i64
-    })
+    toasty::create!(GameScore::[
+        { user_id: "u1", game_title: "chess", top_score: 100_i64 },
+        { user_id: "u2", game_title: "chess", top_score: 200_i64 },
+        { user_id: "u1", game_title: "go", top_score: 50_i64 },
+    ])
     .exec(&mut db)
     .await?;
 
@@ -70,28 +56,11 @@ pub async fn gsi_single_column_model_level(t: &mut Test) -> Result<()> {
 
     let mut db = t.setup_db(models!(Post)).await;
 
-    toasty::create!(Post {
-        id: "p1",
-        name: "first",
-        user_id: "alice",
-        title: "Hello World",
-    })
-    .exec(&mut db)
-    .await?;
-    toasty::create!(Post {
-        id: "p2",
-        name: "second",
-        user_id: "alice",
-        title: "Another Post",
-    })
-    .exec(&mut db)
-    .await?;
-    toasty::create!(Post {
-        id: "p3",
-        name: "third",
-        user_id: "bob",
-        title: "Bob's Post",
-    })
+    toasty::create!(Post::[
+        { id: "p1", name: "first", user_id: "alice", title: "Hello World" },
+        { id: "p2", name: "second", user_id: "alice", title: "Another Post" },
+        { id: "p3", name: "third", user_id: "bob", title: "Bob's Post" },
+    ])
     .exec(&mut db)
     .await?;
 
@@ -135,32 +104,12 @@ pub async fn gsi_two_column_prefix_queries(t: &mut Test) -> Result<()> {
 
     let mut db = t.setup_db(models!(GameScore)).await;
 
-    toasty::create!(GameScore {
-        user_id: "u1",
-        game_title: "chess",
-        top_score: 100_i64
-    })
-    .exec(&mut db)
-    .await?;
-    toasty::create!(GameScore {
-        user_id: "u2",
-        game_title: "chess",
-        top_score: 200_i64
-    })
-    .exec(&mut db)
-    .await?;
-    toasty::create!(GameScore {
-        user_id: "u3",
-        game_title: "chess",
-        top_score: 200_i64
-    })
-    .exec(&mut db)
-    .await?;
-    toasty::create!(GameScore {
-        user_id: "u1",
-        game_title: "go",
-        top_score: 50_i64
-    })
+    toasty::create!(GameScore::[
+        { user_id: "u1", game_title: "chess", top_score: 100_i64 },
+        { user_id: "u2", game_title: "chess", top_score: 200_i64 },
+        { user_id: "u3", game_title: "chess", top_score: 200_i64 },
+        { user_id: "u1", game_title: "go", top_score: 50_i64 },
+    ])
     .exec(&mut db)
     .await?;
 
@@ -220,34 +169,11 @@ pub async fn gsi_multi_attribute_partition_key(t: &mut Test) -> Result<()> {
 
     let mut db = t.setup_db(models!(Match)).await;
 
-    toasty::create!(Match {
-        id: "m1",
-        tournament_id: "WINTER2024",
-        region: "NA-EAST",
-        round: "SEMIFINALS",
-        player1_id: "alice",
-        player2_id: "bob",
-    })
-    .exec(&mut db)
-    .await?;
-    toasty::create!(Match {
-        id: "m2",
-        tournament_id: "WINTER2024",
-        region: "NA-EAST",
-        round: "FINALS",
-        player1_id: "charlie",
-        player2_id: "dave",
-    })
-    .exec(&mut db)
-    .await?;
-    toasty::create!(Match {
-        id: "m3",
-        tournament_id: "WINTER2024",
-        region: "EU-WEST",
-        round: "SEMIFINALS",
-        player1_id: "eve",
-        player2_id: "frank",
-    })
+    toasty::create!(Match::[
+        { id: "m1", tournament_id: "WINTER2024", region: "NA-EAST", round: "SEMIFINALS", player1_id: "alice", player2_id: "bob" },
+        { id: "m2", tournament_id: "WINTER2024", region: "NA-EAST", round: "FINALS", player1_id: "charlie", player2_id: "dave" },
+        { id: "m3", tournament_id: "WINTER2024", region: "EU-WEST", round: "SEMIFINALS", player1_id: "eve", player2_id: "frank" },
+    ])
     .exec(&mut db)
     .await?;
 
@@ -308,44 +234,12 @@ pub async fn gsi_multi_attribute_sort_key(t: &mut Test) -> Result<()> {
 
     let mut db = t.setup_db(models!(PlayerMatch)).await;
 
-    toasty::create!(PlayerMatch {
-        id: "pm1",
-        player_id: "101",
-        match_date: "2024-01-18",
-        round: "SEMIFINALS",
-        opponent_id: "102",
-        score: "3-1",
-    })
-    .exec(&mut db)
-    .await?;
-    toasty::create!(PlayerMatch {
-        id: "pm2",
-        player_id: "101",
-        match_date: "2024-01-18",
-        round: "FINALS",
-        opponent_id: "103",
-        score: "2-1",
-    })
-    .exec(&mut db)
-    .await?;
-    toasty::create!(PlayerMatch {
-        id: "pm3",
-        player_id: "101",
-        match_date: "2024-01-25",
-        round: "SEMIFINALS",
-        opponent_id: "104",
-        score: "3-0",
-    })
-    .exec(&mut db)
-    .await?;
-    toasty::create!(PlayerMatch {
-        id: "pm4",
-        player_id: "999",
-        match_date: "2024-01-18",
-        round: "QUARTERFINALS",
-        opponent_id: "101",
-        score: "1-3",
-    })
+    toasty::create!(PlayerMatch::[
+        { id: "pm1", player_id: "101", match_date: "2024-01-18", round: "SEMIFINALS", opponent_id: "102", score: "3-1" },
+        { id: "pm2", player_id: "101", match_date: "2024-01-18", round: "FINALS", opponent_id: "103", score: "2-1" },
+        { id: "pm3", player_id: "101", match_date: "2024-01-25", round: "SEMIFINALS", opponent_id: "104", score: "3-0" },
+        { id: "pm4", player_id: "999", match_date: "2024-01-18", round: "QUARTERFINALS", opponent_id: "101", score: "1-3" },
+    ])
     .exec(&mut db)
     .await?;
 
@@ -414,36 +308,12 @@ pub async fn gsi_sql_three_column(t: &mut Test) -> Result<()> {
 
     let mut db = t.setup_db(models!(Address)).await;
 
-    toasty::create!(Address {
-        country: "US",
-        city: "Seattle",
-        zip_code: "98101",
-        street: "1st Ave",
-    })
-    .exec(&mut db)
-    .await?;
-    toasty::create!(Address {
-        country: "US",
-        city: "Seattle",
-        zip_code: "98102",
-        street: "2nd Ave",
-    })
-    .exec(&mut db)
-    .await?;
-    toasty::create!(Address {
-        country: "US",
-        city: "Portland",
-        zip_code: "97201",
-        street: "Oak St",
-    })
-    .exec(&mut db)
-    .await?;
-    toasty::create!(Address {
-        country: "CA",
-        city: "Toronto",
-        zip_code: "M5V",
-        street: "King St",
-    })
+    toasty::create!(Address::[
+        { country: "US", city: "Seattle", zip_code: "98101", street: "1st Ave" },
+        { country: "US", city: "Seattle", zip_code: "98102", street: "2nd Ave" },
+        { country: "US", city: "Portland", zip_code: "97201", street: "Oak St" },
+        { country: "CA", city: "Toronto", zip_code: "M5V", street: "King St" },
+    ])
     .exec(&mut db)
     .await?;
 

--- a/crates/toasty-driver-integration-suite/src/tests/gsi_composite.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/gsi_composite.rs
@@ -106,7 +106,7 @@ pub async fn gsi_single_column_model_level(t: &mut Test) -> Result<()> {
     if t.capability().sql {
         assert_struct!(op, Operation::QuerySql(_));
     } else {
-        assert_struct!(op, Operation::FindPkByIndex(_));
+        assert_struct!(op, Operation::QueryPk(_));
     }
 
     Ok(())
@@ -173,7 +173,7 @@ pub async fn gsi_two_column_prefix_queries(t: &mut Test) -> Result<()> {
     if t.capability().sql {
         assert_struct!(op, Operation::QuerySql(_));
     } else {
-        assert_struct!(op, Operation::FindPkByIndex(_));
+        assert_struct!(op, Operation::QueryPk(_));
     }
 
     t.log().clear();
@@ -189,7 +189,7 @@ pub async fn gsi_two_column_prefix_queries(t: &mut Test) -> Result<()> {
     if t.capability().sql {
         assert_struct!(op, Operation::QuerySql(_));
     } else {
-        assert_struct!(op, Operation::FindPkByIndex(_));
+        assert_struct!(op, Operation::QueryPk(_));
     }
 
     Ok(())
@@ -199,8 +199,8 @@ pub async fn gsi_two_column_prefix_queries(t: &mut Test) -> Result<()> {
 ///
 /// A model with `#[index(partition = tournament_id, partition = region, local = round)]`
 /// creates a GSI with 2 HASH + 1 RANGE attributes. Verifies that:
-/// - `filter_by_tournament_id_and_region()` issues `FindPkByIndex`
-/// - `filter_by_tournament_id_and_region_and_round()` issues `FindPkByIndex`
+/// - `filter_by_tournament_id_and_region()` issues `QueryPk` (with index)
+/// - `filter_by_tournament_id_and_region_and_round()` issues `QueryPk` (with index)
 #[driver_test(requires(not(sql)))]
 pub async fn gsi_multi_attribute_partition_key(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
@@ -259,7 +259,7 @@ pub async fn gsi_multi_attribute_partition_key(t: &mut Test) -> Result<()> {
     assert_eq!(matches[1].round, "FINALS");
 
     let op = t.log().pop_op();
-    assert_struct!(op, Operation::FindPkByIndex(_));
+    assert_struct!(op, Operation::QueryPk(_));
 
     t.log().clear();
 
@@ -273,7 +273,7 @@ pub async fn gsi_multi_attribute_partition_key(t: &mut Test) -> Result<()> {
     assert_eq!(matches[0].player1_id, "alice");
 
     let op = t.log().pop_op();
-    assert_struct!(op, Operation::FindPkByIndex(_));
+    assert_struct!(op, Operation::QueryPk(_));
 
     Ok(())
 }
@@ -281,7 +281,8 @@ pub async fn gsi_multi_attribute_partition_key(t: &mut Test) -> Result<()> {
 /// Test D: multi-attribute sort key (DDB-only).
 ///
 /// A model with `#[index(partition = player_id, local = match_date, local = round)]`
-/// creates a GSI with 1 HASH + 2 RANGE attributes. Verifies all valid prefix queries:
+/// creates a GSI with 1 HASH + 2 RANGE attributes. Verifies all valid prefix queries
+/// each issue `QueryPk` (with index):
 /// - `filter_by_player_id()`
 /// - `filter_by_player_id_and_match_date()`
 /// - `filter_by_player_id_and_match_date_and_round()`
@@ -347,7 +348,7 @@ pub async fn gsi_multi_attribute_sort_key(t: &mut Test) -> Result<()> {
     assert_eq!(matches.len(), 3);
 
     let op = t.log().pop_op();
-    assert_struct!(op, Operation::FindPkByIndex(_));
+    assert_struct!(op, Operation::QueryPk(_));
 
     t.log().clear();
 
@@ -359,7 +360,7 @@ pub async fn gsi_multi_attribute_sort_key(t: &mut Test) -> Result<()> {
     assert_eq!(matches.len(), 2);
 
     let op = t.log().pop_op();
-    assert_struct!(op, Operation::FindPkByIndex(_));
+    assert_struct!(op, Operation::QueryPk(_));
 
     t.log().clear();
 
@@ -375,7 +376,7 @@ pub async fn gsi_multi_attribute_sort_key(t: &mut Test) -> Result<()> {
     assert_eq!(matches[0].opponent_id, "102");
 
     let op = t.log().pop_op();
-    assert_struct!(op, Operation::FindPkByIndex(_));
+    assert_struct!(op, Operation::QueryPk(_));
 
     Ok(())
 }

--- a/crates/toasty-driver-integration-suite/src/tests/gsi_composite.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/gsi_composite.rs
@@ -1,0 +1,469 @@
+use crate::prelude::*;
+use toasty_core::driver::Operation;
+
+/// A model with a composite primary key and a composite GSI (partition + sort key).
+/// This tests that model-level `#[index(field_a, field_b)]` creates a proper two-column
+/// GSI on DynamoDB (hash key + range key), not just a single-column index.
+#[driver_test]
+pub async fn gsi_composite_query(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    #[key(user_id, game_title)]
+    #[index(game_title, top_score)]
+    struct GameScore {
+        user_id: String,
+        game_title: String,
+        top_score: i64,
+    }
+
+    let mut db = t.setup_db(models!(GameScore)).await;
+
+    toasty::create!(GameScore {
+        user_id: "u1",
+        game_title: "chess",
+        top_score: 100_i64
+    })
+    .exec(&mut db)
+    .await?;
+    toasty::create!(GameScore {
+        user_id: "u2",
+        game_title: "chess",
+        top_score: 200_i64
+    })
+    .exec(&mut db)
+    .await?;
+    toasty::create!(GameScore {
+        user_id: "u1",
+        game_title: "go",
+        top_score: 50_i64
+    })
+    .exec(&mut db)
+    .await?;
+
+    let mut scores: Vec<GameScore> = GameScore::filter_by_game_title("chess")
+        .exec(&mut db)
+        .await?;
+    scores.sort_by_key(|s| s.top_score);
+
+    assert_eq!(scores.len(), 2);
+    assert_eq!(scores[0].top_score, 100);
+    assert_eq!(scores[1].top_score, 200);
+
+    Ok(())
+}
+
+/// Test A: single-column model-level index (cross-driver).
+///
+/// A model with `#[index(user_id)]` at the struct level — equivalent to placing
+/// `#[index]` on the `user_id` field directly. Verifies that `filter_by_user_id()`
+/// returns the correct records.
+#[driver_test]
+pub async fn gsi_single_column_model_level(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    #[key(id, name)]
+    #[index(user_id)]
+    struct Post {
+        id: String,
+        name: String,
+        user_id: String,
+        title: String,
+    }
+
+    let mut db = t.setup_db(models!(Post)).await;
+
+    Post::create()
+        .id("p1")
+        .name("first")
+        .user_id("alice")
+        .title("Hello World")
+        .exec(&mut db)
+        .await?;
+    Post::create()
+        .id("p2")
+        .name("second")
+        .user_id("alice")
+        .title("Another Post")
+        .exec(&mut db)
+        .await?;
+    Post::create()
+        .id("p3")
+        .name("third")
+        .user_id("bob")
+        .title("Bob's Post")
+        .exec(&mut db)
+        .await?;
+
+    t.log().clear();
+
+    let mut posts: Vec<Post> = Post::filter_by_user_id("alice").exec(&mut db).await?;
+    posts.sort_by(|a, b| a.id.cmp(&b.id));
+
+    assert_eq!(posts.len(), 2);
+    assert_eq!(posts[0].title, "Hello World");
+    assert_eq!(posts[1].title, "Another Post");
+
+    // Verify that an indexed operation was issued (not a full scan)
+    let op = t.log().pop_op();
+    if t.capability().sql {
+        assert_struct!(op, Operation::QuerySql(_));
+    } else {
+        assert_struct!(op, Operation::FindPkByIndex(_));
+    }
+
+    Ok(())
+}
+
+/// Test B: two-column index with prefix queries (cross-driver).
+///
+/// A model with `#[index(game_title, top_score)]` generates two filter methods:
+/// - `filter_by_game_title()` — uses partition key only
+/// - `filter_by_game_title_and_top_score()` — uses both partition and sort key
+///
+/// Verifies both methods issue the correct indexed operation type.
+#[driver_test]
+pub async fn gsi_two_column_prefix_queries(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    #[key(user_id, game_title)]
+    #[index(game_title, top_score)]
+    struct GameScore {
+        user_id: String,
+        game_title: String,
+        top_score: i64,
+    }
+
+    let mut db = t.setup_db(models!(GameScore)).await;
+
+    toasty::create!(GameScore {
+        user_id: "u1",
+        game_title: "chess",
+        top_score: 100_i64
+    })
+    .exec(&mut db)
+    .await?;
+    toasty::create!(GameScore {
+        user_id: "u2",
+        game_title: "chess",
+        top_score: 200_i64
+    })
+    .exec(&mut db)
+    .await?;
+    toasty::create!(GameScore {
+        user_id: "u3",
+        game_title: "chess",
+        top_score: 200_i64
+    })
+    .exec(&mut db)
+    .await?;
+    toasty::create!(GameScore {
+        user_id: "u1",
+        game_title: "go",
+        top_score: 50_i64
+    })
+    .exec(&mut db)
+    .await?;
+
+    t.log().clear();
+
+    // Test prefix query: partition key only
+    let scores: Vec<GameScore> = GameScore::filter_by_game_title("chess")
+        .exec(&mut db)
+        .await?;
+    assert_eq!(scores.len(), 3);
+
+    let op = t.log().pop_op();
+    if t.capability().sql {
+        assert_struct!(op, Operation::QuerySql(_));
+    } else {
+        assert_struct!(op, Operation::FindPkByIndex(_));
+    }
+
+    t.log().clear();
+
+    // Test full key query: partition + sort key
+    let scores: Vec<GameScore> = GameScore::filter_by_game_title_and_top_score("chess", 100)
+        .exec(&mut db)
+        .await?;
+    assert_eq!(scores.len(), 1);
+    assert_eq!(scores[0].user_id, "u1");
+
+    let op = t.log().pop_op();
+    if t.capability().sql {
+        assert_struct!(op, Operation::QuerySql(_));
+    } else {
+        assert_struct!(op, Operation::FindPkByIndex(_));
+    }
+
+    Ok(())
+}
+
+/// Test C: multi-attribute partition key (DDB-only).
+///
+/// A model with `#[index(partition = tournament_id, partition = region, local = round)]`
+/// creates a GSI with 2 HASH + 1 RANGE attributes. Verifies that:
+/// - `filter_by_tournament_id_and_region()` issues `FindPkByIndex`
+/// - `filter_by_tournament_id_and_region_and_round()` issues `FindPkByIndex`
+#[driver_test(requires(not(sql)))]
+pub async fn gsi_multi_attribute_partition_key(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    #[key(id)]
+    #[index(partition = tournament_id, partition = region, local = round)]
+    struct Match {
+        id: String,
+        tournament_id: String,
+        region: String,
+        round: String,
+        player1_id: String,
+        player2_id: String,
+    }
+
+    let mut db = t.setup_db(models!(Match)).await;
+
+    Match::create()
+        .id("m1")
+        .tournament_id("WINTER2024")
+        .region("NA-EAST")
+        .round("SEMIFINALS")
+        .player1_id("alice")
+        .player2_id("bob")
+        .exec(&mut db)
+        .await?;
+    Match::create()
+        .id("m2")
+        .tournament_id("WINTER2024")
+        .region("NA-EAST")
+        .round("FINALS")
+        .player1_id("charlie")
+        .player2_id("dave")
+        .exec(&mut db)
+        .await?;
+    Match::create()
+        .id("m3")
+        .tournament_id("WINTER2024")
+        .region("EU-WEST")
+        .round("SEMIFINALS")
+        .player1_id("eve")
+        .player2_id("frank")
+        .exec(&mut db)
+        .await?;
+
+    t.log().clear();
+
+    // Query by all partition key attributes (required for DDB GSI access)
+    let mut matches: Vec<Match> =
+        Match::filter_by_tournament_id_and_region("WINTER2024", "NA-EAST")
+            .exec(&mut db)
+            .await?;
+    matches.sort_by(|a, b| a.id.cmp(&b.id));
+
+    assert_eq!(matches.len(), 2);
+    assert_eq!(matches[0].round, "SEMIFINALS");
+    assert_eq!(matches[1].round, "FINALS");
+
+    let op = t.log().pop_op();
+    assert_struct!(op, Operation::FindPkByIndex(_));
+
+    t.log().clear();
+
+    // Query by partition key + sort key prefix
+    let matches: Vec<Match> =
+        Match::filter_by_tournament_id_and_region_and_round("WINTER2024", "NA-EAST", "SEMIFINALS")
+            .exec(&mut db)
+            .await?;
+
+    assert_eq!(matches.len(), 1);
+    assert_eq!(matches[0].player1_id, "alice");
+
+    let op = t.log().pop_op();
+    assert_struct!(op, Operation::FindPkByIndex(_));
+
+    Ok(())
+}
+
+/// Test D: multi-attribute sort key (DDB-only).
+///
+/// A model with `#[index(partition = player_id, local = match_date, local = round)]`
+/// creates a GSI with 1 HASH + 2 RANGE attributes. Verifies all valid prefix queries:
+/// - `filter_by_player_id()`
+/// - `filter_by_player_id_and_match_date()`
+/// - `filter_by_player_id_and_match_date_and_round()`
+#[driver_test(requires(not(sql)))]
+pub async fn gsi_multi_attribute_sort_key(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    #[key(id)]
+    #[index(partition = player_id, local = match_date, local = round)]
+    struct PlayerMatch {
+        id: String,
+        player_id: String,
+        match_date: String,
+        round: String,
+        opponent_id: String,
+        score: String,
+    }
+
+    let mut db = t.setup_db(models!(PlayerMatch)).await;
+
+    PlayerMatch::create()
+        .id("pm1")
+        .player_id("101")
+        .match_date("2024-01-18")
+        .round("SEMIFINALS")
+        .opponent_id("102")
+        .score("3-1")
+        .exec(&mut db)
+        .await?;
+    PlayerMatch::create()
+        .id("pm2")
+        .player_id("101")
+        .match_date("2024-01-18")
+        .round("FINALS")
+        .opponent_id("103")
+        .score("2-1")
+        .exec(&mut db)
+        .await?;
+    PlayerMatch::create()
+        .id("pm3")
+        .player_id("101")
+        .match_date("2024-01-25")
+        .round("SEMIFINALS")
+        .opponent_id("104")
+        .score("3-0")
+        .exec(&mut db)
+        .await?;
+    PlayerMatch::create()
+        .id("pm4")
+        .player_id("999")
+        .match_date("2024-01-18")
+        .round("QUARTERFINALS")
+        .opponent_id("101")
+        .score("1-3")
+        .exec(&mut db)
+        .await?;
+
+    t.log().clear();
+
+    // Query by partition key only — all matches for a player
+    let matches: Vec<PlayerMatch> = PlayerMatch::filter_by_player_id("101")
+        .exec(&mut db)
+        .await?;
+    assert_eq!(matches.len(), 3);
+
+    let op = t.log().pop_op();
+    assert_struct!(op, Operation::FindPkByIndex(_));
+
+    t.log().clear();
+
+    // Query by partition key + first sort key — all matches on a specific date
+    let matches: Vec<PlayerMatch> =
+        PlayerMatch::filter_by_player_id_and_match_date("101", "2024-01-18")
+            .exec(&mut db)
+            .await?;
+    assert_eq!(matches.len(), 2);
+
+    let op = t.log().pop_op();
+    assert_struct!(op, Operation::FindPkByIndex(_));
+
+    t.log().clear();
+
+    // Query by partition key + both sort keys — specific match
+    let matches: Vec<PlayerMatch> = PlayerMatch::filter_by_player_id_and_match_date_and_round(
+        "101",
+        "2024-01-18",
+        "SEMIFINALS",
+    )
+    .exec(&mut db)
+    .await?;
+    assert_eq!(matches.len(), 1);
+    assert_eq!(matches[0].opponent_id, "102");
+
+    let op = t.log().pop_op();
+    assert_struct!(op, Operation::FindPkByIndex(_));
+
+    Ok(())
+}
+
+/// Test E: SQL 3-column composite index (SQL-only).
+///
+/// A model with `#[index(country, city, zip_code)]` on a SQL driver creates a
+/// composite index with 3 columns. Verifies all three prefix query methods:
+/// - `filter_by_country()`
+/// - `filter_by_country_and_city()`
+/// - `filter_by_country_and_city_and_zip_code()`
+#[driver_test(requires(sql))]
+pub async fn gsi_sql_three_column(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    #[key(id)]
+    #[index(country, city, zip_code)]
+    struct Address {
+        #[auto]
+        id: u64,
+        country: String,
+        city: String,
+        zip_code: String,
+        street: String,
+    }
+
+    let mut db = t.setup_db(models!(Address)).await;
+
+    Address::create()
+        .country("US")
+        .city("Seattle")
+        .zip_code("98101")
+        .street("1st Ave")
+        .exec(&mut db)
+        .await?;
+    Address::create()
+        .country("US")
+        .city("Seattle")
+        .zip_code("98102")
+        .street("2nd Ave")
+        .exec(&mut db)
+        .await?;
+    Address::create()
+        .country("US")
+        .city("Portland")
+        .zip_code("97201")
+        .street("Oak St")
+        .exec(&mut db)
+        .await?;
+    Address::create()
+        .country("CA")
+        .city("Toronto")
+        .zip_code("M5V")
+        .street("King St")
+        .exec(&mut db)
+        .await?;
+
+    t.log().clear();
+
+    // 1-column prefix: country only
+    let addrs: Vec<Address> = Address::filter_by_country("US").exec(&mut db).await?;
+    assert_eq!(addrs.len(), 3);
+
+    let op = t.log().pop_op();
+    assert_struct!(op, Operation::QuerySql(_));
+
+    t.log().clear();
+
+    // 2-column prefix: country + city
+    let addrs: Vec<Address> = Address::filter_by_country_and_city("US", "Seattle")
+        .exec(&mut db)
+        .await?;
+    assert_eq!(addrs.len(), 2);
+
+    let op = t.log().pop_op();
+    assert_struct!(op, Operation::QuerySql(_));
+
+    t.log().clear();
+
+    // 3-column full key: country + city + zip_code
+    let addrs: Vec<Address> =
+        Address::filter_by_country_and_city_and_zip_code("US", "Seattle", "98101")
+            .exec(&mut db)
+            .await?;
+    assert_eq!(addrs.len(), 1);
+    assert_eq!(addrs[0].street, "1st Ave");
+
+    let op = t.log().pop_op();
+    assert_struct!(op, Operation::QuerySql(_));
+
+    Ok(())
+}

--- a/crates/toasty-driver-integration-suite/src/tests/gsi_composite.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/gsi_composite.rs
@@ -70,27 +70,30 @@ pub async fn gsi_single_column_model_level(t: &mut Test) -> Result<()> {
 
     let mut db = t.setup_db(models!(Post)).await;
 
-    Post::create()
-        .id("p1")
-        .name("first")
-        .user_id("alice")
-        .title("Hello World")
-        .exec(&mut db)
-        .await?;
-    Post::create()
-        .id("p2")
-        .name("second")
-        .user_id("alice")
-        .title("Another Post")
-        .exec(&mut db)
-        .await?;
-    Post::create()
-        .id("p3")
-        .name("third")
-        .user_id("bob")
-        .title("Bob's Post")
-        .exec(&mut db)
-        .await?;
+    toasty::create!(Post {
+        id: "p1",
+        name: "first",
+        user_id: "alice",
+        title: "Hello World",
+    })
+    .exec(&mut db)
+    .await?;
+    toasty::create!(Post {
+        id: "p2",
+        name: "second",
+        user_id: "alice",
+        title: "Another Post",
+    })
+    .exec(&mut db)
+    .await?;
+    toasty::create!(Post {
+        id: "p3",
+        name: "third",
+        user_id: "bob",
+        title: "Bob's Post",
+    })
+    .exec(&mut db)
+    .await?;
 
     t.log().clear();
 
@@ -217,33 +220,36 @@ pub async fn gsi_multi_attribute_partition_key(t: &mut Test) -> Result<()> {
 
     let mut db = t.setup_db(models!(Match)).await;
 
-    Match::create()
-        .id("m1")
-        .tournament_id("WINTER2024")
-        .region("NA-EAST")
-        .round("SEMIFINALS")
-        .player1_id("alice")
-        .player2_id("bob")
-        .exec(&mut db)
-        .await?;
-    Match::create()
-        .id("m2")
-        .tournament_id("WINTER2024")
-        .region("NA-EAST")
-        .round("FINALS")
-        .player1_id("charlie")
-        .player2_id("dave")
-        .exec(&mut db)
-        .await?;
-    Match::create()
-        .id("m3")
-        .tournament_id("WINTER2024")
-        .region("EU-WEST")
-        .round("SEMIFINALS")
-        .player1_id("eve")
-        .player2_id("frank")
-        .exec(&mut db)
-        .await?;
+    toasty::create!(Match {
+        id: "m1",
+        tournament_id: "WINTER2024",
+        region: "NA-EAST",
+        round: "SEMIFINALS",
+        player1_id: "alice",
+        player2_id: "bob",
+    })
+    .exec(&mut db)
+    .await?;
+    toasty::create!(Match {
+        id: "m2",
+        tournament_id: "WINTER2024",
+        region: "NA-EAST",
+        round: "FINALS",
+        player1_id: "charlie",
+        player2_id: "dave",
+    })
+    .exec(&mut db)
+    .await?;
+    toasty::create!(Match {
+        id: "m3",
+        tournament_id: "WINTER2024",
+        region: "EU-WEST",
+        round: "SEMIFINALS",
+        player1_id: "eve",
+        player2_id: "frank",
+    })
+    .exec(&mut db)
+    .await?;
 
     t.log().clear();
 
@@ -302,42 +308,46 @@ pub async fn gsi_multi_attribute_sort_key(t: &mut Test) -> Result<()> {
 
     let mut db = t.setup_db(models!(PlayerMatch)).await;
 
-    PlayerMatch::create()
-        .id("pm1")
-        .player_id("101")
-        .match_date("2024-01-18")
-        .round("SEMIFINALS")
-        .opponent_id("102")
-        .score("3-1")
-        .exec(&mut db)
-        .await?;
-    PlayerMatch::create()
-        .id("pm2")
-        .player_id("101")
-        .match_date("2024-01-18")
-        .round("FINALS")
-        .opponent_id("103")
-        .score("2-1")
-        .exec(&mut db)
-        .await?;
-    PlayerMatch::create()
-        .id("pm3")
-        .player_id("101")
-        .match_date("2024-01-25")
-        .round("SEMIFINALS")
-        .opponent_id("104")
-        .score("3-0")
-        .exec(&mut db)
-        .await?;
-    PlayerMatch::create()
-        .id("pm4")
-        .player_id("999")
-        .match_date("2024-01-18")
-        .round("QUARTERFINALS")
-        .opponent_id("101")
-        .score("1-3")
-        .exec(&mut db)
-        .await?;
+    toasty::create!(PlayerMatch {
+        id: "pm1",
+        player_id: "101",
+        match_date: "2024-01-18",
+        round: "SEMIFINALS",
+        opponent_id: "102",
+        score: "3-1",
+    })
+    .exec(&mut db)
+    .await?;
+    toasty::create!(PlayerMatch {
+        id: "pm2",
+        player_id: "101",
+        match_date: "2024-01-18",
+        round: "FINALS",
+        opponent_id: "103",
+        score: "2-1",
+    })
+    .exec(&mut db)
+    .await?;
+    toasty::create!(PlayerMatch {
+        id: "pm3",
+        player_id: "101",
+        match_date: "2024-01-25",
+        round: "SEMIFINALS",
+        opponent_id: "104",
+        score: "3-0",
+    })
+    .exec(&mut db)
+    .await?;
+    toasty::create!(PlayerMatch {
+        id: "pm4",
+        player_id: "999",
+        match_date: "2024-01-18",
+        round: "QUARTERFINALS",
+        opponent_id: "101",
+        score: "1-3",
+    })
+    .exec(&mut db)
+    .await?;
 
     t.log().clear();
 
@@ -404,34 +414,38 @@ pub async fn gsi_sql_three_column(t: &mut Test) -> Result<()> {
 
     let mut db = t.setup_db(models!(Address)).await;
 
-    Address::create()
-        .country("US")
-        .city("Seattle")
-        .zip_code("98101")
-        .street("1st Ave")
-        .exec(&mut db)
-        .await?;
-    Address::create()
-        .country("US")
-        .city("Seattle")
-        .zip_code("98102")
-        .street("2nd Ave")
-        .exec(&mut db)
-        .await?;
-    Address::create()
-        .country("US")
-        .city("Portland")
-        .zip_code("97201")
-        .street("Oak St")
-        .exec(&mut db)
-        .await?;
-    Address::create()
-        .country("CA")
-        .city("Toronto")
-        .zip_code("M5V")
-        .street("King St")
-        .exec(&mut db)
-        .await?;
+    toasty::create!(Address {
+        country: "US",
+        city: "Seattle",
+        zip_code: "98101",
+        street: "1st Ave",
+    })
+    .exec(&mut db)
+    .await?;
+    toasty::create!(Address {
+        country: "US",
+        city: "Seattle",
+        zip_code: "98102",
+        street: "2nd Ave",
+    })
+    .exec(&mut db)
+    .await?;
+    toasty::create!(Address {
+        country: "US",
+        city: "Portland",
+        zip_code: "97201",
+        street: "Oak St",
+    })
+    .exec(&mut db)
+    .await?;
+    toasty::create!(Address {
+        country: "CA",
+        city: "Toronto",
+        zip_code: "M5V",
+        street: "King St",
+    })
+    .exec(&mut db)
+    .await?;
 
     t.log().clear();
 

--- a/crates/toasty-driver-integration-suite/src/tests/index_composite.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/index_composite.rs
@@ -1,11 +1,10 @@
 use crate::prelude::*;
 use toasty_core::driver::Operation;
 
-/// A model with a composite primary key and a composite GSI (partition + sort key).
-/// This tests that model-level `#[index(field_a, field_b)]` creates a proper two-column
-/// GSI on DynamoDB (hash key + range key), not just a single-column index.
+/// Basic composite index: model-level `#[index(field_a, field_b)]` creates a two-column
+/// index on SQL and a GSI (hash + range key) on DynamoDB.
 #[driver_test]
-pub async fn gsi_composite_query(t: &mut Test) -> Result<()> {
+pub async fn composite_index_basic(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     #[key(user_id, game_title)]
     #[index(game_title, top_score)]
@@ -37,13 +36,12 @@ pub async fn gsi_composite_query(t: &mut Test) -> Result<()> {
     Ok(())
 }
 
-/// Test A: single-column model-level index (cross-driver).
+/// Struct-level `#[index(field)]` is equivalent to field-level `#[index]` (cross-driver).
 ///
-/// A model with `#[index(user_id)]` at the struct level — equivalent to placing
-/// `#[index]` on the `user_id` field directly. Verifies that `filter_by_user_id()`
-/// returns the correct records.
+/// Verifies that `filter_by_user_id()` returns the correct records and issues an
+/// indexed operation rather than a full scan.
 #[driver_test]
-pub async fn gsi_single_column_model_level(t: &mut Test) -> Result<()> {
+pub async fn composite_index_struct_level(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     #[key(id, name)]
     #[index(user_id)]
@@ -84,15 +82,15 @@ pub async fn gsi_single_column_model_level(t: &mut Test) -> Result<()> {
     Ok(())
 }
 
-/// Test B: two-column index with prefix queries (cross-driver).
+/// Two-column index generates prefix query methods for each valid column prefix (cross-driver).
 ///
-/// A model with `#[index(game_title, top_score)]` generates two filter methods:
-/// - `filter_by_game_title()` — uses partition key only
-/// - `filter_by_game_title_and_top_score()` — uses both partition and sort key
+/// `#[index(game_title, top_score)]` generates:
+/// - `filter_by_game_title()` — partition key only
+/// - `filter_by_game_title_and_top_score()` — both columns
 ///
-/// Verifies both methods issue the correct indexed operation type.
+/// Verifies both methods issue an indexed operation.
 #[driver_test]
-pub async fn gsi_two_column_prefix_queries(t: &mut Test) -> Result<()> {
+pub async fn composite_index_prefix_queries(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     #[key(user_id, game_title)]
     #[index(game_title, top_score)]
@@ -147,14 +145,12 @@ pub async fn gsi_two_column_prefix_queries(t: &mut Test) -> Result<()> {
     Ok(())
 }
 
-/// Test C: multi-attribute partition key (DDB-only).
+/// Multi-attribute partition key: `#[index(partition = a, partition = b, local = c)]`
+/// creates a GSI with 2 HASH + 1 RANGE attributes (DDB-only).
 ///
-/// A model with `#[index(partition = tournament_id, partition = region, local = round)]`
-/// creates a GSI with 2 HASH + 1 RANGE attributes. Verifies that:
-/// - `filter_by_tournament_id_and_region()` issues `QueryPk` (with index)
-/// - `filter_by_tournament_id_and_region_and_round()` issues `QueryPk` (with index)
+/// Verifies prefix queries for all valid access patterns.
 #[driver_test(requires(not(sql)))]
-pub async fn gsi_multi_attribute_partition_key(t: &mut Test) -> Result<()> {
+pub async fn composite_index_multi_hash(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     #[key(id)]
     #[index(partition = tournament_id, partition = region, local = round)]
@@ -210,16 +206,12 @@ pub async fn gsi_multi_attribute_partition_key(t: &mut Test) -> Result<()> {
     Ok(())
 }
 
-/// Test D: multi-attribute sort key (DDB-only).
+/// Multi-attribute sort key: `#[index(partition = a, local = b, local = c)]`
+/// creates a GSI with 1 HASH + 2 RANGE attributes (DDB-only).
 ///
-/// A model with `#[index(partition = player_id, local = match_date, local = round)]`
-/// creates a GSI with 1 HASH + 2 RANGE attributes. Verifies all valid prefix queries
-/// each issue `QueryPk` (with index):
-/// - `filter_by_player_id()`
-/// - `filter_by_player_id_and_match_date()`
-/// - `filter_by_player_id_and_match_date_and_round()`
+/// Verifies all three prefix query methods issue indexed operations.
 #[driver_test(requires(not(sql)))]
-pub async fn gsi_multi_attribute_sort_key(t: &mut Test) -> Result<()> {
+pub async fn composite_index_multi_range(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     #[key(id)]
     #[index(partition = player_id, local = match_date, local = round)]
@@ -285,15 +277,11 @@ pub async fn gsi_multi_attribute_sort_key(t: &mut Test) -> Result<()> {
     Ok(())
 }
 
-/// Test E: SQL 3-column composite index (SQL-only).
+/// Three-column composite index on SQL: `#[index(country, city, zip_code)]` (SQL-only).
 ///
-/// A model with `#[index(country, city, zip_code)]` on a SQL driver creates a
-/// composite index with 3 columns. Verifies all three prefix query methods:
-/// - `filter_by_country()`
-/// - `filter_by_country_and_city()`
-/// - `filter_by_country_and_city_and_zip_code()`
+/// Verifies all three prefix query methods return correct results.
 #[driver_test(requires(sql))]
-pub async fn gsi_sql_three_column(t: &mut Test) -> Result<()> {
+pub async fn composite_index_three_columns(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     #[key(id)]
     #[index(country, city, zip_code)]

--- a/crates/toasty-driver-integration-suite/src/tests/index_composite.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/index_composite.rs
@@ -479,6 +479,7 @@ pub async fn composite_index_multiple_indexes(t: &mut Test) -> Result<()> {
 /// Verifies that `setup_db()` succeeds at the limit and that a query using all
 /// 4 partition key attributes returns correct results.
 #[driver_test(requires(not(sql)))]
+#[allow(clippy::too_many_arguments)]
 pub async fn composite_index_max_attributes(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     #[key(id)]
@@ -529,6 +530,7 @@ pub async fn composite_index_max_attributes(t: &mut Test) -> Result<()> {
 /// exceeds the DynamoDB limit of 4. The driver must return `Err(invalid_schema)`
 /// rather than panicking.
 #[driver_test(requires(not(sql)))]
+#[allow(clippy::too_many_arguments)]
 pub async fn composite_index_too_many_range_columns(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     #[key(id)]

--- a/crates/toasty-driver-integration-suite/src/tests/index_composite.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/index_composite.rs
@@ -558,3 +558,47 @@ pub async fn composite_index_too_many_range_columns(t: &mut Test) -> Result<()> 
 
     Ok(())
 }
+
+/// Range filter chained onto a composite index partition query (cross-driver).
+///
+/// `filter_by_game_title("chess")` uses the index to scope by partition key,
+/// then `.filter(GameScore::fields().top_score().gt(150))` applies a range
+/// condition on the sort key.
+#[driver_test]
+pub async fn composite_index_sort_key_range_filter(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    #[key(user_id, game_title)]
+    #[index(game_title, top_score)]
+    struct GameScore {
+        user_id: String,
+        game_title: String,
+        top_score: i64,
+    }
+
+    let mut db = t.setup_db(models!(GameScore)).await;
+
+    toasty::create!(GameScore::[
+        { user_id: "u1", game_title: "chess", top_score: 100_i64 },
+        { user_id: "u2", game_title: "chess", top_score: 200_i64 },
+        { user_id: "u3", game_title: "chess", top_score: 1500_i64 },
+        { user_id: "u4", game_title: "chess", top_score: 50_i64 },
+        { user_id: "u1", game_title: "go", top_score: 9999_i64 },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let mut scores: Vec<GameScore> = GameScore::filter_by_game_title("chess")
+        .filter(GameScore::fields().top_score().gt(150))
+        .exec(&mut db)
+        .await?;
+    scores.sort_by_key(|s| s.top_score);
+
+    assert_eq!(scores.len(), 2);
+    assert_eq!(scores[0].top_score, 200);
+    assert_eq!(scores[1].top_score, 1500);
+
+    // go scores must not appear despite having top_score > 150
+    assert!(scores.iter().all(|s| s.game_title == "chess"));
+
+    Ok(())
+}

--- a/crates/toasty-driver-integration-suite/src/tests/index_composite.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/index_composite.rs
@@ -340,3 +340,221 @@ pub async fn composite_index_three_columns(t: &mut Test) -> Result<()> {
 
     Ok(())
 }
+
+/// Three-column simple-mode index on DynamoDB: `#[index(country, city, zip_code)]` (DDB-only).
+///
+/// In simple mode, the first field becomes HASH and the rest become RANGE.
+/// Verifies all three prefix query methods issue `QueryPk` and return correct results.
+#[driver_test(requires(not(sql)))]
+pub async fn composite_index_simple_three_column_ddb(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    #[key(id)]
+    #[index(country, city, zip_code)]
+    struct Address {
+        id: String,
+        country: String,
+        city: String,
+        zip_code: String,
+        street: String,
+    }
+
+    let mut db = t.setup_db(models!(Address)).await;
+
+    toasty::create!(Address::[
+        { id: "a1", country: "US", city: "Seattle", zip_code: "98101", street: "1st Ave" },
+        { id: "a2", country: "US", city: "Seattle", zip_code: "98102", street: "2nd Ave" },
+        { id: "a3", country: "US", city: "Portland", zip_code: "97201", street: "Oak St" },
+        { id: "a4", country: "CA", city: "Toronto", zip_code: "M5V", street: "King St" },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    t.log().clear();
+
+    // 1-column prefix: HASH key only
+    let addrs: Vec<Address> = Address::filter_by_country("US").exec(&mut db).await?;
+    assert_eq!(addrs.len(), 3);
+
+    let op = t.log().pop_op();
+    assert_struct!(op, Operation::QueryPk(_));
+
+    t.log().clear();
+
+    // 2-column prefix: HASH + first RANGE key
+    let addrs: Vec<Address> = Address::filter_by_country_and_city("US", "Seattle")
+        .exec(&mut db)
+        .await?;
+    assert_eq!(addrs.len(), 2);
+
+    let op = t.log().pop_op();
+    assert_struct!(op, Operation::QueryPk(_));
+
+    t.log().clear();
+
+    // 3-column full key: HASH + both RANGE keys
+    let addrs: Vec<Address> =
+        Address::filter_by_country_and_city_and_zip_code("US", "Seattle", "98101")
+            .exec(&mut db)
+            .await?;
+    assert_eq!(addrs.len(), 1);
+    assert_eq!(addrs[0].street, "1st Ave");
+
+    let op = t.log().pop_op();
+    assert_struct!(op, Operation::QueryPk(_));
+
+    Ok(())
+}
+
+/// Multiple indexes on the same model: verifies the query planner selects the correct
+/// index when a model defines two `#[index]` attributes (cross-driver).
+///
+/// A bug in index selection could silently route queries through the wrong index,
+/// returning incorrect results.
+#[driver_test]
+pub async fn composite_index_multiple_indexes(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    #[key(id)]
+    #[index(category)]
+    #[index(brand)]
+    struct Product {
+        id: String,
+        category: String,
+        brand: String,
+        name: String,
+    }
+
+    let mut db = t.setup_db(models!(Product)).await;
+
+    toasty::create!(Product::[
+        { id: "p1", category: "electronics", brand: "acme", name: "Widget A" },
+        { id: "p2", category: "electronics", brand: "globex", name: "Widget B" },
+        { id: "p3", category: "clothing", brand: "acme", name: "Shirt C" },
+        { id: "p4", category: "clothing", brand: "initech", name: "Pants D" },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    t.log().clear();
+
+    // Query via the first index (category)
+    let mut products: Vec<Product> = Product::filter_by_category("electronics")
+        .exec(&mut db)
+        .await?;
+    products.sort_by(|a, b| a.id.cmp(&b.id));
+
+    assert_eq!(products.len(), 2);
+    assert_eq!(products[0].name, "Widget A");
+    assert_eq!(products[1].name, "Widget B");
+
+    let op = t.log().pop_op();
+    if t.capability().sql {
+        assert_struct!(op, Operation::QuerySql(_));
+    } else {
+        assert_struct!(op, Operation::QueryPk(_));
+    }
+
+    t.log().clear();
+
+    // Query via the second index (brand) — must not use the category index
+    let mut products: Vec<Product> = Product::filter_by_brand("acme").exec(&mut db).await?;
+    products.sort_by(|a, b| a.id.cmp(&b.id));
+
+    assert_eq!(products.len(), 2);
+    assert_eq!(products[0].name, "Widget A");
+    assert_eq!(products[1].name, "Shirt C");
+
+    let op = t.log().pop_op();
+    if t.capability().sql {
+        assert_struct!(op, Operation::QuerySql(_));
+    } else {
+        assert_struct!(op, Operation::QueryPk(_));
+    }
+
+    Ok(())
+}
+
+/// Maximum attribute boundary: `#[index(partition = f1..f4, local = f5..f8)]` (DDB-only).
+///
+/// DynamoDB allows up to 4 HASH + 4 RANGE attributes in a GSI KeySchema.
+/// Verifies that `setup_db()` succeeds at the limit and that a query using all
+/// 4 partition key attributes returns correct results.
+#[driver_test(requires(not(sql)))]
+pub async fn composite_index_max_attributes(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    #[key(id)]
+    #[index(partition = f1, partition = f2, partition = f3, partition = f4, local = f5, local = f6, local = f7, local = f8)]
+    struct MaxIndex {
+        id: String,
+        f1: String,
+        f2: String,
+        f3: String,
+        f4: String,
+        f5: String,
+        f6: String,
+        f7: String,
+        f8: String,
+        value: String,
+    }
+
+    // setup_db must succeed at the 4+4 boundary
+    let mut db = t.setup_db(models!(MaxIndex)).await;
+
+    toasty::create!(MaxIndex::[
+        { id: "r1", f1: "a1", f2: "b1", f3: "c1", f4: "d1", f5: "e1", f6: "g1", f7: "h1", f8: "i1", value: "found" },
+        { id: "r2", f1: "a1", f2: "b1", f3: "c1", f4: "d2", f5: "e1", f6: "g1", f7: "h1", f8: "i1", value: "other" },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    t.log().clear();
+
+    // Query using all 4 partition key attributes (required for DDB multi-attribute HASH key)
+    let records: Vec<MaxIndex> =
+        MaxIndex::filter_by_f1_and_f2_and_f3_and_f4("a1", "b1", "c1", "d1")
+            .exec(&mut db)
+            .await?;
+
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].value, "found");
+
+    let op = t.log().pop_op();
+    assert_struct!(op, Operation::QueryPk(_));
+
+    Ok(())
+}
+
+/// Error condition: more than 4 RANGE columns in simple-mode index (DDB-only).
+///
+/// `#[index(a, b, c, d, e, f)]` in simple mode produces 1 HASH + 5 RANGE, which
+/// exceeds the DynamoDB limit of 4. The driver must return `Err(invalid_schema)`
+/// rather than panicking.
+#[driver_test(requires(not(sql)))]
+pub async fn composite_index_too_many_range_columns(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    #[key(id)]
+    #[index(a, b, c, d, e, f)]
+    struct TooManyRange {
+        id: String,
+        a: String,
+        b: String,
+        c: String,
+        d: String,
+        e: String,
+        f: String,
+    }
+
+    // Do NOT use `?` — capture the error instead of propagating it
+    let result = t.try_setup_db(models!(TooManyRange)).await;
+
+    assert!(
+        result.is_err(),
+        "expected setup_db to fail for 1 HASH + 5 RANGE index"
+    );
+    let err = result.unwrap_err();
+    assert!(
+        err.is_invalid_schema(),
+        "expected invalid_schema error, got: {err}"
+    );
+
+    Ok(())
+}

--- a/crates/toasty-macros/src/model/schema/model.rs
+++ b/crates/toasty-macros/src/model/schema/model.rs
@@ -241,6 +241,44 @@ impl Model {
             })
         };
 
+        // Create indices for model-level #[index(...)] attributes
+        for index_attr in &model_attr.indices {
+            let mut index_fields = vec![];
+
+            // Simple mode (e.g. `#[index(a, b)]`): all fields land in `partition`.
+            // Treat the first as the partition (hash) key and the rest as local (sort) keys,
+            // which matches DynamoDB GSI semantics.
+            let mut partition_iter = index_attr.partition.iter();
+            if let Some(first) = partition_iter.next() {
+                let idx = names.iter().position(|n| n == first).unwrap();
+                index_fields.push(IndexField {
+                    field: idx,
+                    scope: IndexScope::Partition,
+                });
+                for field in partition_iter {
+                    let idx = names.iter().position(|n| n == field).unwrap();
+                    index_fields.push(IndexField {
+                        field: idx,
+                        scope: IndexScope::Local,
+                    });
+                }
+            }
+            // Named mode (e.g. `#[index(partition = a, local = b)]`): respect explicit scopes.
+            for field in &index_attr.local {
+                let idx = names.iter().position(|n| n == field).unwrap();
+                index_fields.push(IndexField {
+                    field: idx,
+                    scope: IndexScope::Local,
+                });
+            }
+
+            indices.push(Index {
+                fields: index_fields,
+                unique: false,
+                primary_key: false,
+            });
+        }
+
         // Create indices for all fields annotated with unique or index
         collect_field_indices(&fields, &mut indices);
 

--- a/crates/toasty-macros/src/model/schema/model.rs
+++ b/crates/toasty-macros/src/model/schema/model.rs
@@ -245,31 +245,41 @@ impl Model {
         for index_attr in &model_attr.indices {
             let mut index_fields = vec![];
 
-            // Simple mode (e.g. `#[index(a, b)]`): all fields land in `partition`.
-            // Treat the first as the partition (hash) key and the rest as local (sort) keys,
-            // which matches DynamoDB GSI semantics.
-            let mut partition_iter = index_attr.partition.iter();
-            if let Some(first) = partition_iter.next() {
-                let idx = names.iter().position(|n| n == first).unwrap();
-                index_fields.push(IndexField {
-                    field: idx,
-                    scope: IndexScope::Partition,
-                });
-                for field in partition_iter {
+            if index_attr.local.is_empty() {
+                // Simple mode (e.g. `#[index(a, b, c)]`): all fields land in `partition`.
+                // First field is the partition (hash) key, rest are local (sort) keys.
+                let mut partition_iter = index_attr.partition.iter();
+                if let Some(first) = partition_iter.next() {
+                    let idx = names.iter().position(|n| n == first).unwrap();
+                    index_fields.push(IndexField {
+                        field: idx,
+                        scope: IndexScope::Partition,
+                    });
+                    for field in partition_iter {
+                        let idx = names.iter().position(|n| n == field).unwrap();
+                        index_fields.push(IndexField {
+                            field: idx,
+                            scope: IndexScope::Local,
+                        });
+                    }
+                }
+            } else {
+                // Named mode (e.g. `#[index(partition = a, partition = b, local = c)]`):
+                // all `partition` fields are hash keys, all `local` fields are sort keys.
+                for field in &index_attr.partition {
+                    let idx = names.iter().position(|n| n == field).unwrap();
+                    index_fields.push(IndexField {
+                        field: idx,
+                        scope: IndexScope::Partition,
+                    });
+                }
+                for field in &index_attr.local {
                     let idx = names.iter().position(|n| n == field).unwrap();
                     index_fields.push(IndexField {
                         field: idx,
                         scope: IndexScope::Local,
                     });
                 }
-            }
-            // Named mode (e.g. `#[index(partition = a, local = b)]`): respect explicit scopes.
-            for field in &index_attr.local {
-                let idx = names.iter().position(|n| n == field).unwrap();
-                index_fields.push(IndexField {
-                    field: idx,
-                    scope: IndexScope::Local,
-                });
             }
 
             indices.push(Index {

--- a/crates/toasty-macros/src/model/schema/model_attr.rs
+++ b/crates/toasty-macros/src/model/schema/model_attr.rs
@@ -5,6 +5,9 @@ pub(crate) struct ModelAttr {
     /// Primary key definition
     pub(crate) key: Option<KeyAttr>,
 
+    /// Model-level secondary index definitions
+    pub(crate) indices: Vec<KeyAttr>,
+
     /// Optional database table name to map the model to
     pub(crate) table: Option<syn::LitStr>,
 }
@@ -23,6 +26,11 @@ impl ModelAttr {
                     errs.push(syn::Error::new_spanned(attr, "duplicate #[key] attribute"));
                 } else {
                     self.key = Some(KeyAttr::from_ast(attr, names)?);
+                }
+            } else if attr.path().is_ident("index") {
+                match KeyAttr::from_ast(attr, names) {
+                    Ok(index_attr) => self.indices.push(index_attr),
+                    Err(e) => errs.push(e),
                 }
             } else if attr.path().is_ident("table") {
                 if self.table.is_some() {

--- a/docs/guide/src/indexes-and-unique-constraints.md
+++ b/docs/guide/src/indexes-and-unique-constraints.md
@@ -214,6 +214,133 @@ let user = User::get_by_country(&mut db, "US").await?;
 # }
 ```
 
+## Multi-column indexes
+
+Struct-level `#[index]` lets you define a composite index spanning multiple
+fields. This is useful when you frequently query by a combination of fields
+rather than a single one.
+
+### Simple mode
+
+List the fields in order — the first field is the leading key, and the remaining
+fields extend it:
+
+```rust
+# use toasty::Model;
+#[derive(Debug, toasty::Model)]
+#[index(game_title, top_score)]
+struct GameScore {
+    #[key]
+    #[auto]
+    id: u64,
+    user_id: String,
+    game_title: String,
+    top_score: i64,
+}
+```
+
+On SQL databases this creates a composite index with columns in the order
+specified:
+
+```sql
+CREATE INDEX idx_game_scores_game_title_top_score
+    ON game_scores (game_title, top_score);
+```
+
+On DynamoDB, the first field becomes the HASH key and the remaining fields
+become RANGE keys of a Global Secondary Index (GSI).
+
+Toasty generates a method for each valid prefix of the index fields:
+
+| Method | Description |
+|---|---|
+| `GameScore::filter_by_game_title(game_title)` | All scores for a game |
+| `GameScore::filter_by_game_title_and_top_score(game_title, top_score)` | Scores for a game with a specific score |
+
+You can use these the same way as single-column index methods:
+
+```rust
+# use toasty::Model;
+# #[derive(Debug, toasty::Model)]
+# #[index(game_title, top_score)]
+# struct GameScore {
+#     #[key]
+#     #[auto]
+#     id: u64,
+#     user_id: String,
+#     game_title: String,
+#     top_score: i64,
+# }
+# async fn __example(mut db: toasty::Db) -> toasty::Result<()> {
+// All scores for "chess"
+let scores: Vec<GameScore> = GameScore::filter_by_game_title("chess")
+    .exec(&mut db)
+    .await?;
+
+// Scores for "chess" with a top score of exactly 1400
+let scores: Vec<GameScore> = GameScore::filter_by_game_title_and_top_score("chess", 1400)
+    .exec(&mut db)
+    .await?;
+# Ok(())
+# }
+```
+
+For a three-column index, Toasty generates three prefix methods. Given
+`#[index(country, city, zip_code)]`:
+
+| Method | Columns matched |
+|---|---|
+| `filter_by_country(country)` | `country` |
+| `filter_by_country_and_city(country, city)` | `country`, `city` |
+| `filter_by_country_and_city_and_zip_code(country, city, zip_code)` | `country`, `city`, `zip_code` |
+
+### Named mode
+
+Use `partition = ...` and `local = ...` to explicitly assign fields to key
+roles. This is required when you need multiple fields in the DynamoDB partition
+key:
+
+```rust
+# use toasty::Model;
+#[derive(Debug, toasty::Model)]
+#[index(partition = tournament_id, partition = region, local = round)]
+struct Match {
+    #[key]
+    #[auto]
+    id: u64,
+    tournament_id: String,
+    region: String,
+    round: String,
+    player1_id: String,
+    player2_id: String,
+}
+```
+
+On DynamoDB, `partition` fields map to `KeyType::Hash` entries and `local`
+fields map to `KeyType::Range` entries in the GSI KeySchema. This allows the
+DynamoDB index to carry a composite identifier — here, a tournament is uniquely
+identified by both `tournament_id` and `region`.
+
+The generated methods require all partition fields:
+
+| Method | Description |
+|---|---|
+| `Match::filter_by_tournament_id_and_region(tournament_id, region)` | All rounds for a tournament+region |
+| `Match::filter_by_tournament_id_and_region_and_round(tournament_id, region, round)` | A specific round |
+
+On SQL databases, the `partition`/`local` distinction is ignored — all fields
+are placed in the composite index in the order they appear, producing
+`CREATE INDEX ... ON matches (tournament_id, region, round)`.
+
+### SQL vs DynamoDB behavior
+
+| Behavior | SQL | DynamoDB |
+|---|---|---|
+| Index structure | `CREATE INDEX` with all columns in order | GSI with HASH and RANGE key entries |
+| Partition / local distinction | Ignored — all columns form a flat composite index | `partition` = `KeyType::Hash`, `local` = `KeyType::Range` |
+| Query matching | Database uses leftmost-prefix matching | All `partition` fields required; `local` fields optional left-to-right |
+| Column limits | No artificial limits | Up to 4 partition and 4 local attributes per index |
+
 ## Indexing newtype fields
 
 Newtype embedded structs (single unnamed field, e.g., `struct Email(String)`)


### PR DESCRIPTION
 ## Summary

  Completes multi-column `#[index]` support for both SQL and DynamoDB backends, building on the struct-level `#[index]` parsing already merged to main.

  - **Macro fix**: Named-mode multi-attribute indexes (`#[index(partition = a, partition = b, local = c)]`) now correctly assign all `partition =` fields as `IndexScope::Partition`. Previously only the first
  was treated as the partition key; the rest were incorrectly assigned as local/sort keys.
  - **DynamoDB driver**: Replace `assert!` panics for invalid GSI column counts with `Err(Error::invalid_schema(...))` so schema violations are recoverable and testable.
  - **Integration tests**: Rename `gsi_composite` → `index_composite` with driver-agnostic test names; convert all inserts to `toasty::create!` batch macro form; add edge case tests for simple-mode 3-column
  DDB indexes, multiple indexes on one model, the 4+4 max boundary, and the >4 RANGE column error condition.
  - **Docs**: Add "Multi-column indexes" section to the indexes guide covering simple mode, named mode, generated prefix query methods, and SQL vs DynamoDB behavior differences.

  ## Test plan

  - [ ] `cargo test -p tests` — all SQLite tests pass
  - [ ] `cargo test -p tests --features dynamodb -- --test-threads=1` — all DynamoDB tests pass
  - [ ] `cargo clippy` — no warnings
  - [ ] `cargo fmt` — no changes

Closes #548
  🤖 Generated with [Claude Code](https://claude.com/claude-code)