### PR TITLE
feat: error on limit() for NoSQL drivers, simplify DynamoDB query_pk

### DIFF
--- a/crates/toasty-driver-dynamodb/src/op/query_pk.rs
+++ b/crates/toasty-driver-dynamodb/src/op/query_pk.rs
@@ -25,74 +25,45 @@ impl Connection {
             .as_ref()
             .map(|expr| ddb_expression(&cx, &mut expr_attrs, false, expr));
 
-        // Build the query based on whether we're querying primary key or an index
-        let result = if let Some(index_id) = op.index {
-            let index = schema.db.index(index_id);
+        // Build base query, then conditionally attach an index
+        let mut query = self
+            .client
+            .query()
+            .table_name(&table.name)
+            .key_condition_expression(key_expression)
+            .set_filter_expression(filter_expression)
+            .set_expression_attribute_names(Some(expr_attrs.attr_names))
+            .set_expression_attribute_values(Some(expr_attrs.attr_values));
 
+        if let Some(index_id) = op.index {
+            let index = schema.db.index(index_id);
             if index.unique {
-                use toasty_core::Error;
-                let err = Error::from_args(format_args!(
+                return Err(toasty_core::Error::from_args(format_args!(
                     "Unique index {} doesn't have fields.",
                     index.name
-                ));
-                Err(err)
-            } else {
-                tracing::trace!(table_name = %table.name, index_name = %index.name, "querying secondary index");
-                let mut query = self
-                    .client
-                    .query()
-                    .table_name(&table.name)
-                    .index_name(&index.name)
-                    .key_condition_expression(key_expression)
-                    .set_filter_expression(filter_expression)
-                    .set_expression_attribute_names(Some(expr_attrs.attr_names))
-                    .set_expression_attribute_values(Some(expr_attrs.attr_values));
-
-                if let Some(limit) = op.limit {
-                    query = query.limit(limit as i32);
-                }
-                if let Some(ref cursor_value) = op.cursor {
-                    query =
-                        query.set_exclusive_start_key(Some(deserialize_ddb_cursor(cursor_value)));
-                }
-                if let Some(ref direction) = op.order {
-                    query = query.scan_index_forward(*direction == stmt::Direction::Asc);
-                }
-
-                query
-                    .send()
-                    .await
-                    .map_err(toasty_core::Error::driver_operation_failed)
+                )));
             }
+            tracing::trace!(table_name = %table.name, index_name = %index.name, "querying secondary index");
+            query = query.index_name(&index.name);
         } else {
             tracing::trace!(table_name = %table.name, "querying primary key");
-            let mut query = self
-                .client
-                .query()
-                .table_name(&table.name)
-                .key_condition_expression(key_expression)
-                .set_filter_expression(filter_expression)
-                .set_expression_attribute_names(Some(expr_attrs.attr_names))
-                .set_expression_attribute_values(Some(expr_attrs.attr_values));
+        }
 
-            if let Some(limit) = op.limit {
-                query = query.limit(limit as i32);
-            }
-            if let Some(ref cursor_value) = op.cursor {
-                query = query.set_exclusive_start_key(Some(deserialize_ddb_cursor(cursor_value)));
-            }
-            if let Some(ref direction) = op.order {
-                query = query.scan_index_forward(*direction == stmt::Direction::Asc);
-            }
-
-            query
-                .send()
-                .await
-                .map_err(toasty_core::Error::driver_operation_failed)
-        };
+        if let Some(limit) = op.limit {
+            query = query.limit(limit as i32);
+        }
+        if let Some(ref cursor_value) = op.cursor {
+            query = query.set_exclusive_start_key(Some(deserialize_ddb_cursor(cursor_value)));
+        }
+        if let Some(ref direction) = op.order {
+            query = query.scan_index_forward(*direction == stmt::Direction::Asc);
+        }
 
         let schema = schema.clone();
-        let res = result?;
+        let res = query
+            .send()
+            .await
+            .map_err(toasty_core::Error::driver_operation_failed)?;
 
         // Capture LastEvaluatedKey for pagination
         let cursor = res.last_evaluated_key.as_ref().map(serialize_ddb_cursor);

--- a/crates/toasty-driver-integration-suite/src/tests/crud_composite_key_pagination.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/crud_composite_key_pagination.rs
@@ -114,7 +114,7 @@ pub async fn paginate_composite_key_asc(test: &mut Test) -> Result<()> {
     Ok(())
 }
 
-#[driver_test]
+#[driver_test(requires(sql))]
 pub async fn limit_composite_key(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     #[key(partition = kind, local = seq)]

--- a/crates/toasty-driver-integration-suite/src/tests/crud_sort_limit.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/crud_sort_limit.rs
@@ -285,3 +285,33 @@ pub async fn paginate_for_dynamodb(test: &mut Test) -> Result<()> {
 
     Ok(())
 }
+
+#[driver_test(requires(not(sql)))]
+pub async fn limit_not_supported_on_nosql(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    #[key(id, order)]
+    struct Item {
+        id: i64,
+        order: i64,
+    }
+
+    let mut db = test.setup_db(models!(Item)).await;
+
+    for order in 0..10 {
+        Item::create().id(0).order(order).exec(&mut db).await?;
+    }
+
+    let err = Item::all()
+        .filter(Item::fields().id().eq(0))
+        .limit(5)
+        .exec(&mut db)
+        .await
+        .unwrap_err();
+
+    assert!(
+        err.is_unsupported_feature(),
+        "expected UnsupportedFeature error, got: {err}"
+    );
+
+    Ok(())
+}

--- a/crates/toasty/src/engine/plan/statement.rs
+++ b/crates/toasty/src/engine/plan/statement.rs
@@ -1192,6 +1192,15 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
             debug_assert!(self.load_data.select_items.is_empty());
         }
 
+        // Limit::Offset (query.limit(n)) is not supported on NoSQL drivers. DynamoDB's
+        // Limit parameter caps evaluated items, not returned items, so results would be
+        // silently incorrect when a filter is active. Use paginate() instead.
+        if let Some(stmt::Limit::Offset(_)) = stmt.as_query().and_then(|q| q.limit.as_ref()) {
+            return Err(toasty_core::Error::unsupported_feature(
+                "limit() is not supported on NoSQL drivers; use paginate() for cursor-based pagination",
+            ));
+        }
+
         // Without SQL capability, we have to plan the execution of the
         // statement based on available indices.
         let mut index_plan = self.planner.engine.plan_index_path(&stmt)?;


### PR DESCRIPTION
## Summary

- **`feat`**: Return a clear `UnsupportedFeature` error when `query.limit(n)` is used on a NoSQL driver. DynamoDB's `Limit` parameter caps *evaluated* items (not returned items), so a filter expression can silently produce fewer results than requested — or zero, even when matching rows exist. The 1 MB per-request cap compounds this regardless of filter presence. Users should use `paginate()` instead, which maps naturally to DynamoDB's per-request semantics.
- **`refactor`**: Eliminate duplicated `QueryFluentBuilder` setup in `exec_query_pk` — the primary key path and GSI path shared identical builder code. Now a single builder is constructed and `.index_name()` attached conditionally.

## Changes

- `crates/toasty/src/engine/plan/statement.rs` — guard in `plan_data_loading_nosql()` returns `unsupported_feature` for any `Limit::Offset` query on a NoSQL driver (mirrors the existing `count()` check)
- `crates/toasty-driver-dynamodb/src/op/query_pk.rs` — consolidate duplicated query builder
- `crates/toasty-driver-integration-suite/src/tests/crud_sort_limit.rs` — add `limit_not_supported_on_nosql` test (`requires(not(sql))`)
- `crates/toasty-driver-integration-suite/src/tests/crud_composite_key_pagination.rs` — mark `limit_composite_key` as `requires(sql)` since it uses `.limit()`

## Test plan

- [ ] `cargo test` passes (SQLite, no external services)
- [ ] `cargo test -p tests --features dynamodb` exercises the new error path on a live DynamoDB instance
- [ ] Existing `limit_offset` and `paginate` tests continue to pass on SQL drivers unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)