### PR TITLE
fix: percent encoding in postgres connection strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ mysql_async = { version = "0.36.2", default-features = false, features = [
 ] }
 pulldown-cmark = { version = "0.13", default-features = false }
 pluralizer = "0.5.0"
+percent-encoding = "2.3.2"
 postgres-types = { version = "0.2.13", features = ["with-uuid-1", "array-impls"] }
 pretty_assertions = "1.4.1"
 proc-macro2 = "1.0.106"

--- a/crates/toasty-driver-postgresql/Cargo.toml
+++ b/crates/toasty-driver-postgresql/Cargo.toml
@@ -38,6 +38,7 @@ bigdecimal = { workspace = true, optional = true }
 jiff = { workspace = true, optional = true }
 lru.workspace = true
 tracing.workspace = true
+percent-encoding.workspace = true
 postgres-types.workspace = true
 tokio.workspace = true
 tokio-postgres.workspace = true

--- a/crates/toasty-driver-postgresql/src/lib.rs
+++ b/crates/toasty-driver-postgresql/src/lib.rs
@@ -20,6 +20,7 @@ mod value;
 pub(crate) use value::Value;
 
 use async_trait::async_trait;
+use percent_encoding::percent_decode_str;
 use std::{borrow::Cow, sync::Arc};
 use toasty_core::{
     Result, Schema,
@@ -80,18 +81,29 @@ impl PostgreSQL {
 
         let mut config = Config::new();
         config.host(host);
-        config.dbname(url.path().trim_start_matches('/'));
+
+        let dbname = percent_decode_str(url.path().trim_start_matches('/'))
+            .decode_utf8()
+            .map_err(|_| {
+                toasty_core::Error::invalid_connection_url("database name is not valid UTF-8")
+            })?;
+        config.dbname(&*dbname);
 
         if let Some(port) = url.port() {
             config.port(port);
         }
 
         if !url.username().is_empty() {
-            config.user(url.username());
+            let user = percent_decode_str(url.username())
+                .decode_utf8()
+                .map_err(|_| {
+                    toasty_core::Error::invalid_connection_url("username is not valid UTF-8")
+                })?;
+            config.user(&*user);
         }
 
         if let Some(password) = url.password() {
-            config.password(password);
+            config.password(percent_decode_str(password).collect::<Vec<u8>>());
         }
 
         #[cfg(feature = "tls")]

--- a/tests/tests/postgresql.rs
+++ b/tests/tests/postgresql.rs
@@ -59,3 +59,81 @@ impl toasty_driver_integration_suite::Setup for PostgreSqlSetup {
 
 // Generate all driver tests
 toasty_driver_integration_suite::generate_driver_tests!(PostgreSqlSetup::new(), bigdecimal_implemented: false);
+
+#[tokio::test]
+async fn url_encoding() {
+    let admin_url = std::env::var("TOASTY_TEST_POSTGRES_URL")
+        .unwrap_or_else(|_| "postgresql://localhost:5432/toasty_test".to_string());
+    let (admin_client, connection) = tokio_postgres::connect(&admin_url, NoTls)
+        .await
+        .expect("failed to connect as admin");
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            eprintln!("connection error: {e}");
+        }
+    });
+
+    let role = "url_encoding#role";
+    let dbname = "url_encoding#db";
+    let password = "p@ss#word";
+
+    // Idempotent setup: drop if leftover from a previous run
+    admin_client
+        .execute(&format!("DROP DATABASE IF EXISTS \"{}\"", dbname), &[])
+        .await
+        .expect("failed to drop test database");
+    admin_client
+        .execute(&format!("DROP ROLE IF EXISTS \"{}\"", role), &[])
+        .await
+        .expect("failed to drop test role");
+
+    admin_client
+        .execute(
+            &format!(
+                "CREATE ROLE \"{}\" WITH LOGIN PASSWORD '{}'",
+                role, password
+            ),
+            &[],
+        )
+        .await
+        .expect("failed to create test role");
+    admin_client
+        .execute(
+            &format!("CREATE DATABASE \"{}\" OWNER \"{}\"", dbname, role),
+            &[],
+        )
+        .await
+        .expect("failed to create test database");
+
+    // Parse the admin URL to extract host/port
+    let parsed = url::Url::parse(&admin_url).expect("failed to parse admin URL");
+    let host = parsed.host_str().unwrap_or("localhost");
+    let port = parsed.port().unwrap_or(5432);
+
+    let encoded_role = url::form_urlencoded::byte_serialize(role.as_bytes()).collect::<String>();
+    let encoded_password =
+        url::form_urlencoded::byte_serialize(password.as_bytes()).collect::<String>();
+    let encoded_dbname =
+        url::form_urlencoded::byte_serialize(dbname.as_bytes()).collect::<String>();
+
+    let test_url = format!(
+        "postgresql://{}:{}@{}:{}/{}",
+        encoded_role, encoded_password, host, port, encoded_dbname
+    );
+
+    let driver = PostgreSQL::new(&test_url).expect("driver creation failed");
+    let conn = toasty_core::driver::Driver::connect(&driver)
+        .await
+        .expect("connection with percent-encoded URL failed");
+    drop(conn);
+
+    // Cleanup
+    admin_client
+        .execute(&format!("DROP DATABASE IF EXISTS \"{}\"", dbname), &[])
+        .await
+        .expect("failed to drop test database");
+    admin_client
+        .execute(&format!("DROP ROLE IF EXISTS \"{}\"", role), &[])
+        .await
+        .expect("failed to drop test role");
+}


### PR DESCRIPTION
## Summary

Closes #661

`url::Url::username()`, `password()`, and `path()` return percent-encoded strings. We were passing these directly to `tokio_postgres::Config`, which expects decoded values. This made it impossible to connect with credentials or database names containing characters like `@`, `#`, `/`, etc.

This matches libpq's behavior, which percent-decodes all URI components via [`conninfo_uri_decode`](https://github.com/postgres/postgres/blob/REL_17_STABLE/src/interfaces/libpq/fe-connect.c#L6764-L6821). libpq calls this (via [`conninfo_storeval`](https://github.com/postgres/postgres/blob/REL_17_STABLE/src/interfaces/libpq/fe-connect.c#L6913-L6916)) for:
- [user (L6454)](https://github.com/postgres/postgres/blob/REL_17_STABLE/src/interfaces/libpq/fe-connect.c#L6454)
- [password (L6467)](https://github.com/postgres/postgres/blob/REL_17_STABLE/src/interfaces/libpq/fe-connect.c#L6467)
- [dbname (L6599)](https://github.com/postgres/postgres/blob/REL_17_STABLE/src/interfaces/libpq/fe-connect.c#L6599)

## Changes

- Decode username, password, and dbname with `percent_encoding::percent_decode_str` before passing to `Config`
- Username and dbname return an error on invalid UTF-8; password is passed as raw bytes
- Added `percent-encoding` as a direct dependency (already a transitive dep via `url` and `tokio-postgres`)
