### PR TITLE
chore: release v0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,20 +48,20 @@ unsafe_code = "deny"
 
 [workspace.dependencies]
 # Toasty crates
-toasty = { version = "0.4.0", path = "crates/toasty" }
-toasty-cli = { version = "0.4.0", path = "crates/toasty-cli" }
-toasty-core = { version = "0.4.0", path = "crates/toasty-core" }
-toasty-macros = { version = "0.4.0", path = "crates/toasty-macros" }
-toasty-sql = { version = "0.4.0", path = "crates/toasty-sql" }
+toasty = { version = "0.5.0", path = "crates/toasty" }
+toasty-cli = { version = "0.5.0", path = "crates/toasty-cli" }
+toasty-core = { version = "0.5.0", path = "crates/toasty-core" }
+toasty-macros = { version = "0.5.0", path = "crates/toasty-macros" }
+toasty-sql = { version = "0.5.0", path = "crates/toasty-sql" }
 # Driver implementations
-toasty-driver-dynamodb = { version = "0.4.0", path = "crates/toasty-driver-dynamodb" }
-toasty-driver-mysql = { version = "0.4.0", path = "crates/toasty-driver-mysql" }
-toasty-driver-postgresql = { version = "0.4.0", path = "crates/toasty-driver-postgresql" }
-toasty-driver-sqlite = { version = "0.4.0", path = "crates/toasty-driver-sqlite" }
+toasty-driver-dynamodb = { version = "0.5.0", path = "crates/toasty-driver-dynamodb" }
+toasty-driver-mysql = { version = "0.5.0", path = "crates/toasty-driver-mysql" }
+toasty-driver-postgresql = { version = "0.5.0", path = "crates/toasty-driver-postgresql" }
+toasty-driver-sqlite = { version = "0.5.0", path = "crates/toasty-driver-sqlite" }
 
 # Driver integration test suite dependencies
-toasty-driver-integration-suite = { version = "0.4.0", path = "crates/toasty-driver-integration-suite" }
-toasty-driver-integration-suite-macros = { version = "0.4.0", path = "crates/toasty-driver-integration-suite-macros" }
+toasty-driver-integration-suite = { version = "0.5.0", path = "crates/toasty-driver-integration-suite" }
+toasty-driver-integration-suite-macros = { version = "0.5.0", path = "crates/toasty-driver-integration-suite-macros" }
 
 # Other crates
 assert-struct = "0.4.2"

--- a/crates/toasty-cli/CHANGELOG.md
+++ b/crates/toasty-cli/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-cli-v0.4.0...toasty-cli-v0.5.0) - 2026-04-27
+
+### Added
+
+- Generate migrations with timestamp prefixes ([#684])
+- Add newlines at the end of generated migration files ([#683])
+
+[#683]: https://github.com/tokio-rs/toasty/pull/683
+[#684]: https://github.com/tokio-rs/toasty/pull/684
+
 ## [0.3.0](https://github.com/tokio-rs/toasty/compare/toasty-cli-v0.2.0...toasty-cli-v0.3.0) - 2026-04-03
 
 ### Other

--- a/crates/toasty-cli/Cargo.toml
+++ b/crates/toasty-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-cli"
-version = "0.4.0"
+version = "0.5.0"
 description = "Command-line interface for Toasty schema management"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-core/CHANGELOG.md
+++ b/crates/toasty-core/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-core-v0.4.0...toasty-core-v0.5.0) - 2026-04-27
+
+### Added
+
+- add starts_with and LIKE string prefix filter operators ([#745])
+- add #[version] optimistic concurrency control for DynamoDB ([#694])
+- support disambiguating has_many/has_one with pair attribute ([#746])
+- add Limit::Offset support to DynamoDB driver ([#674])
+- add support for floats ([#687])
+- add native database enum type support for embedded enums ([#665])
+- export `SchemaMutations` for external drivers ([#686])
+
+### Fixed
+
+- fix GetByKey to handle duplicate input keys correctly ([#750])
+- fix query results when simplification rules encounter unstable expressions ([#703])
+
+[#665]: https://github.com/tokio-rs/toasty/pull/665
+[#674]: https://github.com/tokio-rs/toasty/pull/674
+[#686]: https://github.com/tokio-rs/toasty/pull/686
+[#687]: https://github.com/tokio-rs/toasty/pull/687
+[#694]: https://github.com/tokio-rs/toasty/pull/694
+[#703]: https://github.com/tokio-rs/toasty/pull/703
+[#745]: https://github.com/tokio-rs/toasty/pull/745
+[#746]: https://github.com/tokio-rs/toasty/pull/746
+[#750]: https://github.com/tokio-rs/toasty/pull/750
+
 ## [0.4.0](https://github.com/tokio-rs/toasty/compare/toasty-core-v0.3.0...toasty-core-v0.4.0) - 2026-04-11
 
 ### Added

--- a/crates/toasty-core/Cargo.toml
+++ b/crates/toasty-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-core"
-version = "0.4.0"
+version = "0.5.0"
 description = "Core types, schema representations, and driver interface for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-dynamodb/CHANGELOG.md
+++ b/crates/toasty-driver-dynamodb/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-dynamodb-v0.4.0...toasty-driver-dynamodb-v0.5.0) - 2026-04-27
+
+### Added
+
+- Add starts_with and LIKE string prefix filter operators ([#745])
+- Add #[version] optimistic concurrency control for DynamoDB ([#694])
+- Add Limit::Offset support to DynamoDB driver ([#674])
+- Add support for floats ([#687])
+- Add native database enum type support for embedded enums ([#665])
+- Add multi-column composite index support ([#664])
+
+[#664]: https://github.com/tokio-rs/toasty/pull/664
+[#665]: https://github.com/tokio-rs/toasty/pull/665
+[#674]: https://github.com/tokio-rs/toasty/pull/674
+[#687]: https://github.com/tokio-rs/toasty/pull/687
+[#694]: https://github.com/tokio-rs/toasty/pull/694
+[#745]: https://github.com/tokio-rs/toasty/pull/745
+
 ## [0.4.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-dynamodb-v0.3.0...toasty-driver-dynamodb-v0.4.0) - 2026-04-11
 
 ### Added

--- a/crates/toasty-driver-dynamodb/Cargo.toml
+++ b/crates/toasty-driver-dynamodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-dynamodb"
-version = "0.4.0"
+version = "0.5.0"
 description = "Amazon DynamoDB driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-integration-suite-macros/CHANGELOG.md
+++ b/crates/toasty-driver-integration-suite-macros/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-macros-v0.4.0...toasty-driver-integration-suite-macros-v0.5.0) - 2026-04-27
+
+- Internal improvements only
+
 ## [0.3.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-macros-v0.2.0...toasty-driver-integration-suite-macros-v0.3.0) - 2026-04-03
 
 ### Other

--- a/crates/toasty-driver-integration-suite-macros/Cargo.toml
+++ b/crates/toasty-driver-integration-suite-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-integration-suite-macros"
-version = "0.4.0"
+version = "0.5.0"
 description = "Proc macros for the Toasty driver integration test suite"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-integration-suite/CHANGELOG.md
+++ b/crates/toasty-driver-integration-suite/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-v0.4.0...toasty-driver-integration-suite-v0.5.0) - 2026-04-27
+
+### Added
+
+- String prefix filtering with `starts_with` and `like` operators ([#745])
+- Connection pool configuration to Db builder ([#759])
+- Optimistic concurrency control for DynamoDB with `#[version]` attribute ([#694])
+- Array syntax for partition/local macro attributes ([#738])
+- `pair` attribute to disambiguate `has_many`/`has_one` relationships ([#746])
+- `Limit::Offset` support in DynamoDB driver ([#674])
+- Float type support ([#687])
+- Native database enum type support for embedded enums ([#665])
+- Multi-column composite index support ([#664])
+
+### Fixed
+
+- Preserve non-reference constraints when lifting BelongsTo subqueries ([#777])
+- Deduplicated GetByKey input keys and strengthened HashIndex invariants ([#750])
+- Support for raw identifier fields in model schema ([#761])
+- Nested includes no longer overwritten when sharing a prefix ([#699])
+- [**breaking**] `.first()` returns first row instead of panicking on multiple matches ([#693])
+
+[#664]: https://github.com/tokio-rs/toasty/pull/664
+[#665]: https://github.com/tokio-rs/toasty/pull/665
+[#674]: https://github.com/tokio-rs/toasty/pull/674
+[#687]: https://github.com/tokio-rs/toasty/pull/687
+[#693]: https://github.com/tokio-rs/toasty/pull/693
+[#694]: https://github.com/tokio-rs/toasty/pull/694
+[#699]: https://github.com/tokio-rs/toasty/pull/699
+[#738]: https://github.com/tokio-rs/toasty/pull/738
+[#745]: https://github.com/tokio-rs/toasty/pull/745
+[#746]: https://github.com/tokio-rs/toasty/pull/746
+[#750]: https://github.com/tokio-rs/toasty/pull/750
+[#759]: https://github.com/tokio-rs/toasty/pull/759
+[#761]: https://github.com/tokio-rs/toasty/pull/761
+[#777]: https://github.com/tokio-rs/toasty/pull/777
+
 ## [0.4.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-v0.3.0...toasty-driver-integration-suite-v0.4.0) - 2026-04-11
 
 ### Added

--- a/crates/toasty-driver-integration-suite/Cargo.toml
+++ b/crates/toasty-driver-integration-suite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-integration-suite"
-version = "0.4.0"
+version = "0.5.0"
 description = "Integration test suite for Toasty database drivers"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-mysql/CHANGELOG.md
+++ b/crates/toasty-driver-mysql/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-mysql-v0.4.0...toasty-driver-mysql-v0.5.0) - 2026-04-27
+
+### Added
+
+- Support for float types ([#687])
+- Native database enum types for embedded enums ([#665])
+
+[#665]: https://github.com/tokio-rs/toasty/pull/665
+[#687]: https://github.com/tokio-rs/toasty/pull/687
+
 ## [0.3.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-mysql-v0.2.0...toasty-driver-mysql-v0.3.0) - 2026-04-03
 
 ### Other

--- a/crates/toasty-driver-mysql/Cargo.toml
+++ b/crates/toasty-driver-mysql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-mysql"
-version = "0.4.0"
+version = "0.5.0"
 description = "MySQL driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-postgresql/CHANGELOG.md
+++ b/crates/toasty-driver-postgresql/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-postgresql-v0.4.0...toasty-driver-postgresql-v0.5.0) - 2026-04-27
+
+### Added
+
+- Support for floating-point data types ([#687])
+- Native database enum types for embedded enums ([#665])
+- PostgreSQL client application name configuration ([#680])
+
+[#665]: https://github.com/tokio-rs/toasty/pull/665
+[#680]: https://github.com/tokio-rs/toasty/pull/680
+[#687]: https://github.com/tokio-rs/toasty/pull/687
+
 ## [0.4.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-postgresql-v0.3.0...toasty-driver-postgresql-v0.4.0) - 2026-04-11
 
 ### Added

--- a/crates/toasty-driver-postgresql/Cargo.toml
+++ b/crates/toasty-driver-postgresql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-postgresql"
-version = "0.4.0"
+version = "0.5.0"
 description = "PostgreSQL driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-sqlite/CHANGELOG.md
+++ b/crates/toasty-driver-sqlite/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-sqlite-v0.4.0...toasty-driver-sqlite-v0.5.0) - 2026-04-27
+
+### Added
+
+- Support for float types ([#687])
+- Native database enum type support for embedded enums ([#665])
+
+[#665]: https://github.com/tokio-rs/toasty/pull/665
+[#687]: https://github.com/tokio-rs/toasty/pull/687
+
 ## [0.3.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-sqlite-v0.2.0...toasty-driver-sqlite-v0.3.0) - 2026-04-03
 
 ### Other

--- a/crates/toasty-driver-sqlite/Cargo.toml
+++ b/crates/toasty-driver-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-sqlite"
-version = "0.4.0"
+version = "0.5.0"
 description = "SQLite driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-macros/CHANGELOG.md
+++ b/crates/toasty-macros/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-macros-v0.4.0...toasty-macros-v0.5.0) - 2026-04-27
+
+### Added
+
+- Add optimistic concurrency control with #[version] attribute for DynamoDB ([#694])
+- Support array syntax for partition/local key declarations ([#738])
+- Add pair attribute to disambiguate has_many/has_one relations ([#746])
+- Add support for float types ([#687])
+- Add native database enum support ([#665])
+- Add multi-column composite index support ([#664])
+
+### Fixed
+
+- Support Rust raw identifiers in model schemas ([#761])
+
+[#664]: https://github.com/tokio-rs/toasty/pull/664
+[#665]: https://github.com/tokio-rs/toasty/pull/665
+[#687]: https://github.com/tokio-rs/toasty/pull/687
+[#694]: https://github.com/tokio-rs/toasty/pull/694
+[#738]: https://github.com/tokio-rs/toasty/pull/738
+[#746]: https://github.com/tokio-rs/toasty/pull/746
+[#761]: https://github.com/tokio-rs/toasty/pull/761
+
 ## [0.4.0](https://github.com/tokio-rs/toasty/compare/toasty-macros-v0.3.0...toasty-macros-v0.4.0) - 2026-04-11
 
 ### Added

--- a/crates/toasty-macros/Cargo.toml
+++ b/crates/toasty-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-macros"
-version = "0.4.0"
+version = "0.5.0"
 description = "Derive macros for Toasty models and embeds"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-sql/CHANGELOG.md
+++ b/crates/toasty-sql/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-sql-v0.4.0...toasty-sql-v0.5.0) - 2026-04-27
+
+### Added
+
+- String prefix filtering with begins_with and LIKE operators ([#745])
+- Optimistic concurrency control for DynamoDB with #[version] attribute ([#694])
+- Float type support ([#687])
+- Native database enum type support for embedded enums ([#665])
+
+### Fixed
+
+- Column rename emits last when combined with other schema changes ([#769])
+- Removed unnecessary unique index on primary key ([#682])
+
+[#665]: https://github.com/tokio-rs/toasty/pull/665
+[#682]: https://github.com/tokio-rs/toasty/pull/682
+[#687]: https://github.com/tokio-rs/toasty/pull/687
+[#694]: https://github.com/tokio-rs/toasty/pull/694
+[#745]: https://github.com/tokio-rs/toasty/pull/745
+[#769]: https://github.com/tokio-rs/toasty/pull/769
+
 ## [0.3.0](https://github.com/tokio-rs/toasty/compare/toasty-sql-v0.2.0...toasty-sql-v0.3.0) - 2026-04-03
 
 ### Other

--- a/crates/toasty-sql/Cargo.toml
+++ b/crates/toasty-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-sql"
-version = "0.4.0"
+version = "0.5.0"
 description = "SQL serialization layer for Toasty database drivers"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty/CHANGELOG.md
+++ b/crates/toasty/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-v0.4.0...toasty-v0.5.0) - 2026-04-27
+
+### Added
+
+- String prefix filter operators (`starts_with` and `LIKE`) ([#745])
+- Connection pool configuration ([#759])
+- Optimistic concurrency control for DynamoDB via `#[version]` attribute ([#694])
+- Pair attributes to disambiguate has_many/has_one relationships ([#746])
+- Limit::Offset pagination for DynamoDB ([#674])
+- Float field type support ([#687])
+- Native database enums for embedded enums ([#665])
+- Multiple external crate glob imports in models! macro ([#685])
+
+### Fixed
+
+- Preserve non-reference constraints when lifting BelongsTo IN-subquery ([#777])
+- Deduplicate GetByKey input keys and strengthen HashIndex invariant ([#750])
+- Gate simplification rules on expression stability ([#703])
+- Nested includes sharing a prefix being overwritten ([#699])
+- [**breaking**] `.first()` returns the first row instead of panicking on multiple matches ([#693])
+
+[#665]: https://github.com/tokio-rs/toasty/pull/665
+[#674]: https://github.com/tokio-rs/toasty/pull/674
+[#685]: https://github.com/tokio-rs/toasty/pull/685
+[#687]: https://github.com/tokio-rs/toasty/pull/687
+[#693]: https://github.com/tokio-rs/toasty/pull/693
+[#694]: https://github.com/tokio-rs/toasty/pull/694
+[#699]: https://github.com/tokio-rs/toasty/pull/699
+[#703]: https://github.com/tokio-rs/toasty/pull/703
+[#745]: https://github.com/tokio-rs/toasty/pull/745
+[#746]: https://github.com/tokio-rs/toasty/pull/746
+[#750]: https://github.com/tokio-rs/toasty/pull/750
+[#759]: https://github.com/tokio-rs/toasty/pull/759
+[#777]: https://github.com/tokio-rs/toasty/pull/777
+
 ## [0.4.0](https://github.com/tokio-rs/toasty/compare/toasty-v0.3.0...toasty-v0.4.0) - 2026-04-11
 
 ### Added

--- a/crates/toasty/Cargo.toml
+++ b/crates/toasty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty"
-version = "0.4.0"
+version = "0.5.0"
 description = "An async ORM for Rust supporting SQL and NoSQL databases"
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `toasty-core`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)
* `toasty-driver-dynamodb`: 0.4.0 -> 0.5.0 (✓ API compatible changes)
* `toasty-sql`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)
* `toasty-driver-mysql`: 0.4.0 -> 0.5.0 (✓ API compatible changes)
* `toasty-driver-postgresql`: 0.4.0 -> 0.5.0 (✓ API compatible changes)
* `toasty-driver-sqlite`: 0.4.0 -> 0.5.0 (✓ API compatible changes)
* `toasty-macros`: 0.4.0 -> 0.5.0
* `toasty`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)
* `toasty-cli`: 0.4.0 -> 0.5.0 (✓ API compatible changes)
* `toasty-driver-integration-suite-macros`: 0.4.0 -> 0.5.0
* `toasty-driver-integration-suite`: 0.4.0 -> 0.5.0 (✓ API compatible changes)

### ⚠ `toasty-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Delete.condition in /tmp/.tmpAODwGM/toasty/crates/toasty-core/src/stmt/delete.rs:35
  field Capability.native_enum in /tmp/.tmpAODwGM/toasty/crates/toasty-core/src/driver/capability.rs:77
  field Capability.named_enum_types in /tmp/.tmpAODwGM/toasty/crates/toasty-core/src/driver/capability.rs:88
  field Capability.native_starts_with in /tmp/.tmpAODwGM/toasty/crates/toasty-core/src/driver/capability.rs:114
  field Capability.native_like in /tmp/.tmpAODwGM/toasty/crates/toasty-core/src/driver/capability.rs:119
  field QuerySql.params in /tmp/.tmpAODwGM/toasty/crates/toasty-core/src/driver/operation/query_sql.rs:33
  field ModelRoot.version_field in /tmp/.tmpAODwGM/toasty/crates/toasty-core/src/schema/app/model.rs:167
  field Insert.params in /tmp/.tmpAODwGM/toasty/crates/toasty-core/src/driver/operation/insert.rs:30
  field Field.versionable in /tmp/.tmpAODwGM/toasty/crates/toasty-core/src/schema/app/field.rs:50
  field DeleteByKey.condition in /tmp/.tmpAODwGM/toasty/crates/toasty-core/src/driver/operation/delete_by_key.rs:36
  field Column.versionable in /tmp/.tmpAODwGM/toasty/crates/toasty-core/src/schema/db/column.rs:62

--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type ValueRecord no longer derives Eq, in /tmp/.tmpAODwGM/toasty/crates/toasty-core/src/stmt/value_record.rs:22
  type SparseRecord no longer derives Eq, in /tmp/.tmpAODwGM/toasty/crates/toasty-core/src/stmt/sparse_record.rs:23
  type SparseRecord no longer derives Hash, in /tmp/.tmpAODwGM/toasty/crates/toasty-core/src/stmt/sparse_record.rs:23
  type Value no longer derives Eq, in /tmp/.tmpAODwGM/toasty/crates/toasty-core/src/stmt/value.rs:34
  type Value no longer derives Hash, in /tmp/.tmpAODwGM/toasty/crates/toasty-core/src/stmt/value.rs:34

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Type:F32 in /tmp/.tmpAODwGM/toasty/crates/toasty-core/src/stmt/ty.rs:103
  variant Type:F64 in /tmp/.tmpAODwGM/toasty/crates/toasty-core/src/stmt/ty.rs:106
  variant Type:Float in /tmp/.tmpAODwGM/toasty/crates/toasty-core/src/schema/db/ty.rs:75
  variant Type:Enum in /tmp/.tmpAODwGM/toasty/crates/toasty-core/src/schema/db/ty.rs:110
  variant Value:F32 in /tmp/.tmpAODwGM/toasty/crates/toasty-core/src/stmt/value.rs:63
  variant Value:F64 in /tmp/.tmpAODwGM/toasty/crates/toasty-core/src/stmt/value.rs:66
  variant Expr:Ident in /tmp/.tmpAODwGM/toasty/crates/toasty-core/src/stmt/expr.rs:72
  variant Expr:Like in /tmp/.tmpAODwGM/toasty/crates/toasty-core/src/stmt/expr.rs:92
  variant Expr:StartsWith in /tmp/.tmpAODwGM/toasty/crates/toasty-core/src/stmt/expr.rs:121

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field cursor of struct QueryPk, previously in file /tmp/.tmpomaggW/toasty-core/src/driver/operation/query_pk.rs:59
```

### ⚠ `toasty-sql` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ColumnDef.check in /tmp/.tmpAODwGM/toasty/crates/toasty-sql/src/stmt/column_def.rs:21

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Statement:AlterType in /tmp/.tmpAODwGM/toasty/crates/toasty-sql/src/stmt.rs:64
  variant Statement:CreateType in /tmp/.tmpAODwGM/toasty/crates/toasty-sql/src/stmt.rs:72
  variant Statement:AlterType in /tmp/.tmpAODwGM/toasty/crates/toasty-sql/src/stmt.rs:64
  variant Statement:CreateType in /tmp/.tmpAODwGM/toasty/crates/toasty-sql/src/stmt.rs:72

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  toasty_sql::serializer::Serializer::serialize now takes 1 parameters instead of 2, in /tmp/.tmpAODwGM/toasty/crates/toasty-sql/src/serializer.rs:84
  toasty_sql::Serializer::serialize now takes 1 parameters instead of 2, in /tmp/.tmpAODwGM/toasty/crates/toasty-sql/src/serializer.rs:84

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct toasty_sql::serializer::TypedValue, previously in file /tmp/.tmpomaggW/toasty-sql/src/serializer/params.rs:50
  struct toasty_sql::TypedValue, previously in file /tmp/.tmpomaggW/toasty-sql/src/serializer/params.rs:50
  struct toasty_sql::serializer::InsertContext, previously in file /tmp/.tmpomaggW/toasty-sql/src/serializer.rs:39

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_missing.ron

Failed in:
  trait toasty_sql::serializer::Params, previously in file /tmp/.tmpomaggW/toasty-sql/src/serializer/params.rs:13
  trait toasty_sql::Params, previously in file /tmp/.tmpomaggW/toasty-sql/src/serializer/params.rs:13
```

### ⚠ `toasty` breaking changes

```text
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct toasty::db::PoolConfig, previously in file /tmp/.tmpomaggW/toasty/src/db/pool.rs:22
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `toasty-core`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-core-v0.4.0...toasty-core-v0.5.0) - 2026-04-27

### Added

- add starts_with and LIKE string prefix filter operators ([#745])
- add #[version] optimistic concurrency control for DynamoDB ([#694])
- support disambiguating has_many/has_one with pair attribute ([#746])
- add Limit::Offset support to DynamoDB driver ([#674])
- add support for floats ([#687])
- add native database enum type support for embedded enums ([#665])
- export `SchemaMutations` for external drivers ([#686])

### Fixed

- fix GetByKey to handle duplicate input keys correctly ([#750])
- fix query results when simplification rules encounter unstable expressions ([#703])

[#665]: https://github.com/tokio-rs/toasty/pull/665
[#674]: https://github.com/tokio-rs/toasty/pull/674
[#686]: https://github.com/tokio-rs/toasty/pull/686
[#687]: https://github.com/tokio-rs/toasty/pull/687
[#694]: https://github.com/tokio-rs/toasty/pull/694
[#703]: https://github.com/tokio-rs/toasty/pull/703
[#745]: https://github.com/tokio-rs/toasty/pull/745
[#746]: https://github.com/tokio-rs/toasty/pull/746
[#750]: https://github.com/tokio-rs/toasty/pull/750
</blockquote>

## `toasty-driver-dynamodb`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-dynamodb-v0.4.0...toasty-driver-dynamodb-v0.5.0) - 2026-04-27

### Added

- Add starts_with and LIKE string prefix filter operators ([#745])
- Add #[version] optimistic concurrency control for DynamoDB ([#694])
- Add Limit::Offset support to DynamoDB driver ([#674])
- Add support for floats ([#687])
- Add native database enum type support for embedded enums ([#665])
- Add multi-column composite index support ([#664])

[#664]: https://github.com/tokio-rs/toasty/pull/664
[#665]: https://github.com/tokio-rs/toasty/pull/665
[#674]: https://github.com/tokio-rs/toasty/pull/674
[#687]: https://github.com/tokio-rs/toasty/pull/687
[#694]: https://github.com/tokio-rs/toasty/pull/694
[#745]: https://github.com/tokio-rs/toasty/pull/745
</blockquote>

## `toasty-sql`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-sql-v0.4.0...toasty-sql-v0.5.0) - 2026-04-27

### Added

- String prefix filtering with begins_with and LIKE operators ([#745])
- Optimistic concurrency control for DynamoDB with #[version] attribute ([#694])
- Float type support ([#687])
- Native database enum type support for embedded enums ([#665])

### Fixed

- Column rename emits last when combined with other schema changes ([#769])
- Removed unnecessary unique index on primary key ([#682])

[#665]: https://github.com/tokio-rs/toasty/pull/665
[#682]: https://github.com/tokio-rs/toasty/pull/682
[#687]: https://github.com/tokio-rs/toasty/pull/687
[#694]: https://github.com/tokio-rs/toasty/pull/694
[#745]: https://github.com/tokio-rs/toasty/pull/745
[#769]: https://github.com/tokio-rs/toasty/pull/769
</blockquote>

## `toasty-driver-mysql`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-mysql-v0.4.0...toasty-driver-mysql-v0.5.0) - 2026-04-27

### Added

- Support for float types ([#687])
- Native database enum types for embedded enums ([#665])

[#665]: https://github.com/tokio-rs/toasty/pull/665
[#687]: https://github.com/tokio-rs/toasty/pull/687
</blockquote>

## `toasty-driver-postgresql`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-postgresql-v0.4.0...toasty-driver-postgresql-v0.5.0) - 2026-04-27

### Added

- Support for floating-point data types ([#687])
- Native database enum types for embedded enums ([#665])
- PostgreSQL client application name configuration ([#680])

[#665]: https://github.com/tokio-rs/toasty/pull/665
[#680]: https://github.com/tokio-rs/toasty/pull/680
[#687]: https://github.com/tokio-rs/toasty/pull/687
</blockquote>

## `toasty-driver-sqlite`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-sqlite-v0.4.0...toasty-driver-sqlite-v0.5.0) - 2026-04-27

### Added

- Support for float types ([#687])
- Native database enum type support for embedded enums ([#665])

[#665]: https://github.com/tokio-rs/toasty/pull/665
[#687]: https://github.com/tokio-rs/toasty/pull/687
</blockquote>

## `toasty-macros`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-macros-v0.4.0...toasty-macros-v0.5.0) - 2026-04-27

### Added

- Add optimistic concurrency control with #[version] attribute for DynamoDB ([#694])
- Support array syntax for partition/local key declarations ([#738])
- Add pair attribute to disambiguate has_many/has_one relations ([#746])
- Add support for float types ([#687])
- Add native database enum support ([#665])
- Add multi-column composite index support ([#664])

### Fixed

- Support Rust raw identifiers in model schemas ([#761])

[#664]: https://github.com/tokio-rs/toasty/pull/664
[#665]: https://github.com/tokio-rs/toasty/pull/665
[#687]: https://github.com/tokio-rs/toasty/pull/687
[#694]: https://github.com/tokio-rs/toasty/pull/694
[#738]: https://github.com/tokio-rs/toasty/pull/738
[#746]: https://github.com/tokio-rs/toasty/pull/746
[#761]: https://github.com/tokio-rs/toasty/pull/761
</blockquote>

## `toasty`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-v0.4.0...toasty-v0.5.0) - 2026-04-27

### Added

- String prefix filter operators (`starts_with` and `LIKE`) ([#745])
- Connection pool configuration ([#759])
- Optimistic concurrency control for DynamoDB via `#[version]` attribute ([#694])
- Pair attributes to disambiguate has_many/has_one relationships ([#746])
- Limit::Offset pagination for DynamoDB ([#674])
- Float field type support ([#687])
- Native database enums for embedded enums ([#665])
- Multiple external crate glob imports in models! macro ([#685])

### Fixed

- Preserve non-reference constraints when lifting BelongsTo IN-subquery ([#777])
- Deduplicate GetByKey input keys and strengthen HashIndex invariant ([#750])
- Gate simplification rules on expression stability ([#703])
- Nested includes sharing a prefix being overwritten ([#699])
- [**breaking**] `.first()` returns the first row instead of panicking on multiple matches ([#693])

[#665]: https://github.com/tokio-rs/toasty/pull/665
[#674]: https://github.com/tokio-rs/toasty/pull/674
[#685]: https://github.com/tokio-rs/toasty/pull/685
[#687]: https://github.com/tokio-rs/toasty/pull/687
[#693]: https://github.com/tokio-rs/toasty/pull/693
[#694]: https://github.com/tokio-rs/toasty/pull/694
[#699]: https://github.com/tokio-rs/toasty/pull/699
[#703]: https://github.com/tokio-rs/toasty/pull/703
[#745]: https://github.com/tokio-rs/toasty/pull/745
[#746]: https://github.com/tokio-rs/toasty/pull/746
[#750]: https://github.com/tokio-rs/toasty/pull/750
[#759]: https://github.com/tokio-rs/toasty/pull/759
[#777]: https://github.com/tokio-rs/toasty/pull/777
</blockquote>

## `toasty-cli`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-cli-v0.4.0...toasty-cli-v0.5.0) - 2026-04-27

### Added

- Generate migrations with timestamp prefixes ([#684])
- Add newlines at the end of generated migration files ([#683])

[#683]: https://github.com/tokio-rs/toasty/pull/683
[#684]: https://github.com/tokio-rs/toasty/pull/684
</blockquote>

## `toasty-driver-integration-suite-macros`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-macros-v0.4.0...toasty-driver-integration-suite-macros-v0.5.0) - 2026-04-27

- Internal improvements only
</blockquote>

## `toasty-driver-integration-suite`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-v0.4.0...toasty-driver-integration-suite-v0.5.0) - 2026-04-27

### Added

- String prefix filtering with `starts_with` and `like` operators ([#745])
- Connection pool configuration to Db builder ([#759])
- Optimistic concurrency control for DynamoDB with `#[version]` attribute ([#694])
- Array syntax for partition/local macro attributes ([#738])
- `pair` attribute to disambiguate `has_many`/`has_one` relationships ([#746])
- `Limit::Offset` support in DynamoDB driver ([#674])
- Float type support ([#687])
- Native database enum type support for embedded enums ([#665])
- Multi-column composite index support ([#664])

### Fixed

- Preserve non-reference constraints when lifting BelongsTo subqueries ([#777])
- Deduplicated GetByKey input keys and strengthened HashIndex invariants ([#750])
- Support for raw identifier fields in model schema ([#761])
- Nested includes no longer overwritten when sharing a prefix ([#699])
- [**breaking**] `.first()` returns first row instead of panicking on multiple matches ([#693])

[#664]: https://github.com/tokio-rs/toasty/pull/664
[#665]: https://github.com/tokio-rs/toasty/pull/665
[#674]: https://github.com/tokio-rs/toasty/pull/674
[#687]: https://github.com/tokio-rs/toasty/pull/687
[#693]: https://github.com/tokio-rs/toasty/pull/693
[#694]: https://github.com/tokio-rs/toasty/pull/694
[#699]: https://github.com/tokio-rs/toasty/pull/699
[#738]: https://github.com/tokio-rs/toasty/pull/738
[#745]: https://github.com/tokio-rs/toasty/pull/745
[#746]: https://github.com/tokio-rs/toasty/pull/746
[#750]: https://github.com/tokio-rs/toasty/pull/750
[#759]: https://github.com/tokio-rs/toasty/pull/759
[#761]: https://github.com/tokio-rs/toasty/pull/761
[#777]: https://github.com/tokio-rs/toasty/pull/777
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).