### PR TITLE
fix: unnecessary unique index on primary key

### DIFF
--- a/crates/toasty-sql/src/migration.rs
+++ b/crates/toasty-sql/src/migration.rs
@@ -40,6 +40,9 @@ impl<'a> MigrationStatement<'a> {
                         Cow::Borrowed(schema_diff.next()),
                     ));
                     for index in &table.indices {
+                        if index.primary_key {
+                            continue; // PK indices are created as part of CREATE TABLE
+                        }
                         result.push(Self::new(
                             Statement::create_index(index),
                             Cow::Borrowed(schema_diff.next()),

--- a/crates/toasty-sql/tests/migration_create_table.rs
+++ b/crates/toasty-sql/tests/migration_create_table.rs
@@ -334,3 +334,55 @@ fn create_table_varchar_mysql() {
     assert_eq!(sql.len(), 1);
     assert!(sql[0].contains("VARCHAR(191)"), "got: {}", sql[0]);
 }
+
+/// When the table's `indices` list contains the primary key index (as
+/// #[derive(Model)] produces), migration should NOT emit a separate
+/// CREATE UNIQUE INDEX for it — the PRIMARY KEY in CREATE TABLE is sufficient.
+#[test]
+fn create_table_no_redundant_pk_index() {
+    let from = Schema::default();
+
+    let pk_index = Index {
+        id: IndexId {
+            table: TableId(0),
+            index: 0,
+        },
+        name: "index_users_by_id".to_string(),
+        on: TableId(0),
+        columns: vec![IndexColumn {
+            column: ColumnId {
+                table: TableId(0),
+                index: 0,
+            },
+            op: IndexOp::Eq,
+            scope: IndexScope::Local,
+        }],
+        unique: true,
+        primary_key: true,
+    };
+
+    let to = Schema {
+        tables: vec![make_table(
+            0,
+            "users",
+            vec![
+                make_column(0, 0, "id", Type::Text),
+                make_column(0, 1, "name", Type::Text),
+            ],
+            vec![pk_index],
+        )],
+    };
+
+    let hints = RenameHints::new();
+    let diff = SchemaDiff::from(&from, &to, &hints);
+    let stmts = MigrationStatement::from_diff(&diff, &Capability::SQLITE);
+    let sql = serialize_migration(&stmts, "sqlite");
+
+    assert_eq!(
+        sql.len(),
+        1,
+        "expected only CREATE TABLE, got extra statements: {sql:?}"
+    );
+    assert!(sql[0].starts_with("CREATE TABLE"), "got: {}", sql[0]);
+    assert!(sql[0].contains("PRIMARY KEY"), "got: {}", sql[0]);
+}


### PR DESCRIPTION
- Fixes https://github.com/tokio-rs/toasty/issues/653
- Adds a test in `toasty-sql` that verifies that only one statement is produced for a table whose only index is the primary key