### PR TITLE
feat: enable timestamp migration prefix

### DIFF
--- a/crates/toasty-cli/Cargo.toml
+++ b/crates/toasty-cli/Cargo.toml
@@ -22,6 +22,7 @@ anyhow = "1.0.102"
 clap.workspace = true
 console.workspace = true
 dialoguer.workspace = true
+jiff.workspace = true
 rand.workspace = true
 serde.workspace = true
 toml.workspace = true

--- a/crates/toasty-cli/src/migration/generate.rs
+++ b/crates/toasty-cli/src/migration/generate.rs
@@ -274,13 +274,16 @@ impl GenerateCommand {
         }
 
         let snapshot = SnapshotFile::new(schema.clone());
-        let migration_number = history.next_migration_number();
-        let snapshot_name = format!("{:04}_snapshot.toml", migration_number);
+        let migration_prefix = match config.migration.prefix_style {
+            crate::MigrationPrefixStyle::Sequential => format!("{:04}", history.next_migration_number()),
+            crate::MigrationPrefixStyle::Timestamp => jiff::Timestamp::now().strftime("%Y%m%d_%H%M%S").to_string(),
+        };
+        let snapshot_name = format!("{:04}_snapshot.toml", &migration_prefix);
         let snapshot_path = config.migration.get_snapshots_dir().join(&snapshot_name);
 
         let migration_name = format!(
             "{:04}_{}.sql",
-            migration_number,
+            &migration_prefix,
             self.name.as_deref().unwrap_or("migration")
         );
         let migration_path = config.migration.get_migrations_dir().join(&migration_name);

--- a/crates/toasty-cli/src/migration/generate.rs
+++ b/crates/toasty-cli/src/migration/generate.rs
@@ -275,8 +275,12 @@ impl GenerateCommand {
 
         let snapshot = SnapshotFile::new(schema.clone());
         let migration_prefix = match config.migration.prefix_style {
-            crate::MigrationPrefixStyle::Sequential => format!("{:04}", history.next_migration_number()),
-            crate::MigrationPrefixStyle::Timestamp => jiff::Timestamp::now().strftime("%Y%m%d_%H%M%S").to_string(),
+            crate::MigrationPrefixStyle::Sequential => {
+                format!("{:04}", history.next_migration_number())
+            }
+            crate::MigrationPrefixStyle::Timestamp => {
+                jiff::Timestamp::now().strftime("%Y%m%d_%H%M%S").to_string()
+            }
         };
         let snapshot_name = format!("{:04}_snapshot.toml", &migration_prefix);
         let snapshot_path = config.migration.get_snapshots_dir().join(&snapshot_name);


### PR DESCRIPTION
Closes #652
It still works if the user changes prefix style between migrations but from Timestamp to Sequential, the generated name will be :
- 20260415_143200_migration.sql [Timestamp]
- 20260416_migration.sql [Sequential after Timestamp]