### PR TITLE
feat: allow multiple external crate glob inputs in models! macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ members = [
 
     # Tests
     "tests",
+    "tests/tests/fixtures/post",
+    "tests/tests/fixtures/user",
 
     # Benchmarks
     "benches",

--- a/crates/toasty/src/schema/register.rs
+++ b/crates/toasty/src/schema/register.rs
@@ -130,23 +130,29 @@ pub use inventory;
 #[macro_export]
 macro_rules! models {
     // Register all models from current crate with `models!(crate::*)`
-    (@internal $set:ident crate::* $(,$rest:ty)* $(,)?) => {{
+    (@internal $set:ident crate::* $(,$($rest:tt)*)?) => {{
         ::toasty::codegen_support::DiscoverItem::add_all_from_crate_to(&mut $set, env!("CARGO_PKG_NAME"));
-        $crate::models!(@internal $set $($rest),*);
+        $(
+            $crate::models!(@internal $set $($rest)*);
+        )?
     }};
 
     // Register all models from a third party crate with `models!(third_party::*)`
-    (@internal $set:ident $crate_name:ident::* $(,$rest:ty)* $(,)?) => {{
+    (@internal $set:ident $crate_name:ident::* $(,$($rest:tt)*)?) => {{
         // Make sure the provided crate actually exists.
         { use ::$crate_name; }
         ::toasty::codegen_support::DiscoverItem::add_all_from_crate_to(&mut $set, stringify!($crate_name));
-        $crate::models!(@internal $set $($rest),*);
+        $(
+            $crate::models!(@internal $set $($rest)*);
+        )?
     }};
 
     // Register single model with `models!(ModelName)`
-    (@internal $set:ident $model:ty $(,$rest:ty)* $(,)?) => {{
+    (@internal $set:ident $model:ty $(,$($rest:tt)*)?) => {{
         <$model as ::toasty::schema::Register>::register(&mut $set);
-        $crate::models!(@internal $set $($rest),*);
+        $(
+            $crate::models!(@internal $set $($rest)*);
+        )?
     }};
 
     // Empty list

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -52,6 +52,10 @@ trybuild.workspace = true
 env_logger = "0.11.10"
 url.workspace = true
 
+# Fixtures
+tests-fixture-post = { path = "tests/fixtures/post" }
+tests-fixture-user = { path = "tests/fixtures/user" }
+
 # Third-party types
 uuid.workspace = true
 

--- a/tests/tests/fixtures/post/Cargo.toml
+++ b/tests/tests/fixtures/post/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "tests-fixture-post"
+version = "0.0.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+publish = false
+
+[dependencies]
+toasty = { workspace = true }

--- a/tests/tests/fixtures/post/src/lib.rs
+++ b/tests/tests/fixtures/post/src/lib.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, toasty::Model)]
+pub struct Post {
+    #[key]
+    #[auto]
+    id: u64,
+    title: String,
+}

--- a/tests/tests/fixtures/user/Cargo.toml
+++ b/tests/tests/fixtures/user/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "tests-fixture-user"
+version = "0.0.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+publish = false
+
+[dependencies]
+toasty = { workspace = true }

--- a/tests/tests/fixtures/user/src/lib.rs
+++ b/tests/tests/fixtures/user/src/lib.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, toasty::Model)]
+pub struct User {
+    #[key]
+    #[auto]
+    id: u64,
+    name: String,
+}

--- a/tests/tests/models_macro.rs
+++ b/tests/tests/models_macro.rs
@@ -18,7 +18,8 @@ fn empty_set() {
 
     assert!(
         models.is_empty(),
-        "expected 0 models in model set, got: {:?}", models.len()
+        "expected 0 models in model set, got: {:?}",
+        models.len()
     );
 }
 
@@ -65,7 +66,8 @@ fn current_crate() {
     assert_eq!(
         models.len(),
         2,
-        "expected 2 models in model set, got: {:?}", models.len()
+        "expected 2 models in model set, got: {:?}",
+        models.len()
     );
 }
 
@@ -80,7 +82,8 @@ fn single_external_crate() {
     assert_eq!(
         models.len(),
         1,
-        "expected 1 model in model set, got: {:?}", models.len()
+        "expected 1 model in model set, got: {:?}",
+        models.len()
     );
 }
 
@@ -99,7 +102,8 @@ fn multiple_external_crates() {
     assert_eq!(
         models.len(),
         2,
-        "expected 2 models in model set, got: {:?}", models.len()
+        "expected 2 models in model set, got: {:?}",
+        models.len()
     );
 }
 
@@ -126,7 +130,8 @@ fn mixed_inputs() {
     assert_eq!(
         models.len(),
         4,
-        "expected 4 models in model set, got: {:?}", models.len()
+        "expected 4 models in model set, got: {:?}",
+        models.len()
     );
 }
 
@@ -137,13 +142,14 @@ fn duplicates() {
     assert_eq!(
         models.len(),
         1,
-        "expected 1 model in model set, got: {:?}", models.len()
+        "expected 1 model in model set, got: {:?}",
+        models.len()
     );
 }
 
 #[test]
 fn trailing_comma() {
-    let models = toasty::models!(ModelA, ModelB, );
+    let models = toasty::models!(ModelA, ModelB,);
 
     assert!(
         models.contains(ModelA::id()),
@@ -156,6 +162,7 @@ fn trailing_comma() {
     assert_eq!(
         models.len(),
         2,
-        "expected 2 models in model set, got: {:?}", models.len()
+        "expected 2 models in model set, got: {:?}",
+        models.len()
     );
 }

--- a/tests/tests/models_macro.rs
+++ b/tests/tests/models_macro.rs
@@ -1,0 +1,161 @@
+use toasty::schema::Register;
+
+#[derive(Debug, toasty::Model)]
+struct ModelA {
+    #[key]
+    id: i64,
+}
+
+#[derive(Debug, toasty::Model)]
+struct ModelB {
+    #[key]
+    id: i64,
+}
+
+#[test]
+fn empty_set() {
+    let models = toasty::models!();
+
+    assert!(
+        models.is_empty(),
+        "expected 0 models in model set, got: {:?}", models.len()
+    );
+}
+
+#[test]
+fn single_type() {
+    let models = toasty::models!(ModelA);
+
+    assert!(
+        models.contains(ModelA::id()),
+        "expected ModelA in model set"
+    );
+}
+
+#[test]
+fn multiple_types() {
+    let models = toasty::models!(ModelA, ModelB, tests_fixture_user::User);
+
+    assert!(
+        models.contains(ModelA::id()),
+        "expected ModelA in model set"
+    );
+    assert!(
+        models.contains(ModelB::id()),
+        "expected ModelB in model set"
+    );
+    assert!(
+        models.contains(tests_fixture_user::User::id()),
+        "expected tests_fixture_user::User in model set"
+    );
+}
+
+#[test]
+fn current_crate() {
+    let models = toasty::models!(crate::*);
+
+    assert!(
+        models.contains(ModelA::id()),
+        "expected ModelA in model set"
+    );
+    assert!(
+        models.contains(ModelB::id()),
+        "expected ModelB in model set"
+    );
+    assert_eq!(
+        models.len(),
+        2,
+        "expected 2 models in model set, got: {:?}", models.len()
+    );
+}
+
+#[test]
+fn single_external_crate() {
+    let models = toasty::models!(tests_fixture_user::*);
+
+    assert!(
+        models.contains(tests_fixture_user::User::id()),
+        "expected tests_fixture_user::User in model set"
+    );
+    assert_eq!(
+        models.len(),
+        1,
+        "expected 1 model in model set, got: {:?}", models.len()
+    );
+}
+
+#[test]
+fn multiple_external_crates() {
+    let models = toasty::models!(tests_fixture_post::*, tests_fixture_user::*);
+
+    assert!(
+        models.contains(tests_fixture_post::Post::id()),
+        "expected tests_fixture_user::User in model set"
+    );
+    assert!(
+        models.contains(tests_fixture_user::User::id()),
+        "expected tests_fixture_user::User in model set"
+    );
+    assert_eq!(
+        models.len(),
+        2,
+        "expected 2 models in model set, got: {:?}", models.len()
+    );
+}
+
+#[test]
+fn mixed_inputs() {
+    let models = toasty::models!(crate::*, tests_fixture_user::*, tests_fixture_post::Post);
+
+    assert!(
+        models.contains(ModelA::id()),
+        "expected ModelA in model set"
+    );
+    assert!(
+        models.contains(ModelB::id()),
+        "expected ModelB in model set"
+    );
+    assert!(
+        models.contains(tests_fixture_post::Post::id()),
+        "expected tests_fixture_user::User in model set"
+    );
+    assert!(
+        models.contains(tests_fixture_user::User::id()),
+        "expected tests_fixture_user::User in model set"
+    );
+    assert_eq!(
+        models.len(),
+        4,
+        "expected 4 models in model set, got: {:?}", models.len()
+    );
+}
+
+#[test]
+fn duplicates() {
+    let models = toasty::models!(ModelA, ModelA);
+
+    assert_eq!(
+        models.len(),
+        1,
+        "expected 1 model in model set, got: {:?}", models.len()
+    );
+}
+
+#[test]
+fn trailing_comma() {
+    let models = toasty::models!(ModelA, ModelB, );
+
+    assert!(
+        models.contains(ModelA::id()),
+        "expected ModelA in model set"
+    );
+    assert!(
+        models.contains(ModelB::id()),
+        "expected ModelB in model set"
+    );
+    assert_eq!(
+        models.len(),
+        2,
+        "expected 2 models in model set, got: {:?}", models.len()
+    );
+}


### PR DESCRIPTION
The models! macro now accepts multiple inputs such as `some_crate::*` and registers every discoverable model from the specified crates.

Previously, only types could be used after the first input because `$rest:ty` does not support glob imports like `some_crate::*`. This change extends the macro to support such patterns.