### PR TITLE
feat: export `SchemaMutations` for external drivers

### DIFF
--- a/crates/toasty-core/src/driver.rs
+++ b/crates/toasty-core/src/driver.rs
@@ -20,7 +20,7 @@
 //! ```
 
 mod capability;
-pub use capability::{Capability, StorageTypes};
+pub use capability::{Capability, SchemaMutations, StorageTypes};
 
 mod response;
 pub use response::{ExecResponse, Rows};


### PR DESCRIPTION
Hi, I'm trying to create external database drivers. Refer: #669 

`SchemaMutations` is a part of `Capability` which is required by `Driver` trait.


