### PR TITLE
test: restrict tx rollback tests to auto_increment sql drivers

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_boxed_fk.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_boxed_fk.rs
@@ -7,7 +7,6 @@ pub async fn boxed_u64_fk_crud(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     struct User {
         #[key]
-        #[auto]
         id: u64,
         name: String,
         #[has_many]
@@ -17,7 +16,6 @@ pub async fn boxed_u64_fk_crud(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     struct Todo {
         #[key]
-        #[auto]
         id: u64,
         #[index]
         user_id: Box<u64>,
@@ -29,9 +27,12 @@ pub async fn boxed_u64_fk_crud(test: &mut Test) -> Result<()> {
     let mut db = test.setup_db(models!(User, Todo)).await;
 
     // Create a user
-    let user = toasty::create!(User { name: "Alice" })
-        .exec(&mut db)
-        .await?;
+    let user = toasty::create!(User {
+        id: 1,
+        name: "Alice"
+    })
+    .exec(&mut db)
+    .await?;
 
     // No todos yet
     let todos: Vec<_> = user.todos().exec(&mut db).await?;
@@ -41,6 +42,7 @@ pub async fn boxed_u64_fk_crud(test: &mut Test) -> Result<()> {
     let todo = user
         .todos()
         .create()
+        .id(1)
         .title("Buy groceries")
         .exec(&mut db)
         .await?;
@@ -56,6 +58,7 @@ pub async fn boxed_u64_fk_crud(test: &mut Test) -> Result<()> {
     // Create another todo directly
     let todo2 = Todo::create()
         .user(&user)
+        .id(2)
         .title("Walk the dog")
         .exec(&mut db)
         .await?;
@@ -78,7 +81,6 @@ pub async fn boxed_u64_fk_batch_create(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     struct User {
         #[key]
-        #[auto]
         id: u64,
         name: String,
         #[has_many]
@@ -88,7 +90,6 @@ pub async fn boxed_u64_fk_batch_create(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     struct Todo {
         #[key]
-        #[auto]
         id: u64,
         #[index]
         user_id: Box<u64>,
@@ -101,9 +102,10 @@ pub async fn boxed_u64_fk_batch_create(test: &mut Test) -> Result<()> {
 
     // Create user with todos in one batch
     let user = User::create()
+        .id(1)
         .name("Bob")
-        .todo(Todo::create().title("First task"))
-        .todo(Todo::create().title("Second task"))
+        .todo(Todo::create().id(1).title("First task"))
+        .todo(Todo::create().id(2).title("Second task"))
         .exec(&mut db)
         .await?;
 
@@ -122,7 +124,6 @@ pub async fn boxed_u64_fk_delete_and_update(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     struct User {
         #[key]
-        #[auto]
         id: u64,
         name: String,
         #[has_many]
@@ -132,7 +133,6 @@ pub async fn boxed_u64_fk_delete_and_update(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     struct Todo {
         #[key]
-        #[auto]
         id: u64,
         #[index]
         user_id: Box<u64>,
@@ -143,13 +143,17 @@ pub async fn boxed_u64_fk_delete_and_update(test: &mut Test) -> Result<()> {
 
     let mut db = test.setup_db(models!(User, Todo)).await;
 
-    let user = toasty::create!(User { name: "Carol" })
-        .exec(&mut db)
-        .await?;
+    let user = toasty::create!(User {
+        id: 1,
+        name: "Carol"
+    })
+    .exec(&mut db)
+    .await?;
 
     let mut todo = user
         .todos()
         .create()
+        .id(1)
         .title("Original")
         .exec(&mut db)
         .await?;
@@ -175,7 +179,6 @@ pub async fn arc_u64_fk_crud(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     struct User {
         #[key]
-        #[auto]
         id: u64,
         name: String,
         #[has_many]
@@ -185,7 +188,6 @@ pub async fn arc_u64_fk_crud(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     struct Todo {
         #[key]
-        #[auto]
         id: u64,
         #[index]
         user_id: Arc<u64>,
@@ -196,14 +198,18 @@ pub async fn arc_u64_fk_crud(test: &mut Test) -> Result<()> {
 
     let mut db = test.setup_db(models!(User, Todo)).await;
 
-    let user = toasty::create!(User { name: "Alice" })
-        .exec(&mut db)
-        .await?;
+    let user = toasty::create!(User {
+        id: 1,
+        name: "Alice"
+    })
+    .exec(&mut db)
+    .await?;
 
     // Create via association
     let todo = user
         .todos()
         .create()
+        .id(1)
         .title("Arc task")
         .exec(&mut db)
         .await?;
@@ -218,6 +224,7 @@ pub async fn arc_u64_fk_crud(test: &mut Test) -> Result<()> {
     // Create directly
     let todo2 = Todo::create()
         .user(&user)
+        .id(2)
         .title("Arc task 2")
         .exec(&mut db)
         .await?;
@@ -226,9 +233,10 @@ pub async fn arc_u64_fk_crud(test: &mut Test) -> Result<()> {
 
     // Batch create
     let user2 = User::create()
+        .id(2)
         .name("Bob")
-        .todo(Todo::create().title("Batch 1"))
-        .todo(Todo::create().title("Batch 2"))
+        .todo(Todo::create().id(3).title("Batch 1"))
+        .todo(Todo::create().id(4).title("Batch 2"))
         .exec(&mut db)
         .await?;
 
@@ -247,7 +255,6 @@ pub async fn rc_u64_fk_crud(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     struct User {
         #[key]
-        #[auto]
         id: u64,
         name: String,
         #[has_many]
@@ -257,7 +264,6 @@ pub async fn rc_u64_fk_crud(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     struct Todo {
         #[key]
-        #[auto]
         id: u64,
         #[index]
         user_id: Rc<u64>,
@@ -268,12 +274,21 @@ pub async fn rc_u64_fk_crud(test: &mut Test) -> Result<()> {
 
     let mut db = test.setup_db(models!(User, Todo)).await;
 
-    let user = toasty::create!(User { name: "Alice" })
-        .exec(&mut db)
-        .await?;
+    let user = toasty::create!(User {
+        id: 1,
+        name: "Alice"
+    })
+    .exec(&mut db)
+    .await?;
 
     // Create via association
-    let todo = user.todos().create().title("Rc task").exec(&mut db).await?;
+    let todo = user
+        .todos()
+        .create()
+        .id(1)
+        .title("Rc task")
+        .exec(&mut db)
+        .await?;
 
     assert_eq!(*todo.user_id, user.id);
 
@@ -285,6 +300,7 @@ pub async fn rc_u64_fk_crud(test: &mut Test) -> Result<()> {
     // Create directly
     let todo2 = Todo::create()
         .user(&user)
+        .id(2)
         .title("Rc task 2")
         .exec(&mut db)
         .await?;
@@ -293,9 +309,10 @@ pub async fn rc_u64_fk_crud(test: &mut Test) -> Result<()> {
 
     // Batch create
     let user2 = User::create()
+        .id(2)
         .name("Bob")
-        .todo(Todo::create().title("Batch 1"))
-        .todo(Todo::create().title("Batch 2"))
+        .todo(Todo::create().id(3).title("Batch 1"))
+        .todo(Todo::create().id(4).title("Batch 2"))
         .exec(&mut db)
         .await?;
 

--- a/crates/toasty-driver-integration-suite/src/tests/tx_atomic_stmt.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/tx_atomic_stmt.rs
@@ -65,7 +65,7 @@ pub async fn single_op_skips_transaction(t: &mut Test) -> Result<()> {
 /// explicit transaction wrapping is exercised. With uuid::Uuid IDs the engine
 /// reorders execution (INSERT todo before INSERT user due to the Const
 /// optimization), which produces a different but equally valid log pattern.
-#[driver_test(requires(sql))]
+#[driver_test(requires(and(sql, auto_increment)))]
 pub async fn create_with_has_many_rolls_back_on_failure(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     struct User {
@@ -139,7 +139,7 @@ pub async fn create_with_has_many_rolls_back_on_failure(t: &mut Test) -> Result<
 /// explicit transaction wrapping is exercised. With uuid::Uuid IDs the engine
 /// can combine both inserts into a single atomic SQL statement, which provides
 /// atomicity without an explicit transaction.
-#[driver_test(requires(sql))]
+#[driver_test(requires(and(sql, auto_increment)))]
 pub async fn create_with_has_one_rolls_back_on_failure(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     struct User {


### PR DESCRIPTION
This PR:

* Removes `#[auto]` from `u64` key fields in `relation_has_many_boxed_fk` test and supplies explicit IDs, making them compatible with drivers that don't support auto-increment
* Restricts `create_with_has_many_rolls_back_on_failure` and `create_with_has_one_rolls_back_on_failure` to `auto_increment` drivers, since the explicit transaction wrapping they verify only occurs with auto-increment IDs

I needed this to fix tests failures with the DuckDB driver I'm building and don't support `auto_increment`.