### PR TITLE
chore: handle new clippy warnings and fix CI

### DIFF
--- a/crates/toasty-core/src/stmt/sparse_record.rs
+++ b/crates/toasty-core/src/stmt/sparse_record.rs
@@ -45,7 +45,7 @@ impl Value {
     pub fn sparse_record(fields: PathFieldSet, record: ValueRecord) -> Self {
         let mut values = vec![];
 
-        for (index, value) in fields.iter().zip(record.fields.into_iter()) {
+        for (index, value) in fields.iter().zip(record.fields) {
             while index >= values.len() {
                 values.push(Value::Null);
             }

--- a/crates/toasty/src/engine/plan/nested_merge.rs
+++ b/crates/toasty/src/engine/plan/nested_merge.rs
@@ -292,21 +292,17 @@ impl NestedMergePlanner<'_> {
                         match child_returning {
                             stmt::Returning::Value(returning_expr) if returning_expr.is_const() => {
                                 match child_stmt {
-                                    stmt::Statement::Query(query) => {
-                                        if query.single {
-                                            let stmt::Expr::Value(v) = returning_expr else {
-                                                todo!()
-                                            };
-                                            assert!(!v.is_list());
-                                        }
+                                    stmt::Statement::Query(query) if query.single => {
+                                        let stmt::Expr::Value(v) = returning_expr else {
+                                            todo!()
+                                        };
+                                        assert!(!v.is_list());
                                     }
-                                    stmt::Statement::Insert(insert) => {
-                                        if insert.source.single {
-                                            let stmt::Expr::Value(v) = returning_expr else {
-                                                todo!()
-                                            };
-                                            assert!(!v.is_list());
-                                        }
+                                    stmt::Statement::Insert(insert) if insert.source.single => {
+                                        let stmt::Expr::Value(v) = returning_expr else {
+                                            todo!()
+                                        };
+                                        assert!(!v.is_list());
                                     }
                                     _ => {}
                                 }

--- a/crates/toasty/src/engine/plan/statement.rs
+++ b/crates/toasty/src/engine/plan/statement.rs
@@ -357,24 +357,22 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
                         *expr = stmt::Expr::arg_project(position, [*row, column]);
                     }
                 }
-                stmt::Expr::Reference(expr_reference) => {
-                    if is_returning_projection {
-                        let column = self.load_data_expr_reference_position(expr_reference);
-                        let (position, _) = inputs.insert_full(load_data_node_id);
-                        *expr = stmt::Expr::arg_project(position, [column]);
-                    }
+                stmt::Expr::Reference(expr_reference) if is_returning_projection => {
+                    let column = self.load_data_expr_reference_position(expr_reference);
+                    let (position, _) = inputs.insert_full(load_data_node_id);
+                    *expr = stmt::Expr::arg_project(position, [column]);
                 }
-                stmt::Expr::Func(stmt::ExprFunc::Count(stmt::FuncCount { arg: None, .. })) => {
-                    if is_returning_projection {
-                        let index = self
-                            .stmt_info
-                            .load_data_select_items
-                            .get()
-                            .unwrap()
-                            .get_index_of_count_star();
-                        let (position, _) = inputs.insert_full(load_data_node_id);
-                        *expr = stmt::Expr::arg_project(position, [index]);
-                    }
+                stmt::Expr::Func(stmt::ExprFunc::Count(stmt::FuncCount { arg: None, .. }))
+                    if is_returning_projection =>
+                {
+                    let index = self
+                        .stmt_info
+                        .load_data_select_items
+                        .get()
+                        .unwrap()
+                        .get_index_of_count_star();
+                    let (position, _) = inputs.insert_full(load_data_node_id);
+                    *expr = stmt::Expr::arg_project(position, [index]);
                 }
                 _ => {}
             }

--- a/tests/src/db/postgresql.rs
+++ b/tests/src/db/postgresql.rs
@@ -86,11 +86,10 @@ impl Setup for SetupPostgreSQL {
 
         // Build WHERE clause from filter
         let mut where_conditions = Vec::new();
-        let mut param_index = 1;
 
         // Convert stmt::Values to PostgreSQL parameters
         let mut pg_params = Vec::new();
-        for (col_name, value) in filter {
+        for (param_index, (col_name, value)) in (1..).zip(filter) {
             where_conditions.push(format!("{col_name} = ${param_index}"));
 
             // Convert each value individually to avoid trait bound issues
@@ -100,7 +99,6 @@ impl Setup for SetupPostgreSQL {
                 stmt::Value::U64(u) => pg_params.push((u as i64).to_string()),
                 _ => todo!("Unsupported filter value type: {value:?}"),
             }
-            param_index += 1;
         }
 
         let where_clause = if where_conditions.is_empty() {

--- a/tests/tests/ui/create_scoped_not_scope.stderr
+++ b/tests/tests/ui/create_scoped_not_scope.stderr
@@ -9,7 +9,7 @@ help: the trait `toasty::schema::Scope` is implemented for `toasty::HasMany<T>`
    |
    | impl<T: Relation> Scope for HasMany<T> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: required by a bound in `scope_fields`
+note: required by a bound in `toasty::codegen_support::scope_fields`
   --> $WORKSPACE/crates/toasty/src/lib.rs
    |
    |     pub fn scope_fields<S: Scope>(_scope: &S) -> S::Path<S::Item> {


### PR DESCRIPTION
This PR refactors several code sections to improve readability and reduce nesting by using guard clauses in pattern matching and simplifying iterator usage patterns.

**Key changes made:**

- **statement.rs**: Converted nested `if is_returning_projection` checks into guard clauses on pattern matches for `Reference` and `Count` expressions, reducing indentation and improving code clarity

- **nested_merge.rs**: Moved `single` field checks from nested if statements into guard clauses on the pattern matches for `Query` and `Insert` statements, making the control flow more explicit

- **postgresql.rs**: Simplified parameter indexing by using `(1..).zip(filter)` instead of manually managing a `param_index` variable, eliminating the need for manual increment

- **sparse_record.rs**: Removed unnecessary `.into_iter()` call on `record.fields` since `zip()` can work directly with the owned vector

**Notable implementation details:**

These changes follow Rust idioms for guard clauses in pattern matching, which make the code more concise while maintaining or improving readability. The iterator pattern simplification in postgresql.rs leverages Rust's range iterator to automatically handle enumeration, reducing boilerplate and potential off-by-one errors.

https://claude.ai/code/session_01XtEX3yiNnuZRPCvVQQX5Pq