### PR TITLE
chore: pin Rust stable version and add MSRV checking

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,16 +4,22 @@
     "config:recommended",
     "schedule:weekly",
   ],
-  // The Rust stable toolchain is pinned via `RUST_STABLE_VERSION` in every
-  // workflow under .github/workflows/. This custom manager watches
-  // `rust-lang/rust` releases and opens a PR whenever a newer stable is
-  // released. The PR auto-merges once required CI checks pass.
+  // The Rust stable toolchain is pinned in two places:
+  //   * `RUST_STABLE_VERSION` env var in every `.github/workflows/*.yml`
+  //   * `channel` field in `rust-toolchain.toml` at the repo root
+  // Both are bumped atomically by this custom manager based on
+  // `rust-lang/rust` releases. The PR auto-merges once required CI checks
+  // pass.
   customManagers: [
     {
       customType: "regex",
-      managerFilePatterns: ["/^\\.github/workflows/[^/]+\\.ya?ml$/"],
+      managerFilePatterns: [
+        "/^\\.github/workflows/[^/]+\\.ya?ml$/",
+        "/(^|/)rust-toolchain\\.toml$/",
+      ],
       matchStrings: [
         "RUST_STABLE_VERSION:\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\"",
+        "channel\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\"",
       ],
       depNameTemplate: "rust",
       packageNameTemplate: "rust-lang/rust",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,33 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    "config:recommended",
+    "schedule:weekly",
+  ],
+  // The Rust stable toolchain is pinned via `RUST_STABLE_VERSION` in every
+  // workflow under .github/workflows/. This custom manager watches
+  // `rust-lang/rust` releases and opens a PR whenever a newer stable is
+  // released. The PR auto-merges once required CI checks pass.
+  customManagers: [
+    {
+      customType: "regex",
+      managerFilePatterns: ["/^\\.github/workflows/[^/]+\\.ya?ml$/"],
+      matchStrings: [
+        "RUST_STABLE_VERSION:\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\"",
+      ],
+      depNameTemplate: "rust",
+      packageNameTemplate: "rust-lang/rust",
+      datasourceTemplate: "github-releases",
+      extractVersionTemplate: "^(?<version>\\d+\\.\\d+\\.\\d+)$",
+    },
+  ],
+  packageRules: [
+    {
+      matchManagers: ["custom.regex"],
+      matchDepNames: ["rust"],
+      commitMessageTopic: "Rust",
+      automerge: true,
+      platformAutomerge: true,
+    },
+  ],
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ env:
     CARGO_TERM_COLOR: always
     RUSTFLAGS: -D warnings
     RUST_BACKTRACE: 1
+    # Pinned so a new Rust release cannot break CI on its own. Bumped
+    # automatically by Renovate; see .github/renovate.json5.
+    RUST_STABLE_VERSION: "1.95.0"
     TOASTY_TEST_POSTGRES_URL: "postgresql://toasty:toasty@localhost/toasty"
     TOASTY_TEST_MYSQL_URL: "mysql://toasty:toasty@localhost/toasty"
     AWS_REGION: "us-east-1"
@@ -23,8 +26,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
         - uses: actions/checkout@v4
-        - uses: dtolnay/rust-toolchain@stable
+        - uses: dtolnay/rust-toolchain@master
           with:
+            toolchain: ${{ env.RUST_STABLE_VERSION }}
             components: rustfmt
         - uses: Swatinem/rust-cache@v2
           with:
@@ -39,8 +43,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
         - uses: actions/checkout@v4
-        - uses: dtolnay/rust-toolchain@stable
+        - uses: dtolnay/rust-toolchain@master
           with:
+            toolchain: ${{ env.RUST_STABLE_VERSION }}
             components: clippy
         - uses: Swatinem/rust-cache@v2
           with:
@@ -48,13 +53,35 @@ jobs:
         - name: cargo clippy
           run: cargo clippy --workspace --all-features
 
+    msrv:
+        needs: check
+        name: Check MSRV
+        runs-on: ubuntu-latest
+        steps:
+        - uses: actions/checkout@v4
+        - name: Read MSRV from Cargo.toml
+          id: msrv
+          run: |
+            version=$(awk -F'"' '/^rust-version/ {print $2; exit}' Cargo.toml)
+            echo "version=$version" >> "$GITHUB_OUTPUT"
+        - uses: dtolnay/rust-toolchain@master
+          with:
+            toolchain: ${{ steps.msrv.outputs.version }}
+        - uses: Swatinem/rust-cache@v2
+          with:
+            save-if: ${{ github.ref == 'refs/heads/main' }}
+        - name: cargo check
+          run: cargo check --workspace --all-features
+
     test-sqlite:
       needs: check
       name: Run tests for Sqlite
       runs-on: ubuntu-latest
       steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE_VERSION }}
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -82,7 +109,9 @@ jobs:
             TOASTY_CONNECTION_URL: mysql://toasty:toasty@localhost:3306/toasty
         steps:
         - uses: actions/checkout@v4
-        - uses: dtolnay/rust-toolchain@stable
+        - uses: dtolnay/rust-toolchain@master
+          with:
+            toolchain: ${{ env.RUST_STABLE_VERSION }}
         - uses: Swatinem/rust-cache@v2
           with:
             save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -110,7 +139,9 @@ jobs:
             TOASTY_TEST_POSTGRES_TLS_URL: postgresql://toasty:toasty@localhost:5433/toasty
         steps:
         - uses: actions/checkout@v4
-        - uses: dtolnay/rust-toolchain@stable
+        - uses: dtolnay/rust-toolchain@master
+          with:
+            toolchain: ${{ env.RUST_STABLE_VERSION }}
         - uses: Swatinem/rust-cache@v2
           with:
             save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -135,7 +166,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
         - uses: actions/checkout@v4
-        - uses: dtolnay/rust-toolchain@stable
+        - uses: dtolnay/rust-toolchain@master
+          with:
+            toolchain: ${{ env.RUST_STABLE_VERSION }}
         - uses: Swatinem/rust-cache@v2
           with:
             save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -156,7 +189,9 @@ jobs:
               - macos-latest
         steps:
         - uses: actions/checkout@v4
-        - uses: dtolnay/rust-toolchain@stable
+        - uses: dtolnay/rust-toolchain@master
+          with:
+            toolchain: ${{ env.RUST_STABLE_VERSION }}
         - uses: Swatinem/rust-cache@v2
           with:
             save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -171,7 +206,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
         - uses: actions/checkout@v4
-        - uses: dtolnay/rust-toolchain@stable
+        - uses: dtolnay/rust-toolchain@master
+          with:
+            toolchain: ${{ env.RUST_STABLE_VERSION }}
         - uses: Swatinem/rust-cache@v2
           with:
             save-if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,11 @@ jobs:
         - uses: Swatinem/rust-cache@v2
           with:
             save-if: ${{ github.ref == 'refs/heads/main' }}
+        # `RUSTUP_TOOLCHAIN` overrides `rust-toolchain.toml`, which otherwise
+        # pins this job back to the latest stable and defeats the MSRV check.
         - name: cargo check
+          env:
+            RUSTUP_TOOLCHAIN: ${{ steps.msrv.outputs.version }}
           run: cargo check --workspace --all-features
 
     test-sqlite:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,11 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
+env:
+  # Pinned so a new Rust release cannot break docs builds on its own.
+  # Bumped automatically by Renovate; see .github/renovate.json5.
+  RUST_STABLE_VERSION: "1.95.0"
+
 jobs:
   build:
     if: github.repository == 'tokio-rs/toasty'
@@ -23,7 +28,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE_VERSION }}
 
       - name: Install mdBook and mdbook-linkcheck2
         uses: taiki-e/install-action@v2

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+env:
+  # Pinned so a new Rust release cannot break release-plz on its own.
+  # Bumped automatically by Renovate; see .github/renovate.json5.
+  RUST_STABLE_VERSION: "1.95.0"
+
 jobs:
   release-plz-release:
     name: Release-plz release
@@ -23,7 +28,9 @@ jobs:
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
       - &install-rust
         name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE_VERSION }}
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ homepage = "https://github.com/tokio-rs/toasty"
 keywords = ["orm", "database", "sql", "nosql", "async"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/toasty"
-rust-version = "1.94"
+rust-version = "1.95"
 categories = ["database"]
 
 [workspace.lints.rust]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "stable"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+# Pinned so a new Rust release cannot break local development on its own.
+# Bumped automatically by Renovate in lockstep with `RUST_STABLE_VERSION`
+# in the workflow files; see .github/renovate.json5.
+channel = "1.95.0"


### PR DESCRIPTION
## Summary
This PR pins the Rust stable toolchain version across all CI workflows and adds automated MSRV (Minimum Supported Rust Version) checking. The stable version is now centrally managed via environment variables and automatically updated by Renovate.

## Key Changes
- **Pinned Rust stable version**: Added `RUST_STABLE_VERSION: "1.95.0"` environment variable to `ci.yml`, `docs.yml`, and `release-plz.yml` workflows to prevent CI breakage from new Rust releases
- **Updated toolchain configuration**: Changed all `dtolnay/rust-toolchain@stable` references to `dtolnay/rust-toolchain@master` with explicit `toolchain` parameter using the pinned version
- **Added MSRV job**: New `msrv` workflow job that reads the MSRV from `Cargo.toml` and verifies the project builds with that minimum version
- **Renovate automation**: Added `.github/renovate.json5` configuration to automatically update `RUST_STABLE_VERSION` when new Rust releases are published, with auto-merge enabled
- **Updated MSRV in Cargo.toml**: Bumped `rust-version` from `1.94` to `1.95` to match the pinned stable version

## Implementation Details
- The MSRV job extracts the version from `Cargo.toml` using `awk` and runs `cargo check` with that toolchain
- Renovate is configured with a custom regex manager to watch `rust-lang/rust` releases and automatically open PRs when new stable versions are available
- All workflow files now consistently use the same pinned Rust version, ensuring reproducible CI behavior

https://claude.ai/code/session_013hqWS3m599vjKMqKxtbQi6