### PR TITLE
fix: gate simplification rules on expression stability

### DIFF
--- a/crates/toasty-core/src/stmt/expr.rs
+++ b/crates/toasty-core/src/stmt/expr.rs
@@ -275,6 +275,23 @@ impl Expr {
         }
     }
 
+    /// Returns `true` if `self` and `other` are syntactically identical **and**
+    /// both sides are stable.
+    ///
+    /// This is the soundness-preserving comparison used by simplification
+    /// rules that rewrite on the assumption that two equal sub-expressions
+    /// produce the same value (idempotent, absorption, complement,
+    /// range-to-equality, OR-to-IN, factoring, variant tautology).
+    ///
+    /// Syntactic identity alone is not enough: `LAST_INSERT_ID() =
+    /// LAST_INSERT_ID()` is two independent evaluations and may yield
+    /// different values, so rewriting `a AND a` to `a` would be unsound when
+    /// `a` is non-deterministic. Gating on [`Self::is_stable`] excludes any
+    /// sub-expression whose value may change across evaluations.
+    pub fn is_equivalent_to(&self, other: &Self) -> bool {
+        self == other && self.is_stable()
+    }
+
     /// Returns `true` if the expression is a constant expression.
     ///
     /// A constant expression is one that does not reference any external data.

--- a/crates/toasty/src/engine/simplify/expr_and.rs
+++ b/crates/toasty/src/engine/simplify/expr_and.rs
@@ -29,9 +29,12 @@ impl Simplify<'_> {
 
         // Idempotent law, `a and a` → `a`
         // Note: O(n) lookups are acceptable here since operand lists are typically small.
-        let mut seen = Vec::new();
+        // `is_equivalent_to` (not `PartialEq`) keeps this sound for non-deterministic
+        // operands like `LAST_INSERT_ID()` — two syntactically identical calls may
+        // return different values, so the second occurrence must survive.
+        let mut seen: Vec<Expr> = Vec::new();
         expr.operands.retain(|operand| {
-            if seen.contains(operand) {
+            if seen.iter().any(|e| e.is_equivalent_to(operand)) {
                 false
             } else {
                 seen.push(operand.clone());
@@ -54,7 +57,7 @@ impl Simplify<'_> {
                 !or_expr
                     .operands
                     .iter()
-                    .any(|op| non_or_operands.contains(op))
+                    .any(|op| non_or_operands.iter().any(|e| e.is_equivalent_to(op)))
             } else {
                 true
             }
@@ -113,7 +116,9 @@ impl Simplify<'_> {
             }
 
             // Check if not(operand) exists and operand is non-nullable
-            if negated.contains(&operand) && operand.is_always_non_nullable() {
+            if negated.iter().any(|n| n.is_equivalent_to(operand))
+                && operand.is_always_non_nullable()
+            {
                 return true;
             }
         }
@@ -152,7 +157,7 @@ impl Simplify<'_> {
                     continue;
                 }
 
-                if op_i.lhs == op_j.lhs && op_i.rhs == op_j.rhs {
+                if op_i.lhs.is_equivalent_to(&op_j.lhs) && op_i.rhs.is_equivalent_to(&op_j.rhs) {
                     let lhs = op_i.lhs.clone();
                     let rhs = op_i.rhs.clone();
 
@@ -164,8 +169,8 @@ impl Simplify<'_> {
                     for k in (i + 1)..expr.operands.len() {
                         if let Expr::BinaryOp(op_k) = &expr.operands[k]
                             && matches!(op_k.op, BinaryOp::Ge | BinaryOp::Le)
-                            && op_k.lhs == lhs
-                            && op_k.rhs == rhs
+                            && op_k.lhs.is_equivalent_to(&lhs)
+                            && op_k.rhs.is_equivalent_to(&rhs)
                         {
                             expr.operands[k] = true.into();
                         }
@@ -243,10 +248,11 @@ fn prune_or_branches(expr: &mut stmt::ExprAnd) -> Option<Expr> {
     }
 
     // Deduplicate after flattening (flatten can reintroduce operands
-    // already present in the outer AND).
-    let mut seen = Vec::new();
+    // already present in the outer AND). `is_equivalent_to` skips dedup
+    // of non-deterministic operands, preserving their independent evaluations.
+    let mut seen: Vec<Expr> = Vec::new();
     expr.operands.retain(|operand| {
-        if seen.contains(operand) {
+        if seen.iter().any(|e| e.is_equivalent_to(operand)) {
             false
         } else {
             seen.push(operand.clone());
@@ -270,7 +276,11 @@ fn is_contradicting_eq_constraints(a: &[Expr], b: &[Expr]) -> bool {
                 continue;
             };
 
-            if o_lhs != b_lhs {
+            // Only consider the two lhs sides "the same value" when they are
+            // syntactically equal AND stable. Otherwise `f() == 1 AND f() == 2`
+            // would be rewritten to `false`, but two evaluations of a
+            // non-deterministic `f()` can produce 1 and 2.
+            if !o_lhs.is_equivalent_to(b_lhs) {
                 continue;
             }
 

--- a/crates/toasty/src/engine/simplify/expr_binary_op.rs
+++ b/crates/toasty/src/engine/simplify/expr_binary_op.rs
@@ -199,8 +199,11 @@ impl Simplify<'_> {
             //
             // By this point, constant projections and record projections have been simplified.
             // What remains are projections with opaque bases (e.g., field references).
+            // `lhs.base.is_stable()` keeps this sound: a projection through a
+            // non-deterministic base would evaluate the base twice and could
+            // yield different values each time.
             (Expr::Project(lhs), Expr::Project(rhs))
-                if lhs == rhs && (op.is_eq() || op.is_ne()) =>
+                if lhs == rhs && lhs.base.is_stable() && (op.is_eq() || op.is_ne()) =>
             {
                 // TODO: Check if the projected value is nullable
                 Some(Expr::from(op.is_eq()))

--- a/crates/toasty/src/engine/simplify/expr_or.rs
+++ b/crates/toasty/src/engine/simplify/expr_or.rs
@@ -30,9 +30,12 @@ impl Simplify<'_> {
 
         // Idempotent law, `a or a` → `a`
         // Note: O(n) lookups are acceptable here since operand lists are typically small.
-        let mut seen = Vec::new();
+        // `is_equivalent_to` (not `PartialEq`) keeps this sound for non-deterministic
+        // operands like `LAST_INSERT_ID()` — two syntactically identical calls may
+        // return different values, so the second occurrence must survive.
+        let mut seen: Vec<stmt::Expr> = Vec::new();
         expr.operands.retain(|operand| {
-            if seen.contains(operand) {
+            if seen.iter().any(|e| e.is_equivalent_to(operand)) {
                 false
             } else {
                 seen.push(operand.clone());
@@ -55,7 +58,7 @@ impl Simplify<'_> {
                 !and_expr
                     .operands
                     .iter()
-                    .any(|op| non_and_operands.contains(op))
+                    .any(|op| non_and_operands.iter().any(|e| e.is_equivalent_to(op)))
             } else {
                 true
             }
@@ -122,7 +125,7 @@ impl Simplify<'_> {
             .filter(|op| {
                 expr.operands[1..].iter().all(|other| {
                     if let stmt::Expr::And(other_and) = other {
-                        other_and.operands.contains(op)
+                        other_and.operands.iter().any(|e| e.is_equivalent_to(op))
                     } else {
                         false
                     }
@@ -138,7 +141,8 @@ impl Simplify<'_> {
         // Remove all common factors from each AND
         for operand in &mut expr.operands {
             if let stmt::Expr::And(and) = operand {
-                and.operands.retain(|op| !common.contains(op));
+                and.operands
+                    .retain(|op| !common.iter().any(|c| c.is_equivalent_to(op)));
                 // If only one operand left, unwrap the AND
                 if and.operands.len() == 1 {
                     *operand = and.operands.pop().unwrap();
@@ -182,7 +186,9 @@ impl Simplify<'_> {
             }
 
             // Check if not(operand) exists and operand is non-nullable
-            if negated.contains(&operand) && operand.is_always_non_nullable() {
+            if negated.iter().any(|n| n.is_equivalent_to(operand))
+                && operand.is_always_non_nullable()
+            {
                 return true;
             }
         }
@@ -220,7 +226,11 @@ impl Simplify<'_> {
                 continue;
             };
 
-            if iv.expr != *anchor_expr || iv.variant.model != model_id {
+            // Every `IsVariant` subject must be equivalent to the anchor:
+            // two syntactically different (or non-deterministic) subjects could
+            // disagree at runtime, so covering all variants of the anchor tells
+            // us nothing about them.
+            if !iv.expr.is_equivalent_to(anchor_expr) || iv.variant.model != model_id {
                 return false;
             }
 
@@ -254,10 +264,16 @@ impl Simplify<'_> {
                 && bin_op.op.is_eq()
                 && let stmt::Expr::Value(value) = bin_op.rhs.as_ref()
             {
-                // Find or create index for this LHS
+                // Find or create index for this LHS. `is_equivalent_to` is
+                // crucial here: if the lhs is non-deterministic (e.g. `RAND()`),
+                // it is never equivalent to another occurrence of itself, so
+                // each instance falls into its own singleton group and no IN
+                // list is produced. Rewriting `RAND() = 1 OR RAND() = 2` into
+                // `RAND() IN (1, 2)` would collapse two independent draws into
+                // one, which is unsound.
                 let lhs_idx = lhs_exprs
                     .iter()
-                    .position(|e| e == bin_op.lhs.as_ref())
+                    .position(|e| e.is_equivalent_to(bin_op.lhs.as_ref()))
                     .unwrap_or_else(|| {
                         lhs_exprs.push(bin_op.lhs.as_ref().clone());
                         lhs_exprs.len() - 1

--- a/crates/toasty/src/engine/simplify/tests/expr_and.rs
+++ b/crates/toasty/src/engine/simplify/tests/expr_and.rs
@@ -944,3 +944,112 @@ fn prune_or_end_to_end_via_visit() {
     assert!(and.operands.contains(&Expr::eq(disc, Expr::from(1i64))));
     assert!(and.operands.contains(&Expr::eq(addr, Expr::from("alice"))));
 }
+
+// ---------------------------------------------------------------------------
+// Determinism-aware simplification (issue #236).
+//
+// `is_equivalent_to` gates every "syntactic identity implies semantic
+// equivalence" rewrite on `Expr::is_stable`.  Non-deterministic expressions
+// (e.g.  `LAST_INSERT_ID()`) are re-evaluated on each occurrence and must not
+// be folded even when two occurrences are textually identical.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn idempotent_not_simplified_for_non_deterministic() {
+    let schema = test_schema();
+    let mut simplify = Simplify::new(&schema);
+
+    // `LAST_INSERT_ID() AND LAST_INSERT_ID()` must retain both operands.
+    let mut expr = ExprAnd {
+        operands: vec![Expr::last_insert_id(), Expr::last_insert_id()],
+    };
+    let result = simplify.simplify_expr_and(&mut expr);
+
+    assert!(result.is_none());
+    assert_eq!(expr.operands.len(), 2);
+    assert_eq!(expr.operands[0], Expr::last_insert_id());
+    assert_eq!(expr.operands[1], Expr::last_insert_id());
+}
+
+#[test]
+fn absorption_not_simplified_for_non_deterministic() {
+    use toasty_core::stmt::ExprOr;
+
+    let schema = test_schema();
+    let mut simplify = Simplify::new(&schema);
+
+    // `x AND (x OR y)` would absorb to `x` under PartialEq, but with a
+    // non-deterministic `x` the two occurrences are independent draws, so
+    // absorption must not fire.
+    let x = Expr::eq(Expr::last_insert_id(), 1i64);
+    let mut expr = ExprAnd {
+        operands: vec![
+            x.clone(),
+            Expr::Or(ExprOr {
+                operands: vec![x, Expr::arg(0)],
+            }),
+        ],
+    };
+    let result = simplify.simplify_expr_and(&mut expr);
+
+    assert!(result.is_none());
+    assert_eq!(expr.operands.len(), 2);
+}
+
+#[test]
+fn complement_not_simplified_for_non_deterministic() {
+    use toasty_core::stmt::ExprNot;
+
+    let schema = test_schema();
+    let mut simplify = Simplify::new(&schema);
+
+    // `f() = 1 AND NOT (f() = 1)` — both `f()` calls are independent
+    // evaluations, so complement must NOT fire.  (Compare with
+    // `complement_basic`, which uses `arg` — stable.)
+    let a = Expr::eq(Expr::last_insert_id(), 1i64);
+    let mut expr = ExprAnd {
+        operands: vec![a.clone(), Expr::Not(ExprNot { expr: Box::new(a) })],
+    };
+    let result = simplify.simplify_expr_and(&mut expr);
+
+    assert!(result.is_none());
+    assert_eq!(expr.operands.len(), 2);
+}
+
+#[test]
+fn range_to_equality_not_simplified_for_non_deterministic() {
+    let schema = test_schema();
+    let mut simplify = Simplify::new(&schema);
+
+    // `f() >= 5 AND f() <= 5` — two independent draws of `f()` bracketed
+    // by the same constant do not imply the draws are equal to 5.
+    let mut expr = ExprAnd {
+        operands: vec![
+            Expr::binary_op(Expr::last_insert_id(), BinaryOp::Ge, 5i64),
+            Expr::binary_op(Expr::last_insert_id(), BinaryOp::Le, 5i64),
+        ],
+    };
+    let result = simplify.simplify_expr_and(&mut expr);
+
+    assert!(result.is_none());
+    assert_eq!(expr.operands.len(), 2);
+}
+
+#[test]
+fn contradicting_eq_not_simplified_for_non_deterministic() {
+    let schema = test_schema();
+    let mut simplify = Simplify::new(&schema);
+
+    // `f() == 1 AND f() == 2` — two independent draws can produce 1 and 2
+    // respectively, so this is NOT a contradiction.
+    let mut expr = ExprAnd {
+        operands: vec![
+            Expr::eq(Expr::last_insert_id(), 1i64),
+            Expr::eq(Expr::last_insert_id(), 2i64),
+        ],
+    };
+    let result = simplify.simplify_expr_and(&mut expr);
+
+    assert!(result.is_none());
+    assert_eq!(expr.operands.len(), 2);
+}

--- a/crates/toasty/src/engine/simplify/tests/expr_or.rs
+++ b/crates/toasty/src/engine/simplify/tests/expr_or.rs
@@ -816,6 +816,105 @@ fn error_or_true_becomes_true() {
     assert!(result.unwrap().is_true());
 }
 
+// ---------------------------------------------------------------------------
+// Determinism-aware simplification (issue #236).
+//
+// See the matching block in `expr_and.rs`.  `is_equivalent_to` gates the
+// idempotent, absorption, complement, factoring, and OR-to-IN rewrites on
+// `is_stable`, so non-deterministic sub-expressions survive intact.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn idempotent_not_simplified_for_non_deterministic() {
+    let schema = test_schema();
+    let mut simplify = Simplify::new(&schema);
+
+    // `LAST_INSERT_ID() OR LAST_INSERT_ID()` must retain both operands.
+    let mut expr = ExprOr {
+        operands: vec![Expr::last_insert_id(), Expr::last_insert_id()],
+    };
+    let result = simplify.simplify_expr_or(&mut expr);
+
+    assert!(result.is_none());
+    assert_eq!(expr.operands.len(), 2);
+}
+
+#[test]
+fn complement_not_simplified_for_non_deterministic() {
+    use toasty_core::stmt::ExprNot;
+
+    let schema = test_schema();
+    let mut simplify = Simplify::new(&schema);
+
+    // `f() = 1 OR NOT (f() = 1)` — both draws are independent, so the
+    // complement law must NOT fire.
+    let a = Expr::eq(Expr::last_insert_id(), 1i64);
+    let mut expr = ExprOr {
+        operands: vec![a.clone(), Expr::Not(ExprNot { expr: Box::new(a) })],
+    };
+    let result = simplify.simplify_expr_or(&mut expr);
+
+    assert!(result.is_none());
+    assert_eq!(expr.operands.len(), 2);
+}
+
+#[test]
+fn factoring_not_simplified_for_non_deterministic() {
+    use toasty_core::stmt::ExprAnd;
+
+    let schema = test_schema();
+    let mut simplify = Simplify::new(&schema);
+
+    // `(f() AND b) OR (f() AND c)` would factor to `f() AND (b OR c)` under
+    // PartialEq, but the original evaluates `f()` twice while the factored
+    // form evaluates it once — unsound for non-deterministic `f()`.
+    let mut expr = ExprOr {
+        operands: vec![
+            Expr::And(ExprAnd {
+                operands: vec![Expr::last_insert_id(), Expr::arg(0)],
+            }),
+            Expr::And(ExprAnd {
+                operands: vec![Expr::last_insert_id(), Expr::arg(1)],
+            }),
+        ],
+    };
+    let result = simplify.simplify_expr_or(&mut expr);
+
+    // No factoring should have taken place — we still have two AND branches,
+    // each with the original two operands.
+    assert!(result.is_none());
+    assert_eq!(expr.operands.len(), 2);
+    for operand in &expr.operands {
+        let Expr::And(and) = operand else {
+            panic!("expected AND branch, got {operand:?}");
+        };
+        assert_eq!(and.operands.len(), 2);
+    }
+}
+
+#[test]
+fn or_to_in_list_not_simplified_for_non_deterministic() {
+    let schema = test_schema();
+    let mut simplify = Simplify::new(&schema);
+
+    // `f() = 1 OR f() = 2` must NOT be rewritten to `f() IN (1, 2)`: the
+    // former evaluates `f()` twice (two draws against 1 and 2), the latter
+    // evaluates it once (one draw tested against a set).
+    let mut expr = ExprOr {
+        operands: vec![
+            Expr::eq(Expr::last_insert_id(), 1i64),
+            Expr::eq(Expr::last_insert_id(), 2i64),
+        ],
+    };
+    let result = simplify.simplify_expr_or(&mut expr);
+
+    assert!(result.is_none());
+    assert_eq!(expr.operands.len(), 2);
+    for operand in &expr.operands {
+        assert!(matches!(operand, Expr::BinaryOp(_)));
+    }
+}
+
 // Variant tautology tests
 
 mod variant_tautology {


### PR DESCRIPTION
equivalence was unsound for non-deterministic expressions such as `LAST_INSERT_ID()`, which may yield different values on each evaluation.  Introduces `Expr::is_equivalent_to`, which combines syntactic identity with `is_stable`, and route idempotent, absorption, complement, factoring, range-to-equality, contradicting-equality, variant-tautology, OR-to-IN, and `Project == Project` self-compare rewrites through it.  Regression tests exercise each rule with `LAST_INSERT_ID()` to pin the new semantics.

Closes #236.