### PR TITLE
refactor: wrap hash-based Value lookups in dedicated types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ clap = { version = "4.6.0", features = ["derive"] }
 console = "0.16"
 deadpool = { version = "0.13", features = ["rt_tokio_1"] }
 dialoguer = "0.12"
+hashbrown = "0.16"
 heck = "0.5.0"
 indexmap = "2.13.0"
 index_vec = "0.1.4"

--- a/crates/toasty-core/Cargo.toml
+++ b/crates/toasty-core/Cargo.toml
@@ -17,6 +17,7 @@ documentation = "https://docs.rs/toasty-core"
 assert-struct = { workspace = true, optional = true }
 async-trait.workspace = true
 bit-set.workspace = true
+hashbrown.workspace = true
 indexmap.workspace = true
 jiff = { workspace = true, optional = true }
 rust_decimal = { workspace = true, optional = true }

--- a/crates/toasty-core/src/stmt.rs
+++ b/crates/toasty-core/src/stmt.rs
@@ -259,6 +259,9 @@ mod value_jiff;
 mod value_record;
 pub use value_record::ValueRecord;
 
+mod value_set;
+pub use value_set::ValueSet;
+
 /// Mutable AST visitor trait and helpers.
 pub mod visit_mut;
 pub use visit_mut::VisitMut;

--- a/crates/toasty-core/src/stmt/hash_index.rs
+++ b/crates/toasty-core/src/stmt/hash_index.rs
@@ -1,6 +1,7 @@
+use super::value_set::{HashableValue, HashableValueSlice};
 use super::{Entry, Projection, Value};
 
-use std::collections::HashMap;
+use indexmap::IndexMap;
 
 /// A unique hash index over a borrowed slice of [`Value`]s.
 ///
@@ -33,7 +34,7 @@ use std::collections::HashMap;
 /// assert!(found.is_some());
 /// ```
 pub struct HashIndex<'a> {
-    map: HashMap<Vec<Value>, &'a Value>,
+    map: IndexMap<Vec<HashableValue>, &'a Value>,
 }
 
 impl<'a> HashIndex<'a> {
@@ -42,7 +43,7 @@ impl<'a> HashIndex<'a> {
     /// Each projection navigates into a value to extract one key component. Multiple
     /// projections produce a composite key compared lexicographically.
     pub fn new(values: &'a [Value], projections: &[Projection]) -> Self {
-        let mut map = HashMap::with_capacity(values.len());
+        let mut map = IndexMap::with_capacity(values.len());
 
         for value in values {
             let key = extract_key(value, projections);
@@ -58,19 +59,19 @@ impl<'a> HashIndex<'a> {
     /// `key` must be a slice of values with one entry per projection used at build time.
     /// Returns `None` if no value matches.
     pub fn find(&self, key: &[Value]) -> Option<&'a Value> {
-        self.map.get(key).copied()
+        self.map.get(&HashableValueSlice(key)).copied()
     }
 }
 
 /// Extract the composite key from `value` using `projections`.
 ///
 /// Each projection is applied to `value` in sequence, collecting the resulting
-/// field references into an owned `Vec<Value>`.
-fn extract_key(value: &Value, projections: &[Projection]) -> Vec<Value> {
+/// field references into an owned `Vec<HashableValue>`.
+fn extract_key(value: &Value, projections: &[Projection]) -> Vec<HashableValue> {
     projections
         .iter()
         .map(|proj| match value.entry(proj) {
-            Entry::Value(v) => v.clone(),
+            Entry::Value(v) => HashableValue(v.clone()),
             Entry::Expr(_) => panic!("projection yielded an expression, not a value"),
         })
         .collect()

--- a/crates/toasty-core/src/stmt/hash_index.rs
+++ b/crates/toasty-core/src/stmt/hash_index.rs
@@ -1,7 +1,7 @@
 use super::value_set::{HashableValue, HashableValueSlice};
 use super::{Entry, Projection, Value};
 
-use indexmap::IndexMap;
+use hashbrown::HashMap;
 
 /// A unique hash index over a borrowed slice of [`Value`]s.
 ///
@@ -34,7 +34,7 @@ use indexmap::IndexMap;
 /// assert!(found.is_some());
 /// ```
 pub struct HashIndex<'a> {
-    map: IndexMap<Vec<HashableValue>, &'a Value>,
+    map: HashMap<Vec<HashableValue>, &'a Value>,
 }
 
 impl<'a> HashIndex<'a> {
@@ -43,7 +43,7 @@ impl<'a> HashIndex<'a> {
     /// Each projection navigates into a value to extract one key component. Multiple
     /// projections produce a composite key compared lexicographically.
     pub fn new(values: &'a [Value], projections: &[Projection]) -> Self {
-        let mut map = IndexMap::with_capacity(values.len());
+        let mut map = HashMap::with_capacity(values.len());
 
         for value in values {
             let key = extract_key(value, projections);

--- a/crates/toasty-core/src/stmt/sparse_record.rs
+++ b/crates/toasty-core/src/stmt/sparse_record.rs
@@ -1,5 +1,4 @@
 use super::{PathFieldSet, Type, Value, ValueRecord};
-use std::hash::Hash;
 
 /// A record where only a subset of fields are populated.
 ///
@@ -20,7 +19,7 @@ use std::hash::Hash;
 /// let v = Value::empty_sparse_record();
 /// assert!(matches!(v, Value::SparseRecord(_)));
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct SparseRecord {
     /// Bit set of field indices that are populated in this record.
     pub fields: PathFieldSet,

--- a/crates/toasty-core/src/stmt/value.rs
+++ b/crates/toasty-core/src/stmt/value.rs
@@ -1,6 +1,5 @@
 use super::{Entry, EntryPath, Type, TypeUnion, ValueRecord, sparse_record::SparseRecord};
 use std::cmp::Ordering;
-use std::hash::Hash;
 
 /// A dynamically typed value used throughout Toasty's query engine.
 ///
@@ -31,7 +30,7 @@ use std::hash::Hash;
 /// let v = Value::from(true);
 /// assert_eq!(v, true);
 /// ```
-#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub enum Value {
     /// Boolean value
     Bool(bool),

--- a/crates/toasty-core/src/stmt/value_record.rs
+++ b/crates/toasty-core/src/stmt/value_record.rs
@@ -1,6 +1,6 @@
 use super::Value;
 
-use std::{hash::Hash, ops};
+use std::ops;
 
 /// An ordered sequence of [`Value`]s representing a record (row).
 ///
@@ -18,7 +18,7 @@ use std::{hash::Hash, ops};
 /// assert_eq!(record[0], 1_i64);
 /// assert_eq!(record[1], "alice");
 /// ```
-#[derive(Debug, Default, Clone, Eq)]
+#[derive(Debug, Default, Clone)]
 pub struct ValueRecord {
     /// The field values in this record, ordered by field index.
     pub fields: Vec<Value>,
@@ -90,13 +90,6 @@ impl<'a> IntoIterator for &'a mut ValueRecord {
 impl PartialEq for ValueRecord {
     fn eq(&self, other: &Self) -> bool {
         **self == **other
-    }
-}
-
-// had to impl hash for value record because conflicting implementations of hash trait
-impl Hash for ValueRecord {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        (**self).hash(state);
     }
 }
 

--- a/crates/toasty-core/src/stmt/value_set.rs
+++ b/crates/toasty-core/src/stmt/value_set.rs
@@ -1,0 +1,260 @@
+use super::{SparseRecord, Value, ValueRecord};
+
+use indexmap::{Equivalent, IndexSet};
+use std::hash::{Hash, Hasher};
+
+/// A set of [`Value`]s.
+///
+/// Provides hash-based deduplication with well-defined semantics for every
+/// `Value` variant, including future floating-point variants (which will use
+/// bitwise comparison so `NaN == NaN` and `+0.0 != -0.0`). `Value` itself does
+/// not implement `Hash`/`Eq` because the right float policy is
+/// context-dependent; `ValueSet` picks the policy suitable for deduplication.
+#[derive(Debug, Default, Clone)]
+pub struct ValueSet {
+    inner: IndexSet<HashableValue>,
+}
+
+impl ValueSet {
+    /// Creates an empty set.
+    pub fn new() -> Self {
+        Self {
+            inner: IndexSet::new(),
+        }
+    }
+
+    /// Creates an empty set with capacity for at least `capacity` values.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            inner: IndexSet::with_capacity(capacity),
+        }
+    }
+
+    /// Inserts a value into the set. Returns `true` if the value was not
+    /// already present.
+    pub fn insert(&mut self, value: Value) -> bool {
+        self.inner.insert(HashableValue(value))
+    }
+
+    /// Returns the number of values in the set.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Returns `true` if the set contains no values.
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+}
+
+/// A `Value` wrapped so it can be used as a hash-table key.
+///
+/// Hash/equality semantics are "literal bits": recursive, with bitwise
+/// comparison for floats once they are added (so `NaN` hashes equal to itself
+/// and `+0.0` is distinct from `-0.0`). This is appropriate for deduplication
+/// and join-index lookup, not for SQL-semantic equality.
+#[derive(Clone, Debug)]
+pub(super) struct HashableValue(pub(super) Value);
+
+impl PartialEq for HashableValue {
+    fn eq(&self, other: &Self) -> bool {
+        value_eq(&self.0, &other.0)
+    }
+}
+
+impl Eq for HashableValue {}
+
+impl Hash for HashableValue {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        hash_value(&self.0, state);
+    }
+}
+
+/// Borrowed view over a `&[Value]`, used to query hash tables keyed by
+/// `Vec<HashableValue>` without per-lookup allocation. Implements
+/// [`Equivalent`] against the owned key type.
+///
+/// The `Hash` impl here must produce a byte stream identical to
+/// `<Vec<HashableValue> as Hash>` for equivalent contents.
+pub(super) struct HashableValueSlice<'a>(pub(super) &'a [Value]);
+
+impl Hash for HashableValueSlice<'_> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Mirror `<[HashableValue] as Hash>::hash`: length prefix, then each
+        // element. `usize::hash` and the default `write_length_prefix` both
+        // resolve to `Hasher::write_usize`, so the two paths agree.
+        self.0.len().hash(state);
+        for v in self.0 {
+            hash_value(v, state);
+        }
+    }
+}
+
+impl Equivalent<Vec<HashableValue>> for HashableValueSlice<'_> {
+    fn equivalent(&self, key: &Vec<HashableValue>) -> bool {
+        self.0.len() == key.len() && self.0.iter().zip(key).all(|(v, hv)| value_eq(v, &hv.0))
+    }
+}
+
+// Each variant is spelled out rather than collapsed into a blanket `a == b`
+// fallback for two reasons:
+//
+// 1. Some variants must diverge from `PartialEq`: containers (List, Record,
+//    SparseRecord) recurse through `value_eq` so that future float variants
+//    inside them use bitwise comparison instead of `PartialEq`'s NaN-never-
+//    equal semantics. Future F32/F64 variants will themselves diverge, using
+//    `to_bits()` equality.
+// 2. Listing every variant forces a deliberate choice when a new one is
+//    added. A tuple match can't be compiler-exhaustive without a catch-all,
+//    so the real exhaustiveness check lives in `hash_value` below (single-
+//    value match, no `_` arm) — adding a variant there errors until it's
+//    handled, at which point the author is prompted to audit this function.
+pub(super) fn value_eq(a: &Value, b: &Value) -> bool {
+    use Value::*;
+    match (a, b) {
+        (Null, Null) => true,
+        (Bool(a), Bool(b)) => a == b,
+        (I8(a), I8(b)) => a == b,
+        (I16(a), I16(b)) => a == b,
+        (I32(a), I32(b)) => a == b,
+        (I64(a), I64(b)) => a == b,
+        (U8(a), U8(b)) => a == b,
+        (U16(a), U16(b)) => a == b,
+        (U32(a), U32(b)) => a == b,
+        (U64(a), U64(b)) => a == b,
+        (String(a), String(b)) => a == b,
+        (Bytes(a), Bytes(b)) => a == b,
+        (Uuid(a), Uuid(b)) => a == b,
+        (List(a), List(b)) => a.len() == b.len() && a.iter().zip(b).all(|(x, y)| value_eq(x, y)),
+        (Record(a), Record(b)) => record_eq(a, b),
+        (SparseRecord(a), SparseRecord(b)) => sparse_record_eq(a, b),
+        #[cfg(feature = "rust_decimal")]
+        (Decimal(a), Decimal(b)) => a == b,
+        #[cfg(feature = "bigdecimal")]
+        (BigDecimal(a), BigDecimal(b)) => a == b,
+        #[cfg(feature = "jiff")]
+        (Timestamp(a), Timestamp(b)) => a == b,
+        #[cfg(feature = "jiff")]
+        (Zoned(a), Zoned(b)) => a == b,
+        #[cfg(feature = "jiff")]
+        (Date(a), Date(b)) => a == b,
+        #[cfg(feature = "jiff")]
+        (Time(a), Time(b)) => a == b,
+        #[cfg(feature = "jiff")]
+        (DateTime(a), DateTime(b)) => a == b,
+        _ => false,
+    }
+}
+
+fn record_eq(a: &ValueRecord, b: &ValueRecord) -> bool {
+    a.fields.len() == b.fields.len() && a.fields.iter().zip(&b.fields).all(|(x, y)| value_eq(x, y))
+}
+
+fn sparse_record_eq(a: &SparseRecord, b: &SparseRecord) -> bool {
+    a.fields == b.fields
+        && a.values.len() == b.values.len()
+        && a.values.iter().zip(&b.values).all(|(x, y)| value_eq(x, y))
+}
+
+pub(super) fn hash_value<H: Hasher>(v: &Value, state: &mut H) {
+    // Hash the discriminant so that two variants with equal payload bits
+    // don't collide (e.g. `I32(0)` vs `U32(0)`).
+    std::mem::discriminant(v).hash(state);
+    match v {
+        Value::Null => {}
+        Value::Bool(x) => x.hash(state),
+        Value::I8(x) => x.hash(state),
+        Value::I16(x) => x.hash(state),
+        Value::I32(x) => x.hash(state),
+        Value::I64(x) => x.hash(state),
+        Value::U8(x) => x.hash(state),
+        Value::U16(x) => x.hash(state),
+        Value::U32(x) => x.hash(state),
+        Value::U64(x) => x.hash(state),
+        Value::String(x) => x.hash(state),
+        Value::Bytes(x) => x.hash(state),
+        Value::Uuid(x) => x.hash(state),
+        Value::List(items) => {
+            items.len().hash(state);
+            for it in items {
+                hash_value(it, state);
+            }
+        }
+        Value::Record(r) => {
+            r.fields.len().hash(state);
+            for v in &r.fields {
+                hash_value(v, state);
+            }
+        }
+        Value::SparseRecord(r) => {
+            r.fields.hash(state);
+            r.values.len().hash(state);
+            for v in &r.values {
+                hash_value(v, state);
+            }
+        }
+        #[cfg(feature = "rust_decimal")]
+        Value::Decimal(x) => x.hash(state),
+        #[cfg(feature = "bigdecimal")]
+        Value::BigDecimal(x) => {
+            // `bigdecimal::BigDecimal` implements `Hash`.
+            x.hash(state);
+        }
+        #[cfg(feature = "jiff")]
+        Value::Timestamp(x) => x.hash(state),
+        #[cfg(feature = "jiff")]
+        Value::Zoned(x) => x.hash(state),
+        #[cfg(feature = "jiff")]
+        Value::Date(x) => x.hash(state),
+        #[cfg(feature = "jiff")]
+        Value::Time(x) => x.hash(state),
+        #[cfg(feature = "jiff")]
+        Value::DateTime(x) => x.hash(state),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::hash_map::DefaultHasher;
+
+    fn hash<T: Hash + ?Sized>(v: &T) -> u64 {
+        let mut h = DefaultHasher::new();
+        v.hash(&mut h);
+        h.finish()
+    }
+
+    #[test]
+    fn slice_and_vec_hash_match() {
+        // HashableValueSlice must produce the same hash as Vec<HashableValue>
+        // for equivalent contents. If this fails, `HashIndex` lookups will
+        // miss entries even when equal.
+        let values = [Value::from(1_i64), Value::from("hello"), Value::from(true)];
+        let owned: Vec<HashableValue> = values.iter().cloned().map(HashableValue).collect();
+
+        assert_eq!(hash(&HashableValueSlice(&values)), hash(&owned));
+    }
+
+    #[test]
+    fn slice_and_vec_hash_match_empty() {
+        let values: [Value; 0] = [];
+        let owned: Vec<HashableValue> = vec![];
+        assert_eq!(hash(&HashableValueSlice(&values)), hash(&owned));
+    }
+
+    #[test]
+    fn slice_equivalent_to_vec() {
+        let values = [Value::from(1_i64), Value::from(2_i64)];
+        let owned: Vec<HashableValue> = values.iter().cloned().map(HashableValue).collect();
+        assert!(HashableValueSlice(&values).equivalent(&owned));
+    }
+
+    #[test]
+    fn value_set_dedup() {
+        let mut set = ValueSet::new();
+        assert!(set.insert(Value::from(1_i64)));
+        assert!(!set.insert(Value::from(1_i64)));
+        assert!(set.insert(Value::from(2_i64)));
+        assert_eq!(set.len(), 2);
+    }
+}

--- a/crates/toasty-core/src/stmt/value_set.rs
+++ b/crates/toasty-core/src/stmt/value_set.rs
@@ -1,6 +1,6 @@
 use super::{SparseRecord, Value, ValueRecord};
 
-use indexmap::{Equivalent, IndexSet};
+use hashbrown::{Equivalent, HashSet};
 use std::hash::{Hash, Hasher};
 
 /// A set of [`Value`]s.
@@ -12,21 +12,21 @@ use std::hash::{Hash, Hasher};
 /// context-dependent; `ValueSet` picks the policy suitable for deduplication.
 #[derive(Debug, Default, Clone)]
 pub struct ValueSet {
-    inner: IndexSet<HashableValue>,
+    inner: HashSet<HashableValue>,
 }
 
 impl ValueSet {
     /// Creates an empty set.
     pub fn new() -> Self {
         Self {
-            inner: IndexSet::new(),
+            inner: HashSet::new(),
         }
     }
 
     /// Creates an empty set with capacity for at least `capacity` values.
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            inner: IndexSet::with_capacity(capacity),
+            inner: HashSet::with_capacity(capacity),
         }
     }
 

--- a/crates/toasty/src/engine/simplify/expr_in_list.rs
+++ b/crates/toasty/src/engine/simplify/expr_in_list.rs
@@ -1,6 +1,5 @@
 use super::Simplify;
-use std::collections::HashSet;
-use toasty_core::stmt::{self, Expr, Value};
+use toasty_core::stmt::{self, Expr, Value, ValueSet};
 
 impl Simplify<'_> {
     pub(super) fn simplify_expr_in_list(&self, expr: &mut stmt::ExprInList) -> Option<Expr> {
@@ -26,7 +25,7 @@ impl Simplify<'_> {
     /// Remove duplicate values from a `Value::List` in-place, preserving order.
     fn dedup_expr_in_list_values(&self, expr: &mut stmt::ExprInList) {
         if let Expr::Value(Value::List(values)) = &mut *expr.list {
-            let mut seen = HashSet::new();
+            let mut seen = ValueSet::new();
             values.retain(|v| seen.insert(v.clone()));
         }
     }


### PR DESCRIPTION
## Summary

Prepares `stmt::Value` for future floating-point variants by removing its `Hash`/`Eq` derives and replacing the two hash-based call sites with dedicated wrapper types that own an explicit float-hashing policy.

## Changes

### Removed trait derives
- `Value`: dropped `Eq` and `Hash` (kept `PartialEq`).
- `ValueRecord`: dropped `Eq` and the manual `Hash` impl.
- `SparseRecord`: dropped `Eq` and `Hash`.

### New `stmt::ValueSet` (public)
Lives in `crates/toasty-core/src/stmt/value_set.rs`. Wraps `hashbrown::HashSet<HashableValue>` to provide deduplication with bitwise float semantics (once floats are added: `NaN == NaN`, `+0.0 != -0.0`). Exposes `new`/`with_capacity`/`insert`/`len`/`is_empty`. Used by `simplify::expr_in_list::dedup_expr_in_list_values`.

### New private wrappers (same module)
- `HashableValue(Value)` — implements `Hash + Eq` with recursive bitwise semantics. Containers (`List`, `Record`, `SparseRecord`) recurse through the module's `value_eq` / `hash_value` helpers so that nested floats use the right policy.
- `HashableValueSlice<'a>(&'a [Value])` — borrowed view implementing `Hash + hashbrown::Equivalent<Vec<HashableValue>>`. Enables zero-allocation lookup on `HashIndex` while keeping `find(&[Value])` as the public signature.
- A `#[cfg(test)]` module asserts the owned and borrowed key types hash to identical bytes for equivalent contents — the invariant `Equivalent`-based lookup depends on.

Both wrappers are `pub(super)` so they stay internal to `stmt`; only `ValueSet` is exported.

### `HashIndex` migration
`crates/toasty-core/src/stmt/hash_index.rs` now stores `HashMap<Vec<HashableValue>, &'a Value>` (using `hashbrown::HashMap`). `find(&[Value])` queries via `HashableValueSlice(key)` — public API unchanged, no per-lookup allocation.

### Simplifier dedup
`crates/toasty/src/engine/simplify/expr_in_list.rs` replaces `HashSet<Value>` with `ValueSet`.

### Dependency
Added `hashbrown = \"0.16\"` as a workspace dependency (`Cargo.toml`) and consumed via `hashbrown.workspace = true` in `toasty-core/Cargo.toml`. Chosen over `indexmap` because `HashIndex` and `ValueSet` don't need insertion-order preservation.

### Why enumerate every variant in `value_eq`/`hash_value`?
`value_eq` lists each variant rather than falling back to `Value::PartialEq` for scalars. An inline comment explains why: containers must diverge from `PartialEq` so nested floats use bitwise comparison, and `hash_value`'s exhaustive single-value match acts as the compiler-enforced reminder to update both functions when a new variant is added.

## Test plan
- [x] `cargo build` clean
- [x] `cargo test -p toasty-core` (95 tests + doctests pass)
- [x] `cargo test -p toasty --lib` (257 tests pass)
- [x] New unit tests in `value_set.rs` verify `HashableValueSlice` and `Vec<HashableValue>` produce identical hashes, and `ValueSet` deduplicates
- [x] `cargo fmt`