### PR TITLE
refactor: handle relation fields in Relation trait

### DIFF
--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -150,45 +150,24 @@ impl Expand<'_> {
                     });
 
                     nullable = quote!(<#ty as #toasty::Relation>::nullable());
-                    field_ty = quote!(#toasty::core::schema::app::FieldTy::BelongsTo(#toasty::core::schema::app::BelongsTo {
-                        target:  <#ty as #toasty::Relation>::Model::id(),
-                        expr_ty: #toasty::core::stmt::Type::Model(<#ty as #toasty::Relation>::Model::id()),
-                        // The pair is populated at runtime.
-                        pair: None,
-                        foreign_key: #toasty::core::schema::app::ForeignKey {
+                    field_ty = quote!(<#ty as #toasty::Relation>::belongs_to_field_ty(
+                        #toasty::core::schema::app::ForeignKey {
                             fields: vec![ #( #fk_fields ),* ],
                         },
-                    }));
+                    ));
                 }
                 FieldTy::HasMany(rel) => {
                     let ty = &rel.ty;
                     let singular_name = expand_name(toasty, &rel.singular);
 
                     nullable = quote!(<#ty as #toasty::Relation>::nullable());
-                    field_ty = quote!(#toasty::core::schema::app::FieldTy::HasMany(#toasty::core::schema::app::HasMany {
-                        target: <#ty as #toasty::Relation>::Model::id(),
-                        expr_ty: #toasty::core::stmt::Type::List(Box::new(#toasty::core::stmt::Type::Model(<#ty as #toasty::Relation>::Model::id()))),
-                        singular: #singular_name,
-                        // The pair is populated at runtime.
-                        pair: #toasty::core::schema::app::FieldId {
-                            model: #toasty::core::schema::app::ModelId(usize::MAX),
-                            index: usize::MAX,
-                        },
-                    }));
+                    field_ty = quote!(<#ty as #toasty::Relation>::has_many_field_ty(#singular_name));
                 }
                 FieldTy::HasOne(rel) => {
                     let ty = &rel.ty;
 
                     nullable = quote!(<#ty as #toasty::Relation>::nullable());
-                    field_ty = quote!(#toasty::core::schema::app::FieldTy::HasOne(#toasty::core::schema::app::HasOne {
-                        target: <#ty as #toasty::Relation>::Model::id(),
-                        expr_ty: #toasty::core::stmt::Type::Model(<#ty as #toasty::Relation>::Model::id()),
-                        // The pair is populated at runtime.
-                        pair: #toasty::core::schema::app::FieldId {
-                            model: #toasty::core::schema::app::ModelId(usize::MAX),
-                            index: usize::MAX,
-                        },
-                    }));
+                    field_ty = quote!(<#ty as #toasty::Relation>::has_one_field_ty());
                 }
             }
 

--- a/crates/toasty/src/schema/belongs_to.rs
+++ b/crates/toasty/src/schema/belongs_to.rs
@@ -1,5 +1,6 @@
-use super::{Load, Relation};
+use super::{Load, Register, Relation};
 
+use toasty_core::schema::app::{self, FieldTy, ForeignKey};
 use toasty_core::stmt::{self, Value};
 
 use std::fmt;
@@ -79,6 +80,16 @@ impl<T: Relation> Relation for BelongsTo<T> {
 
     fn nullable() -> bool {
         T::nullable()
+    }
+
+    fn belongs_to_field_ty(foreign_key: ForeignKey) -> FieldTy {
+        FieldTy::BelongsTo(app::BelongsTo {
+            target: <T::Model as Register>::id(),
+            expr_ty: stmt::Type::Model(<T::Model as Register>::id()),
+            // The pair is populated at runtime.
+            pair: None,
+            foreign_key,
+        })
     }
 }
 

--- a/crates/toasty/src/schema/has_many.rs
+++ b/crates/toasty/src/schema/has_many.rs
@@ -1,6 +1,8 @@
-use super::{Load, Relation, Scope};
+use super::{Load, Register, Relation, Scope};
 
-use toasty_core::stmt::Value;
+use toasty_core::schema::Name;
+use toasty_core::schema::app::{self, FieldId, FieldTy, ModelId};
+use toasty_core::stmt::{self, Value};
 
 use std::fmt;
 
@@ -20,8 +22,8 @@ pub struct HasMany<T> {
 impl<T: Relation> Load for HasMany<T> {
     type Output = Self;
 
-    fn ty() -> toasty_core::stmt::Type {
-        toasty_core::stmt::Type::list(T::ty())
+    fn ty() -> stmt::Type {
+        stmt::Type::list(T::ty())
     }
 
     fn load(input: Value) -> crate::Result<Self> {
@@ -92,6 +94,19 @@ impl<T: Relation> Relation for HasMany<T> {
 
     fn nullable() -> bool {
         T::nullable()
+    }
+
+    fn has_many_field_ty(singular: Name) -> FieldTy {
+        FieldTy::HasMany(app::HasMany {
+            target: <T::Model as Register>::id(),
+            expr_ty: stmt::Type::List(Box::new(stmt::Type::Model(<T::Model as Register>::id()))),
+            singular,
+            // The pair is populated at runtime.
+            pair: FieldId {
+                model: ModelId(usize::MAX),
+                index: usize::MAX,
+            },
+        })
     }
 }
 

--- a/crates/toasty/src/schema/has_one.rs
+++ b/crates/toasty/src/schema/has_one.rs
@@ -1,6 +1,7 @@
-use super::{Load, Relation};
+use super::{Load, Register, Relation};
 
-use toasty_core::stmt::Value;
+use toasty_core::schema::app::{self, FieldId, FieldTy, ModelId};
+use toasty_core::stmt::{self, Value};
 
 use std::fmt;
 
@@ -19,7 +20,7 @@ pub struct HasOne<T> {
 impl<T: Relation> Load for HasOne<T> {
     type Output = Self;
 
-    fn ty() -> toasty_core::stmt::Type {
+    fn ty() -> stmt::Type {
         T::ty_relation()
     }
 
@@ -79,6 +80,18 @@ impl<T: Relation> Relation for HasOne<T> {
 
     fn nullable() -> bool {
         T::nullable()
+    }
+
+    fn has_one_field_ty() -> FieldTy {
+        FieldTy::HasOne(app::HasOne {
+            target: <T::Model as Register>::id(),
+            expr_ty: stmt::Type::Model(<T::Model as Register>::id()),
+            // The pair is populated at runtime.
+            pair: FieldId {
+                model: ModelId(usize::MAX),
+                index: usize::MAX,
+            },
+        })
     }
 }
 

--- a/crates/toasty/src/schema/relation.rs
+++ b/crates/toasty/src/schema/relation.rs
@@ -1,7 +1,8 @@
 use super::{Load, Model};
 use crate::stmt::{IntoExpr, IntoInsert, List, Path};
 
-use toasty_core::schema::app::FieldId;
+use toasty_core::schema::Name;
+use toasty_core::schema::app::{FieldId, FieldTy, ForeignKey};
 
 /// Describes how a model participates in associations.
 ///
@@ -59,5 +60,30 @@ pub trait Relation: Load<Output = Self> {
     /// `Option`). The default is `false`.
     fn nullable() -> bool {
         false
+    }
+
+    /// Build the [`FieldTy`] for a `BelongsTo` relation wrapper, given the
+    /// foreign key resolved from the field's `#[belongs_to(...)]` attribute.
+    ///
+    /// Only [`BelongsTo`](super::BelongsTo) overrides this; the default
+    /// panics so that misuse (e.g. applying `#[belongs_to]` to a field whose
+    /// type is not a `BelongsTo<T>`) fails loudly.
+    fn belongs_to_field_ty(_foreign_key: ForeignKey) -> FieldTy {
+        unimplemented!("not a BelongsTo relation wrapper")
+    }
+
+    /// Build the [`FieldTy`] for a `HasMany` relation wrapper, given the
+    /// singular name derived from the field identifier.
+    ///
+    /// Only [`HasMany`](super::HasMany) overrides this.
+    fn has_many_field_ty(_singular: Name) -> FieldTy {
+        unimplemented!("not a HasMany relation wrapper")
+    }
+
+    /// Build the [`FieldTy`] for a `HasOne` relation wrapper.
+    ///
+    /// Only [`HasOne`](super::HasOne) overrides this.
+    fn has_one_field_ty() -> FieldTy {
+        unimplemented!("not a HasOne relation wrapper")
     }
 }


### PR DESCRIPTION
Move the inline FieldTy::BelongsTo / HasMany / HasOne construction from the #[derive(Model)] macro into overridable methods on the Relation trait. The three methods (`belongs_to_field_ty`, `has_many_field_ty`, `has_one_field_ty`) default to panics so that applying a relation attribute to a non-wrapper type fails loudly.

Addresses the "doesn't handle relation fields" portion of #326; the Primitive -> Field rename and UpdateBuilder -> Update rename were already landed in #568.