### PR TITLE
fix: add id-token permission to claude triage workflow

### DIFF
--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -18,6 +18,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -80,6 +81,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- The `anthropics/claude-code-action@v1` action needs an OIDC token, which requires `id-token: write` permission on the job.
- Without it, every triage run failed with `Could not fetch an OIDC token. Did you remember to add id-token: write to your workflow permissions?`
- Added the permission to both the `triage-issue` and `triage-pr` jobs.

## Test plan
- [ ] Open a throwaway issue and confirm labels are applied automatically.
- [ ] Open a throwaway PR and confirm labels are applied automatically.