### PR TITLE
fix: switch PR triage to pull_request event

### DIFF
--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -8,7 +8,7 @@ name: Claude Triage
 on:
   issues:
     types: [opened]
-  pull_request_target:
+  pull_request:
     types: [opened, ready_for_review]
 
 jobs:
@@ -76,7 +76,7 @@ jobs:
             --allowed-tools "Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh label list:*)"
 
   triage-pr:
-    if: github.event_name == 'pull_request_target'
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Switches the `triage-pr` job in `.github/workflows/claude-triage.yml` from `pull_request_target` to `pull_request`.

Every PR triage run since the workflow landed (#711) has failed at the OIDC → app-token exchange with `401 Unauthorized - Invalid OIDC token`. The root cause: GitHub stamps `pull_request_target` events with OIDC subject `repo:owner/repo:pull_request`, which Anthropic's GitHub App install rejects. The `issues` event uses `ref:refs/heads/main` and works — that's why issue triage has been fine.

`pull_request` is the form used in [anthropics/claude-code-action's PR examples](https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-comprehensive.yml) and should exchange successfully for same-repo PRs.

Tradeoff: fork PRs will no longer trigger auto-triage, since GitHub withholds secrets from `pull_request` runs originating on forks. Those PRs can be labeled manually.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test
- [ ] Implements a previously accepted design
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean (no Rust changes)
- [x] `cargo test` passes (no Rust changes)
- [ ] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [ ] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers

Watch the Actions tab after merge: the next PR opened against `main` should successfully run `triage-pr` and apply labels. If OIDC still fails with the same `Invalid OIDC token` message, the next option is the `workflow_run` indirection pattern (a small `pull_request_target` job hands off to a `workflow_run` job whose OIDC subject is `ref:refs/heads/main`).