### PR TITLE
chore: group non-major renovate updates into a single PR

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,7 @@
   extends: [
     "config:recommended",
     "schedule:weekly",
+    "group:all",
   ],
   // The Rust stable toolchain is pinned in two places:
   //   * `RUST_STABLE_VERSION` env var in every `.github/workflows/*.yml`

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,7 +3,7 @@
   extends: [
     "config:recommended",
     "schedule:weekly",
-    "group:all",
+    "group:allNonMajor",
   ],
   // The Rust stable toolchain is pinned in two places:
   //   * `RUST_STABLE_VERSION` env var in every `.github/workflows/*.yml`


### PR DESCRIPTION
## Summary
- Extend `group:allNonMajor` in `.github/renovate.json5` so Renovate batches non-major dependency updates into one PR per run, while still opening separate PRs for major bumps (where 0.x minor bumps count as major).

## Test plan
- [ ] Next scheduled Renovate run groups non-major updates into a single PR; major bumps remain separate.