### PR TITLE
docs: add commit and PR authoring guidelines

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: commit
+description: Always use this skill before authoring a commit message in the Toasty repository
+---
+
+# Authoring Commit Messages
+
+Load this skill before writing any git commit message in this project.
+
+**Always read [`docs/dev/COMMITS.md`](../../../docs/dev/COMMITS.md) before
+authoring a commit message.** It is the authoritative source for the
+format, allowed types, scope conventions, subject/body/footer rules, and
+breaking-change notation.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: pr
+description: Always use this skill before opening a pull request in the Toasty repository
+---
+
+# Opening Pull Requests
+
+Load this skill before opening a pull request in this project.
+
+## Base the title and body on the full branch diff
+
+Draft the title and body from the **full diff of the current branch against
+`main`**, not from the latest commit or the last few commits. Use
+`git diff main...HEAD` and `git log main..HEAD` to see everything the PR
+will introduce. A PR often bundles several commits (fixups, review
+response, refactors) — the title and body describe the net change that
+lands on `main`, not the most recent work-in-progress.
+
+## Title
+
+The PR title follows the same Conventional Commits format as commit
+messages, because it becomes the squash-merge commit message. Read
+[`docs/dev/COMMITS.md`](../../../docs/dev/COMMITS.md) when drafting the
+title and make sure it stands on its own.
+
+## Body
+
+Fill in the PR body using the template at
+[`.github/pull_request_template.md`](../../../.github/pull_request_template.md).
+Keep the section headings and the checklist; replace the HTML comment
+placeholders with real content. Delete checklist items that do not apply
+rather than leaving them unchecked with no explanation.
+
+## Labels
+
+**Do not apply labels when creating the PR.** Maintainers triage and
+label issues and PRs separately — see
+[`docs/dev/labels.md`](../../../docs/dev/labels.md). Passing `--label`
+to `gh pr create` or setting labels in any other way bypasses that
+process.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -7,34 +7,39 @@ description: Always use this skill before opening a pull request in the Toasty r
 
 Load this skill before opening a pull request in this project.
 
-## Base the title and body on the full branch diff
+## Base the title and body on the PR diff, not the latest commit
 
-Draft the title and body from the **full diff of the current branch against
-`main`**, not from the latest commit or the last few commits. Use
-`git diff main...HEAD` and `git log main..HEAD` to see everything the PR
-will introduce. A PR often bundles several commits (fixups, review
-response, refactors) — the title and body describe the net change that
-lands on `main`, not the most recent work-in-progress.
+A branch usually contains several commits — initial work, fixups,
+review responses, rebases. The PR title and body describe the **net
+change that will land on the base branch**, not the most recent commit.
+
+Identify the PR's base branch first. It is usually `main`, but a PR
+stacked on another feature branch has that feature branch as its base.
+Then read the full diff against the base:
+
+```
+git diff <base>...HEAD
+git log <base>..HEAD
+```
+
+Draft the title and body from what that diff actually contains.
 
 ## Title
 
-The PR title follows the same Conventional Commits format as commit
-messages, because it becomes the squash-merge commit message. Read
-[`docs/dev/COMMITS.md`](../../../docs/dev/COMMITS.md) when drafting the
-title and make sure it stands on its own.
+Follows the same Conventional Commits format as a commit message — it
+becomes the squash-merge commit. See
+[`docs/dev/COMMITS.md`](../../../docs/dev/COMMITS.md).
 
 ## Body
 
-Fill in the PR body using the template at
+Fill in the template at
 [`.github/pull_request_template.md`](../../../.github/pull_request_template.md).
 Keep the section headings and the checklist; replace the HTML comment
-placeholders with real content. Delete checklist items that do not apply
-rather than leaving them unchecked with no explanation.
+placeholders with real content. Delete checklist items that do not
+apply rather than leaving them unchecked with no explanation.
 
 ## Labels
 
-**Do not apply labels when creating the PR.** Maintainers triage and
-label issues and PRs separately — see
-[`docs/dev/labels.md`](../../../docs/dev/labels.md). Passing `--label`
-to `gh pr create` or setting labels in any other way bypasses that
-process.
+Do not apply labels when creating the PR. Maintainers triage and label
+PRs separately — see [`docs/dev/labels.md`](../../../docs/dev/labels.md).
+Passing `--label` to `gh pr create` bypasses that process.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,21 +35,6 @@ cargo fmt
 
 Always run `cargo fmt` after finishing work on a change.
 
-## Commit and PR Conventions
-
-This repository follows the [Conventional Commits](https://www.conventionalcommits.org/) specification.
-All commit messages and PR titles must use the format:
-
-```
-type: description
-```
-
-For example: `feat: add new pattern`, `fix: resolve parsing bug`.
-
-Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.
-
-Scopes are optional. Subjects must begin with a lowercase letter.
-
 ## Architecture
 
 Toasty is a Rust ORM supporting SQL (SQLite, PostgreSQL, MySQL) and NoSQL (DynamoDB) databases. It is a Cargo workspace.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,9 @@ Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`,
 `build`, `ci`, `chore`, `revert`. Scopes are optional. The subject begins
 with a lowercase letter.
 
+See [`docs/dev/COMMITS.md`](docs/dev/COMMITS.md) for the full commit
+message format, scope conventions, and examples.
+
 [cc]: https://www.conventionalcommits.org/
 
 ### Before you push

--- a/docs/dev/COMMITS.md
+++ b/docs/dev/COMMITS.md
@@ -1,0 +1,117 @@
+# Git Commit Guidelines
+
+Toasty follows the [Conventional Commits][cc] specification. Precise rules
+about commit message formatting lead to **more readable messages** that are
+easy to follow when looking through the **project history**, and let us use
+commit messages to **generate the change log**.
+
+[cc]: https://www.conventionalcommits.org/
+
+## Commit Message Format
+
+Each commit message consists of a **header**, an optional **body**, and an
+optional **footer**. The header has a special format that includes a
+**type**, an optional **scope**, and a **subject**:
+
+```
+<type>(<scope>): <subject>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+No line of the commit message should be longer than 100 characters. This
+keeps messages readable on GitHub and in various git tools.
+
+The PR title must follow the same format — it becomes the squash-merge
+commit message.
+
+## Type
+
+Must be one of the following:
+
+* **feat**: a new feature
+* **fix**: a bug fix
+* **docs**: documentation only changes
+* **style**: changes that do not affect the meaning of the code
+  (white-space, formatting, missing semi-colons, etc.)
+* **refactor**: a code change that neither fixes a bug nor adds a feature
+* **perf**: a code change that improves performance
+* **test**: adding or correcting tests
+* **build**: changes to the build system or external dependencies
+* **ci**: changes to CI configuration and scripts
+* **chore**: changes to auxiliary tooling that do not affect source or
+  tests
+* **revert**: reverts a previous commit
+
+## Scope
+
+The scope is optional. When present, it should refer to the area of
+Toasty being touched. Common scopes:
+
+* `core` — `toasty-core` (schema, statement AST, driver interface)
+* `macros` — `toasty-macros` (`#[derive(Model)]`, `#[derive(Embed)]`)
+* `sql` — `toasty-sql` (SQL serialization)
+* `engine` — the query engine inside `toasty` (simplify, lower, plan, exec)
+* `sqlite`, `postgresql`, `mysql`, `dynamodb` — individual drivers
+* `tests` — integration test suite (`toasty-driver-integration-suite`)
+* `docs` — only when `type` is not already `docs`
+
+Omit the scope when the change does not fit cleanly into one area, or
+when the type alone is descriptive enough (e.g., `chore: bump
+dependencies`).
+
+## Subject
+
+The subject contains a succinct description of the change:
+
+* use the imperative, present tense: "add" not "added" nor "adds"
+* begin with a lowercase letter
+* no dot (`.`) at the end
+
+## Body
+
+Just as in the **subject**, use the imperative, present tense. The body
+should include the motivation for the change and contrast it with
+previous behavior. Most commits do not need a body — add one when the
+"what" is not self-evident from the subject, or when the "why" would not
+be obvious to a future reader.
+
+## Footer
+
+The footer is the place to reference GitHub issues that this commit
+**Closes** (`Closes #123`) and to note any **Breaking Changes**.
+
+The last line of a commit that introduces a breaking change should be in
+the form:
+
+```
+BREAKING CHANGE: <description of what breaks and how to migrate>
+```
+
+## Examples
+
+```
+feat(engine): simplify uniform-arms Match into a projection
+
+When every arm of a Match produces the same shape, projection can be
+pushed through the Match and the arms folded together. This enables
+the planner to emit a single SQL expression for enum-over-primitive
+comparisons instead of a CASE.
+```
+
+```
+fix(sqlite): quote reserved identifiers in column definitions
+```
+
+```
+docs: link COMMITS.md from CONTRIBUTING
+```
+
+```
+refactor(core)!: rename `Schema::apps` to `Schema::models`
+
+BREAKING CHANGE: `Schema::apps()` is now `Schema::models()`. Call sites
+must be updated; the old name is not re-exported.
+```

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -42,4 +42,5 @@ Planned work and feature gaps.
 
 ## Project
 
+- [Commit Guidelines](./COMMITS.md)
 - [GitHub Labels](./labels.md)


### PR DESCRIPTION
## Summary

Add `docs/dev/COMMITS.md` with a detailed commit message guide adapted from hyper — allowed types, scope conventions for Toasty crates, subject/body/footer rules, and breaking-change notation. Link it from `CONTRIBUTING.md` and the dev docs index, and remove the abbreviated commit conventions section from `CLAUDE.md` that it supersedes.

Also add two Claude Code skills (`.claude/skills/commit/`, `.claude/skills/pr/`) that point contributors at `docs/dev/COMMITS.md` when authoring commit messages and at `.github/pull_request_template.md` when opening PRs, and remind them that labels are applied by maintainers rather than at PR creation.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format

## Notes for reviewers

Pure docs/tooling — no code changes, so `cargo fmt`, `cargo clippy`, and `cargo test` are no-ops here. The `CLAUDE.md` section that was removed is now covered by `docs/dev/COMMITS.md` plus the two new skills.