### PR TITLE
refactor: use hashbrown's HashMap/HashSet instead of std

### DIFF
--- a/crates/toasty-cli/Cargo.toml
+++ b/crates/toasty-cli/Cargo.toml
@@ -22,6 +22,7 @@ anyhow = "1.0.102"
 clap.workspace = true
 console.workspace = true
 dialoguer.workspace = true
+hashbrown.workspace = true
 jiff.workspace = true
 rand.workspace = true
 serde.workspace = true

--- a/crates/toasty-cli/src/migration/apply.rs
+++ b/crates/toasty-cli/src/migration/apply.rs
@@ -3,7 +3,7 @@ use crate::Config;
 use anyhow::Result;
 use clap::Parser;
 use console::style;
-use std::collections::HashSet;
+use hashbrown::HashSet;
 use std::fs;
 use toasty::Db;
 use toasty::schema::db::Migration;

--- a/crates/toasty-cli/src/migration/generate.rs
+++ b/crates/toasty-cli/src/migration/generate.rs
@@ -4,8 +4,8 @@ use anyhow::Result;
 use clap::Parser;
 use console::style;
 use dialoguer::Select;
+use hashbrown::{HashMap, HashSet};
 use rand::RngExt;
-use std::collections::{HashMap, HashSet};
 use std::fs;
 use toasty::{
     Db,

--- a/crates/toasty-core/src/schema/db/column.rs
+++ b/crates/toasty-core/src/schema/db/column.rs
@@ -1,11 +1,8 @@
 use super::{DiffContext, TableId, Type, table};
 use crate::stmt;
 
-use std::{
-    collections::{HashMap, HashSet},
-    fmt,
-    ops::Deref,
-};
+use hashbrown::{HashMap, HashSet};
+use std::{fmt, ops::Deref};
 
 /// A column in a database table.
 ///

--- a/crates/toasty-core/src/schema/db/diff.rs
+++ b/crates/toasty-core/src/schema/db/diff.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use hashbrown::HashMap;
 
 use crate::schema::db::{ColumnId, IndexId, Schema, TableId};
 

--- a/crates/toasty-core/src/schema/db/index.rs
+++ b/crates/toasty-core/src/schema/db/index.rs
@@ -1,11 +1,8 @@
 use super::{Column, ColumnId, DiffContext, Schema, TableId};
 use crate::stmt;
 
-use std::{
-    collections::{HashMap, HashSet},
-    fmt,
-    ops::Deref,
-};
+use hashbrown::{HashMap, HashSet};
+use std::{fmt, ops::Deref};
 
 /// A database index over one or more columns of a table.
 ///

--- a/crates/toasty-core/src/schema/db/table.rs
+++ b/crates/toasty-core/src/schema/db/table.rs
@@ -4,11 +4,8 @@ use crate::{
     stmt,
 };
 
-use std::{
-    collections::{HashMap, HashSet},
-    fmt,
-    ops::Deref,
-};
+use hashbrown::{HashMap, HashSet};
+use std::{fmt, ops::Deref};
 
 /// A database table with its columns, primary key, and indices.
 ///

--- a/crates/toasty-core/src/schema/db/ty_enum_diff.rs
+++ b/crates/toasty-core/src/schema/db/ty_enum_diff.rs
@@ -99,8 +99,8 @@ impl<'a> TypesDiff<'a> {
 ///
 /// If the same type name appears on multiple columns, the first occurrence wins
 /// (they must be identical per the schema verifier).
-fn collect_named_enums(schema: &Schema) -> std::collections::HashMap<&str, &TypeEnum> {
-    let mut result = std::collections::HashMap::new();
+fn collect_named_enums(schema: &Schema) -> hashbrown::HashMap<&str, &TypeEnum> {
+    let mut result = hashbrown::HashMap::new();
     for table in &schema.tables {
         for column in &table.columns {
             if let super::Type::Enum(type_enum) = &column.storage_ty

--- a/crates/toasty-core/src/schema/verify.rs
+++ b/crates/toasty-core/src/schema/verify.rs
@@ -7,7 +7,7 @@ use super::{
 };
 use crate::stmt;
 
-use std::collections::{HashMap, HashSet};
+use hashbrown::{HashMap, HashSet};
 
 struct Verify<'a> {
     schema: &'a Schema,

--- a/crates/toasty-driver-dynamodb/Cargo.toml
+++ b/crates/toasty-driver-dynamodb/Cargo.toml
@@ -18,6 +18,7 @@ async-trait.workspace = true
 toasty-core.workspace = true
 aws-config.workspace = true
 aws-sdk-dynamodb.workspace = true
+hashbrown.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true

--- a/crates/toasty-driver-dynamodb/src/op/create_table.rs
+++ b/crates/toasty-driver-dynamodb/src/op/create_table.rs
@@ -31,7 +31,7 @@ impl Connection {
         }
 
         // Calculate which attributes need to be defined
-        let mut defined_attributes = std::collections::HashSet::new();
+        let mut defined_attributes = hashbrown::HashSet::new();
 
         let pk_cols: Vec<&db::Column> = table.primary_key_columns().collect();
 

--- a/crates/toasty-driver-integration-suite-macros/Cargo.toml
+++ b/crates/toasty-driver-integration-suite-macros/Cargo.toml
@@ -17,6 +17,7 @@ documentation = "https://docs.rs/toasty-driver-integration-suite-macros"
 proc-macro = true
 
 [dependencies]
+hashbrown.workspace = true
 proc-macro2.workspace = true
 quote.workspace = true
 syn = { workspace = true, features = ["visit", "visit-mut"] }

--- a/crates/toasty-driver-integration-suite-macros/src/parse.rs
+++ b/crates/toasty-driver-integration-suite-macros/src/parse.rs
@@ -82,7 +82,7 @@ pub struct Expansion {
     pub id_ident: Option<String>,
 
     /// Matrix dimension values (e.g., {"single": true, "composite": false})
-    pub matrix_values: std::collections::HashMap<String, bool>,
+    pub matrix_values: hashbrown::HashMap<String, bool>,
 
     /// The predicate to evaluate for this expansion
     pub predicate: Option<BoolExpr>,
@@ -485,7 +485,7 @@ impl DriverTest {
             return vec![Expansion {
                 id_variant: None,
                 id_ident: None,
-                matrix_values: std::collections::HashMap::new(),
+                matrix_values: hashbrown::HashMap::new(),
                 predicate: None,
             }];
         }
@@ -545,18 +545,16 @@ impl DriverTest {
     /// - {a: true, b: false, c: false}
     /// - {a: false, b: true, c: false}
     /// - {a: false, b: false, c: true}
-    fn generate_matrix_combinations(
-        matrix: &[String],
-    ) -> Vec<std::collections::HashMap<String, bool>> {
+    fn generate_matrix_combinations(matrix: &[String]) -> Vec<hashbrown::HashMap<String, bool>> {
         if matrix.is_empty() {
-            return vec![std::collections::HashMap::new()];
+            return vec![hashbrown::HashMap::new()];
         }
 
         let mut combinations = Vec::new();
 
         // Generate one combination for each matrix value where only that value is true
         for (i, _key) in matrix.iter().enumerate() {
-            let mut combination = std::collections::HashMap::new();
+            let mut combination = hashbrown::HashMap::new();
             for (j, other_key) in matrix.iter().enumerate() {
                 combination.insert(other_key.clone(), i == j);
             }

--- a/crates/toasty-driver-integration-suite-macros/src/test_registry.rs
+++ b/crates/toasty-driver-integration-suite-macros/src/test_registry.rs
@@ -44,7 +44,7 @@ fn scan_test_directory(dir: &Path) -> TestStructure {
         requires: Vec::new(),
     };
 
-    let mut all_requires = std::collections::HashSet::new();
+    let mut all_requires = hashbrown::HashSet::new();
 
     // Read all .rs files in the directory
     for entry in fs::read_dir(dir).expect("Failed to read tests directory") {
@@ -80,7 +80,7 @@ fn scan_test_directory(dir: &Path) -> TestStructure {
     }
 
     // Extract all capability identifiers from the BoolExpr requirements
-    let mut capability_names = std::collections::HashSet::new();
+    let mut capability_names = hashbrown::HashSet::new();
     for req_expr in &all_requires {
         extract_capability_names(req_expr, &mut capability_names);
     }
@@ -100,7 +100,7 @@ fn scan_test_directory(dir: &Path) -> TestStructure {
 }
 
 /// Extract all capability names from a BoolExpr (ignoring matrix identifiers)
-fn extract_capability_names(expr: &BoolExpr, result: &mut std::collections::HashSet<String>) {
+fn extract_capability_names(expr: &BoolExpr, result: &mut hashbrown::HashSet<String>) {
     match expr {
         BoolExpr::Ident(name) => {
             // Skip common matrix identifiers
@@ -256,7 +256,7 @@ fn generate_capability_runtime_test(structure: &TestStructure) -> TokenStream2 {
                 let capability = t.capability();
 
                 // Parse capability flags from macro arguments
-                let mut expected_capabilities = ::std::collections::HashMap::new();
+                let mut expected_capabilities = ::hashbrown::HashMap::new();
 
                 // Default all capabilities to true
                 #(
@@ -284,7 +284,7 @@ fn generate_capability_runtime_test(structure: &TestStructure) -> TokenStream2 {
         }
 
         #[allow(dead_code)]
-        fn __parse_capability_flags(map: &mut ::std::collections::HashMap<String, bool>, input: &str) {
+        fn __parse_capability_flags(map: &mut ::hashbrown::HashMap<String, bool>, input: &str) {
             // Parse "cap1: false, cap2: true" format
             for part in input.split(',') {
                 let part = part.trim();

--- a/crates/toasty-driver-integration-suite-macros/src/test_variants.rs
+++ b/crates/toasty-driver-integration-suite-macros/src/test_variants.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use hashbrown::HashMap;
 
 use proc_macro::TokenStream;
 use quote::quote;

--- a/crates/toasty-driver-integration-suite/Cargo.toml
+++ b/crates/toasty-driver-integration-suite/Cargo.toml
@@ -17,6 +17,7 @@ documentation = "https://docs.rs/toasty-driver-integration-suite"
 assert-struct.workspace = true
 async-trait.workspace = true
 bigdecimal.workspace = true
+hashbrown = { workspace = true, features = ["serde"] }
 jiff.workspace = true
 rust_decimal.workspace = true
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/toasty-driver-integration-suite/src/macros.rs
+++ b/crates/toasty-driver-integration-suite/src/macros.rs
@@ -1,7 +1,7 @@
 #[macro_export]
 macro_rules! assert_eq_unordered {
     ($actual:expr, $expect:expr) => {
-        let mut vals = std::collections::HashSet::new();
+        let mut vals = ::hashbrown::HashSet::new();
 
         for val in $actual {
             assert!(vals.insert(val));

--- a/crates/toasty-driver-integration-suite/src/tests/batch_rollback.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/batch_rollback.rs
@@ -93,7 +93,7 @@ pub async fn batch_create_and_update_rolls_back_on_update_failure(t: &mut Test) 
     // "bob" was rolled back and "alice" was not renamed
     let all: Vec<User> = User::all().exec(&mut db).await?;
     assert_eq!(2, all.len());
-    let emails: std::collections::HashSet<_> = all.iter().map(|u| u.email.as_str()).collect();
+    let emails: hashbrown::HashSet<_> = all.iter().map(|u| u.email.as_str()).collect();
     assert!(emails.contains("alice@example.com"));
     assert!(emails.contains("taken@example.com"));
 

--- a/crates/toasty-driver-integration-suite/src/tests/relation_belongs_to_self_referential.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_belongs_to_self_referential.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use std::collections::HashMap;
+use hashbrown::HashMap;
 
 #[driver_test(id(ID))]
 pub async fn crud_person_self_referential(t: &mut Test) -> Result<()> {

--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_crud.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_crud.rs
@@ -2,7 +2,7 @@
 //! during query time. All associations are accessed via queries on demand.
 
 use crate::prelude::*;
-use std::collections::HashMap;
+use hashbrown::HashMap;
 
 #[driver_test(id(ID), scenario(crate::scenarios::has_many_belongs_to))]
 pub async fn crud_user_todos(test: &mut Test) -> Result<()> {

--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_multi.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_multi.rs
@@ -1,7 +1,7 @@
 //! Test has_many associations with multiple relations to the same model
 
 use crate::prelude::*;
-use std::collections::HashMap;
+use hashbrown::HashMap;
 
 #[driver_test(id(ID), scenario(crate::scenarios::has_many_multi_relation))]
 pub async fn crud_user_todos_categories(test: &mut Test) -> Result<()> {

--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_n_plus_1.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_n_plus_1.rs
@@ -1,7 +1,7 @@
 //! Test N+1 query behavior with has_many associations
 
 use crate::prelude::*;
-use std::collections::HashSet;
+use hashbrown::HashSet;
 
 #[driver_test(id(ID), scenario(crate::scenarios::has_many_multi_relation))]
 pub async fn hello_world(test: &mut Test) -> Result<()> {

--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_scoped_query.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_scoped_query.rs
@@ -1,7 +1,7 @@
 //! Test scoped queries on has_many associations
 
 use crate::prelude::*;
-use std::collections::HashSet;
+use hashbrown::HashSet;
 
 #[driver_test(id(ID), matrix(single, composite), requires(or(single, not(id_u64))))]
 pub async fn scoped_query_eq(test: &mut Test) -> Result<()> {

--- a/crates/toasty-driver-integration-suite/src/tests/type_serialize.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/type_serialize.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 
+use hashbrown::HashMap;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use toasty_core::{
     driver::{Operation, Rows},
     stmt::{Assignment, Expr, ExprSet, Statement, Value},

--- a/crates/toasty-driver-integration-suite/src/util.rs
+++ b/crates/toasty-driver-integration-suite/src/util.rs
@@ -1,5 +1,6 @@
+use hashbrown::HashSet;
 use rand::seq::SliceRandom;
-use std::{collections::HashSet, hash::Hash};
+use std::hash::Hash;
 
 pub(crate) trait NumUtil: PartialOrd + Ord + Eq {
     fn is_even(&self) -> bool;

--- a/crates/toasty-driver-postgresql/Cargo.toml
+++ b/crates/toasty-driver-postgresql/Cargo.toml
@@ -33,6 +33,7 @@ jiff = ["dep:jiff", "toasty-core/jiff", "postgres-types/with-jiff-0_2"]
 async-trait.workspace = true
 toasty-core.workspace = true
 toasty-sql.workspace = true
+hashbrown.workspace = true
 rust_decimal = { workspace = true, optional = true, features = ["db-postgres"] }
 bigdecimal = { workspace = true, optional = true }
 jiff = { workspace = true, optional = true }

--- a/crates/toasty-driver-postgresql/src/lib.rs
+++ b/crates/toasty-driver-postgresql/src/lib.rs
@@ -419,7 +419,7 @@ impl toasty_core::driver::Connection for Connection {
 
         // Create PostgreSQL enum types before creating tables.
         // Collect unique enum types across all columns.
-        let mut created_enum_types = std::collections::HashSet::new();
+        let mut created_enum_types = hashbrown::HashSet::new();
         for table in &schema.db.tables {
             for column in &table.columns {
                 if let toasty_core::schema::db::Type::Enum(type_enum) = &column.storage_ty

--- a/crates/toasty-driver-postgresql/src/oid_cache.rs
+++ b/crates/toasty-driver-postgresql/src/oid_cache.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use hashbrown::{HashMap, HashSet};
 
 use toasty_core::{Result, schema::db};
 use tokio_postgres::{

--- a/crates/toasty-macros/Cargo.toml
+++ b/crates/toasty-macros/Cargo.toml
@@ -19,6 +19,7 @@ proc-macro = true
 [dependencies]
 toasty-core.workspace = true
 
+hashbrown.workspace = true
 heck.workspace = true
 pluralizer.workspace = true
 proc-macro2.workspace = true

--- a/crates/toasty-macros/src/model/expand/filters.rs
+++ b/crates/toasty-macros/src/model/expand/filters.rs
@@ -1,9 +1,9 @@
 use super::Expand;
 use crate::model::schema::{FieldTy, Index, Model};
 
+use hashbrown::HashMap;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
-use std::collections::HashMap;
 
 /// Combination of fields for which filter a method should be generated.
 #[derive(Debug)]

--- a/crates/toasty/Cargo.toml
+++ b/crates/toasty/Cargo.toml
@@ -54,6 +54,7 @@ serde_json = { workspace = true, optional = true }
 
 bit-set.workspace = true
 by_address.workspace = true
+hashbrown.workspace = true
 rust_decimal = { workspace = true, optional = true }
 bigdecimal = { workspace = true, optional = true }
 deadpool.workspace = true

--- a/crates/toasty/src/engine/hir.rs
+++ b/crates/toasty/src/engine/hir.rs
@@ -1,8 +1,9 @@
 use std::{
     cell::{Cell, OnceCell},
-    collections::{HashMap, HashSet},
     ops,
 };
+
+use hashbrown::{HashMap, HashSet};
 
 use index_vec::IndexVec;
 use indexmap::IndexSet;

--- a/crates/toasty/src/engine/index.rs
+++ b/crates/toasty/src/engine/index.rs
@@ -7,7 +7,7 @@ mod index_plan;
 pub(crate) use index_plan::IndexPlan;
 
 use crate::{Result, engine::Engine};
-use std::collections::HashMap;
+use hashbrown::HashMap;
 use toasty_core::{
     Schema,
     driver::Capability,

--- a/crates/toasty/src/engine/index/index_match.rs
+++ b/crates/toasty/src/engine/index/index_match.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, hash_map};
+use hashbrown::{HashMap, hash_map};
 
 use by_address::ByAddress;
 use toasty_core::{schema::db::Index, stmt};

--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -3,7 +3,9 @@ mod paginate;
 mod relation;
 mod returning;
 
-use std::{cell::Cell, collections::HashSet};
+use std::cell::Cell;
+
+use hashbrown::HashSet;
 
 use index_vec::IndexVec;
 use toasty_core::{

--- a/crates/toasty/src/engine/simplify/expr_or.rs
+++ b/crates/toasty/src/engine/simplify/expr_or.rs
@@ -248,7 +248,7 @@ impl Simplify<'_> {
     /// Groups equality comparisons by their LHS and converts groups with 2+
     /// values into IN lists. Non-equality operands are preserved.
     fn try_or_to_in_list(&self, expr: &mut stmt::ExprOr) -> Option<stmt::Expr> {
-        use std::collections::HashMap;
+        use hashbrown::HashMap;
 
         // Group equalities by their LHS expression
         // Key: index into `lhs_exprs`, Value: list of RHS constant values

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -24,6 +24,7 @@ assert-struct.workspace = true
 async-trait.workspace = true
 rust_decimal.workspace = true
 bigdecimal.workspace = true
+hashbrown.workspace = true
 jiff.workspace = true
 toasty = { workspace = true, features = ["rust_decimal", "bigdecimal", "jiff"] }
 toasty-core = { workspace = true, features = ["assert-struct"] }

--- a/tests/src/db/dynamodb.rs
+++ b/tests/src/db/dynamodb.rs
@@ -1,5 +1,5 @@
 use crate::{Setup, isolation::TestIsolation};
-use std::collections::HashMap;
+use hashbrown::HashMap;
 use toasty_core::driver::{Capability, Driver};
 use toasty_driver_dynamodb::DynamoDb;
 use tokio::runtime::Runtime;

--- a/tests/src/db/dynamodb.rs
+++ b/tests/src/db/dynamodb.rs
@@ -76,8 +76,8 @@ impl Setup for SetupDynamoDb {
         // Get the per-test-instance DynamoDB client
         let client = self.get_client().await;
 
-        // Convert filter to DynamoDB key
-        let mut key = HashMap::new();
+        // Convert filter to DynamoDB key (AWS SDK requires std HashMap)
+        let mut key = std::collections::HashMap::new();
         for (col_name, value) in filter {
             let attr_value = self.stmt_value_to_dynamodb_attr(&value)?;
             key.insert(col_name, attr_value);

--- a/tests/src/db/mysql.rs
+++ b/tests/src/db/mysql.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use hashbrown::HashMap;
 use toasty::db::Connect;
 use toasty_core::driver::{Capability, Driver};
 

--- a/tests/src/db/postgresql.rs
+++ b/tests/src/db/postgresql.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use hashbrown::HashMap;
 use std::sync::Arc;
 use toasty::db::Connect;
 use toasty_core::driver::{Capability, Driver};

--- a/tests/src/db/sqlite.rs
+++ b/tests/src/db/sqlite.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use hashbrown::HashMap;
 use std::sync::Mutex;
 use tempfile::NamedTempFile;
 use toasty::db::{self, Connect};

--- a/tests/src/db_test.rs
+++ b/tests/src/db_test.rs
@@ -1,8 +1,6 @@
 use crate::{Setup, exec_log::ExecLog, logging_driver::LoggingDriver};
-use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex},
-};
+use hashbrown::HashMap;
+use std::sync::{Arc, Mutex};
 use toasty::{Db, schema::ModelSet};
 use toasty_core::stmt;
 

--- a/tests/src/macros.rs
+++ b/tests/src/macros.rs
@@ -1,7 +1,7 @@
 #[macro_export]
 macro_rules! assert_eq_unordered {
     ($actual:expr, $expect:expr) => {
-        let mut vals = std::collections::HashSet::new();
+        let mut vals = ::hashbrown::HashSet::new();
 
         for val in $actual {
             assert!(vals.insert(val));

--- a/tests/src/setup.rs
+++ b/tests/src/setup.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use hashbrown::HashMap;
 use toasty_core::driver::{Capability, Driver};
 
 #[async_trait::async_trait]


### PR DESCRIPTION
Replace std::collections::{HashMap, HashSet} with hashbrown equivalents
throughout the workspace. AWS SDK boundary code in toasty-driver-dynamodb
continues to use std::collections::HashMap where the SDK's APIs require it.

https://claude.ai/code/session_01W4EX6q85XFMUGLjduDBgqn