### PR TITLE
ci: tighten area-label criteria in triage bot

### DIFF
--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -45,8 +45,14 @@ jobs:
                - C-docs         user docs, dev docs, rustdoc
                - C-chore        CI, release tooling, scripts, lint fixes
 
-            3. Choose zero or more area labels based on paths / crate names
-               mentioned in the body:
+            3. Choose zero or more area labels. Apply A-<area> only when
+               the issue is clearly about that area — the body names the
+               crate/path, or describes behavior that obviously lives
+               there. Most issues carry 0 or 1 A- labels; 2 is possible
+               for a genuinely cross-cutting issue. More than 2 is almost
+               never right. When the issue is vague, broad, or doesn't
+               clearly belong to an area, leave A- labels off.
+
                - A-engine     toasty/src/engine/
                - A-macros     toasty-macros, create!, models!
                - A-schema     toasty-core/src/schema/
@@ -111,7 +117,11 @@ jobs:
                - C-docs         docs:
                - C-chore        chore:, ci:, build:
 
-            3. Choose zero or more area labels based on CHANGED FILES:
+            3. Choose area labels. Most PRs carry 0, 1, or 2 A- labels.
+               More than 2 is unusual and requires each area to be a
+               genuine focus of the PR.
+
+               Area paths (necessary but not sufficient):
                - A-engine     crates/toasty/src/engine/**
                - A-macros     crates/toasty-macros/**
                - A-schema     crates/toasty-core/src/schema/**
@@ -122,9 +132,25 @@ jobs:
                - A-docs       docs/**
                - A-ci         .github/**, scripts/**
 
-               If a PR spans many areas, apply A- labels that cover the bulk
-               of changes — skip areas touched only by incidental edits
-               (e.g. a one-line import fix).
+               Apply A-<area> only when the PR meaningfully changes that
+               area: modifies its logic, behavior, or public API, or fixes
+               a bug specific to it. Tests added alongside a feature or
+               fix are covered by the PR's primary area — they do not
+               earn A-tests on their own. Apply A-tests only when the PR
+               is primarily a testing effort.
+
+               Do NOT apply an A- label for:
+               - Mechanical or sweeping changes that touch a crate
+                 without changing its behavior: dependency swaps, import
+                 rewrites, mass renames, formatting passes. These often
+                 warrant C-refactor or C-chore with zero A- labels.
+               - Incidental touches: a handful of lines changed only
+                 because a helper moved, a type was renamed, or an API
+                 shifted elsewhere.
+               - Pure Cargo.toml dependency bumps.
+
+               When in doubt, leave the label off. Fewer labels beats
+               over-labeling.
 
             4. Apply labels, skipping any already present:
                gh pr edit ${{ github.event.pull_request.number }} --add-label <label>


### PR DESCRIPTION
## Summary

The triage bot applied `A-*` labels any time a PR touched files in an area's path. On sweeping mechanical refactors this over-labels: [#729] swapped `std::collections::HashMap` for `hashbrown::HashMap` across seven crates and picked up six `A-*` labels despite no area being meaningfully changed.

Rework the prompt in `.github/workflows/claude-triage.yml` so area paths are a necessary but not sufficient signal. `A-<area>` now requires a meaningful change — logic, behavior, public API, or a bug specific to the area. The prompt explicitly excludes mechanical/sweeping refactors, incidental touches, and pure `Cargo.toml` bumps, and suggests a typical budget of 0–2 labels. The issue-side prompt gets parallel "leave A- off when vague" guidance.

Dry-ran the new prompt on five recent PRs:

| PR | Old | New prompt output |
|---|---|---|
| #729 (sweeping refactor) | C-refactor + 6 A-* | **C-refactor, no A-*** |
| #728 (docs guidelines) | C-docs, A-docs | unchanged |
| #722 (renovate config) | C-chore, A-ci | unchanged |
| #721 (triage workflow fix) | — | C-chore, A-ci |
| #710 (mdbook migration) | — | C-chore, A-docs, A-ci |

Also relabeled [#729] to match the new heuristic (C-refactor only).

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format

## Notes for reviewers

No code changes — only the prompt text the triage action feeds to Claude. The workflow's tool allowlist and permissions are unchanged.

[#729]: https://github.com/tokio-rs/toasty/pull/729