### PR TITLE
chore: add issue authoring skill

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: issue
+description: Always use this skill before opening an issue in the Toasty repository
+---
+
+# Opening Issues
+
+Load this skill before filing any issue in this project.
+
+## Writing style
+
+An issue is project documentation. Follow the conventions from the
+[`write-docs`](../write-docs/SKILL.md) skill: be fact-focused, direct,
+and concrete. No buzzwords, no fluff, no dramatic terms. State what
+happened or what is being proposed, not how important it is.
+
+## Pick the right template
+
+Issue templates live in
+[`.github/ISSUE_TEMPLATE/`](../../../.github/ISSUE_TEMPLATE):
+
+- [`bug_report.yml`](../../../.github/ISSUE_TEMPLATE/bug_report.yml) —
+  incorrect or unexpected behavior. Requires a reproducer, the affected
+  driver(s), and the Toasty version or commit SHA.
+- [`feature_proposal.yml`](../../../.github/ISSUE_TEMPLATE/feature_proposal.yml) —
+  new features, public-API changes, or anything that affects driver
+  implementations. Requires the problem, proposed solution,
+  alternatives considered, and a scope estimate.
+
+Read the template before writing. Fill in every field it asks for;
+don't drop sections or leave placeholders. If a field does not apply,
+say so explicitly rather than leaving it blank.
+
+## Bug reports
+
+A small, self-contained reproducer is the single most useful thing in a
+bug report. A failing test in
+`crates/toasty-driver-integration-suite/src/tests/` is ideal; a
+standalone snippet works too. Include the exact error, generated SQL,
+or backtrace when relevant.
+
+## Feature proposals
+
+Describe the problem before the solution. Name who is affected —
+Toasty users, driver implementors, or both. Sketch the user-facing API
+concretely; vague proposals are hard to discuss. List the alternatives
+you considered and why you discarded them.
+
+Non-trivial features follow the path in
+[`CONTRIBUTING.md`](../../../CONTRIBUTING.md): discuss in an issue,
+land a roadmap entry and design doc, then land the implementation.
+
+## Labels
+
+Do not apply labels when creating the issue. The templates set the
+initial `C-*` label; maintainers triage and add the rest. See
+[`docs/dev/labels.md`](../../../docs/dev/labels.md).


### PR DESCRIPTION
## Summary

Adds a Claude Code skill that loads before filing a GitHub issue. It
points contributors at the `write-docs` style conventions and the right
template in `.github/ISSUE_TEMPLATE/` (bug report vs. feature proposal),
and mirrors the existing `commit` and `pr` skills.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format

## Notes for reviewers

Skill markdown only — no code changes, so `cargo fmt`/`clippy`/`test`
are not applicable.