### PR TITLE
feat(macros): replace repeated partition/local syntax with array form

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/index_composite.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/index_composite.rs
@@ -145,7 +145,7 @@ pub async fn composite_index_prefix_queries(t: &mut Test) -> Result<()> {
     Ok(())
 }
 
-/// Multi-attribute partition key: `#[index(partition = a, partition = b, local = c)]`
+/// Multi-attribute partition key: `#[index(partition = [a, b], local = [c])]`
 /// creates a GSI with 2 HASH + 1 RANGE attributes (DDB-only).
 ///
 /// Verifies prefix queries for all valid access patterns.
@@ -153,7 +153,7 @@ pub async fn composite_index_prefix_queries(t: &mut Test) -> Result<()> {
 pub async fn composite_index_multi_hash(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     #[key(id)]
-    #[index(partition = tournament_id, partition = region, local = round)]
+    #[index(partition = [tournament_id, region], local = [round])]
     struct Match {
         id: String,
         tournament_id: String,
@@ -206,7 +206,7 @@ pub async fn composite_index_multi_hash(t: &mut Test) -> Result<()> {
     Ok(())
 }
 
-/// Multi-attribute sort key: `#[index(partition = a, local = b, local = c)]`
+/// Multi-attribute sort key: `#[index(partition = [a], local = [b, c])]`
 /// creates a GSI with 1 HASH + 2 RANGE attributes (DDB-only).
 ///
 /// Verifies all three prefix query methods issue indexed operations.
@@ -214,7 +214,7 @@ pub async fn composite_index_multi_hash(t: &mut Test) -> Result<()> {
 pub async fn composite_index_multi_range(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     #[key(id)]
-    #[index(partition = player_id, local = match_date, local = round)]
+    #[index(partition = [player_id], local = [match_date, round])]
     struct PlayerMatch {
         id: String,
         player_id: String,
@@ -473,7 +473,7 @@ pub async fn composite_index_multiple_indexes(t: &mut Test) -> Result<()> {
     Ok(())
 }
 
-/// Maximum attribute boundary: `#[index(partition = f1..f4, local = f5..f8)]` (DDB-only).
+/// Maximum attribute boundary: `#[index(partition = [f1, f2, f3, f4], local = [f5, f6, f7, f8])]` (DDB-only).
 ///
 /// DynamoDB allows up to 4 HASH + 4 RANGE attributes in a GSI KeySchema.
 /// Verifies that `setup_db()` succeeds at the limit and that a query using all
@@ -483,7 +483,7 @@ pub async fn composite_index_multiple_indexes(t: &mut Test) -> Result<()> {
 pub async fn composite_index_max_attributes(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     #[key(id)]
-    #[index(partition = f1, partition = f2, partition = f3, partition = f4, local = f5, local = f6, local = f7, local = f8)]
+    #[index(partition = [f1, f2, f3, f4], local = [f5, f6, f7, f8])]
     struct MaxIndex {
         id: String,
         f1: String,

--- a/crates/toasty-macros/src/lib.rs
+++ b/crates/toasty-macros/src/lib.rs
@@ -78,12 +78,12 @@ use proc_macro::TokenStream;
 /// DynamoDB); `local` fields scope within a partition. For SQL databases
 /// both behave as a regular composite primary key.
 ///
-/// Multiple `partition` and `local` entries are allowed:
+/// Multiple `partition` and `local` fields are allowed using bracket syntax:
 ///
 /// ```
 /// # use toasty::Model;
 /// # #[derive(Model)]
-/// #[key(partition = tenant, partition = org, local = id)]
+/// #[key(partition = [tenant, org], local = [id])]
 /// # struct Example { tenant: String, org: String, id: String }
 /// ```
 ///

--- a/crates/toasty-macros/src/model/schema/key_attr.rs
+++ b/crates/toasty-macros/src/model/schema/key_attr.rs
@@ -20,22 +20,46 @@ impl KeyAttr {
                     ));
                 }
 
-                has_named = true;
-                let value = meta.value()?;
-                let ident: syn::Ident = value.parse()?;
+                let is_partition = meta.path.is_ident("partition");
+                let target = if is_partition {
+                    &mut partition
+                } else {
+                    &mut local
+                };
 
-                if !names.contains(&ident) {
+                if !target.is_empty() {
                     return Err(syn::Error::new_spanned(
-                        &ident,
-                        format!("unknown field `{ident}`"),
+                        &meta.path,
+                        if is_partition {
+                            "`partition` specified more than once; use `partition = [a, b]` for multiple fields"
+                        } else {
+                            "`local` specified more than once; use `local = [a, b]` for multiple fields"
+                        },
                     ));
                 }
 
-                if meta.path.is_ident("partition") {
-                    partition.push(ident);
+                has_named = true;
+                let value = meta.value()?;
+
+                let idents: Vec<syn::Ident> = if value.peek(syn::token::Bracket) {
+                    let content;
+                    syn::bracketed!(content in value);
+                    let punctuated = syn::punctuated::Punctuated::<syn::Ident, syn::Token![,]>::parse_terminated(&content)?;
+                    punctuated.into_iter().collect()
                 } else {
-                    local.push(ident);
+                    vec![value.parse::<syn::Ident>()?]
+                };
+
+                for ident in &idents {
+                    if !names.contains(ident) {
+                        return Err(syn::Error::new_spanned(
+                            ident,
+                            format!("unknown field `{ident}`"),
+                        ));
+                    }
                 }
+
+                *target = idents;
             } else {
                 if has_named {
                     return Err(syn::Error::new_spanned(
@@ -70,14 +94,14 @@ impl KeyAttr {
             if partition.is_empty() {
                 return Err(syn::Error::new_spanned(
                     attr,
-                    "expected at least one `partition` attribute",
+                    "expected at least one `partition` field",
                 ));
             }
 
             if local.is_empty() {
                 return Err(syn::Error::new_spanned(
                     attr,
-                    "expected at least one `local` attribute",
+                    "expected at least one `local` field",
                 ));
             }
         }

--- a/crates/toasty-macros/src/model/schema/model_attr.rs
+++ b/crates/toasty-macros/src/model/schema/model_attr.rs
@@ -25,7 +25,10 @@ impl ModelAttr {
                 if self.key.is_some() {
                     errs.push(syn::Error::new_spanned(attr, "duplicate #[key] attribute"));
                 } else {
-                    self.key = Some(KeyAttr::from_ast(attr, names)?);
+                    match KeyAttr::from_ast(attr, names) {
+                        Ok(key_attr) => self.key = Some(key_attr),
+                        Err(e) => errs.push(e),
+                    }
                 }
             } else if attr.path().is_ident("index") {
                 match KeyAttr::from_ast(attr, names) {
@@ -60,6 +63,10 @@ impl ModelAttr {
 
                 self.table = Some(lit.clone());
             }
+        }
+
+        if let Some(err) = errs.collect() {
+            return Err(err);
         }
 
         Ok(())

--- a/docs/guide/src/indexes-and-unique-constraints.md
+++ b/docs/guide/src/indexes-and-unique-constraints.md
@@ -303,7 +303,7 @@ key:
 ```rust
 # use toasty::Model;
 #[derive(Debug, toasty::Model)]
-#[index(partition = tournament_id, partition = region, local = round)]
+#[index(partition = [tournament_id, region], local = [round])]
 struct Match {
     #[key]
     #[auto]


### PR DESCRIPTION
## Summary

Closes #696.

> **Stacked on #694** — this PR includes those commits. The meaningful diff
> is the single commit on top: `feat(macros): replace repeated partition/local
> syntax with array form`.

Replaces the repeated-key syntax introduced in #664 with a more concise
bracket form:

```rust
// Before
#[index(partition = tournament_id, partition = region, local = round)]

// After
#[index(partition = [tournament_id, region], local = [round])]
```

The old repeated form (`partition = a, partition = b`) is now a compile
error pointing to the array syntax. A new UI test
(`index_repeated_partition.rs`) covers this case.

Also fixes a pre-existing bug in `model_attr.rs` where errors returned
by `KeyAttr::from_ast` were pushed into a local `ErrorSet` that was
never finalized, silently accepting invalid `#[key]` and `#[index]`
attributes.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes