### PR TITLE
ci: restore checkout step to triage workflow

### DIFF
--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - name: Run Claude Code for Issue Triage
         uses: anthropics/claude-code-action@v1
         with:
@@ -107,8 +107,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
-      - name: Run Claude Code for Issue Triage
+          fetch-depth: 1
+      - name: Run Claude Code for PR Triage
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -34,8 +34,12 @@ jobs:
       contents: read
       issues: write
     steps:
-      # No checkout: this job only reads/writes issue metadata via `gh`.
-      - uses: anthropics/claude-code-action@v1
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Run Claude Code for Issue Triage
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -100,11 +104,12 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      # No checkout: running under `pull_request_target`, any checkout of
-      # the PR ref would place untrusted fork code in a job that has
-      # access to secrets. This job only reads PR metadata and applies
-      # labels via `gh`, so no working tree is needed.
-      - uses: anthropics/claude-code-action@v1
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Run Claude Code for Issue Triage
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

After #742 merged, the triage workflow still failed — this time with `Command failed: git fetch origin main --depth=1 --no-recurse-submodules` (exit 128). `anthropics/claude-code-action@v1` runs its own git commands during setup (to configure the git user and fetch the base ref), independent of the tools Claude is allowed to invoke. Without a git working tree, those internal commands fail.

Re-add `actions/checkout` to both jobs with `fetch-depth: 1`. The action does its own shallow fetch of `main` internally, so a shallow initial checkout is sufficient.

Security posture is unchanged. Under `pull_request_target`, `actions/checkout` defaults to the base branch — no PR/fork code lands on disk. The file-level SECURITY comment added in #742 still spells out the threat model.

## Type of change

- [x] Small / obvious change — bug fix

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format

## Notes for reviewers

Two commits in this branch; they'll squash to the PR title.