### PR TITLE
feat: support disambiguating has_many/has_one with pair attribute

### DIFF
--- a/crates/toasty-core/src/schema/app/field.rs
+++ b/crates/toasty-core/src/schema/app/field.rs
@@ -541,6 +541,10 @@ impl FieldId {
             index: usize::MAX,
         }
     }
+
+    pub(crate) fn is_placeholder(&self) -> bool {
+        self.index == usize::MAX && self.model == ModelId::placeholder()
+    }
 }
 
 impl From<&Self> for FieldId {

--- a/crates/toasty-core/src/schema/app/relation/has_many.rs
+++ b/crates/toasty-core/src/schema/app/relation/has_many.rs
@@ -31,14 +31,11 @@ pub struct HasMany {
     pub singular: Name,
 
     /// The [`BelongsTo`] field on the target model that pairs with this
-    /// relation.
+    /// relation. If a `#[has_many(pair = <field>)]` was supplied, the macro
+    /// resolves this at schema-construction time via `field_name_to_id` on
+    /// the target. Otherwise the linker fills it in by searching the target
+    /// model for a unique `BelongsTo` back to the source.
     pub pair: FieldId,
-
-    /// User-supplied name of the paired `BelongsTo` field on the target
-    /// model (from `#[has_many(pair = <field>)]`). When present, it is used
-    /// during schema linking to disambiguate between multiple `BelongsTo`
-    /// relations on the target that reference the source model.
-    pub pair_hint: Option<Name>,
 }
 
 impl HasMany {

--- a/crates/toasty-core/src/schema/app/relation/has_many.rs
+++ b/crates/toasty-core/src/schema/app/relation/has_many.rs
@@ -33,6 +33,12 @@ pub struct HasMany {
     /// The [`BelongsTo`] field on the target model that pairs with this
     /// relation.
     pub pair: FieldId,
+
+    /// User-supplied name of the paired `BelongsTo` field on the target
+    /// model (from `#[has_many(pair = <field>)]`). When present, it is used
+    /// during schema linking to disambiguate between multiple `BelongsTo`
+    /// relations on the target that reference the source model.
+    pub pair_hint: Option<Name>,
 }
 
 impl HasMany {

--- a/crates/toasty-core/src/schema/app/relation/has_one.rs
+++ b/crates/toasty-core/src/schema/app/relation/has_one.rs
@@ -1,5 +1,5 @@
 use crate::{
-    schema::app::{BelongsTo, FieldId, FieldTy, Model, ModelId, Schema},
+    schema::app::{BelongsTo, FieldId, FieldTy, Model, ModelId, Name, Schema},
     stmt,
 };
 
@@ -29,6 +29,12 @@ pub struct HasOne {
     /// The [`BelongsTo`] field on the target model that pairs with this
     /// relation.
     pub pair: FieldId,
+
+    /// User-supplied name of the paired `BelongsTo` field on the target
+    /// model (from `#[has_one(pair = <field>)]`). When present, it is used
+    /// during schema linking to disambiguate between multiple `BelongsTo`
+    /// relations on the target that reference the source model.
+    pub pair_hint: Option<Name>,
 }
 
 impl HasOne {

--- a/crates/toasty-core/src/schema/app/relation/has_one.rs
+++ b/crates/toasty-core/src/schema/app/relation/has_one.rs
@@ -1,5 +1,5 @@
 use crate::{
-    schema::app::{BelongsTo, FieldId, FieldTy, Model, ModelId, Name, Schema},
+    schema::app::{BelongsTo, FieldId, FieldTy, Model, ModelId, Schema},
     stmt,
 };
 
@@ -27,14 +27,11 @@ pub struct HasOne {
     pub expr_ty: stmt::Type,
 
     /// The [`BelongsTo`] field on the target model that pairs with this
-    /// relation.
+    /// relation. If a `#[has_one(pair = <field>)]` was supplied, the macro
+    /// resolves this at schema-construction time via `field_name_to_id` on
+    /// the target. Otherwise the linker fills it in by searching the target
+    /// model for a unique `BelongsTo` back to the source.
     pub pair: FieldId,
-
-    /// User-supplied name of the paired `BelongsTo` field on the target
-    /// model (from `#[has_one(pair = <field>)]`). When present, it is used
-    /// during schema linking to disambiguate between multiple `BelongsTo`
-    /// relations on the target that reference the source model.
-    pub pair_hint: Option<Name>,
 }
 
 impl HasOne {

--- a/crates/toasty-core/src/schema/app/schema.rs
+++ b/crates/toasty-core/src/schema/app/schema.rs
@@ -249,7 +249,9 @@ impl Builder {
                 if let FieldTy::HasMany(has_many) = &field.ty {
                     let target = has_many.target;
                     let field_name = field.name.app_unwrap().to_string();
-                    let pair = self.find_has_many_pair(src, target, &field_name)?;
+                    let pair_hint = has_many.pair_hint.clone();
+                    let pair =
+                        self.find_has_many_pair(src, target, &field_name, pair_hint.as_ref())?;
                     self.models[curr].as_root_mut_unwrap().fields[index]
                         .ty
                         .as_has_many_mut_unwrap()
@@ -272,7 +274,13 @@ impl Builder {
                     FieldTy::HasOne(has_one) => {
                         let target = has_one.target;
                         let field_name = field.name.app_unwrap().to_string();
-                        let pair = match self.find_belongs_to_pair(src, target, &field_name)? {
+                        let pair_hint = has_one.pair_hint.clone();
+                        let pair = match self.find_belongs_to_pair(
+                            src,
+                            target,
+                            &field_name,
+                            pair_hint.as_ref(),
+                        )? {
                             Some(pair) => pair,
                             None => {
                                 return Err(crate::Error::invalid_schema(format!(
@@ -368,6 +376,7 @@ impl Builder {
         src: ModelId,
         target: ModelId,
         field_name: &str,
+        pair_hint: Option<&super::Name>,
     ) -> crate::Result<Option<FieldId>> {
         let src_model = &self.models[&src];
 
@@ -394,11 +403,37 @@ impl Builder {
             })
             .collect();
 
+        // If the user provided a `pair = <field>` hint, use it to pick the
+        // matching `BelongsTo` by field name. This disambiguates cases where
+        // the target model has multiple `BelongsTo` relations pointing back
+        // at the source model.
+        if let Some(hint) = pair_hint {
+            let hint = hint.snake_case();
+            return match belongs_to
+                .iter()
+                .find(|field| field.name.app_unwrap() == hint)
+            {
+                Some(field) => Ok(Some(field.id)),
+                None => Err(crate::Error::invalid_schema(format!(
+                    "field `{}::{}` specifies `pair = {}`, but `{}` has no `BelongsTo` field \
+                     named `{}` targeting `{}`",
+                    src_model.name().upper_camel_case(),
+                    field_name,
+                    hint,
+                    target.name().upper_camel_case(),
+                    hint,
+                    src_model.name().upper_camel_case(),
+                ))),
+            };
+        }
+
         match &belongs_to[..] {
             [field] => Ok(Some(field.id)),
             [] => Ok(None),
             _ => Err(crate::Error::invalid_schema(format!(
-                "model `{}` has more than one `BelongsTo` relation targeting `{}`",
+                "model `{}` has more than one `BelongsTo` relation targeting `{}`; \
+                 disambiguate by adding `pair = <field>` on the paired `has_many`/`has_one` \
+                 field",
                 target.name().upper_camel_case(),
                 src_model.name().upper_camel_case(),
             ))),
@@ -410,8 +445,9 @@ impl Builder {
         src: ModelId,
         target: ModelId,
         field_name: &str,
+        pair_hint: Option<&super::Name>,
     ) -> crate::Result<FieldId> {
-        if let Some(field_id) = self.find_belongs_to_pair(src, target, field_name)? {
+        if let Some(field_id) = self.find_belongs_to_pair(src, target, field_name, pair_hint)? {
             return Ok(field_id);
         }
 

--- a/crates/toasty-core/src/schema/app/schema.rs
+++ b/crates/toasty-core/src/schema/app/schema.rs
@@ -249,9 +249,12 @@ impl Builder {
                 if let FieldTy::HasMany(has_many) = &field.ty {
                     let target = has_many.target;
                     let field_name = field.name.app_unwrap().to_string();
-                    let pair_hint = has_many.pair_hint.clone();
-                    let pair =
-                        self.find_has_many_pair(src, target, &field_name, pair_hint.as_ref())?;
+                    let pair = if has_many.pair.is_placeholder() {
+                        self.find_has_many_pair(src, target, &field_name)?
+                    } else {
+                        self.validate_pair(src, target, &field_name, has_many.pair)?;
+                        has_many.pair
+                    };
                     self.models[curr].as_root_mut_unwrap().fields[index]
                         .ty
                         .as_has_many_mut_unwrap()
@@ -274,21 +277,20 @@ impl Builder {
                     FieldTy::HasOne(has_one) => {
                         let target = has_one.target;
                         let field_name = field.name.app_unwrap().to_string();
-                        let pair_hint = has_one.pair_hint.clone();
-                        let pair = match self.find_belongs_to_pair(
-                            src,
-                            target,
-                            &field_name,
-                            pair_hint.as_ref(),
-                        )? {
-                            Some(pair) => pair,
-                            None => {
-                                return Err(crate::Error::invalid_schema(format!(
-                                    "field `{}::{}` has no matching `BelongsTo` relation on the target model",
-                                    self.models[curr].name().upper_camel_case(),
-                                    field_name,
-                                )));
+                        let pair = if has_one.pair.is_placeholder() {
+                            match self.find_belongs_to_pair(src, target, &field_name)? {
+                                Some(pair) => pair,
+                                None => {
+                                    return Err(crate::Error::invalid_schema(format!(
+                                        "field `{}::{}` has no matching `BelongsTo` relation on the target model",
+                                        self.models[curr].name().upper_camel_case(),
+                                        field_name,
+                                    )));
+                                }
                             }
+                        } else {
+                            self.validate_pair(src, target, &field_name, has_one.pair)?;
+                            has_one.pair
                         };
 
                         self.models[curr].as_root_mut_unwrap().fields[index]
@@ -376,7 +378,6 @@ impl Builder {
         src: ModelId,
         target: ModelId,
         field_name: &str,
-        pair_hint: Option<&super::Name>,
     ) -> crate::Result<Option<FieldId>> {
         let src_model = &self.models[&src];
 
@@ -403,30 +404,6 @@ impl Builder {
             })
             .collect();
 
-        // If the user provided a `pair = <field>` hint, use it to pick the
-        // matching `BelongsTo` by field name. This disambiguates cases where
-        // the target model has multiple `BelongsTo` relations pointing back
-        // at the source model.
-        if let Some(hint) = pair_hint {
-            let hint = hint.snake_case();
-            return match belongs_to
-                .iter()
-                .find(|field| field.name.app_unwrap() == hint)
-            {
-                Some(field) => Ok(Some(field.id)),
-                None => Err(crate::Error::invalid_schema(format!(
-                    "field `{}::{}` specifies `pair = {}`, but `{}` has no `BelongsTo` field \
-                     named `{}` targeting `{}`",
-                    src_model.name().upper_camel_case(),
-                    field_name,
-                    hint,
-                    target.name().upper_camel_case(),
-                    hint,
-                    src_model.name().upper_camel_case(),
-                ))),
-            };
-        }
-
         match &belongs_to[..] {
             [field] => Ok(Some(field.id)),
             [] => Ok(None),
@@ -445,9 +422,8 @@ impl Builder {
         src: ModelId,
         target: ModelId,
         field_name: &str,
-        pair_hint: Option<&super::Name>,
     ) -> crate::Result<FieldId> {
-        if let Some(field_id) = self.find_belongs_to_pair(src, target, field_name, pair_hint)? {
+        if let Some(field_id) = self.find_belongs_to_pair(src, target, field_name)? {
             return Ok(field_id);
         }
 
@@ -456,5 +432,54 @@ impl Builder {
             self.models[&src].name().upper_camel_case(),
             field_name,
         )))
+    }
+
+    /// Verify that `pair` — resolved from `#[has_many(pair = <field>)]` or
+    /// `#[has_one(pair = <field>)]` via `field_name_to_id` on the target —
+    /// names a `BelongsTo` field on `target` that points back at `src`.
+    fn validate_pair(
+        &self,
+        src: ModelId,
+        target: ModelId,
+        field_name: &str,
+        pair: FieldId,
+    ) -> crate::Result<()> {
+        let src_model = &self.models[&src];
+
+        let target_model = match self.models.get(&target) {
+            Some(target) => target,
+            None => {
+                return Err(crate::Error::invalid_schema(format!(
+                    "field `{}::{}` references a model that was not registered with the schema; \
+                     did you forget to register it with `Db::builder()`?",
+                    src_model.name().upper_camel_case(),
+                    field_name,
+                )));
+            }
+        };
+
+        if pair.model != target {
+            return Err(crate::Error::invalid_schema(format!(
+                "field `{}::{}` specifies a `pair` on a model other than its target `{}`",
+                src_model.name().upper_camel_case(),
+                field_name,
+                target_model.name().upper_camel_case(),
+            )));
+        }
+
+        let paired = &target_model.as_root_unwrap().fields[pair.index];
+        match &paired.ty {
+            FieldTy::BelongsTo(rel) if rel.target == src => Ok(()),
+            _ => Err(crate::Error::invalid_schema(format!(
+                "field `{}::{}` specifies `pair = {}`, but `{}::{}` is not a `BelongsTo` \
+                 targeting `{}`",
+                src_model.name().upper_camel_case(),
+                field_name,
+                paired.name.app_unwrap(),
+                target_model.name().upper_camel_case(),
+                paired.name.app_unwrap(),
+                src_model.name().upper_camel_case(),
+            ))),
+        }
     }
 }

--- a/crates/toasty-core/tests/schema_missing_model.rs
+++ b/crates/toasty-core/tests/schema_missing_model.rs
@@ -93,6 +93,7 @@ fn has_many_target_not_registered() {
                     model: MISSING,
                     index: 0,
                 },
+                pair_hint: None,
             }),
         )],
     )];
@@ -118,6 +119,7 @@ fn has_one_target_not_registered() {
                     model: MISSING,
                     index: 0,
                 },
+                pair_hint: None,
             }),
         )],
     )];

--- a/crates/toasty-core/tests/schema_missing_model.rs
+++ b/crates/toasty-core/tests/schema_missing_model.rs
@@ -93,7 +93,6 @@ fn has_many_target_not_registered() {
                     model: MISSING,
                     index: 0,
                 },
-                pair_hint: None,
             }),
         )],
     )];
@@ -119,7 +118,6 @@ fn has_one_target_not_registered() {
                     model: MISSING,
                     index: 0,
                 },
-                pair_hint: None,
             }),
         )],
     )];

--- a/crates/toasty-driver-integration-suite/src/scenarios.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios.rs
@@ -1,5 +1,6 @@
 pub mod has_many_belongs_to;
 pub mod has_many_multi_relation;
+pub mod has_many_same_target;
 pub mod has_one_optional_belongs_to;
 pub mod two_models;
 pub mod user_unique_email;

--- a/crates/toasty-driver-integration-suite/src/scenarios/has_many_same_target.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios/has_many_same_target.rs
@@ -1,0 +1,45 @@
+use crate::prelude::*;
+
+scenario! {
+    #![id(ID)]
+
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+
+        name: String,
+
+        #[has_many(pair = author)]
+        authored_articles: toasty::HasMany<Article>,
+
+        #[has_many(pair = reviewer)]
+        reviewed_articles: toasty::HasMany<Article>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Article {
+        #[key]
+        #[auto]
+        id: ID,
+
+        title: String,
+
+        #[index]
+        author_id: ID,
+
+        #[index]
+        reviewer_id: ID,
+
+        #[belongs_to(key = author_id, references = id)]
+        author: toasty::BelongsTo<User>,
+
+        #[belongs_to(key = reviewer_id, references = id)]
+        reviewer: toasty::BelongsTo<User>,
+    }
+
+    async fn setup(test: &mut Test) -> toasty::Db {
+        test.setup_db(models!(User, Article)).await
+    }
+}

--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -54,6 +54,7 @@ pub mod relation_has_many_filter;
 pub mod relation_has_many_link_unlink;
 pub mod relation_has_many_multi;
 pub mod relation_has_many_n_plus_1;
+pub mod relation_has_many_same_target;
 pub mod relation_has_many_scoped_query;
 pub mod relation_has_one_crud;
 pub mod relation_preload;

--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_same_target.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_same_target.rs
@@ -1,0 +1,92 @@
+//! Test has_many/belongs_to associations where multiple `belongs_to` fields on
+//! the same child model target the same parent model, disambiguated by
+//! `#[has_many(pair = <field>)]`.
+
+use crate::prelude::*;
+use hashbrown::HashSet;
+
+#[driver_test(id(ID), scenario(crate::scenarios::has_many_same_target))]
+pub async fn pair_hint_disambiguates_has_many(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let alice = User::create().name("Alice").exec(&mut db).await?;
+    let bob = User::create().name("Bob").exec(&mut db).await?;
+
+    // Alice authors two articles, each reviewed by Bob.
+    let a1 = Article::create()
+        .title("one")
+        .author(&alice)
+        .reviewer(&bob)
+        .exec(&mut db)
+        .await?;
+    let a2 = Article::create()
+        .title("two")
+        .author(&alice)
+        .reviewer(&bob)
+        .exec(&mut db)
+        .await?;
+
+    // Bob authors one article, reviewed by Alice.
+    let a3 = Article::create()
+        .title("three")
+        .author(&bob)
+        .reviewer(&alice)
+        .exec(&mut db)
+        .await?;
+
+    // Each has_many side picks up only the articles that match its paired
+    // belongs_to — not every article referencing the user.
+    let alice_authored: HashSet<_> = alice
+        .authored_articles()
+        .exec(&mut db)
+        .await?
+        .into_iter()
+        .map(|a| a.id)
+        .collect();
+    assert_eq!(alice_authored, HashSet::from_iter([a1.id, a2.id]));
+
+    let alice_reviewed: HashSet<_> = alice
+        .reviewed_articles()
+        .exec(&mut db)
+        .await?
+        .into_iter()
+        .map(|a| a.id)
+        .collect();
+    assert_eq!(alice_reviewed, HashSet::from_iter([a3.id]));
+
+    // Navigating back from an article to each parent resolves the correct user.
+    let a1_author = a1.author().exec(&mut db).await?;
+    let a1_reviewer = a1.reviewer().exec(&mut db).await?;
+    assert_eq!(a1_author.id, alice.id);
+    assert_eq!(a1_reviewer.id, bob.id);
+
+    Ok(())
+}
+
+#[driver_test(id(ID), scenario(crate::scenarios::has_many_same_target))]
+pub async fn pair_hint_create_via_has_many_accessor(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let alice = User::create().name("Alice").exec(&mut db).await?;
+    let bob = User::create().name("Bob").exec(&mut db).await?;
+
+    // Create an article scoped to Alice's authored side — the other FK still
+    // needs a concrete reviewer, and the side you create through should be
+    // filled by the accessor.
+    let article = alice
+        .authored_articles()
+        .create()
+        .title("draft")
+        .reviewer(&bob)
+        .exec(&mut db)
+        .await?;
+
+    assert_eq!(article.author_id, alice.id);
+    assert_eq!(article.reviewer_id, bob.id);
+
+    // The reviewer side for Alice is still empty even though she has an
+    // authored article.
+    assert!(alice.reviewed_articles().exec(&mut db).await?.is_empty());
+
+    Ok(())
+}

--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_same_target.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_same_target.rs
@@ -9,30 +9,24 @@ use hashbrown::HashSet;
 pub async fn pair_hint_disambiguates_has_many(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
-    let alice = User::create().name("Alice").exec(&mut db).await?;
-    let bob = User::create().name("Bob").exec(&mut db).await?;
+    let users = toasty::create!(User::[
+        { name: "Alice" },
+        { name: "Bob" },
+    ])
+    .exec(&mut db)
+    .await?;
+    let (alice, bob) = (&users[0], &users[1]);
 
-    // Alice authors two articles, each reviewed by Bob.
-    let a1 = Article::create()
-        .title("one")
-        .author(&alice)
-        .reviewer(&bob)
-        .exec(&mut db)
-        .await?;
-    let a2 = Article::create()
-        .title("two")
-        .author(&alice)
-        .reviewer(&bob)
-        .exec(&mut db)
-        .await?;
-
-    // Bob authors one article, reviewed by Alice.
-    let a3 = Article::create()
-        .title("three")
-        .author(&bob)
-        .reviewer(&alice)
-        .exec(&mut db)
-        .await?;
+    // Alice authors two articles (both reviewed by Bob); Bob authors one
+    // (reviewed by Alice).
+    let articles = toasty::create!(Article::[
+        { title: "one",   author: alice, reviewer: bob },
+        { title: "two",   author: alice, reviewer: bob },
+        { title: "three", author: bob,   reviewer: alice },
+    ])
+    .exec(&mut db)
+    .await?;
+    let (a1, a2, a3) = (&articles[0], &articles[1], &articles[2]);
 
     // Each has_many side picks up only the articles that match its paired
     // belongs_to — not every article referencing the user.
@@ -67,19 +61,23 @@ pub async fn pair_hint_disambiguates_has_many(test: &mut Test) -> Result<()> {
 pub async fn pair_hint_create_via_has_many_accessor(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
-    let alice = User::create().name("Alice").exec(&mut db).await?;
-    let bob = User::create().name("Bob").exec(&mut db).await?;
+    let users = toasty::create!(User::[
+        { name: "Alice" },
+        { name: "Bob" },
+    ])
+    .exec(&mut db)
+    .await?;
+    let (alice, bob) = (&users[0], &users[1]);
 
-    // Create an article scoped to Alice's authored side — the other FK still
-    // needs a concrete reviewer, and the side you create through should be
-    // filled by the accessor.
-    let article = alice
-        .authored_articles()
-        .create()
-        .title("draft")
-        .reviewer(&bob)
-        .exec(&mut db)
-        .await?;
+    // Create an article scoped to Alice's authored side — the scoped create
+    // should fill in the `author` FK, and the other side (`reviewer`) still
+    // needs to be specified.
+    let article = toasty::create!(in alice.authored_articles() {
+        title: "draft",
+        reviewer: bob,
+    })
+    .exec(&mut db)
+    .await?;
 
     assert_eq!(article.author_id, alice.id);
     assert_eq!(article.reviewer_id, bob.id);

--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -159,17 +159,17 @@ impl Expand<'_> {
                 FieldTy::HasMany(rel) => {
                     let ty = &rel.ty;
                     let singular_name = expand_name(toasty, &rel.singular);
-                    let pair_hint = expand_pair_hint(toasty, rel.pair.as_ref());
+                    let pair = expand_pair(toasty, ty, rel.pair.as_ref());
 
                     nullable = quote!(<#ty as #toasty::Relation>::nullable());
-                    field_ty = quote!(<#ty as #toasty::Relation>::has_many_field_ty(#singular_name, #pair_hint));
+                    field_ty = quote!(<#ty as #toasty::Relation>::has_many_field_ty(#singular_name, #pair));
                 }
                 FieldTy::HasOne(rel) => {
                     let ty = &rel.ty;
-                    let pair_hint = expand_pair_hint(toasty, rel.pair.as_ref());
+                    let pair = expand_pair(toasty, ty, rel.pair.as_ref());
 
                     nullable = quote!(<#ty as #toasty::Relation>::nullable());
-                    field_ty = quote!(<#ty as #toasty::Relation>::has_one_field_ty(#pair_hint));
+                    field_ty = quote!(<#ty as #toasty::Relation>::has_one_field_ty(#pair));
                 }
             }
 
@@ -376,12 +376,15 @@ pub(super) fn expand_name(toasty: &TokenStream, name: &Name) -> TokenStream {
     }
 }
 
-fn expand_pair_hint(toasty: &TokenStream, pair: Option<&syn::Ident>) -> TokenStream {
+fn expand_pair(
+    toasty: &TokenStream,
+    target_ty: &syn::Type,
+    pair: Option<&syn::Ident>,
+) -> TokenStream {
     match pair {
         Some(ident) => {
-            let name = Name::from_ident(ident);
-            let expanded = expand_name(toasty, &name);
-            quote! { Some(#expanded) }
+            let name = ident.to_string();
+            quote! { Some(<#target_ty as #toasty::Relation>::field_name_to_id(#name)) }
         }
         None => quote! { None },
     }

--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -159,15 +159,17 @@ impl Expand<'_> {
                 FieldTy::HasMany(rel) => {
                     let ty = &rel.ty;
                     let singular_name = expand_name(toasty, &rel.singular);
+                    let pair_hint = expand_pair_hint(toasty, rel.pair.as_ref());
 
                     nullable = quote!(<#ty as #toasty::Relation>::nullable());
-                    field_ty = quote!(<#ty as #toasty::Relation>::has_many_field_ty(#singular_name));
+                    field_ty = quote!(<#ty as #toasty::Relation>::has_many_field_ty(#singular_name, #pair_hint));
                 }
                 FieldTy::HasOne(rel) => {
                     let ty = &rel.ty;
+                    let pair_hint = expand_pair_hint(toasty, rel.pair.as_ref());
 
                     nullable = quote!(<#ty as #toasty::Relation>::nullable());
-                    field_ty = quote!(<#ty as #toasty::Relation>::has_one_field_ty());
+                    field_ty = quote!(<#ty as #toasty::Relation>::has_one_field_ty(#pair_hint));
                 }
             }
 
@@ -371,5 +373,16 @@ pub(super) fn expand_name(toasty: &TokenStream, name: &Name) -> TokenStream {
         #toasty::core::schema::Name {
             parts: vec![#( #parts ),*],
         }
+    }
+}
+
+fn expand_pair_hint(toasty: &TokenStream, pair: Option<&syn::Ident>) -> TokenStream {
+    match pair {
+        Some(ident) => {
+            let name = Name::from_ident(ident);
+            let expanded = expand_name(toasty, &name);
+            quote! { Some(#expanded) }
+        }
+        None => quote! { None },
     }
 }

--- a/crates/toasty-macros/src/model/schema/field.rs
+++ b/crates/toasty-macros/src/model/schema/field.rs
@@ -297,7 +297,11 @@ impl Field {
                         "field has more than one relation attribute",
                     ));
                 } else {
-                    ty = Some(FieldTy::HasOne(HasOne::from_ast(&field.ty, field.span())?));
+                    ty = Some(FieldTy::HasOne(HasOne::from_ast(
+                        attr,
+                        &field.ty,
+                        field.span(),
+                    )?));
                 }
             }
         }

--- a/crates/toasty-macros/src/model/schema/has_many.rs
+++ b/crates/toasty-macros/src/model/schema/has_many.rs
@@ -21,26 +21,11 @@ impl HasMany {
         ty: &syn::Type,
         span: proc_macro2::Span,
     ) -> syn::Result<Self> {
-        let mut pair = None;
         let singular = Name::from_str(
             &pluralizer::pluralize(&name.to_string(), 1, false),
             name.span(),
         );
-        if let syn::Meta::List(_) = &attr.meta {
-            attr.parse_nested_meta(|meta| {
-                if meta.path.is_ident("pair") {
-                    let value = meta.value()?;
-                    pair = Some(value.parse()?);
-                } else {
-                    return Err(syn::Error::new_spanned(
-                        &meta.path,
-                        "expected `pair` attribute",
-                    ));
-                }
-
-                Ok(())
-            })?;
-        }
+        let pair = parse_pair_attr(attr)?;
 
         Ok(Self {
             ty: ty.clone(),
@@ -49,4 +34,29 @@ impl HasMany {
             span,
         })
     }
+}
+
+/// Parse the `pair = <ident>` payload on a `#[has_many(...)]` or
+/// `#[has_one(...)]` attribute. Both relations use this mechanism to
+/// disambiguate the paired `BelongsTo` field on the target model when
+/// multiple `BelongsTo` fields there point at the source.
+pub(super) fn parse_pair_attr(attr: &syn::Attribute) -> syn::Result<Option<syn::Ident>> {
+    let mut pair = None;
+
+    if let syn::Meta::List(_) = &attr.meta {
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("pair") {
+                let value = meta.value()?;
+                pair = Some(value.parse()?);
+                Ok(())
+            } else {
+                Err(syn::Error::new_spanned(
+                    &meta.path,
+                    "expected `pair` attribute",
+                ))
+            }
+        })?;
+    }
+
+    Ok(pair)
 }

--- a/crates/toasty-macros/src/model/schema/has_one.rs
+++ b/crates/toasty-macros/src/model/schema/has_one.rs
@@ -1,3 +1,5 @@
+use super::has_many::parse_pair_attr;
+
 #[derive(Debug)]
 pub(crate) struct HasOne {
     /// Target type
@@ -15,27 +17,9 @@ impl HasOne {
         ty: &syn::Type,
         span: proc_macro2::Span,
     ) -> syn::Result<Self> {
-        let mut pair = None;
-
-        if let syn::Meta::List(_) = &attr.meta {
-            attr.parse_nested_meta(|meta| {
-                if meta.path.is_ident("pair") {
-                    let value = meta.value()?;
-                    pair = Some(value.parse()?);
-                } else {
-                    return Err(syn::Error::new_spanned(
-                        &meta.path,
-                        "expected `pair` attribute",
-                    ));
-                }
-
-                Ok(())
-            })?;
-        }
-
         Ok(Self {
             ty: ty.clone(),
-            pair,
+            pair: parse_pair_attr(attr)?,
             span,
         })
     }

--- a/crates/toasty-macros/src/model/schema/has_one.rs
+++ b/crates/toasty-macros/src/model/schema/has_one.rs
@@ -3,13 +3,39 @@ pub(crate) struct HasOne {
     /// Target type
     pub(crate) ty: syn::Type,
 
+    /// Field on target that the relation references
+    pub(crate) pair: Option<syn::Ident>,
+
     pub(crate) span: proc_macro2::Span,
 }
 
 impl HasOne {
-    pub(super) fn from_ast(ty: &syn::Type, span: proc_macro2::Span) -> syn::Result<Self> {
+    pub(super) fn from_ast(
+        attr: &syn::Attribute,
+        ty: &syn::Type,
+        span: proc_macro2::Span,
+    ) -> syn::Result<Self> {
+        let mut pair = None;
+
+        if let syn::Meta::List(_) = &attr.meta {
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("pair") {
+                    let value = meta.value()?;
+                    pair = Some(value.parse()?);
+                } else {
+                    return Err(syn::Error::new_spanned(
+                        &meta.path,
+                        "expected `pair` attribute",
+                    ));
+                }
+
+                Ok(())
+            })?;
+        }
+
         Ok(Self {
             ty: ty.clone(),
+            pair,
             span,
         })
     }

--- a/crates/toasty/src/schema/has_many.rs
+++ b/crates/toasty/src/schema/has_many.rs
@@ -96,7 +96,7 @@ impl<T: Relation> Relation for HasMany<T> {
         T::nullable()
     }
 
-    fn has_many_field_ty(singular: Name) -> FieldTy {
+    fn has_many_field_ty(singular: Name, pair_hint: Option<Name>) -> FieldTy {
         FieldTy::HasMany(app::HasMany {
             target: <T::Model as Register>::id(),
             expr_ty: stmt::Type::List(Box::new(stmt::Type::Model(<T::Model as Register>::id()))),
@@ -106,6 +106,7 @@ impl<T: Relation> Relation for HasMany<T> {
                 model: ModelId(usize::MAX),
                 index: usize::MAX,
             },
+            pair_hint,
         })
     }
 }

--- a/crates/toasty/src/schema/has_many.rs
+++ b/crates/toasty/src/schema/has_many.rs
@@ -96,17 +96,16 @@ impl<T: Relation> Relation for HasMany<T> {
         T::nullable()
     }
 
-    fn has_many_field_ty(singular: Name, pair_hint: Option<Name>) -> FieldTy {
+    fn has_many_field_ty(singular: Name, pair: Option<FieldId>) -> FieldTy {
         FieldTy::HasMany(app::HasMany {
             target: <T::Model as Register>::id(),
             expr_ty: stmt::Type::List(Box::new(stmt::Type::Model(<T::Model as Register>::id()))),
             singular,
-            // The pair is populated at runtime.
-            pair: FieldId {
+            // If unresolved, the pair is populated by the schema linker.
+            pair: pair.unwrap_or(FieldId {
                 model: ModelId(usize::MAX),
                 index: usize::MAX,
-            },
-            pair_hint,
+            }),
         })
     }
 }

--- a/crates/toasty/src/schema/has_one.rs
+++ b/crates/toasty/src/schema/has_one.rs
@@ -1,6 +1,5 @@
 use super::{Load, Register, Relation};
 
-use toasty_core::schema::Name;
 use toasty_core::schema::app::{self, FieldId, FieldTy, ModelId};
 use toasty_core::stmt::{self, Value};
 
@@ -83,16 +82,15 @@ impl<T: Relation> Relation for HasOne<T> {
         T::nullable()
     }
 
-    fn has_one_field_ty(pair_hint: Option<Name>) -> FieldTy {
+    fn has_one_field_ty(pair: Option<FieldId>) -> FieldTy {
         FieldTy::HasOne(app::HasOne {
             target: <T::Model as Register>::id(),
             expr_ty: stmt::Type::Model(<T::Model as Register>::id()),
-            // The pair is populated at runtime.
-            pair: FieldId {
+            // If unresolved, the pair is populated by the schema linker.
+            pair: pair.unwrap_or(FieldId {
                 model: ModelId(usize::MAX),
                 index: usize::MAX,
-            },
-            pair_hint,
+            }),
         })
     }
 }

--- a/crates/toasty/src/schema/has_one.rs
+++ b/crates/toasty/src/schema/has_one.rs
@@ -1,5 +1,6 @@
 use super::{Load, Register, Relation};
 
+use toasty_core::schema::Name;
 use toasty_core::schema::app::{self, FieldId, FieldTy, ModelId};
 use toasty_core::stmt::{self, Value};
 
@@ -82,7 +83,7 @@ impl<T: Relation> Relation for HasOne<T> {
         T::nullable()
     }
 
-    fn has_one_field_ty() -> FieldTy {
+    fn has_one_field_ty(pair_hint: Option<Name>) -> FieldTy {
         FieldTy::HasOne(app::HasOne {
             target: <T::Model as Register>::id(),
             expr_ty: stmt::Type::Model(<T::Model as Register>::id()),
@@ -91,6 +92,7 @@ impl<T: Relation> Relation for HasOne<T> {
                 model: ModelId(usize::MAX),
                 index: usize::MAX,
             },
+            pair_hint,
         })
     }
 }

--- a/crates/toasty/src/schema/relation.rs
+++ b/crates/toasty/src/schema/relation.rs
@@ -74,20 +74,24 @@ pub trait Relation: Load<Output = Self> {
 
     /// Build the [`FieldTy`] for a `HasMany` relation wrapper, given the
     /// singular name derived from the field identifier and an optional
-    /// pair hint naming the paired `BelongsTo` field on the target model
-    /// (from `#[has_many(pair = <field>)]`).
+    /// paired `BelongsTo` field on the target model resolved from
+    /// `#[has_many(pair = <field>)]`. When `None`, the linker selects the
+    /// pair by searching the target for a unique `BelongsTo` back to the
+    /// source.
     ///
     /// Only [`HasMany`](super::HasMany) overrides this.
-    fn has_many_field_ty(_singular: Name, _pair_hint: Option<Name>) -> FieldTy {
+    fn has_many_field_ty(_singular: Name, _pair: Option<FieldId>) -> FieldTy {
         unimplemented!("not a HasMany relation wrapper")
     }
 
     /// Build the [`FieldTy`] for a `HasOne` relation wrapper, given an
-    /// optional pair hint naming the paired `BelongsTo` field on the
-    /// target model (from `#[has_one(pair = <field>)]`).
+    /// optional paired `BelongsTo` field on the target model resolved
+    /// from `#[has_one(pair = <field>)]`. When `None`, the linker selects
+    /// the pair by searching the target for a unique `BelongsTo` back to
+    /// the source.
     ///
     /// Only [`HasOne`](super::HasOne) overrides this.
-    fn has_one_field_ty(_pair_hint: Option<Name>) -> FieldTy {
+    fn has_one_field_ty(_pair: Option<FieldId>) -> FieldTy {
         unimplemented!("not a HasOne relation wrapper")
     }
 }

--- a/crates/toasty/src/schema/relation.rs
+++ b/crates/toasty/src/schema/relation.rs
@@ -73,17 +73,21 @@ pub trait Relation: Load<Output = Self> {
     }
 
     /// Build the [`FieldTy`] for a `HasMany` relation wrapper, given the
-    /// singular name derived from the field identifier.
+    /// singular name derived from the field identifier and an optional
+    /// pair hint naming the paired `BelongsTo` field on the target model
+    /// (from `#[has_many(pair = <field>)]`).
     ///
     /// Only [`HasMany`](super::HasMany) overrides this.
-    fn has_many_field_ty(_singular: Name) -> FieldTy {
+    fn has_many_field_ty(_singular: Name, _pair_hint: Option<Name>) -> FieldTy {
         unimplemented!("not a HasMany relation wrapper")
     }
 
-    /// Build the [`FieldTy`] for a `HasOne` relation wrapper.
+    /// Build the [`FieldTy`] for a `HasOne` relation wrapper, given an
+    /// optional pair hint naming the paired `BelongsTo` field on the
+    /// target model (from `#[has_one(pair = <field>)]`).
     ///
     /// Only [`HasOne`](super::HasOne) overrides this.
-    fn has_one_field_ty() -> FieldTy {
+    fn has_one_field_ty(_pair_hint: Option<Name>) -> FieldTy {
         unimplemented!("not a HasOne relation wrapper")
     }
 }


### PR DESCRIPTION
## Summary

Adds support for the `pair` attribute on `#[has_many(...)]` and `#[has_one(...)]` relations to explicitly specify which `BelongsTo` field on the target model pairs with the relation. This enables models to have multiple `BelongsTo` fields targeting the same parent model, with each `has_many`/`has_one` relation disambiguated by naming its paired field.

For example, an `Article` model can have both `author` and `reviewer` fields pointing to `User`, and the `User` model can have `authored_articles` and `reviewed_articles` relations that each specify their paired field via `#[has_many(pair = author)]` and `#[has_many(pair = reviewer)]`.

## Type of change

- [x] Implements a previously accepted design

## Changes

- **Schema macro expansion**: Updated `HasMany` and `HasOne` parsing to extract the optional `pair` attribute and pass it through to the relation field type constructors
- **Relation trait**: Modified `has_many_field_ty()` and `has_one_field_ty()` to accept an optional `FieldId` parameter representing the pre-resolved pair
- **Schema linker**: Enhanced pair resolution logic to:
  - Use the explicitly provided pair when `#[has_many(pair = ...)]` or `#[has_one(pair = ...)]` is specified
  - Fall back to automatic pair detection (searching for a unique `BelongsTo`) when no pair is specified
  - Validate that explicitly provided pairs reference valid `BelongsTo` fields on the target model
  - Provide improved error messages when multiple `BelongsTo` fields exist without disambiguation
- **Field ID**: Added `is_placeholder()` helper to distinguish unresolved pairs from resolved ones
- **Tests**: Added comprehensive integration tests covering:
  - Querying through disambiguated relations
  - Navigating back from child to parent through different relations
  - Creating records through scoped `has_many` accessors

## Checklist

- [x] PR title uses Conventional Commits format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Added integration tests covering the new functionality

## Notes for reviewers

The key insight is that the `pair` attribute is resolved at two different times:
1. **Macro time** (via `field_name_to_id` on the target relation type): Converts the field name string to a `FieldId`
2. **Schema linker time**: Validates the resolved pair and uses it to populate the relation metadata

When no `pair` is specified, the linker performs automatic detection by searching for a unique `BelongsTo` field, maintaining backward compatibility with existing code.

https://claude.ai/code/session_01L78dYP4VPL5381nj2qGh5r