### PR TITLE
chore: rename write-docs skill to prose and add design skill

### DIFF
--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: design
+description: Always use this skill before authoring or editing a Toasty design document under docs/dev/design/
+---
+
+# Authoring Toasty Design Documents
+
+Load this skill before writing or editing a design document in
+[`docs/dev/design/`](../../../docs/dev/design/).
+
+## Format and layout
+
+**Always read [`docs/dev/design/_template.md`](../../../docs/dev/design/_template.md)
+before writing.** It is the authoritative source for section order,
+section purposes, and the framing the doc should adopt. Copy the
+template to `docs/dev/design/<feature-name>.md` and fill it in. Keep the
+section order; if a section genuinely does not apply, delete it and
+explain why in one line rather than leaving it empty.
+
+## Writing style
+
+Follow the conventions from the [`prose`](../prose/SKILL.md) skill: be
+fact-focused, direct, and concrete. No buzzwords, no fluff, no dramatic
+terms.
+
+## Framing
+
+A design doc is **guide-level**, not implementation-level. Write it for
+the two audiences the template names:
+
+- Toasty users — Rust developers writing models and queries.
+- Driver implementors — anyone implementing the `Driver` trait.
+
+Describe what those audiences will see, call, and have to do. Omit
+internal module layouts and implementation choices that have no
+observable effect on either audience. The `User-facing API` section
+should read like a chapter of the user guide — prose with runnable
+examples, not an API catalog.
+
+## Workflow
+
+Non-trivial features follow the path in
+[`CONTRIBUTING.md`](../../../CONTRIBUTING.md): open a feature-proposal
+issue first, then land a roadmap entry in
+[`docs/dev/roadmap/`](../../../docs/dev/roadmap/) and the design doc
+**in the same PR**. The implementation lands as a follow-up PR once the
+design is accepted.

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -10,7 +10,7 @@ Load this skill before filing any issue in this project.
 ## Writing style
 
 An issue is project documentation. Follow the conventions from the
-[`write-docs`](../write-docs/SKILL.md) skill: be fact-focused, direct,
+[`prose`](../prose/SKILL.md) skill: be fact-focused, direct,
 and concrete. No buzzwords, no fluff, no dramatic terms. State what
 happened or what is being proposed, not how important it is.
 

--- a/.claude/skills/prose/SKILL.md
+++ b/.claude/skills/prose/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: write-docs
-description: Author or edit documentation for the Toasty project, following project writing conventions
+name: prose
+description: Author or edit any prose for the Toasty project — documentation, design docs, READMEs, PR descriptions, issue bodies, commit message bodies, or other human-readable text — following project writing conventions
 ---
 
-# Writing Toasty Documentation
+# Writing Toasty Prose
 
-Load this skill when writing or editing any documentation in the `docs/` directory or other markdown files in this project.
+Load this skill whenever writing or editing prose for this project: documentation in `docs/`, READMEs, design docs, PR descriptions, issue bodies, commit message bodies, or any other human-readable markdown.
 
 ## Writing Style
 


### PR DESCRIPTION
## Summary

Two improvements to the agent skills under `.claude/skills/`:

- Rename `write-docs` → `prose` and broaden its description from "documentation" to any prose the agent writes for the project — design docs, READMEs, PR descriptions, issue bodies, commit message bodies, or other markdown. The old name was too narrow; in practice the same writing conventions apply to all prose, and the rename makes the skill trigger reliably for those broader cases. Updates the cross-link in the `issue` skill.
- Add a new `design` skill for authoring design documents under `docs/dev/design/`. It directs the agent to `docs/dev/design/_template.md` as the authoritative layout, delegates writing style to the `prose` skill, and restates the guide-level / two-audience framing so the agent keeps the right reader in mind.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format

`cargo fmt` / `cargo clippy` / `cargo test` and the public-API / driver
checklist items are omitted — this PR only touches markdown under
`.claude/skills/`.

## Notes for reviewers

The conversation that produced this also weighed renaming `write-tests` to `test` for consistency with the single-word-noun pattern of the other skills (`commit`, `issue`, `pr`, `prose`, `design`). We decided to keep `write-tests` as-is: "test" is too ambiguous given how often the repo discusses running, debugging, and fixing tests, so the verb prefix is load-bearing there.