### PR TITLE
refactor: replace with_field closures with stmt::patch for embedded updates

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/embed_struct.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embed_struct.rs
@@ -582,9 +582,9 @@ pub async fn update_with_embedded_field_filter(t: &mut Test) -> Result<()> {
     Ok(())
 }
 
-/// Tests partial updates of embedded struct fields using with_field() builders.
-/// This validates that we can update individual fields within an embedded struct
-/// without replacing the entire struct.
+/// Tests partial updates of embedded struct fields via `stmt::patch` /
+/// `stmt::apply`. This validates that individual fields within an embedded
+/// struct can be updated without replacing the entire struct.
 #[driver_test(id(ID))]
 pub async fn partial_update_embedded_fields(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Embed)]
@@ -625,9 +625,7 @@ pub async fn partial_update_embedded_fields(t: &mut Test) -> Result<()> {
 
     // Partial update: only change city, leave street and zip unchanged
     user.update()
-        .with_address(|a| {
-            a.city("Seattle");
-        })
+        .address(toasty::stmt::patch(Address::fields().city(), "Seattle"))
         .exec(&mut db)
         .await?;
 
@@ -648,9 +646,10 @@ pub async fn partial_update_embedded_fields(t: &mut Test) -> Result<()> {
 
     // Multiple field update in one call
     user.update()
-        .with_address(|a| {
-            a.city("Portland").zip("97201");
-        })
+        .address(toasty::stmt::apply([
+            toasty::stmt::patch(Address::fields().city(), "Portland"),
+            toasty::stmt::patch(Address::fields().zip(), "97201"),
+        ]))
         .exec(&mut db)
         .await?;
 
@@ -669,14 +668,13 @@ pub async fn partial_update_embedded_fields(t: &mut Test) -> Result<()> {
         zip: "97201",
     });
 
-    // Multiple calls to with_address should accumulate
+    // Multiple calls to the address setter should accumulate
     user.update()
-        .with_address(|a| {
-            a.street("456 Oak Ave");
-        })
-        .with_address(|a| {
-            a.zip("97202");
-        })
+        .address(toasty::stmt::patch(
+            Address::fields().street(),
+            "456 Oak Ave",
+        ))
+        .address(toasty::stmt::patch(Address::fields().zip(), "97202"))
         .exec(&mut db)
         .await?;
 
@@ -1116,9 +1114,10 @@ pub async fn crud_nested_embedded(t: &mut Test) -> Result<()> {
     Ok(())
 }
 
-/// Tests partial updates of deeply nested embedded fields using chained closures.
-/// Validates that `with_outer(|o| o.with_inner(|i| i.field(v)))` updates only
-/// the targeted leaf field, leaving all other fields unchanged in the database.
+/// Tests partial updates of deeply nested embedded fields via nested
+/// `stmt::patch` calls. Validates that patching a leaf field inside an
+/// outer embedded struct updates only that leaf, leaving all other fields
+/// unchanged in the database.
 #[driver_test(id(ID))]
 pub async fn partial_update_nested_embedded(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Embed)]
@@ -1160,11 +1159,10 @@ pub async fn partial_update_nested_embedded(t: &mut Test) -> Result<()> {
     // street and headquarters.name must remain unchanged.
     company
         .update()
-        .with_headquarters(|h| {
-            h.with_address(|a| {
-                a.city("Seattle");
-            });
-        })
+        .headquarters(toasty::stmt::patch(
+            Office::fields().address().city(),
+            "Seattle",
+        ))
         .exec(&mut db)
         .await?;
 
@@ -1181,9 +1179,10 @@ pub async fn partial_update_nested_embedded(t: &mut Test) -> Result<()> {
     // address fields must remain unchanged.
     company
         .update()
-        .with_headquarters(|h| {
-            h.name("West Coast HQ");
-        })
+        .headquarters(toasty::stmt::patch(
+            Office::fields().name(),
+            "West Coast HQ",
+        ))
         .exec(&mut db)
         .await?;
 
@@ -1197,14 +1196,13 @@ pub async fn partial_update_nested_embedded(t: &mut Test) -> Result<()> {
     });
 
     // Combined update: change headquarters.name and headquarters.address.city
-    // in a single with_headquarters call. street must remain unchanged.
+    // in a single call via stmt::apply. street must remain unchanged.
     company
         .update()
-        .with_headquarters(|h| {
-            h.name("East Coast HQ").with_address(|a| {
-                a.city("Boston");
-            });
-        })
+        .headquarters(toasty::stmt::apply([
+            toasty::stmt::patch(Office::fields().name(), "East Coast HQ"),
+            toasty::stmt::patch(Office::fields().address().city(), "Boston"),
+        ]))
         .exec(&mut db)
         .await?;
 
@@ -1220,8 +1218,9 @@ pub async fn partial_update_nested_embedded(t: &mut Test) -> Result<()> {
 }
 
 /// Tests partial updates of embedded fields using the query/filter-based path.
-/// `User::filter_by_id(id).update().with_address(...)` follows a different code path
-/// than the instance-based `user.update().with_address(...)`, so both need coverage.
+/// `User::filter_by_id(id).update().address(stmt::patch(...))` follows a different
+/// code path than the instance-based `user.update().address(stmt::patch(...))`,
+/// so both need coverage.
 #[driver_test(id(ID))]
 pub async fn query_based_partial_update_embedded(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Embed)]
@@ -1256,9 +1255,7 @@ pub async fn query_based_partial_update_embedded(t: &mut Test) -> Result<()> {
     // street and zip must remain unchanged.
     User::filter_by_id(user.id)
         .update()
-        .with_address(|a| {
-            a.city("Seattle");
-        })
+        .address(toasty::stmt::patch(Address::fields().city(), "Seattle"))
         .exec(&mut db)
         .await?;
 
@@ -1272,9 +1269,10 @@ pub async fn query_based_partial_update_embedded(t: &mut Test) -> Result<()> {
     // Multiple fields: update city and zip together, leave street unchanged.
     User::filter_by_id(user.id)
         .update()
-        .with_address(|a| {
-            a.city("Portland").zip("97201");
-        })
+        .address(toasty::stmt::apply([
+            toasty::stmt::patch(Address::fields().city(), "Portland"),
+            toasty::stmt::patch(Address::fields().zip(), "97201"),
+        ]))
         .exec(&mut db)
         .await?;
 
@@ -1379,9 +1377,10 @@ pub async fn unit_enum_in_embedded_struct(t: &mut Test) -> Result<()> {
     assert_eq!(found.meta.priority, Priority::High);
 
     task.update()
-        .with_meta(|m| {
-            m.priority(Priority::Normal);
-        })
+        .meta(toasty::stmt::patch(
+            Meta::fields().priority().into(),
+            Priority::Normal,
+        ))
         .exec(&mut db)
         .await?;
 

--- a/crates/toasty-macros/src/lib.rs
+++ b/crates/toasty-macros/src/lib.rs
@@ -778,8 +778,8 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
 ///
 /// Reference an embedded type as a field on a [`Model`][`derive@Model`]
 /// struct. The parent model's create and update builders gain a setter for
-/// the embedded field. For embedded structs, a `with_<field>` method
-/// supports partial updates of individual sub-fields:
+/// the embedded field. Partial updates of individual sub-fields use
+/// `stmt::patch`:
 ///
 /// ```no_run
 /// # #[derive(toasty::Embed)]
@@ -793,14 +793,16 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
 /// #     address: Address,
 /// # }
 /// # async fn example(mut db: toasty::Db, mut user: User) -> toasty::Result<()> {
+/// use toasty::stmt;
+///
 /// // Full replacement
 /// user.update()
 ///     .address(Address { street: "456 Oak Ave".into(), city: "Seattle".into() })
 ///     .exec(&mut db).await?;
 ///
-/// // Partial update (struct only) — updates city, leaves street unchanged
+/// // Partial update — updates city, leaves street unchanged
 /// user.update()
-///     .with_address(|a| { a.city("Portland"); })
+///     .address(stmt::patch(Address::fields().city(), "Portland"))
 ///     .exec(&mut db).await?;
 /// # Ok(())
 /// # }
@@ -891,8 +893,12 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
 /// ).exec(&mut db).await?;
 ///
 /// // Partial update
+/// use toasty::stmt;
 /// doc.update()
-///     .with_meta(|m| { m.version(2).status("published"); })
+///     .meta(stmt::apply([
+///         stmt::patch(Metadata::fields().version(), 2),
+///         stmt::patch(Metadata::fields().status(), "published"),
+///     ]))
 ///     .exec(&mut db).await?;
 /// # Ok(())
 /// # }

--- a/crates/toasty-macros/src/model/expand/embedded_enum.rs
+++ b/crates/toasty-macros/src/model/expand/embedded_enum.rs
@@ -207,6 +207,12 @@ impl Expand<'_> {
                 #comparison_methods
             }
 
+            impl<__Origin> Into<#toasty::Path<__Origin, #model_ident>> for #field_struct_ident<__Origin> {
+                fn into(self) -> #toasty::Path<__Origin, #model_ident> {
+                    self.path
+                }
+            }
+
             #( #variant_field_structs )*
         }
     }

--- a/crates/toasty-macros/src/model/expand/update.rs
+++ b/crates/toasty-macros/src/model/expand/update.rs
@@ -24,28 +24,16 @@ impl Expand<'_> {
         }
     }
 
-    /// Expand all update methods for all fields.
-    /// Generates both the field setter methods and the .with_field() method for each field.
+    /// Expand the field setter methods for an update builder.
     /// For embedded builders: uses self.projection.clone().push(index) and self.assignments
     /// For root builders: uses Projection::from_index(index) and self.assignments
     fn expand_update_field_methods(&self, is_embedded: bool) -> TokenStream {
         let toasty = &self.toasty;
         let vis = &self.model.vis;
 
-        // For root builders, self.assignments is Assignments (owned),
-        // so &mut self.assignments gives &mut Assignments.
-        // For embedded builders, self.assignments is &'a mut Assignments,
-        // so we need &mut *self.assignments to reborrow.
-        let assignments_for_builder = if is_embedded {
-            quote!(&mut *self.assignments)
-        } else {
-            quote!(&mut self.assignments)
-        };
-
         self.model.fields.iter().enumerate().map(|(field_index, field)| {
             let field_ident = &field.name.ident;
             let set_field_ident = &field.set_ident;
-            let with_field_ident = &field.with_ident;
 
             let index = util::int(field_index);
             let projection = if is_embedded {
@@ -158,16 +146,6 @@ impl Expand<'_> {
                     #vis fn #set_field_ident(&mut self, #field_ident: impl #toasty::Assign<#ty>) -> &mut Self {
                         let projection = #projection;
                         #field_ident.assign(&mut self.assignments, projection);
-                        self
-                    }
-
-                    #vis fn #with_field_ident(
-                        mut self,
-                        f: impl FnOnce(<#ty as #toasty::Field>::Update<'_>)
-                    ) -> Self {
-                        let projection = #projection;
-                        let builder = <#ty as #toasty::Field>::new_update(#assignments_for_builder, projection);
-                        f(builder);
                         self
                     }
                 }

--- a/crates/toasty-macros/src/model/schema/field.rs
+++ b/crates/toasty-macros/src/model/schema/field.rs
@@ -34,9 +34,6 @@ pub(crate) struct Field {
     /// Identifier for setter method on update builder
     pub(crate) set_ident: syn::Ident,
 
-    /// Identifier for the `with_field` builder method on update builder
-    pub(crate) with_ident: syn::Ident,
-
     /// If this field belongs to an enum variant, the variant's index within
     /// the enum. `None` for fields on root models and embedded structs.
     pub(crate) variant: Option<usize>,
@@ -257,7 +254,6 @@ impl Field {
         };
 
         let set_ident = syn::Ident::new(&name.with_prefix("set"), span);
-        let with_ident = syn::Ident::new(&name.with_prefix("with"), span);
 
         let mut attrs = FieldAttr::from_attrs(&field.attrs)?;
 
@@ -393,7 +389,6 @@ impl Field {
             name,
             ty,
             set_ident,
-            with_ident,
             variant: None,
         })
     }

--- a/docs/guide/src/embedded-types.md
+++ b/docs/guide/src/embedded-types.md
@@ -200,17 +200,30 @@ user.update()
     .await?;
 ```
 
-Or update individual fields within the struct using a closure:
+Or patch individual fields within the struct with `stmt::patch`:
 
 ```rust,ignore
+use toasty::stmt;
+
 user.update()
-    .with_address(|a| { a.city("Portland"); })
+    .address(stmt::patch(Address::fields().city(), "Portland"))
     .exec(&mut db)
     .await?;
 ```
 
-The closure receives the embedded struct's update builder, so you only need to
-set the fields you want to change.
+`stmt::patch` targets a sub-field by its typed path and leaves the other
+fields of the embedded struct unchanged. Combine multiple sub-field updates
+with `stmt::apply`:
+
+```rust,ignore
+user.update()
+    .address(stmt::apply([
+        stmt::patch(Address::fields().street(), "456 Oak Ave"),
+        stmt::patch(Address::fields().city(), "Portland"),
+    ]))
+    .exec(&mut db)
+    .await?;
+```
 
 ### Nested embedding
 

--- a/tests/tests/ui/relation_has_one_requires_attr.stderr
+++ b/tests/tests/ui/relation_has_one_requires_attr.stderr
@@ -16,24 +16,6 @@ error[E0277]: the trait bound `toasty::HasOne<Option<Profile>>: toasty::schema::
           and $N others
 
 error[E0277]: the trait bound `toasty::HasOne<Option<Profile>>: toasty::schema::Field` is not satisfied
- --> tests/ui/relation_has_one_requires_attr.rs:1:10
-  |
-1 | #[derive(toasty::Model)]
-  |          ^^^^^^^^^^^^^ the trait `toasty::schema::Field` is not implemented for `toasty::HasOne<Option<Profile>>`
-  |
-  = help: the following other types implement trait `toasty::schema::Field`:
-            Arc<T>
-            Box<T>
-            Option<T>
-            Rc<T>
-            Vec<u8>
-            bigdecimal::BigDecimal
-            bool
-            f32
-          and $N others
-  = note: this error originates in the derive macro `toasty::Model` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the trait bound `toasty::HasOne<Option<Profile>>: toasty::schema::Field` is not satisfied
  --> tests/ui/relation_has_one_requires_attr.rs:7:14
   |
 7 |     profile: toasty::HasOne<Option<Profile>>,


### PR DESCRIPTION
## Summary

This PR replaces the closure-based `with_field()` builder methods for partial updates of embedded struct fields with the more explicit `stmt::patch()` and `stmt::apply()` API. This change simplifies the generated code and provides a clearer, more composable interface for targeting specific nested fields.

### Key Changes

1. **Removed `with_field()` methods** from the update builder code generation in `expand_update_field_methods()`. These closure-based methods are no longer generated for embedded fields.

2. **Updated all test cases** to use the new `stmt::patch()` API:
   - Single field updates: `.address(stmt::patch(Address::fields().city(), "Seattle"))`
   - Multiple field updates: `.address(stmt::apply([stmt::patch(...), stmt::patch(...)]))`
   - Nested embedded updates: `.headquarters(stmt::patch(Office::fields().address().city(), "Seattle"))`

3. **Added `Into<Path>` implementation** for embedded enum field structs to support conversion to path types needed by `stmt::patch()`.

4. **Updated documentation** in the `Embed` derive macro docs and the embedded types guide to reflect the new API and remove references to closure-based updates.

5. **Removed field metadata** (`with_ident`) that was only used for generating the now-removed `with_field()` methods.

6. **Fixed UI test expectations** to account for the removal of duplicate error messages (the `with_field()` method generation no longer produces additional trait bound errors).

### Benefits

- **Clearer intent**: `stmt::patch()` explicitly shows which field is being targeted
- **Better composability**: Multiple patches can be combined with `stmt::apply()`
- **Reduced code generation**: Eliminates the need for closure-based builder methods
- **Consistent API**: Uses the same `stmt::patch()` mechanism across instance-based and query-based updates

## Type of change

- [x] Implements a previously accepted design
- [ ] Small / obvious change — bug fix, docs, internal cleanup, or test
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → design covered by the refactoring
- [x] Updated integration tests and documentation

## Notes for reviewers

The core logic change is in `expand_update_field_methods()` where the `with_field()` method generation was removed. All integration tests have been updated to use the new API and pass. The UI test changes reflect the removal of duplicate error messages that were generated when `with_field()` methods were created.

https://claude.ai/code/session_013BCYW2Y6wsGDMFWkNgncMK