### PR TITLE
docs: explain why transaction APIs take `&mut self`

### DIFF
--- a/crates/toasty/src/db.rs
+++ b/crates/toasty/src/db.rs
@@ -128,12 +128,24 @@ impl Db {
     }
 
     /// Begin a transaction, acquiring a connection from the pool.
+    ///
+    /// Takes `&mut self` so the `Db` handle is exclusively borrowed while the
+    /// transaction is open. This prevents accidentally running a statement
+    /// against the pool — which would execute on a separate connection and
+    /// bypass the transaction — when you meant to run it against `&mut tx`.
+    ///
+    /// If you need a second handle while the transaction is open, clone the
+    /// `Db` before calling this method. Clones share the same pool.
     pub async fn transaction(&mut self) -> Result<Transaction<'_>> {
         <Self as Executor>::transaction(self).await
     }
 
     /// Returns a [`TransactionBuilder`] that will acquire a connection from
     /// the pool when [`begin`](TransactionBuilder::begin) is called.
+    ///
+    /// Like [`transaction`](Self::transaction), this takes `&mut self` so the
+    /// `Db` handle stays locked for the lifetime of the transaction. Clone
+    /// the `Db` beforehand if you need a separate handle.
     pub fn transaction_builder(&mut self) -> TransactionBuilder<'_> {
         TransactionBuilder::new(tx::TxSource::Db(self))
     }

--- a/crates/toasty/src/db/connection.rs
+++ b/crates/toasty/src/db/connection.rs
@@ -68,12 +68,20 @@ impl Connection {
     }
 
     /// Begin a transaction on this connection.
+    ///
+    /// Takes `&mut self` so the `Connection` is exclusively borrowed while
+    /// the transaction is open. This prevents statements from running on the
+    /// connection directly — bypassing the transaction — when they should
+    /// have gone through `&mut tx`.
     pub async fn transaction(&mut self) -> crate::Result<super::Transaction<'_>> {
         <Self as super::Executor>::transaction(self).await
     }
 
     /// Returns a [`TransactionBuilder`](super::TransactionBuilder) that will
     /// use this connection.
+    ///
+    /// Like [`transaction`](Self::transaction), this takes `&mut self` so the
+    /// `Connection` stays locked for the lifetime of the transaction.
     pub fn transaction_builder(&mut self) -> super::TransactionBuilder<'_> {
         super::TransactionBuilder::new(super::tx::TxSource::Connection(self))
     }

--- a/crates/toasty/src/db/executor.rs
+++ b/crates/toasty/src/db/executor.rs
@@ -13,6 +13,11 @@ use toasty_core::{Schema, driver::ExecResponse};
 #[async_trait]
 pub trait Executor: Send + Sync {
     /// Starts a (potentially nested) transaction.
+    ///
+    /// Takes `&mut self` so the executor is exclusively borrowed while the
+    /// transaction is open. This prevents statements from accidentally
+    /// executing on the parent handle rather than through `&mut tx`, which
+    /// would bypass the transaction.
     async fn transaction(&mut self) -> Result<Transaction<'_>>;
 
     /// Execute an untyped statement, returning the full execution response.

--- a/crates/toasty/src/db/tx.rs
+++ b/crates/toasty/src/db/tx.rs
@@ -154,6 +154,11 @@ impl<'a> Transaction<'a> {
     }
 
     /// Create a nested transaction (savepoint).
+    ///
+    /// Takes `&mut self` so the outer transaction is exclusively borrowed
+    /// while the nested one is open. This prevents statements from running
+    /// against the outer transaction — bypassing the savepoint — when they
+    /// should have gone through the nested handle.
     pub async fn transaction(&mut self) -> Result<Transaction<'_>> {
         <Self as Executor>::transaction(self).await
     }

--- a/docs/guide/src/transactions.md
+++ b/docs/guide/src/transactions.md
@@ -39,6 +39,31 @@ The transaction borrows `&mut Db`, preventing other operations on the same `Db`
 handle while the transaction is open. Pass `&mut tx` to query builders the same
 way you pass `&mut db`.
 
+The exclusive borrow is deliberate. Without it, it would be easy to run a
+statement against `db` while holding `tx` — that statement would execute on a
+separate connection pulled from the pool, bypassing the transaction entirely.
+The `&mut` keeps `db` unusable until the transaction ends, so every statement
+has to go through `&mut tx`.
+
+If you genuinely need a second handle while a transaction is open — for
+example, an independent task doing unrelated work — clone the `Db` before
+starting the transaction:
+
+```rust,ignore
+let mut db2 = db.clone();
+let mut tx = db.transaction().await?;
+
+// `db2` is a separate handle backed by the same pool; use it freely
+// for work that is not part of `tx`.
+```
+
+Clones share the underlying pool, so cloning is cheap and does not open a new
+connection.
+
+The same rule applies to transactions started from a `Connection` and to
+nested transactions created from an existing `Transaction`: each takes
+`&mut self` so statements cannot accidentally bypass the innermost scope.
+
 ## Running queries in a transaction
 
 All the same operations work inside a transaction — creates, queries, updates,


### PR DESCRIPTION
## Summary

Document on every transaction-starting API — `Db::transaction`, `Db::transaction_builder`, `Connection::transaction`, `Connection::transaction_builder`, `Transaction::transaction` (nested/savepoint), and the `Executor::transaction` trait method — that the exclusive `&mut self` borrow is deliberate: it stops callers from accidentally running a statement on the parent handle, pulling a fresh connection from the pool and bypassing the transaction.

Also expand the transactions guide with the same explanation, plus a short snippet showing the escape hatch — clone the `Db` beforehand when a parallel handle is genuinely needed.

Docs-only; no behavior change.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

Wording is the main thing to look at. The rustdoc notes are deliberately short and consistent across the five methods; the guide carries the longer version with the clone example.