### PR TITLE
ci: allow non-write users in Claude triage workflow

### DIFF
--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_non_write_users: "*"
           prompt: |
             You are a triage bot for the toasty repository. Apply GitHub labels
             to issue #${{ github.event.issue.number }} based on its content.


### PR DESCRIPTION
## Summary

Updates the Claude triage workflow to allow non-write users to trigger the workflow by setting `allowed_non_write_users` to `"*"`. This enables the triage bot to process issues from all users, not just those with write access to the repository.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format

## Notes for reviewers

This change expands the triage bot's accessibility to process issues from external contributors and users without write permissions to the repository.

https://claude.ai/code/session_01AHwQpfCrYJTpFv6bzuxhQm