### PR TITLE
fix: support raw identifier fields in model schema

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -45,6 +45,7 @@ pub mod infra_reset_db;
 pub mod infra_sync_send;
 pub mod key_unsigned;
 pub mod query_count;
+pub mod raw_identifier_fields;
 pub mod record_not_found;
 pub mod relation_belongs_to_configured;
 pub mod relation_belongs_to_one_way;

--- a/crates/toasty-driver-integration-suite/src/tests/raw_identifier_fields.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/raw_identifier_fields.rs
@@ -1,0 +1,36 @@
+use crate::prelude::*;
+
+#[driver_test(id(ID))]
+pub async fn create_filter_update_by_raw_identifier_field(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+
+        #[index]
+        r#type: String,
+    }
+
+    let mut db = t.setup_db(models!(User)).await;
+
+    let mut user = toasty::create!(User { r#type: "admin" })
+        .exec(&mut db)
+        .await?;
+    assert_eq!(user.r#type, "admin");
+
+    let reload = User::get_by_id(&mut db, &user.id).await?;
+    assert_eq!(reload.r#type, "admin");
+
+    let by_type = User::filter_by_type("admin").exec(&mut db).await?;
+    assert_eq!(by_type.len(), 1);
+    assert_eq!(by_type[0].id, user.id);
+
+    user.update().r#type("guest").exec(&mut db).await?;
+    assert_eq!(user.r#type, "guest");
+
+    let reload = User::get_by_id(&mut db, &user.id).await?;
+    assert_eq!(reload.r#type, "guest");
+
+    Ok(())
+}

--- a/crates/toasty-macros/src/model/expand/embedded_enum.rs
+++ b/crates/toasty-macros/src/model/expand/embedded_enum.rs
@@ -276,7 +276,7 @@ impl Expand<'_> {
             .iter()
             .map(|field| {
                 let index = util::int(field.id);
-                let app_name = field.name.ident.to_string();
+                let app_name = field.name.as_str();
                 let ty = primitive_ty_unwrap(field);
                 let variant_index = field.variant.expect("enum field must have variant");
                 let variant_idx = util::int(variant_index);

--- a/crates/toasty-macros/src/model/expand/fields.rs
+++ b/crates/toasty-macros/src/model/expand/fields.rs
@@ -248,7 +248,7 @@ impl Expand<'_> {
             .iter()
             .enumerate()
             .map(move |(offset, field)| {
-                let field_name = field.name.ident.to_string();
+                let field_name = field.name.as_str();
                 let field_offset = util::int(offset);
 
                 quote!( #field_name => #toasty::core::schema::app::FieldId { model: Self::id(), index: #field_offset }, )

--- a/crates/toasty-macros/src/model/expand/filters.rs
+++ b/crates/toasty-macros/src/model/expand/filters.rs
@@ -323,7 +323,7 @@ impl<'a> BuildModelFilters<'a> {
 
         for index in fields {
             name.push_str(prefix);
-            name.push_str(&self.model.fields[*index].name.as_str());
+            name.push_str(self.model.fields[*index].name.as_str());
 
             prefix = "_and_";
         }

--- a/crates/toasty-macros/src/model/expand/filters.rs
+++ b/crates/toasty-macros/src/model/expand/filters.rs
@@ -323,7 +323,7 @@ impl<'a> BuildModelFilters<'a> {
 
         for index in fields {
             name.push_str(prefix);
-            name.push_str(&self.model.fields[*index].name.ident.to_string());
+            name.push_str(&self.model.fields[*index].name.as_str());
 
             prefix = "_and_";
         }

--- a/crates/toasty-macros/src/model/expand/model.rs
+++ b/crates/toasty-macros/src/model/expand/model.rs
@@ -389,7 +389,7 @@ impl Expand<'_> {
         let field_loads = self.model.fields.iter().enumerate().map(|(index, field)| {
             let field_ident = &field.name.ident;
             let index_tokenized = util::int(index);
-            let field_name_str = field.name.ident.to_string();
+            let field_name_str = field.name.as_str();
 
             let field_name = if fields_named {
                 quote!(#field_ident:)
@@ -469,7 +469,7 @@ impl Expand<'_> {
 
         let reload_arms = self.model.fields.iter().enumerate().map(|(index, field)| {
             let i = util::int(index);
-            let field_name_str = field.name.ident.to_string();
+            let field_name_str = field.name.as_str();
 
             // For newtypes, access via tuple index (target.0); otherwise by name
             let field_access = if fields_named {

--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -91,7 +91,7 @@ impl Expand<'_> {
 
             let name = {
                 let app_name = if field_named {
-                    let n = field.name.ident.to_string();
+                    let n = field.name.as_str();
                     quote! { Some(#n.to_string()) }
                 } else {
                     quote! { None }

--- a/crates/toasty-macros/src/model/expand/update.rs
+++ b/crates/toasty-macros/src/model/expand/update.rs
@@ -349,7 +349,7 @@ impl Expand<'_> {
         self.model.fields.iter().enumerate().map(|(offset, field)| {
             let i = util::int(offset);
             let field_ident = &field.name.ident;
-            let field_name_str = field.name.ident.to_string();
+            let field_name_str = field.name.as_str();
 
             match &field.ty {
                 FieldTy::Primitive(_ty) if field.attrs.serialize.is_some() => {

--- a/crates/toasty-macros/src/model/schema/name.rs
+++ b/crates/toasty-macros/src/model/schema/name.rs
@@ -16,6 +16,13 @@ impl Name {
     }
 
     pub(crate) fn from_str(src: &str, span: Span) -> Self {
+        // Strip the raw identifier prefix (`r#`) if present so it does not get
+        // mangled by snake-case conversion (e.g. `r#type` → `r_type`).
+        let (raw, src) = match src.strip_prefix("r#") {
+            Some(stripped) => (true, stripped),
+            None => (false, src),
+        };
+
         // TODO: improve logic. There are a bunch of issues going on here. The
         // big one is, unnamed fields call this method passing in names like
         // `_0`. `to_snake_case` strips leading underscores (e.g. "_0" → "0"),
@@ -29,14 +36,26 @@ impl Name {
         };
         let parts: Vec<_> = snake.split("_").map(String::from).collect();
 
-        let ident = syn::Ident::new(&parts.join("_"), span);
+        let joined = parts.join("_");
+        let ident = if raw {
+            syn::Ident::new_raw(&joined, span)
+        } else {
+            syn::Ident::new(&joined, span)
+        };
 
         Self { parts, ident }
     }
 
+    /// The bare snake-case name as a string, without any `r#` prefix.
+    pub(crate) fn as_str(&self) -> String {
+        self.parts.join("_")
+    }
+
     pub(crate) fn with_prefix(&self, prefix: &str) -> String {
-        // Another hack (handling the same case as described in from_str).
-        let name = self.ident.to_string();
+        // Use the bare name (without any `r#` prefix) so the result is a valid
+        // Rust identifier. Another hack: handles the `_0` case described in
+        // `from_str` by checking for a leading underscore.
+        let name = self.as_str();
 
         if name.starts_with("_") {
             format!("{prefix}{name}")

--- a/crates/toasty-macros/src/model/schema/name.rs
+++ b/crates/toasty-macros/src/model/schema/name.rs
@@ -6,6 +6,10 @@ pub(crate) struct Name {
     /// Name parts
     pub(crate) parts: Vec<String>,
 
+    /// Snake-case form of the name (`parts` joined by `_`), without any
+    /// raw-identifier (`r#`) prefix.
+    pub(crate) snake_case: String,
+
     /// field/var identifier
     pub(crate) ident: syn::Ident,
 }
@@ -36,26 +40,30 @@ impl Name {
         };
         let parts: Vec<_> = snake.split("_").map(String::from).collect();
 
-        let joined = parts.join("_");
+        let snake_case = parts.join("_");
         let ident = if raw {
-            syn::Ident::new_raw(&joined, span)
+            syn::Ident::new_raw(&snake_case, span)
         } else {
-            syn::Ident::new(&joined, span)
+            syn::Ident::new(&snake_case, span)
         };
 
-        Self { parts, ident }
+        Self {
+            parts,
+            snake_case,
+            ident,
+        }
     }
 
-    /// The bare snake-case name as a string, without any `r#` prefix.
-    pub(crate) fn as_str(&self) -> String {
-        self.parts.join("_")
+    /// The bare snake-case name, without any `r#` prefix.
+    pub(crate) fn as_str(&self) -> &str {
+        &self.snake_case
     }
 
     pub(crate) fn with_prefix(&self, prefix: &str) -> String {
         // Use the bare name (without any `r#` prefix) so the result is a valid
         // Rust identifier. Another hack: handles the `_0` case described in
         // `from_str` by checking for a leading underscore.
-        let name = self.as_str();
+        let name = &self.snake_case;
 
         if name.starts_with("_") {
             format!("{prefix}{name}")

--- a/crates/toasty-macros/src/model/schema/variant.rs
+++ b/crates/toasty-macros/src/model/schema/variant.rs
@@ -68,7 +68,8 @@ impl Variant {
     ) -> syn::Result<Self> {
         let fields_named = matches!(&variant.fields, syn::Fields::Named(_));
         let name = Name::from_ident(&variant.ident);
-        let is_method_ident = syn::Ident::new(&format!("is_{}", name.ident), variant.ident.span());
+        let is_method_ident =
+            syn::Ident::new(&format!("is_{}", name.as_str()), variant.ident.span());
 
         let (variant_handle_ident, field_struct_ident) = if !has_fields {
             (None, None)


### PR DESCRIPTION
## Summary

This change fixes support for Rust raw identifier syntax (e.g., `r#type`) in model field names. Previously, the `Name` struct would mangle raw identifiers during snake-case conversion, causing issues with field name generation for filters, updates, and schema operations.

The fix introduces a `snake_case` field to the `Name` struct that stores the bare snake-case name without the `r#` prefix, and adds an `as_str()` method to access it. This ensures that generated code uses the correct field names in all contexts (filters, updates, schema definitions) while preserving the raw identifier syntax in the actual Rust identifiers.

Fixes #754 

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Added integration test covering raw identifier fields

## Notes for reviewers

The key changes are:
1. **`Name::from_str()`**: Now strips the `r#` prefix before snake-case conversion and stores both the raw identifier flag and the bare snake-case name
2. **`Name::as_str()`**: New method to access the bare snake-case name without `r#` prefix
3. **`Name::with_prefix()`**: Updated to use the bare name to ensure valid Rust identifiers
4. **Code generation**: All field name string generation now uses `field.name.as_str()` instead of `field.name.ident.to_string()` to avoid including the `r#` prefix in generated code
5. **Integration test**: New test `create_filter_update_by_raw_identifier_field` verifies that models with raw identifier fields (like `r#type`) work correctly for create, filter, and update operations

https://claude.ai/code/session_016kcjfiDnLAU3bGZTVE8UKV