### PR TITLE
docs: clarify limit and pagination behavior with filtering

### DIFF
--- a/crates/toasty/src/stmt/page.rs
+++ b/crates/toasty/src/stmt/page.rs
@@ -9,7 +9,12 @@ use toasty_core::stmt;
 ///
 /// Obtained by calling [`Paginate::exec`]. The
 /// page contains up to `per_page` items and optional cursors for fetching the
-/// next or previous page.
+/// next or previous page. `per_page` is an upper bound, not a guarantee:
+/// Toasty applies the page size at the database query and may filter the
+/// returned rows further, so a page can have fewer items than `per_page` even
+/// when more results exist. Use [`has_next`](Page::has_next) (or check
+/// `next_cursor`) to detect the end of the result set rather than relying on
+/// page size.
 ///
 /// `Page<M>` dereferences to `[M]`, so it can be used anywhere a slice is
 /// expected.

--- a/crates/toasty/src/stmt/paginate.rs
+++ b/crates/toasty/src/stmt/paginate.rs
@@ -171,7 +171,11 @@ impl<M: Load> Paginate<M> {
     /// Execute the paginated query and return a [`Page`](super::Page).
     ///
     /// The returned page contains up to `per_page` items along with optional
-    /// cursors for the next and previous pages.
+    /// cursors for the next and previous pages. `per_page` is an upper bound,
+    /// not a guarantee. The page size is applied to the database query, but
+    /// Toasty may filter the returned rows further, so a page can have fewer
+    /// than `per_page` items even when more results exist. Continue paging
+    /// until `next_cursor` is `None` to consume the full result set.
     ///
     /// # Examples
     ///

--- a/crates/toasty/src/stmt/query.rs
+++ b/crates/toasty/src/stmt/query.rs
@@ -175,6 +175,12 @@ impl<T> Query<T> {
 
     /// Limit the number of records returned.
     ///
+    /// `n` is an upper bound, not a guarantee. The limit is applied to the
+    /// database query, but Toasty may apply additional filtering to the rows
+    /// the database returns. When that happens, the final result can have
+    /// fewer than `n` records even if more than `n` rows match the filter
+    /// expression.
+    ///
     /// # Examples
     ///
     /// ```
@@ -300,6 +306,10 @@ impl<T> Query<List<T>> {
     /// The resulting `Query<Option<T>>` returns `Some(record)` if at least one
     /// row matches, or `None` if no rows match.
     ///
+    /// This applies `LIMIT 1` to the database query. Toasty may then filter
+    /// the returned row, so `None` does not always mean that no rows in the
+    /// table match the filter expression.
+    ///
     /// # Examples
     ///
     /// ```
@@ -326,6 +336,10 @@ impl<T> Query<List<T>> {
     ///
     /// The resulting `Query<T>` returns the record directly. If no rows match,
     /// execution returns an error.
+    ///
+    /// This applies `LIMIT 1` to the database query. If Toasty filters the
+    /// returned row out, execution returns the same error as when the database
+    /// returns no rows.
     ///
     /// # Examples
     ///

--- a/docs/guide/src/sorting-limits-and-pagination.md
+++ b/docs/guide/src/sorting-limits-and-pagination.md
@@ -84,6 +84,13 @@ let items = Item::all().limit(5).exec(&mut db).await?;
 If the query matches fewer records than the limit, all matching records are
 returned.
 
+`.limit(n)` is an upper bound, not a guarantee. Toasty applies the limit to
+the database query, but it may filter the returned rows further before
+producing the final result set. When that happens, a query can return fewer
+than `n` records even if more than `n` rows match the filter expression. Use
+[cursor-based pagination](#cursor-based-pagination) to walk every matching
+record.
+
 Combine `.order_by()` with `.limit()` to get the top or bottom N records:
 
 ```rust
@@ -178,6 +185,13 @@ println!("items: {}", page.len());
 
 A `Page` dereferences to a slice, so you can index into it, iterate over it, and
 call slice methods like `.len()` and `.iter()` directly.
+
+`per_page` is an upper bound on the page size, not a guarantee. Toasty
+applies it to the database query, but it may filter the returned rows further
+before producing the page. A page can therefore contain fewer than `per_page`
+items even when more results exist. Check `.has_next()` (or follow
+`.next()` until it returns `None`) to detect the end of the result set rather
+than relying on the size of any individual page.
 
 ### Navigating pages
 


### PR DESCRIPTION
## Summary

This PR adds documentation clarifying that `limit()` and pagination methods (`one()`, `one_or_error()`, and `exec()` on paginated queries) apply size constraints to the database query, but Toasty may apply additional filtering to the returned rows. This means the final result can have fewer records than the limit/page size even when more rows match the filter expression.

The changes document this behavior in:
- Rust doc comments for `Query::limit()`, `Query::one()`, and `Query::one_or_error()`
- Rust doc comments for `Page` and `Paginate::exec()`
- User guide documentation in `sorting-limits-and-pagination.md`

This clarification helps users understand why they might receive fewer results than expected and guides them toward cursor-based pagination for walking every matching record.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Documentation only change

## Notes for reviewers

This is a documentation-only change that clarifies existing behavior. No code logic is modified, only comments and guide documentation are updated to better explain how limits and pagination interact with Toasty's filtering.

https://claude.ai/code/session_01WNxo18NZEeCBH7fHw4yzX1