### PR TITLE
chore: filter generated changelogs through Claude

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -51,9 +51,17 @@ jobs:
     steps:
       - *checkout
       - *install-rust
+      # The changelog postprocessor in release-plz.toml shells out to
+      # `claude` to filter each rendered release section down to changes
+      # that matter to library consumers. The script falls back to
+      # passthrough on any error, so an outage or missing token will
+      # surface the unfiltered changelog rather than block the release.
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -4,6 +4,15 @@ pr_draft = true
 pr_labels = ["release"]
 release_always = true
 
+[changelog]
+# Pipe each rendered release section through Claude to filter for
+# user-relevant changes only (drops internal refactors, CI, dev docs,
+# tests). The script falls back to passthrough on any failure, so a
+# missing claude binary or auth issue won't break a release.
+postprocessors = [
+  { pattern = '(?s).*', replace_command = 'scripts/rewrite-changelog.sh' },
+]
+
 [[package]]
 name = "toasty"
 version_group = "toasty"

--- a/scripts/rewrite-changelog.sh
+++ b/scripts/rewrite-changelog.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Reads a release-plz / git-cliff changelog section on stdin and prints a
+# user-focused rewrite on stdout.
+#
+# Designed to be wired into release-plz.toml as a [changelog] postprocessor:
+#
+#     [changelog]
+#     postprocessors = [
+#       { pattern = '(?s).*', replace_command = 'scripts/rewrite-changelog.sh' },
+#     ]
+#
+# Behavior:
+#   * Reads entire stdin.
+#   * If the input is empty or doesn't look like a release section
+#     (no `## [` heading), passes it through unchanged.
+#   * Otherwise, invokes `claude -p` to rewrite the section, keeping only
+#     entries that matter to library consumers (features and fixes that
+#     affect behavior or public API). Internal refactors, CI, chores, dev
+#     docs, and test changes are dropped.
+#   * Caches successful rewrites by SHA-256 of stdin so repeated invocations
+#     with the same input (release-plz calls the postprocessor several
+#     times per release) only pay for one Claude call.
+#   * On any failure (claude missing, non-zero exit, suspicious output),
+#     prints the original input unchanged so release-plz never breaks.
+
+set -uo pipefail
+
+INPUT="$(cat)"
+
+# Only rewrite real release sections — must contain a versioned heading
+# (## [X.Y...]) AND at least one bullet. Skip the file header and skip
+# empty queries.
+if [ -z "$INPUT" ] \
+  || ! printf '%s' "$INPUT" | grep -Eq '^## \[[0-9]' \
+  || ! printf '%s' "$INPUT" | grep -Eq '^- '; then
+  printf '%s' "$INPUT"
+  exit 0
+fi
+
+CACHE_DIR="${CHANGELOG_REWRITE_CACHE_DIR:-${TMPDIR:-/tmp}/toasty-changelog-rewrite}"
+mkdir -p "$CACHE_DIR"
+HASH="$(printf '%s' "$INPUT" | shasum -a 256 | awk '{print $1}')"
+CACHE_FILE="$CACHE_DIR/$HASH.md"
+
+if [ -f "$CACHE_FILE" ]; then
+  cat "$CACHE_FILE"
+  exit 0
+fi
+
+if ! command -v claude >/dev/null 2>&1; then
+  printf '%s' "$INPUT"
+  exit 0
+fi
+
+read -r -d '' PROMPT <<'PROMPT_EOF' || true
+You are rewriting one release section of a Rust crate changelog so that only changes that matter to LIBRARY CONSUMERS appear. Output ONLY the rewritten markdown — no preamble, no commentary, no code fences, no XML tags, no system reminders.
+
+Rules:
+
+KEEP:
+  - New public API, new features, new query/macro capabilities.
+  - Bug fixes that affect runtime behavior, panics, query results, or codegen.
+  - Breaking changes (mark with [**breaking**] if not already marked).
+  - New driver or database support.
+  - User-visible performance improvements.
+
+DROP:
+  - Internal refactors and code reorganizations with no API change.
+  - CI / tooling / lint / clippy / formatting changes.
+  - Test-only changes.
+  - Dev-doc updates (design docs, contributing guides, internal architecture notes).
+  - README typo or link fixes that don't change documented behavior.
+  - Dependency bumps unless they raise MSRV or change a public re-export.
+  - Typo fixes in code comments.
+  - Renames that are not visible in the public API.
+
+FORMAT:
+  - Preserve the version heading line (## [...]...) exactly as given.
+  - Use ### Added, ### Fixed, and ### Changed subsections only. Drop ### Other entirely (move kept items into the right section, or drop them).
+  - Preserve PR links exactly as given (e.g. ([#123](...))).
+  - Rewrite each kept bullet so it reads as a user-facing benefit. Drop implementation jargon. Use sentence case. No trailing period.
+  - Group related entries; merge near-duplicates into a single line.
+  - Omit empty subsections.
+  - If no entries are user-relevant at all, output the version heading followed by a blank line and one bullet: "- Internal improvements only."
+  - End with exactly one trailing newline.
+
+Input changelog section:
+
+PROMPT_EOF
+
+OUTPUT="$(printf '%s%s\n' "$PROMPT" "$INPUT" | claude -p \
+  --model claude-haiku-4-5 \
+  --setting-sources '' \
+  --disable-slash-commands \
+  --permission-mode plan \
+  2>/dev/null)"
+
+# Sanity-check the output: must be non-empty, must not be a login error,
+# must contain the original version heading line.
+HEADING="$(printf '%s' "$INPUT" | grep -m1 '^## \[' || true)"
+if [ -z "$OUTPUT" ] \
+  || printf '%s' "$OUTPUT" | grep -qi 'not logged in\|please run /login\|api error' \
+  || ! printf '%s' "$OUTPUT" | grep -qF "$HEADING"; then
+  printf '%s' "$INPUT"
+  exit 0
+fi
+
+# Strip any leaked <system-reminder>...</system-reminder> blocks and trim any
+# leading or trailing blank lines from Claude output. release-plz/git-cliff
+# expect each rendered section to be wrapped with one leading and one trailing
+# blank line so that consecutive sections in the assembled CHANGELOG.md are
+# separated, so we re-add those wrappers ourselves below.
+OUTPUT="$(printf '%s\n' "$OUTPUT" | awk '
+  /<system-reminder>/ { skip=1; next }
+  /<\/system-reminder>/ { skip=0; next }
+  !skip { lines[++n] = $0 }
+  END {
+    s = 1; while (s <= n && lines[s] == "") s++
+    e = n; while (e >= s && lines[e] == "") e--
+    for (i = s; i <= e; i++) print lines[i]
+  }
+')"
+
+FINAL=$'\n'"$OUTPUT"$'\n'
+printf '%s' "$FINAL" >"$CACHE_FILE"
+printf '%s' "$FINAL"


### PR DESCRIPTION
## Summary

Pipe each rendered release section through `claude -p` so the published changelog reflects what matters to library consumers — features, fixes, breaking changes — and drops internal refactors, CI, dev-doc, and test-only entries.

`scripts/rewrite-changelog.sh` is wired in as a release-plz `[changelog]` postprocessor. The `release-plz-pr` workflow job installs the Claude Code CLI and forwards the existing `CLAUDE_CODE_OAUTH_TOKEN` secret (the same one the triage workflow already uses). The script caches by content hash — release-plz invokes postprocessors multiple times per release — and falls back to passthrough on any error, so a missing CLI, expired token, or API outage surfaces the unfiltered changelog rather than blocking the release.

## Type of change

- [x] Other: release-tooling change with no impact on the published crate.

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format

## Notes for reviewers

The KEEP / DROP rules and formatting rules live inside the script's prompt — that's the surface to tweak if the rewrite output doesn't match the voice you want.

The fallback-to-passthrough path is the load-bearing safety net: the script's exit-0 cases on missing binary, login error, output that doesn't contain the input version heading, or empty output all just echo stdin back. Worth a careful read.

Tested locally against the `toasty-v0.4.0..HEAD` range over all 11 crates via `release-plz update --allow-dirty`. Sample diff for the toasty crate's `[0.4.1]` section:

**Before** (current default):
```
### Fixed
- roadmap link in README (#758)
- gate simplification rules on expression stability (#703)
- nested includes sharing a prefix being overwritten (#699)
- `.first()` to return first row instead of panicking on multiple matches (#693)

### Other
- explain why transaction APIs take `&mut self` (#752)
- use hashbrown's HashMap/HashSet instead of std (#729)
- setup pr/issue templates (#715)
- engine/lower: fix 'occured' -> 'occurred' in doc comment (#690)
- handle relation fields in Relation trait (#706)
- wrap hash-based Value lookups in dedicated types (#705)
- handle new clippy warnings and fix CI (#695)
```

**After**:
```
### Fixed
- Simplification rules are now properly gated on expression stability (#703)
- Nested includes sharing a prefix no longer get overwritten (#699)
- `.first()` now returns the first row instead of panicking on multiple matches (#693)
```

`### Other` is dropped entirely; the README link, comment-typo fix, and refactor/CI entries are gone; surviving bullets are sentence-cased and given user-facing wording. The full per-crate before/after lives in `/tmp/changelog-demo/` on my machine — happy to paste any specific crate into a comment.