### PR TITLE
chore: add succinctness guidance to prose-writing skills

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -11,3 +11,10 @@ Load this skill before writing any git commit message in this project.
 authoring a commit message.** It is the authoritative source for the
 format, allowed types, scope conventions, subject/body/footer rules, and
 breaking-change notation.
+
+## Be succinct
+
+Maintainers reading the log already know Toasty and Rust. Keep the
+subject and body high-signal: state what changed and why. Skip
+restated context, obvious explanations, and throat-clearing. A
+maintainer should grasp the important bits in seconds.

--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -23,6 +23,13 @@ Follow the conventions from the [`prose`](../prose/SKILL.md) skill: be
 fact-focused, direct, and concrete. No buzzwords, no fluff, no dramatic
 terms.
 
+## Be succinct
+
+Readers already know Toasty and Rust. Lead with the problem and the
+proposal so a maintainer can grasp the important bits quickly. Cut
+restated background, obvious explanations, and throat-clearing.
+Length is not a virtue; clarity is.
+
 ## Framing
 
 A design doc is **guide-level**, not implementation-level. Write it for

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -14,6 +14,14 @@ An issue is project documentation. Follow the conventions from the
 and concrete. No buzzwords, no fluff, no dramatic terms. State what
 happened or what is being proposed, not how important it is.
 
+## Be succinct
+
+Maintainers reading the issue already know Toasty and Rust. Keep the
+prose high-signal: lead with the bug or proposal, then the reproducer
+or API sketch, then the alternatives. Skip restated background and
+throat-clearing. A maintainer should grasp the problem in seconds, not
+paragraphs.
+
 ## Pick the right template
 
 Issue templates live in

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -38,6 +38,14 @@ Keep the section headings and the checklist; replace the HTML comment
 placeholders with real content. Delete checklist items that do not
 apply rather than leaving them unchecked with no explanation.
 
+## Be succinct
+
+Reviewers already know Toasty and Rust. Keep the body high-signal:
+state the problem, the change, and anything a reviewer needs to know
+to evaluate it. Skip restated context, obvious explanations, and
+throat-clearing. A reviewer should grasp the important bits in
+seconds.
+
 ## Labels
 
 Do not apply labels when creating the PR. Maintainers triage and label


### PR DESCRIPTION
## Summary

Add a "Be succinct" section to the `commit`, `issue`, `pr`, and `design` skills. The audience for these artifacts already knows Toasty and Rust, so prose should lead with the important bits (problem, change, proposal) and skip restated context. The `prose` skill itself is unchanged.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format