### PR TITLE
fix: emit column rename last when combined with other changes

### DIFF
--- a/crates/toasty-sql/src/stmt/alter_column.rs
+++ b/crates/toasty-sql/src/stmt/alter_column.rs
@@ -52,6 +52,10 @@ impl AlterColumnChanges {
     }
 
     /// Splits up this set of changes into a [`Vec`] of individual changes.
+    ///
+    /// The rename change is emitted last so that any preceding statements
+    /// (type, nullability, auto-increment) still find the column under its
+    /// pre-rename name.
     pub fn split(self) -> Vec<Self> {
         let Self {
             new_name,
@@ -66,12 +70,6 @@ impl AlterColumnChanges {
             new_auto_increment: None,
         };
         let mut result = vec![];
-        if new_name.is_some() {
-            result.push(Self {
-                new_name,
-                ..default.clone()
-            });
-        }
         if new_ty.is_some() {
             result.push(Self {
                 new_ty,
@@ -87,6 +85,12 @@ impl AlterColumnChanges {
         if new_auto_increment.is_some() {
             result.push(Self {
                 new_auto_increment,
+                ..default.clone()
+            });
+        }
+        if new_name.is_some() {
+            result.push(Self {
+                new_name,
                 ..default.clone()
             });
         }

--- a/crates/toasty-sql/tests/migration_alter_column.rs
+++ b/crates/toasty-sql/tests/migration_alter_column.rs
@@ -303,6 +303,111 @@ fn alter_column_multiple_changes_postgresql() {
 }
 
 #[test]
+fn alter_column_rename_and_change_type_postgresql() {
+    // Column renamed is_admin → user_type AND type changed Boolean → Text
+    // The type change must reference the column by its OLD name; the rename
+    // therefore has to come last. (See issue #755.)
+    let from = Schema {
+        tables: vec![make_table(
+            0,
+            "users",
+            vec![
+                make_column(0, 0, "id", Type::Integer(8)),
+                make_column(0, 1, "is_admin", Type::Boolean),
+            ],
+        )],
+    };
+
+    let mut renamed = make_column(0, 1, "user_type", Type::Text);
+    renamed.primary_key = false;
+
+    let to = Schema {
+        tables: vec![make_table(
+            0,
+            "users",
+            vec![make_column(0, 0, "id", Type::Integer(8)), renamed],
+        )],
+    };
+
+    let mut hints = RenameHints::new();
+    hints.add_column_hint(
+        ColumnId {
+            table: TableId(0),
+            index: 1,
+        },
+        ColumnId {
+            table: TableId(0),
+            index: 1,
+        },
+    );
+
+    let diff = SchemaDiff::from(&from, &to, &hints);
+    let stmts = MigrationStatement::from_diff(&diff, &Capability::POSTGRESQL);
+    let sql = serialize_migration(&stmts, "postgresql");
+
+    assert_eq!(
+        sql,
+        vec![
+            "ALTER TABLE \"users\" ALTER COLUMN \"is_admin\" TYPE TEXT;",
+            "ALTER TABLE \"users\" RENAME COLUMN \"is_admin\" TO \"user_type\";",
+        ]
+    );
+}
+
+#[test]
+fn alter_column_rename_and_drop_not_null_postgresql() {
+    // Column renamed name → full_name AND nullability changed NOT NULL → NULL.
+    // Both changes must reference the OLD column name, so the rename comes
+    // last.
+    let from = Schema {
+        tables: vec![make_table(
+            0,
+            "users",
+            vec![
+                make_column(0, 0, "id", Type::Integer(8)),
+                make_column(0, 1, "name", Type::Text),
+            ],
+        )],
+    };
+
+    let mut renamed = make_column(0, 1, "full_name", Type::Text);
+    renamed.primary_key = false;
+    renamed.nullable = true;
+
+    let to = Schema {
+        tables: vec![make_table(
+            0,
+            "users",
+            vec![make_column(0, 0, "id", Type::Integer(8)), renamed],
+        )],
+    };
+
+    let mut hints = RenameHints::new();
+    hints.add_column_hint(
+        ColumnId {
+            table: TableId(0),
+            index: 1,
+        },
+        ColumnId {
+            table: TableId(0),
+            index: 1,
+        },
+    );
+
+    let diff = SchemaDiff::from(&from, &to, &hints);
+    let stmts = MigrationStatement::from_diff(&diff, &Capability::POSTGRESQL);
+    let sql = serialize_migration(&stmts, "postgresql");
+
+    assert_eq!(
+        sql,
+        vec![
+            "ALTER TABLE \"users\" ALTER COLUMN \"name\" DROP NOT NULL;",
+            "ALTER TABLE \"users\" RENAME COLUMN \"name\" TO \"full_name\";",
+        ]
+    );
+}
+
+#[test]
 fn alter_column_multiple_changes_with_table_rename_postgresql() {
     let mut value = make_column(0, 1, "value", Type::Integer(4));
     value.nullable = true;


### PR DESCRIPTION
## Summary

Fixes issue #755 by ensuring that when a column is renamed along with other changes (type change, nullability change, etc.), the rename statement is emitted **last**. This is necessary because PostgreSQL requires that type and nullability changes reference the column by its **original name**, not the new name.

For example, when renaming `is_admin` → `user_type` AND changing type `Boolean` → `Text`, the generated SQL must be:
1. `ALTER TABLE "users" ALTER COLUMN "is_admin" TYPE TEXT;`
2. `ALTER TABLE "users" RENAME COLUMN "is_admin" TO "user_type";`

Not the other way around, which would fail because `is_admin` no longer exists after the rename.

## Changes

- **`crates/toasty-sql/src/stmt/alter_column.rs`**: Modified `AlterColumnChanges::split()` to emit the rename change last instead of first. Added documentation explaining why this ordering is necessary.

- **`crates/toasty-sql/tests/migration_alter_column.rs`**: Added two new test cases:
  - `alter_column_rename_and_change_type_postgresql`: Tests renaming a column while changing its type
  - `alter_column_rename_and_drop_not_null_postgresql`: Tests renaming a column while changing nullability

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses Conventional Commits format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Added tests covering the fix

## Notes for reviewers

The fix is straightforward: reorder the split logic so that `new_name` is pushed to the result vector last, ensuring it's the final statement emitted. The new tests verify the correct SQL generation for both type changes and nullability changes combined with renames.

https://claude.ai/code/session_014U44kiv2B8Eb5RLMWYsdHN