### PR TITLE
docs: note design-doc Rust snippets are not rustdoc-compiled

### DIFF
--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -30,6 +30,13 @@ proposal so a maintainer can grasp the important bits quickly. Cut
 restated background, obvious explanations, and throat-clearing.
 Length is not a virtue; clarity is.
 
+## Rust examples
+
+Rust code blocks in design docs are illustrative and are **not** run
+through rustdoc. Do not add `#`-prefixed hidden boilerplate (imports,
+`fn main`, etc.) just to make the snippet compile. Show only the lines
+that matter to the reader.
+
 ## Framing
 
 A design doc is **guide-level**, not implementation-level. Write it for


### PR DESCRIPTION
## Summary

Update the `design` skill to tell authors that Rust code blocks in
design docs are illustrative — they are not run through rustdoc, so do
not pad them with `#`-prefixed hidden lines (`use` imports, `fn main`,
etc.) just to make them compile. Show only the lines that matter.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format