### PR TITLE
fix: preserve non-reference constraints when lifting BelongsTo IN-subquery

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -48,6 +48,7 @@ pub mod infra_pool_config;
 pub mod infra_reset_db;
 pub mod infra_sync_send;
 pub mod key_unsigned;
+pub mod lift_belongs_to_complex_filter;
 pub mod query_count;
 pub mod raw_identifier_fields;
 pub mod record_not_found;

--- a/crates/toasty-driver-integration-suite/src/tests/lift_belongs_to_complex_filter.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/lift_belongs_to_complex_filter.rs
@@ -1,0 +1,75 @@
+//! Regression test for `lift_belongs_to_in_subquery` silently dropping
+//! filter constraints whose operands are neither side an `Expr::Reference`.
+//!
+//! Before the fix, the visitor's catch-all match arm did nothing — leaving
+//! `fail = false` and `operands = []`. The lift then produced an empty
+//! `ExprAnd` (= `true`), so the inner WHERE clause was discarded and the
+//! IN subquery returned all rows of the target model.
+//!
+//! Embedded struct field access inside an `in_query` produces such a
+//! constraint, since `address.city` lowers to `Project(ref(address), [city])`.
+
+use crate::prelude::*;
+
+#[driver_test(id(ID), requires(sql))]
+pub async fn lift_belongs_to_preserves_embedded_field_filter(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Embed)]
+    struct Address {
+        city: String,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+
+        address: Address,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Post {
+        #[key]
+        #[auto]
+        id: ID,
+
+        title: String,
+
+        #[index]
+        user_id: ID,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: toasty::BelongsTo<User>,
+    }
+
+    let mut db = t.setup_db(models!(User, Post, Address)).await;
+
+    toasty::create!(Post::[
+        {
+            title: "Seattle post",
+            user: { address: Address { city: "Seattle".into() } },
+        },
+        {
+            title: "NYC post",
+            user: { address: Address { city: "NYC".into() } },
+        },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    // The inner filter `address.city = "Seattle"` is a `Project` over a
+    // reference, not a bare reference. Before the fix, the visitor silently
+    // dropped this constraint and the IN subquery matched every user.
+    let posts: Vec<Post> = Post::filter(
+        Post::fields()
+            .user()
+            .in_query(User::filter(User::fields().address().city().eq("Seattle"))),
+    )
+    .exec(&mut db)
+    .await?;
+
+    assert_eq!(posts.len(), 1);
+    assert_eq!(posts[0].title, "Seattle post");
+
+    Ok(())
+}

--- a/crates/toasty/src/engine/simplify/lift_in_subquery.rs
+++ b/crates/toasty/src/engine/simplify/lift_in_subquery.rs
@@ -200,7 +200,14 @@ impl Visit for LiftBelongsTo<'_> {
                     self.fail = true;
                 }
             }
-            _ => {}
+            // Constraints we can't lift to a direct FK comparison (e.g. a
+            // projection through an embedded field). Bail to the IN-subquery
+            // form so the filter is preserved verbatim — without this, the
+            // empty `operands` list silently produced an empty AND (= true)
+            // and the subquery returned every row.
+            _ => {
+                self.fail = true;
+            }
         }
     }
 }


### PR DESCRIPTION
<!--
PR title uses Conventional Commits, e.g.
    feat: add upsert support
    fix: handle composite key in IN-list rewrite
See CONTRIBUTING.md for the full process.
-->

## Summary
`LiftBelongsTo::visit_expr_binary_op` had a catch-all `_ => {}` arm for
constraints whose operands aren't `Expr::Reference` (e.g. an embedded
field accessed inside an `in_query`: `Project(ref(addr), [city]) = "X"`).
That left `fail = false` with `operands = []`, so the lift returned an
empty `ExprAnd` (= `true`) — silently dropping the inner WHERE clause and
making the IN subquery match every row of the target model.

Set `fail = true` in the catch-all so we fall through to the
IN-subquery form that preserves the filter verbatim.

Added a regression test (`lift_belongs_to_preserves_embedded_field_filter`)
that filters posts by an embedded field on the related user — fails on
main, passes with the fix.

<!-- What does this change and why? Link the issue it closes. -->

## Type of change

<!-- Check one. -->

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers
This was found and fixed by claude code.