### PR TITLE
fix: support starts_with and like on Option<String> fields

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/filter_like.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/filter_like.rs
@@ -55,3 +55,39 @@ pub async fn like_no_match(test: &mut Test) -> Result<()> {
 
     Ok(())
 }
+
+/// LIKE on an `Option<String>` field — matches non-null values; rows with NULL
+/// values are excluded since `NULL LIKE pattern` is unknown.
+#[driver_test(requires(sql))]
+pub async fn like_optional_field(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct OptItem {
+        #[key]
+        id: i64,
+        nickname: Option<String>,
+    }
+
+    let mut db = test.setup_db(models!(OptItem)).await;
+
+    toasty::create!(OptItem::[
+        { id: 1_i64, nickname: Some("Alice".to_string())   },
+        { id: 2_i64, nickname: Some("Alicia".to_string())  },
+        { id: 3_i64, nickname: Some("Bob".to_string())     },
+        { id: 4_i64, nickname: None                        },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let mut items: Vec<OptItem> =
+        OptItem::filter(OptItem::fields().nickname().like("Al%".to_string()))
+            .exec(&mut db)
+            .await?;
+
+    items.sort_by_key(|i| i.id);
+
+    assert_eq!(items.len(), 2);
+    assert_eq!(items[0].nickname.as_deref(), Some("Alice"));
+    assert_eq!(items[1].nickname.as_deref(), Some("Alicia"));
+
+    Ok(())
+}

--- a/crates/toasty-driver-integration-suite/src/tests/starts_with.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/starts_with.rs
@@ -135,6 +135,42 @@ pub async fn starts_with_empty_prefix_sql(test: &mut Test) -> Result<()> {
     Ok(())
 }
 
+/// starts_with on an `Option<String>` field — matches non-null values with
+/// the given prefix; rows with NULL values are excluded.
+#[driver_test]
+pub async fn starts_with_optional_field(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct OptItem {
+        #[key]
+        id: i64,
+        nickname: Option<String>,
+    }
+
+    let mut db = test.setup_db(models!(OptItem)).await;
+
+    toasty::create!(OptItem::[
+        { id: 1_i64, nickname: Some("Ali".to_string())     },
+        { id: 2_i64, nickname: Some("Alicia".to_string())  },
+        { id: 3_i64, nickname: Some("Bob".to_string())     },
+        { id: 4_i64, nickname: None                        },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let mut items: Vec<OptItem> =
+        OptItem::filter(OptItem::fields().nickname().starts_with("Al".to_string()))
+            .exec(&mut db)
+            .await?;
+
+    items.sort_by_key(|i| i.id);
+
+    assert_eq!(items.len(), 2);
+    assert_eq!(items[0].nickname.as_deref(), Some("Ali"));
+    assert_eq!(items[1].nickname.as_deref(), Some("Alicia"));
+
+    Ok(())
+}
+
 /// starts_with on the partition key — DynamoDB returns a runtime error since
 /// starts_with is not valid in a KeyConditionExpression on the partition key.
 #[driver_test(requires(not(sql)))]

--- a/crates/toasty-driver-integration-suite/src/tests/starts_with.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/starts_with.rs
@@ -140,8 +140,9 @@ pub async fn starts_with_empty_prefix_sql(test: &mut Test) -> Result<()> {
 #[driver_test]
 pub async fn starts_with_optional_field(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
+    #[key(partition = partition_id, local = id)]
     struct OptItem {
-        #[key]
+        partition_id: i64,
         id: i64,
         nickname: Option<String>,
     }
@@ -149,18 +150,22 @@ pub async fn starts_with_optional_field(test: &mut Test) -> Result<()> {
     let mut db = test.setup_db(models!(OptItem)).await;
 
     toasty::create!(OptItem::[
-        { id: 1_i64, nickname: Some("Ali".to_string())     },
-        { id: 2_i64, nickname: Some("Alicia".to_string())  },
-        { id: 3_i64, nickname: Some("Bob".to_string())     },
-        { id: 4_i64, nickname: None                        },
+        { partition_id: 1_i64, id: 1_i64, nickname: Some("Ali".to_string())     },
+        { partition_id: 1_i64, id: 2_i64, nickname: Some("Alicia".to_string())  },
+        { partition_id: 1_i64, id: 3_i64, nickname: Some("Bob".to_string())     },
+        { partition_id: 1_i64, id: 4_i64, nickname: None                        },
     ])
     .exec(&mut db)
     .await?;
 
-    let mut items: Vec<OptItem> =
-        OptItem::filter(OptItem::fields().nickname().starts_with("Al".to_string()))
-            .exec(&mut db)
-            .await?;
+    let mut items: Vec<OptItem> = OptItem::filter(
+        OptItem::fields()
+            .partition_id()
+            .eq(1_i64)
+            .and(OptItem::fields().nickname().starts_with("Al".to_string())),
+    )
+    .exec(&mut db)
+    .await?;
 
     items.sort_by_key(|i| i.id);
 

--- a/crates/toasty/src/stmt/path.rs
+++ b/crates/toasty/src/stmt/path.rs
@@ -1,5 +1,5 @@
 use super::{Expr, IntoExpr, IntoStatement, List};
-use crate::schema::Register;
+use crate::schema::{Field, Register};
 use std::{fmt, marker::PhantomData};
 use toasty_core::{
     schema::app::VariantId,
@@ -464,12 +464,16 @@ impl<T, U> Path<T, Option<U>> {
     }
 }
 
-impl<T> Path<T, String> {
+impl<T, U> Path<T, U>
+where
+    U: Field<Inner = String>,
+{
     /// Test whether this string field starts with `prefix`.
     ///
-    /// Only available on `String`-typed fields. For DynamoDB, this maps to
-    /// `begins_with` in a `KeyConditionExpression` (sort key) or
-    /// `FilterExpression` (non-key attribute).
+    /// Available on any string-valued field, including `String`,
+    /// `Option<String>`, and other wrappers whose `Field::Inner` is `String`.
+    /// For DynamoDB, this maps to `begins_with` in a `KeyConditionExpression`
+    /// (sort key) or `FilterExpression` (non-key attribute).
     ///
     /// # Examples
     ///
@@ -479,8 +483,10 @@ impl<T> Path<T, String> {
     /// #     #[key]
     /// #     id: i64,
     /// #     name: String,
+    /// #     nickname: Option<String>,
     /// # }
     /// let filter = User::fields().name().starts_with("Al".to_string());
+    /// let filter = User::fields().nickname().starts_with("Al".to_string());
     /// ```
     pub fn starts_with(self, prefix: impl IntoExpr<String>) -> Expr<bool> {
         Expr {
@@ -491,9 +497,11 @@ impl<T> Path<T, String> {
 
     /// Test whether this string field matches a SQL `LIKE` pattern.
     ///
-    /// Only available on `String`-typed fields. The caller is responsible for
-    /// including any `%` or `_` wildcard characters in `pattern`. Not supported
-    /// by the DynamoDB driver — use [`starts_with`](Self::starts_with) instead.
+    /// Available on any string-valued field, including `String`,
+    /// `Option<String>`, and other wrappers whose `Field::Inner` is `String`.
+    /// The caller is responsible for including any `%` or `_` wildcard
+    /// characters in `pattern`. Not supported by the DynamoDB driver — use
+    /// [`starts_with`](Self::starts_with) instead.
     ///
     /// # Examples
     ///
@@ -503,8 +511,10 @@ impl<T> Path<T, String> {
     /// #     #[key]
     /// #     id: i64,
     /// #     name: String,
+    /// #     nickname: Option<String>,
     /// # }
     /// let filter = User::fields().name().like("Al%".to_string());
+    /// let filter = User::fields().nickname().like("Al%".to_string());
     /// ```
     pub fn like(self, pattern: impl IntoExpr<String>) -> Expr<bool> {
         Expr {


### PR DESCRIPTION
Generalize the starts_with/like impl on Path from Path<T, String> to
Path<T, U> where U: Field<Inner = String>. This picks up Option<String>
(and other string-valued field wrappers) without duplicating the impl.

Closes #771