### PR TITLE
fix(engine): escape LIKE wildcards in starts_with prefix

### DIFF
--- a/crates/toasty-core/src/driver/capability.rs
+++ b/crates/toasty-core/src/driver/capability.rs
@@ -106,6 +106,18 @@ pub struct Capability {
     /// DynamoDB: false. All other backends: true (SQL backends never use index key conditions).
     pub index_or_predicate: bool,
 
+    /// Whether the database has a native prefix-match operator that does not
+    /// require LIKE-style escaping. When `true`, `starts_with` is left in the
+    /// AST and the driver renders it natively (DynamoDB's `begins_with()`,
+    /// PostgreSQL's `^@`). When `false`, the lowering rewrites it to a
+    /// `LIKE` expression — which requires `native_like` to be `true`.
+    pub native_starts_with: bool,
+
+    /// Whether the database has a native `LIKE` expression. When `false`,
+    /// `Expr::Like` cannot be sent to the driver; `starts_with` lowering
+    /// will not produce one.
+    pub native_like: bool,
+
     /// Whether to test connection pool behavior.
     /// TODO: We only need this for the `connection_per_clone.rs` test, come up with a better way.
     pub test_connection_pool: bool,
@@ -295,6 +307,9 @@ impl Capability {
 
         index_or_predicate: true,
 
+        native_starts_with: false,
+        native_like: true,
+
         test_connection_pool: false,
     };
 
@@ -306,6 +321,9 @@ impl Capability {
         select_for_update: true,
         auto_increment: true,
         bigdecimal_implemented: false,
+
+        // PostgreSQL has the `^@` prefix-match operator.
+        native_starts_with: true,
 
         // PostgreSQL has CREATE TYPE ... AS ENUM
         native_enum: true,
@@ -381,6 +399,10 @@ impl Capability {
         decimal_arbitrary_precision: false,
 
         index_or_predicate: false,
+
+        // DynamoDB has `begins_with()` but no LIKE.
+        native_starts_with: true,
+        native_like: false,
 
         test_connection_pool: false,
     };

--- a/crates/toasty-core/src/stmt/expr_like.rs
+++ b/crates/toasty-core/src/stmt/expr_like.rs
@@ -18,14 +18,20 @@ pub struct ExprLike {
 
     /// The LIKE pattern (including any % or _ wildcards).
     pub pattern: Box<Expr>,
+
+    /// Optional escape character. When `Some(c)`, occurrences of `c` in the
+    /// pattern make the following `%`, `_`, or `c` match literally, and the
+    /// serializer emits an `ESCAPE 'c'` clause.
+    pub escape: Option<char>,
 }
 
 impl Expr {
-    /// Creates a `expr LIKE pattern` expression.
+    /// Creates a `expr LIKE pattern` expression with no escape character.
     pub fn like(expr: impl Into<Self>, pattern: impl Into<Self>) -> Self {
         ExprLike {
             expr: Box::new(expr.into()),
             pattern: Box::new(pattern.into()),
+            escape: None,
         }
         .into()
     }

--- a/crates/toasty-driver-integration-suite/src/tests/starts_with.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/starts_with.rs
@@ -135,6 +135,79 @@ pub async fn starts_with_empty_prefix_sql(test: &mut Test) -> Result<()> {
     Ok(())
 }
 
+/// starts_with prefix containing SQL LIKE wildcards (`%`, `_`) and the
+/// chosen escape char (`!`). On SQL drivers the prefix is escaped before
+/// being lowered to LIKE so these characters match literally.
+#[driver_test]
+pub async fn starts_with_special_chars(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    #[key(partition = partition_id, local = sort_key)]
+    struct StringItem {
+        partition_id: i64,
+        sort_key: String,
+    }
+
+    let mut db = test.setup_db(models!(StringItem)).await;
+
+    toasty::create!(StringItem::[
+        { partition_id: 1_i64, sort_key: "100%-discount" },
+        { partition_id: 1_i64, sort_key: "100xdiscount"  },
+        { partition_id: 1_i64, sort_key: "1009"          },
+        { partition_id: 1_i64, sort_key: "a_b-literal"   },
+        { partition_id: 1_i64, sort_key: "axb-wildcard"  },
+        { partition_id: 1_i64, sort_key: "!bang-literal" },
+        { partition_id: 1_i64, sort_key: "x!bang"        },
+    ])
+    .exec(&mut db)
+    .await
+    .unwrap();
+
+    // `%` must match literally, not as a wildcard.
+    let mut items: Vec<StringItem> = StringItem::filter(
+        StringItem::fields().partition_id().eq(1_i64).and(
+            StringItem::fields()
+                .sort_key()
+                .starts_with("100%".to_string()),
+        ),
+    )
+    .exec(&mut db)
+    .await?;
+    items.sort_by(|a, b| a.sort_key.cmp(&b.sort_key));
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].sort_key, "100%-discount");
+
+    // `_` must match literally, not as a single-char wildcard.
+    let mut items: Vec<StringItem> = StringItem::filter(
+        StringItem::fields().partition_id().eq(1_i64).and(
+            StringItem::fields()
+                .sort_key()
+                .starts_with("a_b".to_string()),
+        ),
+    )
+    .exec(&mut db)
+    .await?;
+    items.sort_by(|a, b| a.sort_key.cmp(&b.sort_key));
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].sort_key, "a_b-literal");
+
+    // `!` (the escape char chosen by the SQL lowering) must also match
+    // literally when present in the user-supplied prefix.
+    let mut items: Vec<StringItem> = StringItem::filter(
+        StringItem::fields().partition_id().eq(1_i64).and(
+            StringItem::fields()
+                .sort_key()
+                .starts_with("!bang".to_string()),
+        ),
+    )
+    .exec(&mut db)
+    .await?;
+    items.sort_by(|a, b| a.sort_key.cmp(&b.sort_key));
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].sort_key, "!bang-literal");
+
+    Ok(())
+}
+
 /// starts_with on the partition key — DynamoDB returns a runtime error since
 /// starts_with is not valid in a KeyConditionExpression on the partition key.
 #[driver_test(requires(not(sql)))]

--- a/crates/toasty-sql/src/serializer/expr.rs
+++ b/crates/toasty-sql/src/serializer/expr.rs
@@ -50,6 +50,25 @@ impl ToSql for &stmt::Expr {
             }
             stmt::Expr::Like(expr) => {
                 fmt!(cx, f, expr.expr " LIKE " expr.pattern);
+                if let Some(escape) = expr.escape {
+                    let escape = &stmt::Value::String(escape.to_string());
+                    fmt!(cx, f, " ESCAPE " escape);
+                }
+            }
+            stmt::Expr::StartsWith(expr) => {
+                // The lowering pass leaves `StartsWith` in place when
+                // `Capability::native_prefix_match_op` is true. PostgreSQL
+                // is the only such SQL flavor today (`^@` operator).
+                match f.serializer.flavor {
+                    Flavor::Postgresql => {
+                        fmt!(cx, f, expr.expr " ^@ " expr.prefix);
+                    }
+                    Flavor::Sqlite | Flavor::Mysql => {
+                        unreachable!(
+                            "StartsWith should have been lowered to LIKE for non-PostgreSQL flavors"
+                        );
+                    }
+                }
             }
             stmt::Expr::Not(expr) => {
                 fmt!(cx, f, "NOT (" expr.expr ")");

--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -423,7 +423,9 @@ impl visit_mut::VisitMut for LowerStatement<'_, '_> {
                     self.curr_stmt_info().deps.insert(target_id);
                 }
             }
-            stmt::Expr::StartsWith(_) if self.capability().sql => {
+            stmt::Expr::StartsWith(_)
+                if self.capability().sql && !self.capability().native_starts_with =>
+            {
                 self.lower_expr_starts_with(expr);
             }
             stmt::Expr::Exists(_) if !self.capability().sql => {

--- a/crates/toasty/src/engine/lower/expr_pattern.rs
+++ b/crates/toasty/src/engine/lower/expr_pattern.rs
@@ -4,10 +4,18 @@ use super::LowerStatement;
 
 impl LowerStatement<'_, '_> {
     pub(super) fn lower_expr_starts_with(&mut self, expr: &mut stmt::Expr) {
-        // SQL drivers don't have a native starts_with; rewrite to
-        // `Like(expr, prefix || '%')`. The prefix is still a literal
-        // Value at this point (extract_params hasn't run), so we can
-        // append `%` directly instead of emitting a concat.
+        // SQL drivers without a native starts_with rewrite to
+        // `Like(expr, prefix || '%')`. If the prefix contains LIKE wildcards
+        // (`%` or `_`) we pick an escape character that doesn't appear in
+        // the prefix, prepend it to each wildcard, and emit
+        // `LIKE 'pattern' ESCAPE 'c'`. If the prefix is wildcard-free, no
+        // escape clause is needed and the AST stays free of one — matching
+        // what a hand-written `Path::like("foo%")` would produce.
+        assert!(
+            self.capability().native_like,
+            "lowering starts_with to LIKE requires native_like capability",
+        );
+
         let stmt::Expr::StartsWith(mut e) = expr.take() else {
             panic!()
         };
@@ -15,14 +23,75 @@ impl LowerStatement<'_, '_> {
         self.visit_expr_mut(&mut e.expr);
         self.visit_expr_mut(&mut e.prefix);
 
-        let pattern = match *e.prefix {
-            stmt::Expr::Value(stmt::Value::String(mut s)) => {
-                s.push('%');
-                stmt::Expr::Value(stmt::Value::String(s))
-            }
-            other => panic!("unexpected StartsWith prefix expression: {other:?}"),
+        let stmt::Expr::Value(stmt::Value::String(s)) = *e.prefix else {
+            panic!("unexpected StartsWith prefix expression: {:?}", e.prefix);
         };
 
-        *expr = stmt::Expr::like(*e.expr, pattern);
+        let escape = pick_escape_char(&s);
+        let mut pattern = String::with_capacity(s.len() + 1);
+        for c in s.chars() {
+            if let Some(esc) = escape
+                && (c == '%' || c == '_')
+            {
+                pattern.push(esc);
+            }
+            pattern.push(c);
+        }
+        pattern.push('%');
+
+        *expr = stmt::ExprLike {
+            expr: Box::new(*e.expr),
+            pattern: Box::new(stmt::Expr::Value(stmt::Value::String(pattern))),
+            escape,
+        }
+        .into();
+    }
+}
+
+/// Pick a `LIKE` escape character for a starts_with prefix, or `None` if no
+/// escape is needed (the prefix has no `%` or `_` wildcards).
+///
+/// The chosen char must not appear in the prefix — that way it never
+/// accidentally escapes a literal character, and we don't have to
+/// double-escape the escape char itself.
+fn pick_escape_char(prefix: &str) -> Option<char> {
+    if !prefix.contains('%') && !prefix.contains('_') {
+        return None;
+    }
+    // Try common, visually-quiet ASCII candidates first. Almost every prefix
+    // hits one of these on the first try.
+    for c in ['!', '~', '#', '@', '|', '^', '`', '\\'] {
+        if !prefix.contains(c) {
+            return Some(c);
+        }
+    }
+    // Pathological prefix containing every common candidate — fall back to
+    // a low-ASCII control character. The codepoint range below excludes
+    // NUL, tab, and the line terminators, leaving plenty of choices.
+    for c in '\x01'..='\x08' {
+        if !prefix.contains(c) {
+            return Some(c);
+        }
+    }
+    panic!("could not find a LIKE escape character for prefix {prefix:?}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pick_escape_char;
+
+    #[test]
+    fn no_wildcards_returns_none() {
+        assert_eq!(pick_escape_char(""), None);
+        assert_eq!(pick_escape_char("alpha"), None);
+        assert_eq!(pick_escape_char("café\\!"), None);
+    }
+
+    #[test]
+    fn first_unused_candidate_wins() {
+        assert_eq!(pick_escape_char("100%"), Some('!'));
+        assert_eq!(pick_escape_char("a_b"), Some('!'));
+        assert_eq!(pick_escape_char("!100%"), Some('~'));
+        assert_eq!(pick_escape_char("!~100%"), Some('#'));
     }
 }


### PR DESCRIPTION
starts_with("100%") was lowering to LIKE '100%%', leaking the % as a
wildcard. The prefix is now escaped before being appended with the
trailing %, and an ESCAPE clause is emitted when needed.

Adds two driver capabilities so the lowering can pick the right
strategy per backend:

- native_starts_with: leave the AST node alone (PostgreSQL renders
  ^@; DynamoDB renders begins_with).
- native_like: required for the LIKE fallback used by SQLite/MySQL.

The escape character is chosen per-prefix: if the prefix has no %
or _, no ESCAPE clause is emitted; otherwise the lowering picks a
character that doesn't appear in the prefix, so Path::like() raw
patterns are unaffected.

Closes #772