### PR TITLE
feat: filter by fields on associated models

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -54,6 +54,7 @@ pub mod record_not_found;
 pub mod relation_belongs_to_configured;
 pub mod relation_belongs_to_one_way;
 pub mod relation_belongs_to_self_referential;
+pub mod relation_filter_association;
 pub mod relation_has_many_batch_create;
 pub mod relation_has_many_boxed_fk;
 pub mod relation_has_many_crud;

--- a/crates/toasty-driver-integration-suite/src/tests/relation_filter_association.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_filter_association.rs
@@ -1,0 +1,154 @@
+//! Tests for filtering models by conditions on associated (HasOne, BelongsTo) fields.
+
+use crate::prelude::*;
+
+/// Filter a parent by a HasOne field, with eq and a non-commutative op.
+#[driver_test(id(ID), requires(sql))]
+pub async fn filter_by_has_one_field(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+
+        name: String,
+
+        #[has_one]
+        profile: toasty::HasOne<Option<Profile>>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Profile {
+        #[key]
+        #[auto]
+        id: ID,
+
+        score: i64,
+
+        #[unique]
+        user_id: Option<ID>,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: toasty::BelongsTo<Option<User>>,
+    }
+
+    let mut db = t.setup_db(models!(User, Profile)).await;
+
+    toasty::create!(User::[
+        { name: "alice", profile: { score: 80 } },
+        { name: "bob",   profile: { score: 30 } },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let users: Vec<User> = User::filter(User::fields().profile().score().eq(80))
+        .exec(&mut db)
+        .await?;
+    assert_eq!(
+        users.iter().map(|u| u.name.as_str()).collect::<Vec<_>>(),
+        ["alice"]
+    );
+
+    let users: Vec<User> = User::filter(User::fields().profile().score().gt(50))
+        .exec(&mut db)
+        .await?;
+    assert_eq!(
+        users.iter().map(|u| u.name.as_str()).collect::<Vec<_>>(),
+        ["alice"]
+    );
+
+    Ok(())
+}
+
+/// Filter a child by a BelongsTo field.
+#[driver_test(
+    id(ID),
+    requires(sql),
+    scenario(crate::scenarios::has_one_optional_belongs_to)
+)]
+pub async fn filter_by_belongs_to_field(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    toasty::create!(User::[
+        { name: "alice", profile: { bio: "alice's bio" } },
+        { name: "bob",   profile: { bio: "bob's bio" } },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let profiles: Vec<Profile> = Profile::filter(Profile::fields().user().name().eq("alice"))
+        .exec(&mut db)
+        .await?;
+    assert_eq!(
+        profiles.iter().map(|p| p.bio.as_str()).collect::<Vec<_>>(),
+        ["alice's bio"]
+    );
+
+    Ok(())
+}
+
+/// Filter through three chained HasOne associations: `A.b.c.name == ...`.
+#[driver_test(id(ID), requires(sql))]
+pub async fn filter_by_nested_has_one_chain(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct A {
+        #[key]
+        #[auto]
+        id: ID,
+
+        label: String,
+
+        #[has_one]
+        b: toasty::HasOne<Option<B>>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct B {
+        #[key]
+        #[auto]
+        id: ID,
+
+        #[unique]
+        a_id: Option<ID>,
+
+        #[belongs_to(key = a_id, references = id)]
+        a: toasty::BelongsTo<Option<A>>,
+
+        #[has_one]
+        c: toasty::HasOne<Option<C>>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct C {
+        #[key]
+        #[auto]
+        id: ID,
+
+        name: String,
+
+        #[unique]
+        b_id: Option<ID>,
+
+        #[belongs_to(key = b_id, references = id)]
+        b: toasty::BelongsTo<Option<B>>,
+    }
+
+    let mut db = t.setup_db(models!(A, B, C)).await;
+
+    toasty::create!(A::[
+        { label: "match",    b: { c: { name: "target" } } },
+        { label: "no-match", b: { c: { name: "other" } } },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let results: Vec<A> = A::filter(A::fields().b().c().name().eq("target"))
+        .exec(&mut db)
+        .await?;
+    assert_eq!(
+        results.iter().map(|a| a.label.as_str()).collect::<Vec<_>>(),
+        ["match"]
+    );
+
+    Ok(())
+}

--- a/crates/toasty/src/engine/simplify/expr_binary_op.rs
+++ b/crates/toasty/src/engine/simplify/expr_binary_op.rs
@@ -1,7 +1,7 @@
 use std::cmp::PartialOrd;
 
 use super::Simplify;
-use toasty_core::schema::app::FieldTy;
+use toasty_core::schema::app::{FieldId, FieldTy};
 use toasty_core::stmt::{self, Expr, ResolvedRef, VisitMut};
 
 impl Simplify<'_> {
@@ -224,7 +224,67 @@ impl Simplify<'_> {
             return Some(Expr::null());
         }
 
-        None
+        // Relation field traversal: project(ref_self_field(relation), [idx...]) op rhs
+        // → relation_field IN (SELECT * FROM Target WHERE Target.idx op rhs)
+        // The commute on the swapped call preserves comparison direction for
+        // non-commutative ops (e.g. `5 < user.profile.score` becomes
+        // `user.profile.score > 5` once lifted).
+        if let Some(r) = self.try_lift_relation_path_comparison(op, lhs, rhs) {
+            return Some(r);
+        }
+        self.try_lift_relation_path_comparison(op.commute(), rhs, lhs)
+    }
+
+    /// Rewrites `project(ref_self_field(relation_field), [idx, ..]) op other`
+    /// into an IN subquery on the relation's target model, then defers to
+    /// [`lift_in_subquery`] to translate the relation reference into a
+    /// foreign-key comparison.
+    ///
+    /// Returns `None` if `project_side` is not a project through a relation
+    /// field reference.
+    fn try_lift_relation_path_comparison(
+        &mut self,
+        op: stmt::BinaryOp,
+        project_side: &stmt::Expr,
+        other_side: &stmt::Expr,
+    ) -> Option<stmt::Expr> {
+        let Expr::Project(project_expr) = project_side else {
+            return None;
+        };
+        let Expr::Reference(expr_ref) = &*project_expr.base else {
+            return None;
+        };
+        let ResolvedRef::Field(field) = self.cx.resolve_expr_reference(expr_ref) else {
+            return None;
+        };
+
+        let target_model_id = match &field.ty {
+            FieldTy::HasOne(rel) => rel.target,
+            FieldTy::BelongsTo(rel) => rel.target,
+            FieldTy::HasMany(rel) => rel.target,
+            _ => return None,
+        };
+
+        // Re-root the projection at the target model: the leading index
+        // points at the relation field itself, the rest indexes into the
+        // related model's fields.
+        let (head_idx, tail) = project_expr.projection.as_slice().split_first()?;
+        let target_field = Expr::ref_self_field(FieldId {
+            model: target_model_id,
+            index: *head_idx,
+        });
+        let target_lhs = if tail.is_empty() {
+            target_field
+        } else {
+            Expr::project(target_field, stmt::Projection::from(tail))
+        };
+
+        let subquery = stmt::Query::new_select(
+            stmt::Source::from(target_model_id),
+            Expr::binary_op(target_lhs, op, other_side.clone()),
+        );
+
+        self.lift_in_subquery(&project_expr.base, &subquery)
     }
 
     /// Returns `true` if `expr` is a column reference that resolves to a


### PR DESCRIPTION
## Summary

Lets users filter a model by a field on a related model directly:
  ```rust
// User has one Profile
User::filter(User::fields().profile().first_name().eq("Alice"))
```

## Type of change


- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers

This functionality is already available through `in_subquery` this is just an easier way to express it. Also all the heavy lifting is done in the `lift_in_subquery`.