### PR TITLE
ci: drop intra-release fix-for-new-feature entries from changelog

### DIFF
--- a/scripts/rewrite-changelog.sh
+++ b/scripts/rewrite-changelog.sh
@@ -77,6 +77,7 @@ DROP:
   - Dependency bumps unless they raise MSRV or change a public re-export.
   - Typo fixes in code comments.
   - Renames that are not visible in the public API.
+  - Fixes for bugs introduced by another entry in this same release. The feature ships in its fixed form, so the fix is not a user-visible change relative to the previous release. Example: if "Added: starts_with operator" appears in the same section as "Fixed: escape LIKE wildcards in starts_with", drop the fix — consumers only ever see the working version. Be conservative: only drop when the fix is clearly tied to a feature/change in the same release (shared subject, shared PR thread, the fix would be nonsensical without the feature). When in doubt, keep the fix.
 
 FORMAT:
   - Preserve the version heading line (## [...]...) exactly as given.


### PR DESCRIPTION
## Summary

Teach the release-plz changelog rewriter to drop "Fixed" entries that
patch a bug introduced by another entry in the same release. Consumers
only ever see the feature in its fixed form, so the fix is redundant
relative to the previous release.

The current toasty-core release surfaced this: `Add starts_with and LIKE
string prefix filter operators (#745)` shipped alongside `Escape LIKE
wildcards in starts_with prefix (#780)`. The new rule drops the latter.

The rule is conservative — only drops when the fix is clearly tied to a
feature/change in the same release (shared subject, shared PR thread,
the fix would be nonsensical without the feature). When in doubt, the
prompt instructs the model to keep the fix.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format

## Notes for reviewers

Verified end-to-end by piping the current toasty-core 0.42.0 section
through the script: `#780` is now dropped, while `#703` and `#750` are
kept (they aren't tied to anything added in this release).