### PR TITLE
feat: add all filter for associations

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_filter.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_filter.rs
@@ -148,3 +148,42 @@ pub async fn filter_parent_no_matching_children(test: &mut Test) -> Result<()> {
 
     Ok(())
 }
+
+#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::has_many_belongs_to))]
+pub async fn filter_parent_all_children_match(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    toasty::create!(User::[
+        { name: "Alice", todos: [{ title: "urgent" }] },
+        { name: "Bob", todos: [{ title: "later" }, { title: "later" }] },
+        { name: "Carol", todos: [{ title: "urgent" }, { title: "later" }] },
+        // Dan has no todos — should match `all(...)` vacuously.
+        { name: "Dan" },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    // All todos "urgent" → Alice (only urgent) and Dan (no todos, vacuous).
+    let users: Vec<_> = User::filter(
+        User::fields()
+            .todos()
+            .all(Todo::fields().title().eq("urgent")),
+    )
+    .exec(&mut db)
+    .await?;
+
+    assert_eq_unordered!(users.iter().map(|u| &u.name[..]), ["Alice", "Dan"]);
+
+    // All todos "later" → Bob and Dan.
+    let users: Vec<_> = User::filter(
+        User::fields()
+            .todos()
+            .all(Todo::fields().title().eq("later")),
+    )
+    .exec(&mut db)
+    .await?;
+
+    assert_eq_unordered!(users.iter().map(|u| &u.name[..]), ["Bob", "Dan"]);
+
+    Ok(())
+}

--- a/crates/toasty-macros/src/model/expand/fields.rs
+++ b/crates/toasty-macros/src/model/expand/fields.rs
@@ -154,7 +154,7 @@ impl Expand<'_> {
             TokenStream::new()
         };
 
-        // any() is only available on root models (requires Model trait bound)
+        // any() / all() are only available on root models (requires Model trait bound)
         let any_method = if is_root {
             quote! {
                 /// Filter the parent model by a condition on the associated
@@ -162,6 +162,14 @@ impl Expand<'_> {
                 /// satisfies `filter`.
                 #vis fn any(self, filter: #toasty::stmt::Expr<bool>) -> #toasty::stmt::Expr<bool> {
                     self.path.any(filter)
+                }
+
+                /// Filter the parent model by a condition on the associated
+                /// (child) model. Returns `true` when **all** associated records
+                /// satisfy `filter` (vacuously true when there are no
+                /// associated records).
+                #vis fn all(self, filter: #toasty::stmt::Expr<bool>) -> #toasty::stmt::Expr<bool> {
+                    self.path.all(filter)
                 }
             }
         } else {

--- a/crates/toasty/src/stmt/path.rs
+++ b/crates/toasty/src/stmt/path.rs
@@ -418,6 +418,51 @@ impl<T, U> Path<T, List<U>> {
             _p: PhantomData,
         }
     }
+
+    /// Build a `NOT IN subquery` expression that tests whether **all** associated
+    /// records satisfy `filter`.
+    ///
+    /// The path must point to a `HasMany` (or similar collection) field on the
+    /// parent model. Returns `true` when every associated record matches
+    /// `filter`, including the vacuous case where the parent has no associated
+    /// records (matching Rust's `[].iter().all()` semantics).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[derive(Debug, toasty::Model)]
+    /// # struct User {
+    /// #     #[key]
+    /// #     id: i64,
+    /// #     name: String,
+    /// # }
+    /// # #[derive(Debug, toasty::Model)]
+    /// # struct Todo {
+    /// #     #[key]
+    /// #     id: i64,
+    /// #     complete: bool,
+    /// # }
+    /// use toasty::stmt::{Path, List};
+    ///
+    /// // Find users whose todos are all complete
+    /// let todos_path = Path::<User, List<Todo>>::from_field_index(2);
+    /// let filter = todos_path.all(Todo::fields().complete().eq(true));
+    /// ```
+    pub fn all(self, filter: Expr<bool>) -> Expr<bool>
+    where
+        U: crate::schema::Model,
+    {
+        // parent NOT IN (SELECT child_fk FROM child WHERE NOT filter)
+        let child_query = super::Query::<List<U>>::filter(filter.not());
+
+        Expr {
+            untyped: stmt::Expr::not(stmt::Expr::in_subquery(
+                self.untyped.into_stmt(),
+                child_query.untyped,
+            )),
+            _p: PhantomData,
+        }
+    }
 }
 
 impl<T, U> Path<T, Option<U>> {


### PR DESCRIPTION
## Summary

This pr add a new `all` filter similar to the `any` filter.

## Type of change

<!-- Check one. -->

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers
None