### PR TITLE
chore: release v0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,20 +69,20 @@ unsafe_code = "deny"
 
 [workspace.dependencies]
 # Toasty crates
-toasty = { version = "0.5.0", path = "crates/toasty" }
-toasty-cli = { version = "0.5.0", path = "crates/toasty-cli" }
-toasty-core = { version = "0.5.0", path = "crates/toasty-core" }
-toasty-macros = { version = "0.5.0", path = "crates/toasty-macros" }
-toasty-sql = { version = "0.5.0", path = "crates/toasty-sql" }
+toasty = { version = "0.6.0", path = "crates/toasty" }
+toasty-cli = { version = "0.6.0", path = "crates/toasty-cli" }
+toasty-core = { version = "0.6.0", path = "crates/toasty-core" }
+toasty-macros = { version = "0.6.0", path = "crates/toasty-macros" }
+toasty-sql = { version = "0.6.0", path = "crates/toasty-sql" }
 # Driver implementations
-toasty-driver-dynamodb = { version = "0.5.0", path = "crates/toasty-driver-dynamodb" }
-toasty-driver-mysql = { version = "0.5.0", path = "crates/toasty-driver-mysql" }
-toasty-driver-postgresql = { version = "0.5.0", path = "crates/toasty-driver-postgresql" }
-toasty-driver-sqlite = { version = "0.5.0", path = "crates/toasty-driver-sqlite" }
+toasty-driver-dynamodb = { version = "0.6.0", path = "crates/toasty-driver-dynamodb" }
+toasty-driver-mysql = { version = "0.6.0", path = "crates/toasty-driver-mysql" }
+toasty-driver-postgresql = { version = "0.6.0", path = "crates/toasty-driver-postgresql" }
+toasty-driver-sqlite = { version = "0.6.0", path = "crates/toasty-driver-sqlite" }
 
 # Driver integration test suite dependencies
-toasty-driver-integration-suite = { version = "0.5.0", path = "crates/toasty-driver-integration-suite" }
-toasty-driver-integration-suite-macros = { version = "0.5.0", path = "crates/toasty-driver-integration-suite-macros" }
+toasty-driver-integration-suite = { version = "0.6.0", path = "crates/toasty-driver-integration-suite" }
+toasty-driver-integration-suite-macros = { version = "0.6.0", path = "crates/toasty-driver-integration-suite-macros" }
 
 # Other crates
 assert-struct = "0.4.2"

--- a/crates/toasty-cli/CHANGELOG.md
+++ b/crates/toasty-cli/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-cli-v0.5.0...toasty-cli-v0.6.0) - 2026-05-09
+
+### Fixed
+
+- The CLI now automatically creates a default config file when needed ([#795])
+
+[#795]: https://github.com/tokio-rs/toasty/pull/795
+
 ## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-cli-v0.4.0...toasty-cli-v0.5.0) - 2026-04-27
 
 ### Added

--- a/crates/toasty-cli/Cargo.toml
+++ b/crates/toasty-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-cli"
-version = "0.5.0"
+version = "0.6.0"
 description = "Command-line interface for Toasty schema management"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-core/CHANGELOG.md
+++ b/crates/toasty-core/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-core-v0.5.0...toasty-core-v0.6.0) - 2026-05-09
+
+### Added
+
+- Custom index names via the `name` attribute ([#842])
+- Auto proxy support through tuple-newtype Embed types ([#836])
+- .select() projection through BelongsTo relations ([#827])
+- PostgreSQL IN-list binding as a single array parameter ([#818])
+- Full-table scan support for DynamoDB ([#821])
+- #[deferred] support for embedded types ([#799])
+- Backward pagination support ([#757])
+- ilike() filter method for case-insensitive queries ([#801])
+- #[deferred] field attribute and Deferred<T> wrapper ([#793])
+
+[#757]: https://github.com/tokio-rs/toasty/pull/757
+[#793]: https://github.com/tokio-rs/toasty/pull/793
+[#799]: https://github.com/tokio-rs/toasty/pull/799
+[#801]: https://github.com/tokio-rs/toasty/pull/801
+[#818]: https://github.com/tokio-rs/toasty/pull/818
+[#821]: https://github.com/tokio-rs/toasty/pull/821
+[#827]: https://github.com/tokio-rs/toasty/pull/827
+[#836]: https://github.com/tokio-rs/toasty/pull/836
+[#842]: https://github.com/tokio-rs/toasty/pull/842
+
 ## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-core-v0.4.0...toasty-core-v0.5.0) - 2026-04-27
 
 ### Added

--- a/crates/toasty-core/Cargo.toml
+++ b/crates/toasty-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-core"
-version = "0.5.0"
+version = "0.6.0"
 description = "Core types, schema representations, and driver interface for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-dynamodb/CHANGELOG.md
+++ b/crates/toasty-driver-dynamodb/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-dynamodb-v0.5.0...toasty-driver-dynamodb-v0.6.0) - 2026-05-09
+
+### Added
+
+- Add full-table scan support ([#821])
+
+[#821]: https://github.com/tokio-rs/toasty/pull/821
+
 ## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-dynamodb-v0.4.0...toasty-driver-dynamodb-v0.5.0) - 2026-04-27
 
 ### Added

--- a/crates/toasty-driver-dynamodb/Cargo.toml
+++ b/crates/toasty-driver-dynamodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-dynamodb"
-version = "0.5.0"
+version = "0.6.0"
 description = "Amazon DynamoDB driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-integration-suite-macros/CHANGELOG.md
+++ b/crates/toasty-driver-integration-suite-macros/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-macros-v0.5.0...toasty-driver-integration-suite-macros-v0.6.0) - 2026-05-09
+
+- Internal improvements only.
+
 ## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-macros-v0.4.0...toasty-driver-integration-suite-macros-v0.5.0) - 2026-04-27
 
 - Internal improvements only

--- a/crates/toasty-driver-integration-suite-macros/Cargo.toml
+++ b/crates/toasty-driver-integration-suite-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-integration-suite-macros"
-version = "0.5.0"
+version = "0.6.0"
 description = "Proc macros for the Toasty driver integration test suite"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-integration-suite/CHANGELOG.md
+++ b/crates/toasty-driver-integration-suite/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-v0.5.0...toasty-driver-integration-suite-v0.6.0) - 2026-05-09
+
+### Added
+
+- Support custom index names in macro definitions ([#842])
+- Auto now works with tuple-newtype Embed types ([#836])
+- Per-call column projection with .select() ([#820])
+- Column projection through BelongsTo relations via .select() ([#827])
+- Case-insensitive filtering with ilike() method ([#801])
+- Filter associated models by their fields ([#781])
+- all filter for associations ([#784])
+- #[deferred] attribute for deferred field loading ([#793])
+- Deferred field loading support in embedded types ([#799])
+- latest_by query for finding latest records ([#707])
+- Backward pagination support in drivers ([#757])
+- IN-list parameters now bound as single arrays on PostgreSQL ([#818])
+- Full-table scan support for DynamoDB ([#821])
+
+### Fixed
+
+- Record equality comparisons now apply cast rules correctly ([#838])
+
+[#707]: https://github.com/tokio-rs/toasty/pull/707
+[#757]: https://github.com/tokio-rs/toasty/pull/757
+[#781]: https://github.com/tokio-rs/toasty/pull/781
+[#784]: https://github.com/tokio-rs/toasty/pull/784
+[#793]: https://github.com/tokio-rs/toasty/pull/793
+[#799]: https://github.com/tokio-rs/toasty/pull/799
+[#801]: https://github.com/tokio-rs/toasty/pull/801
+[#818]: https://github.com/tokio-rs/toasty/pull/818
+[#820]: https://github.com/tokio-rs/toasty/pull/820
+[#821]: https://github.com/tokio-rs/toasty/pull/821
+[#827]: https://github.com/tokio-rs/toasty/pull/827
+[#836]: https://github.com/tokio-rs/toasty/pull/836
+[#838]: https://github.com/tokio-rs/toasty/pull/838
+[#842]: https://github.com/tokio-rs/toasty/pull/842
+
 ## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-v0.4.0...toasty-driver-integration-suite-v0.5.0) - 2026-04-27
 
 ### Added

--- a/crates/toasty-driver-integration-suite/Cargo.toml
+++ b/crates/toasty-driver-integration-suite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-integration-suite"
-version = "0.5.0"
+version = "0.6.0"
 description = "Integration test suite for Toasty database drivers"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-mysql/Cargo.toml
+++ b/crates/toasty-driver-mysql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-mysql"
-version = "0.5.0"
+version = "0.6.0"
 description = "MySQL driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-postgresql/CHANGELOG.md
+++ b/crates/toasty-driver-postgresql/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-postgresql-v0.5.0...toasty-driver-postgresql-v0.6.0) - 2026-05-09
+
+### Added
+
+- Improved IN-list query performance on PostgreSQL ([#818])
+
+[#818]: https://github.com/tokio-rs/toasty/pull/818
+
 ## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-postgresql-v0.4.0...toasty-driver-postgresql-v0.5.0) - 2026-04-27
 
 ### Added

--- a/crates/toasty-driver-postgresql/Cargo.toml
+++ b/crates/toasty-driver-postgresql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-postgresql"
-version = "0.5.0"
+version = "0.6.0"
 description = "PostgreSQL driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-sqlite/CHANGELOG.md
+++ b/crates/toasty-driver-sqlite/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-sqlite-v0.5.0...toasty-driver-sqlite-v0.6.0) - 2026-05-09
+
+- Internal improvements only.
+
 ## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-sqlite-v0.4.0...toasty-driver-sqlite-v0.5.0) - 2026-04-27
 
 ### Added

--- a/crates/toasty-driver-sqlite/Cargo.toml
+++ b/crates/toasty-driver-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-sqlite"
-version = "0.5.0"
+version = "0.6.0"
 description = "SQLite driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-macros/CHANGELOG.md
+++ b/crates/toasty-macros/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-macros-v0.5.0...toasty-macros-v0.6.0) - 2026-05-09
+
+### Added
+
+- *(macros)* Support custom index names via the `name` parameter ([#842])
+- Support `Auto` with tuple-newtype `Embed` types ([#836])
+- Support `.select()` projections through `BelongsTo` relations ([#827])
+- *(macros)* Compile-time validation of column storage types ([#832])
+- Per-call `.select()` column projections ([#820])
+- Compile-time validation for `create!` macro field sets ([#648])
+- `#[deferred]` field attribute and `Deferred<T>` wrapper type, with support for embedded types ([#793], [#799])
+- `latest_by` query ([#707])
+- `all` filter for associations ([#784])
+
+[#648]: https://github.com/tokio-rs/toasty/pull/648
+[#707]: https://github.com/tokio-rs/toasty/pull/707
+[#784]: https://github.com/tokio-rs/toasty/pull/784
+[#793]: https://github.com/tokio-rs/toasty/pull/793
+[#799]: https://github.com/tokio-rs/toasty/pull/799
+[#820]: https://github.com/tokio-rs/toasty/pull/820
+[#827]: https://github.com/tokio-rs/toasty/pull/827
+[#832]: https://github.com/tokio-rs/toasty/pull/832
+[#836]: https://github.com/tokio-rs/toasty/pull/836
+[#842]: https://github.com/tokio-rs/toasty/pull/842
+
 ## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-macros-v0.4.0...toasty-macros-v0.5.0) - 2026-04-27
 
 ### Added

--- a/crates/toasty-macros/Cargo.toml
+++ b/crates/toasty-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-macros"
-version = "0.5.0"
+version = "0.6.0"
 description = "Derive macros for Toasty models and embeds"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-sql/CHANGELOG.md
+++ b/crates/toasty-sql/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-sql-v0.5.0...toasty-sql-v0.6.0) - 2026-05-09
+
+### Added
+
+- PostgreSQL now binds IN-list clauses as a single array parameter for better performance ([#818])
+- Add `ilike()` filter method for case-insensitive text matching ([#801])
+
+[#801]: https://github.com/tokio-rs/toasty/pull/801
+[#818]: https://github.com/tokio-rs/toasty/pull/818
+
 ## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-sql-v0.4.0...toasty-sql-v0.5.0) - 2026-04-27
 
 ### Added

--- a/crates/toasty-sql/Cargo.toml
+++ b/crates/toasty-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-sql"
-version = "0.5.0"
+version = "0.6.0"
 description = "SQL serialization layer for Toasty database drivers"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty/CHANGELOG.md
+++ b/crates/toasty/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-v0.5.0...toasty-v0.6.0) - 2026-05-09
+
+### Added
+
+- Auto trait support for tuple-newtype Embed types ([#836])
+- Select column projection through BelongsTo relations ([#827])
+- Compile-time column storage type validation ([#832])
+- PostgreSQL IN-list binding as a single array parameter ([#818])
+- Full-table scan support for DynamoDB ([#821])
+- Per-call column selection ([#820])
+- Compile-time field set validation in create! macro ([#648])
+- #[deferred] support for embedded types ([#799])
+- Backward pagination support ([#757])
+- ilike() filter method ([#801])
+- #[deferred] field attribute and Deferred<T> wrapper ([#793])
+- latest_by query ([#707])
+- Filter by fields on associated models ([#781])
+- all filter for associations ([#784])
+
+### Fixed
+
+- Record comparisons now correctly apply casting rules ([#838])
+
+[#648]: https://github.com/tokio-rs/toasty/pull/648
+[#707]: https://github.com/tokio-rs/toasty/pull/707
+[#757]: https://github.com/tokio-rs/toasty/pull/757
+[#781]: https://github.com/tokio-rs/toasty/pull/781
+[#784]: https://github.com/tokio-rs/toasty/pull/784
+[#793]: https://github.com/tokio-rs/toasty/pull/793
+[#799]: https://github.com/tokio-rs/toasty/pull/799
+[#801]: https://github.com/tokio-rs/toasty/pull/801
+[#818]: https://github.com/tokio-rs/toasty/pull/818
+[#820]: https://github.com/tokio-rs/toasty/pull/820
+[#821]: https://github.com/tokio-rs/toasty/pull/821
+[#827]: https://github.com/tokio-rs/toasty/pull/827
+[#832]: https://github.com/tokio-rs/toasty/pull/832
+[#836]: https://github.com/tokio-rs/toasty/pull/836
+[#838]: https://github.com/tokio-rs/toasty/pull/838
+
 ## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-v0.4.0...toasty-v0.5.0) - 2026-04-27
 
 ### Added

--- a/crates/toasty/Cargo.toml
+++ b/crates/toasty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty"
-version = "0.5.0"
+version = "0.6.0"
 description = "An async ORM for Rust supporting SQL and NoSQL databases"
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `toasty-core`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)
* `toasty-driver-dynamodb`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `toasty-sql`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `toasty-driver-mysql`: 0.5.0 -> 0.6.0
* `toasty-driver-postgresql`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `toasty-driver-sqlite`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `toasty-macros`: 0.5.0 -> 0.6.0
* `toasty`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `toasty-cli`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `toasty-driver-integration-suite-macros`: 0.5.0 -> 0.6.0
* `toasty-driver-integration-suite`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)

### ⚠ `toasty-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field FieldStruct.default_returning in /tmp/.tmppCkTb2/toasty/crates/toasty-core/src/schema/mapping/field.rs:239
  field ExprLike.case_insensitive in /tmp/.tmppCkTb2/toasty/crates/toasty-core/src/stmt/expr_like.rs:28
  field Index.name in /tmp/.tmppCkTb2/toasty/crates/toasty-core/src/schema/app/index.rs:41
  field Capability.scan in /tmp/.tmppCkTb2/toasty/crates/toasty-core/src/driver/capability.rs:130
  field Capability.scan_supports_sort in /tmp/.tmppCkTb2/toasty/crates/toasty-core/src/driver/capability.rs:139
  field Capability.backward_pagination in /tmp/.tmppCkTb2/toasty/crates/toasty-core/src/driver/capability.rs:147
  field Capability.bind_list_param in /tmp/.tmppCkTb2/toasty/crates/toasty-core/src/driver/capability.rs:153
  field Capability.predicate_match_any in /tmp/.tmppCkTb2/toasty/crates/toasty-core/src/driver/capability.rs:158
  field Model.default_returning in /tmp/.tmppCkTb2/toasty/crates/toasty-core/src/schema/mapping/model.rs:76
  field FieldEnum.default_returning in /tmp/.tmppCkTb2/toasty/crates/toasty-core/src/schema/mapping/field.rs:279
  field FieldPrimitive.column_expr in /tmp/.tmppCkTb2/toasty/crates/toasty-core/src/schema/mapping/field.rs:190
  field Field.deferred in /tmp/.tmppCkTb2/toasty/crates/toasty-core/src/schema/app/field.rs:54

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_missing.ron

Failed in:
  enum toasty_core::driver::operation::QueryPkLimit, previously in file /tmp/.tmpzYVQzJ/toasty-core/src/driver/operation/query_pk.rs:9

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Expr:AllOp in /tmp/.tmppCkTb2/toasty/crates/toasty-core/src/stmt/expr.rs:39
  variant Expr:AnyOp in /tmp/.tmppCkTb2/toasty/crates/toasty-core/src/stmt/expr.rs:48
  variant Returning:Project in /tmp/.tmppCkTb2/toasty/crates/toasty-core/src/stmt/returning.rs:29
  variant Type:List in /tmp/.tmppCkTb2/toasty/crates/toasty-core/src/schema/db/ty.rs:115
  variant Operation:Scan in /tmp/.tmppCkTb2/toasty/crates/toasty-core/src/driver/operation.rs:92
  variant Operation:Scan in /tmp/.tmppCkTb2/toasty/crates/toasty-core/src/driver/operation.rs:92

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant Returning::Value, previously in file /tmp/.tmpzYVQzJ/toasty-core/src/stmt/returning.rs:32

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  Returning::from_expr_iter, previously in file /tmp/.tmpzYVQzJ/toasty-core/src/stmt/returning.rs:38
  Returning::as_expr, previously in file /tmp/.tmpzYVQzJ/toasty-core/src/stmt/returning.rs:84
  Returning::as_expr_unwrap, previously in file /tmp/.tmpzYVQzJ/toasty-core/src/stmt/returning.rs:97
  Returning::as_expr_mut, previously in file /tmp/.tmpzYVQzJ/toasty-core/src/stmt/returning.rs:104
  Returning::as_expr_mut_unwrap, previously in file /tmp/.tmpzYVQzJ/toasty-core/src/stmt/returning.rs:117
  Returning::set_expr, previously in file /tmp/.tmpzYVQzJ/toasty-core/src/stmt/returning.rs:126
  Returning::is_value, previously in file /tmp/.tmpzYVQzJ/toasty-core/src/stmt/returning.rs:131
  Type::from_value, previously in file /tmp/.tmpzYVQzJ/toasty-core/src/schema/db/ty.rs:170
```

### ⚠ `toasty-driver-integration-suite` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function toasty_driver_integration_suite::tests::dynamodb_limit_boundary::limit_offset_spans_page_boundary, previously in file /tmp/.tmpzYVQzJ/toasty-driver-integration-suite/src/tests/dynamodb_limit_boundary.rs:55
  function toasty_driver_integration_suite::tests::dynamodb_limit_boundary::limit_spans_page_boundary, previously in file /tmp/.tmpzYVQzJ/toasty-driver-integration-suite/src/tests/dynamodb_limit_boundary.rs:19
  function toasty_driver_integration_suite::tests::dynamodb_limit_boundary::limit_offset_spans_page_boundary_gsi, previously in file /tmp/.tmpzYVQzJ/toasty-driver-integration-suite/src/tests/dynamodb_limit_boundary.rs:134
  function toasty_driver_integration_suite::tests::dynamodb_limit_boundary::limit_spans_page_boundary_gsi, previously in file /tmp/.tmpzYVQzJ/toasty-driver-integration-suite/src/tests/dynamodb_limit_boundary.rs:94

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/module_missing.ron

Failed in:
  mod toasty_driver_integration_suite::tests::dynamodb_limit_boundary, previously in file /tmp/.tmpzYVQzJ/toasty-driver-integration-suite/src/tests/dynamodb_limit_boundary.rs:1
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `toasty-core`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-core-v0.5.0...toasty-core-v0.6.0) - 2026-05-09

### Added

- Custom index names via the `name` attribute ([#842])
- Auto proxy support through tuple-newtype Embed types ([#836])
- .select() projection through BelongsTo relations ([#827])
- PostgreSQL IN-list binding as a single array parameter ([#818])
- Full-table scan support for DynamoDB ([#821])
- #[deferred] support for embedded types ([#799])
- Backward pagination support ([#757])
- ilike() filter method for case-insensitive queries ([#801])
- #[deferred] field attribute and Deferred<T> wrapper ([#793])

[#757]: https://github.com/tokio-rs/toasty/pull/757
[#793]: https://github.com/tokio-rs/toasty/pull/793
[#799]: https://github.com/tokio-rs/toasty/pull/799
[#801]: https://github.com/tokio-rs/toasty/pull/801
[#818]: https://github.com/tokio-rs/toasty/pull/818
[#821]: https://github.com/tokio-rs/toasty/pull/821
[#827]: https://github.com/tokio-rs/toasty/pull/827
[#836]: https://github.com/tokio-rs/toasty/pull/836
[#842]: https://github.com/tokio-rs/toasty/pull/842
</blockquote>

## `toasty-driver-dynamodb`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-dynamodb-v0.5.0...toasty-driver-dynamodb-v0.6.0) - 2026-05-09

### Added

- Add full-table scan support ([#821])

[#821]: https://github.com/tokio-rs/toasty/pull/821
</blockquote>

## `toasty-sql`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-sql-v0.5.0...toasty-sql-v0.6.0) - 2026-05-09

### Added

- PostgreSQL now binds IN-list clauses as a single array parameter for better performance ([#818])
- Add `ilike()` filter method for case-insensitive text matching ([#801])

[#801]: https://github.com/tokio-rs/toasty/pull/801
[#818]: https://github.com/tokio-rs/toasty/pull/818
</blockquote>

## `toasty-driver-mysql`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-mysql-v0.4.0...toasty-driver-mysql-v0.5.0) - 2026-04-27

### Added

- Support for float types ([#687])
- Native database enum types for embedded enums ([#665])

[#665]: https://github.com/tokio-rs/toasty/pull/665
[#687]: https://github.com/tokio-rs/toasty/pull/687
</blockquote>

## `toasty-driver-postgresql`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-postgresql-v0.5.0...toasty-driver-postgresql-v0.6.0) - 2026-05-09

### Added

- Improved IN-list query performance on PostgreSQL ([#818])

[#818]: https://github.com/tokio-rs/toasty/pull/818
</blockquote>

## `toasty-driver-sqlite`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-sqlite-v0.5.0...toasty-driver-sqlite-v0.6.0) - 2026-05-09

- Internal improvements only.
</blockquote>

## `toasty-macros`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-macros-v0.5.0...toasty-macros-v0.6.0) - 2026-05-09

### Added

- *(macros)* Support custom index names via the `name` parameter ([#842])
- Support `Auto` with tuple-newtype `Embed` types ([#836])
- Support `.select()` projections through `BelongsTo` relations ([#827])
- *(macros)* Compile-time validation of column storage types ([#832])
- Per-call `.select()` column projections ([#820])
- Compile-time validation for `create!` macro field sets ([#648])
- `#[deferred]` field attribute and `Deferred<T>` wrapper type, with support for embedded types ([#793], [#799])
- `latest_by` query ([#707])
- `all` filter for associations ([#784])

[#648]: https://github.com/tokio-rs/toasty/pull/648
[#707]: https://github.com/tokio-rs/toasty/pull/707
[#784]: https://github.com/tokio-rs/toasty/pull/784
[#793]: https://github.com/tokio-rs/toasty/pull/793
[#799]: https://github.com/tokio-rs/toasty/pull/799
[#820]: https://github.com/tokio-rs/toasty/pull/820
[#827]: https://github.com/tokio-rs/toasty/pull/827
[#832]: https://github.com/tokio-rs/toasty/pull/832
[#836]: https://github.com/tokio-rs/toasty/pull/836
[#842]: https://github.com/tokio-rs/toasty/pull/842
</blockquote>

## `toasty`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-v0.5.0...toasty-v0.6.0) - 2026-05-09

### Added

- Auto trait support for tuple-newtype Embed types ([#836])
- Select column projection through BelongsTo relations ([#827])
- Compile-time column storage type validation ([#832])
- PostgreSQL IN-list binding as a single array parameter ([#818])
- Full-table scan support for DynamoDB ([#821])
- Per-call column selection ([#820])
- Compile-time field set validation in create! macro ([#648])
- #[deferred] support for embedded types ([#799])
- Backward pagination support ([#757])
- ilike() filter method ([#801])
- #[deferred] field attribute and Deferred<T> wrapper ([#793])
- latest_by query ([#707])
- Filter by fields on associated models ([#781])
- all filter for associations ([#784])

### Fixed

- Record comparisons now correctly apply casting rules ([#838])

[#648]: https://github.com/tokio-rs/toasty/pull/648
[#707]: https://github.com/tokio-rs/toasty/pull/707
[#757]: https://github.com/tokio-rs/toasty/pull/757
[#781]: https://github.com/tokio-rs/toasty/pull/781
[#784]: https://github.com/tokio-rs/toasty/pull/784
[#793]: https://github.com/tokio-rs/toasty/pull/793
[#799]: https://github.com/tokio-rs/toasty/pull/799
[#801]: https://github.com/tokio-rs/toasty/pull/801
[#818]: https://github.com/tokio-rs/toasty/pull/818
[#820]: https://github.com/tokio-rs/toasty/pull/820
[#821]: https://github.com/tokio-rs/toasty/pull/821
[#827]: https://github.com/tokio-rs/toasty/pull/827
[#832]: https://github.com/tokio-rs/toasty/pull/832
[#836]: https://github.com/tokio-rs/toasty/pull/836
[#838]: https://github.com/tokio-rs/toasty/pull/838
</blockquote>

## `toasty-cli`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-cli-v0.5.0...toasty-cli-v0.6.0) - 2026-05-09

### Fixed

- The CLI now automatically creates a default config file when needed ([#795])

[#795]: https://github.com/tokio-rs/toasty/pull/795
</blockquote>

## `toasty-driver-integration-suite-macros`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-macros-v0.5.0...toasty-driver-integration-suite-macros-v0.6.0) - 2026-05-09

- Internal improvements only.
</blockquote>

## `toasty-driver-integration-suite`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-v0.5.0...toasty-driver-integration-suite-v0.6.0) - 2026-05-09

### Added

- Support custom index names in macro definitions ([#842])
- Auto now works with tuple-newtype Embed types ([#836])
- Per-call column projection with .select() ([#820])
- Column projection through BelongsTo relations via .select() ([#827])
- Case-insensitive filtering with ilike() method ([#801])
- Filter associated models by their fields ([#781])
- all filter for associations ([#784])
- #[deferred] attribute for deferred field loading ([#793])
- Deferred field loading support in embedded types ([#799])
- latest_by query for finding latest records ([#707])
- Backward pagination support in drivers ([#757])
- IN-list parameters now bound as single arrays on PostgreSQL ([#818])
- Full-table scan support for DynamoDB ([#821])

### Fixed

- Record equality comparisons now apply cast rules correctly ([#838])

[#707]: https://github.com/tokio-rs/toasty/pull/707
[#757]: https://github.com/tokio-rs/toasty/pull/757
[#781]: https://github.com/tokio-rs/toasty/pull/781
[#784]: https://github.com/tokio-rs/toasty/pull/784
[#793]: https://github.com/tokio-rs/toasty/pull/793
[#799]: https://github.com/tokio-rs/toasty/pull/799
[#801]: https://github.com/tokio-rs/toasty/pull/801
[#818]: https://github.com/tokio-rs/toasty/pull/818
[#820]: https://github.com/tokio-rs/toasty/pull/820
[#821]: https://github.com/tokio-rs/toasty/pull/821
[#827]: https://github.com/tokio-rs/toasty/pull/827
[#836]: https://github.com/tokio-rs/toasty/pull/836
[#838]: https://github.com/tokio-rs/toasty/pull/838
[#842]: https://github.com/tokio-rs/toasty/pull/842
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).