### PR TITLE
docs: tell pr skill to link rendered markdown PRs

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -38,6 +38,25 @@ Keep the section headings and the checklist; replace the HTML comment
 placeholders with real content. Delete checklist items that do not
 apply rather than leaving them unchecked with no explanation.
 
+## Markdown-doc PRs: link the rendered version
+
+When a PR's primary change is adding or substantially modifying a single
+markdown file (e.g., a design doc or a major docs rewrite), put a link
+to the rendered version on the branch as the first line under
+`## Summary`:
+
+```
+## Summary
+
+[Rendered](https://github.com/tokio-rs/toasty/blob/<branch-name>/<path-to-file>.md)
+
+<rest of summary>
+```
+
+Use the PR's head branch name in the URL so the link renders the
+version under review, not what's on `main`. PR
+[#787](https://github.com/tokio-rs/toasty/pull/787) is an example.
+
 ## Be succinct
 
 Reviewers already know Toasty and Rust. Keep the body high-signal:


### PR DESCRIPTION
## Summary

[Rendered](https://github.com/tokio-rs/toasty/blob/worktree-zazzy-wobbling-gosling/.claude/skills/pr/SKILL.md)

When a PR is primarily a single markdown file (a design doc, a major docs rewrite), the rendered version is far easier to review than the raw diff. Add a section to the `pr` skill instructing the PR body to lead `## Summary` with a `[Rendered](.../blob/<branch>/<path>.md)` link in those cases. Cite #787 as an example.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format