### PR TITLE
refactor(core): rename Returning variants Expr→Project, Value→Expr

### DIFF
--- a/crates/toasty-core/src/stmt/cx.rs
+++ b/crates/toasty-core/src/stmt/cx.rs
@@ -416,7 +416,7 @@ impl<'a, T: Resolve> ExprContext<'a, T> {
                 if single { ty } else { Type::list(ty) }
             }
             Returning::Changed => todo!(),
-            Returning::Expr(expr) => {
+            Returning::Project(expr) => {
                 let ty = self.infer_expr_ty2(&arg_ty_stack, expr, false);
 
                 if single { ty } else { Type::list(ty) }

--- a/crates/toasty-core/src/stmt/cx.rs
+++ b/crates/toasty-core/src/stmt/cx.rs
@@ -421,7 +421,7 @@ impl<'a, T: Resolve> ExprContext<'a, T> {
 
                 if single { ty } else { Type::list(ty) }
             }
-            Returning::Value(expr) => self.infer_expr_ty2(&arg_ty_stack, expr, true),
+            Returning::Expr(expr) => self.infer_expr_ty2(&arg_ty_stack, expr, true),
         }
     }
 

--- a/crates/toasty-core/src/stmt/query.rs
+++ b/crates/toasty-core/src/stmt/query.rs
@@ -291,9 +291,7 @@ impl QueryBuilder {
     }
 
     /// Sets the returning clause on the query's `SELECT` body.
-    pub fn returning(mut self, returning: impl Into<Returning>) -> Self {
-        let returning = returning.into();
-
+    pub fn returning(mut self, returning: Returning) -> Self {
         match &mut self.query.body {
             ExprSet::Select(select) => {
                 select.returning = returning;

--- a/crates/toasty-core/src/stmt/query.rs
+++ b/crates/toasty-core/src/stmt/query.rs
@@ -1,6 +1,6 @@
 use super::{
-    Delete, ExprSet, Limit, Node, OrderBy, Path, Returning, Select, Source, Statement, Update,
-    UpdateTarget, Values, Visit, VisitMut, With,
+    Delete, Expr, ExprSet, Limit, Node, OrderBy, Path, Returning, Select, Source, Statement,
+    Update, UpdateTarget, Values, Visit, VisitMut, With,
 };
 use crate::stmt::{self, Filter};
 
@@ -300,6 +300,18 @@ impl QueryBuilder {
         }
 
         self
+    }
+
+    /// Sets the returning clause to `Returning::Project` containing the given
+    /// expression.
+    pub fn returning_project(self, expr: impl Into<Expr>) -> Self {
+        self.returning(Returning::Project(expr.into()))
+    }
+
+    /// Sets the returning clause to `Returning::Expr` containing the given
+    /// expression.
+    pub fn returning_expr(self, expr: impl Into<Expr>) -> Self {
+        self.returning(Returning::Expr(expr.into()))
     }
 
     /// Consumes this builder and returns the constructed [`Query`].

--- a/crates/toasty-core/src/stmt/returning.rs
+++ b/crates/toasty-core/src/stmt/returning.rs
@@ -177,6 +177,18 @@ impl Statement {
         }
     }
 
+    /// Set the `Returning` clause to `Returning::Project` containing the given
+    /// expression.
+    pub fn set_returning_project(&mut self, expr: impl Into<Expr>) {
+        self.set_returning(Returning::Project(expr.into()));
+    }
+
+    /// Set the `Returning` clause to `Returning::Expr` containing the given
+    /// expression.
+    pub fn set_returning_expr(&mut self, expr: impl Into<Expr>) {
+        self.set_returning(Returning::Expr(expr.into()));
+    }
+
     /// Returns a reference to this statement's `RETURNING` clause.
     ///
     /// # Panics

--- a/crates/toasty-core/src/stmt/returning.rs
+++ b/crates/toasty-core/src/stmt/returning.rs
@@ -1,5 +1,5 @@
 use super::{Expr, Path};
-use crate::stmt::{self, ExprSet, Node, Query, Statement, Value};
+use crate::stmt::{self, ExprSet, Node, Query, Statement};
 
 /// Specifies what data a statement returns.
 ///
@@ -265,27 +265,6 @@ impl Query {
             stmt::ExprSet::Select(select) => &mut select.returning,
             body => panic!("expected query to have RETURNING clause; actual={body:#?}"),
         }
-    }
-}
-
-impl<T> From<T> for Returning
-where
-    Value: From<T>,
-{
-    fn from(value: T) -> Self {
-        Returning::Expr(Value::from(value).into())
-    }
-}
-
-impl From<Expr> for Returning {
-    fn from(value: Expr) -> Self {
-        Self::Expr(value)
-    }
-}
-
-impl From<Vec<Expr>> for Returning {
-    fn from(value: Vec<Expr>) -> Self {
-        stmt::Returning::Expr(stmt::Expr::record_from_vec(value))
     }
 }
 

--- a/crates/toasty-core/src/stmt/returning.rs
+++ b/crates/toasty-core/src/stmt/returning.rs
@@ -26,20 +26,20 @@ pub enum Returning {
     Changed,
 
     /// Return the result of evaluating an expression against the source rows.
-    Expr(Expr),
+    Project(Expr),
 
     /// Return a fixed value, independent of the statement source.
     Value(Expr),
 }
 
 impl Returning {
-    /// Creates a `Returning::Expr` from an iterator of expressions, combining
+    /// Creates a `Returning::Project` from an iterator of expressions, combining
     /// them into a record expression.
-    pub fn from_expr_iter<T>(items: impl IntoIterator<Item = T>) -> Self
+    pub fn from_project_iter<T>(items: impl IntoIterator<Item = T>) -> Self
     where
         T: Into<Expr>,
     {
-        Returning::Expr(Expr::record(items))
+        Returning::Project(Expr::record(items))
     }
 
     /// Returns `true` if this is the `Model` variant.
@@ -74,16 +74,16 @@ impl Returning {
         matches!(self, Self::Changed)
     }
 
-    /// Returns `true` if this is the `Expr` variant.
-    pub fn is_expr(&self) -> bool {
-        matches!(self, Self::Expr(_))
+    /// Returns `true` if this is the `Project` variant.
+    pub fn is_project(&self) -> bool {
+        matches!(self, Self::Project(_))
     }
 
-    /// Returns a reference to the inner expression if this is the `Expr`
+    /// Returns a reference to the inner expression if this is the `Project`
     /// variant.
-    pub fn as_expr(&self) -> Option<&Expr> {
+    pub fn as_project(&self) -> Option<&Expr> {
         match self {
-            Self::Expr(expr) => Some(expr),
+            Self::Project(expr) => Some(expr),
             _ => None,
         }
     }
@@ -92,18 +92,18 @@ impl Returning {
     ///
     /// # Panics
     ///
-    /// Panics if this is not the `Expr` variant.
+    /// Panics if this is not the `Project` variant.
     #[track_caller]
-    pub fn as_expr_unwrap(&self) -> &Expr {
-        self.as_expr()
-            .unwrap_or_else(|| panic!("expected stmt::Returning::Expr; actual={self:#?}"))
+    pub fn as_project_unwrap(&self) -> &Expr {
+        self.as_project()
+            .unwrap_or_else(|| panic!("expected stmt::Returning::Project; actual={self:#?}"))
     }
 
     /// Returns a mutable reference to the inner expression if this is the
-    /// `Expr` variant.
-    pub fn as_expr_mut(&mut self) -> Option<&mut Expr> {
+    /// `Project` variant.
+    pub fn as_project_mut(&mut self) -> Option<&mut Expr> {
         match self {
-            Self::Expr(expr) => Some(expr),
+            Self::Project(expr) => Some(expr),
             _ => None,
         }
     }
@@ -112,19 +112,19 @@ impl Returning {
     ///
     /// # Panics
     ///
-    /// Panics if this is not the `Expr` variant.
+    /// Panics if this is not the `Project` variant.
     #[track_caller]
-    pub fn as_expr_mut_unwrap(&mut self) -> &mut Expr {
+    pub fn as_project_mut_unwrap(&mut self) -> &mut Expr {
         match self {
-            Self::Expr(expr) => expr,
-            _ => panic!("expected stmt::Returning::Expr; actual={self:#?}"),
+            Self::Project(expr) => expr,
+            _ => panic!("expected stmt::Returning::Project; actual={self:#?}"),
         }
     }
 
-    /// Replaces this returning clause with `Returning::Expr` containing the
+    /// Replaces this returning clause with `Returning::Project` containing the
     /// given expression.
-    pub fn set_expr(&mut self, expr: impl Into<Expr>) {
-        *self = Returning::Expr(expr.into());
+    pub fn set_project(&mut self, expr: impl Into<Expr>) {
+        *self = Returning::Project(expr.into());
     }
 
     /// Returns `true` if this is the `Value` variant.
@@ -132,10 +132,10 @@ impl Returning {
         matches!(self, Self::Value(..))
     }
 
-    /// Takes this returning clause, replacing it with `Returning::Expr(null)`,
+    /// Takes this returning clause, replacing it with `Returning::Project(null)`,
     /// and returns the original value.
     pub fn take(&mut self) -> Returning {
-        std::mem::replace(self, Returning::Expr(stmt::Expr::null()))
+        std::mem::replace(self, Returning::Project(stmt::Expr::null()))
     }
 }
 

--- a/crates/toasty-core/src/stmt/returning.rs
+++ b/crates/toasty-core/src/stmt/returning.rs
@@ -28,8 +28,8 @@ pub enum Returning {
     /// Return the result of evaluating an expression against the source rows.
     Project(Expr),
 
-    /// Return a fixed value, independent of the statement source.
-    Value(Expr),
+    /// Return a fixed expression, independent of the statement source.
+    Expr(Expr),
 }
 
 impl Returning {
@@ -127,9 +127,9 @@ impl Returning {
         *self = Returning::Project(expr.into());
     }
 
-    /// Returns `true` if this is the `Value` variant.
-    pub fn is_value(&self) -> bool {
-        matches!(self, Self::Value(..))
+    /// Returns `true` if this is the `Expr` variant.
+    pub fn is_expr(&self) -> bool {
+        matches!(self, Self::Expr(..))
     }
 
     /// Takes this returning clause, replacing it with `Returning::Project(null)`,

--- a/crates/toasty-core/src/stmt/visit.rs
+++ b/crates/toasty-core/src/stmt/visit.rs
@@ -1252,7 +1252,7 @@ where
             }
         }
         Returning::Changed => {}
-        Returning::Expr(expr) => v.visit_expr(expr),
+        Returning::Project(expr) => v.visit_expr(expr),
         Returning::Value(expr) => v.visit_expr(expr),
     }
 }

--- a/crates/toasty-core/src/stmt/visit.rs
+++ b/crates/toasty-core/src/stmt/visit.rs
@@ -1253,7 +1253,7 @@ where
         }
         Returning::Changed => {}
         Returning::Project(expr) => v.visit_expr(expr),
-        Returning::Value(expr) => v.visit_expr(expr),
+        Returning::Expr(expr) => v.visit_expr(expr),
     }
 }
 

--- a/crates/toasty-core/src/stmt/visit_mut.rs
+++ b/crates/toasty-core/src/stmt/visit_mut.rs
@@ -1255,7 +1255,7 @@ where
         }
         Returning::Changed => {}
         Returning::Project(expr) => v.visit_expr_mut(expr),
-        Returning::Value(expr) => v.visit_expr_mut(expr),
+        Returning::Expr(expr) => v.visit_expr_mut(expr),
     }
 }
 

--- a/crates/toasty-core/src/stmt/visit_mut.rs
+++ b/crates/toasty-core/src/stmt/visit_mut.rs
@@ -1254,7 +1254,7 @@ where
             }
         }
         Returning::Changed => {}
-        Returning::Expr(expr) => v.visit_expr_mut(expr),
+        Returning::Project(expr) => v.visit_expr_mut(expr),
         Returning::Value(expr) => v.visit_expr_mut(expr),
     }
 }

--- a/crates/toasty-driver-sqlite/src/lib.rs
+++ b/crates/toasty-driver-sqlite/src/lib.rs
@@ -205,23 +205,23 @@ impl toasty_core::driver::Connection for Connection {
         let width = match &sql {
             sql::Statement::Query(stmt) => match &stmt.body {
                 stmt::ExprSet::Select(stmt) => {
-                    Some(stmt.returning.as_expr_unwrap().as_record_unwrap().len())
+                    Some(stmt.returning.as_project_unwrap().as_record_unwrap().len())
                 }
                 _ => todo!(),
             },
             sql::Statement::Insert(stmt) => stmt
                 .returning
                 .as_ref()
-                .map(|returning| returning.as_expr_unwrap().as_record_unwrap().len()),
+                .map(|returning| returning.as_project_unwrap().as_record_unwrap().len()),
             sql::Statement::Delete(stmt) => stmt
                 .returning
                 .as_ref()
-                .map(|returning| returning.as_expr_unwrap().as_record_unwrap().len()),
+                .map(|returning| returning.as_project_unwrap().as_record_unwrap().len()),
             sql::Statement::Update(stmt) => {
                 assert!(stmt.condition.is_none(), "stmt={stmt:#?}");
                 stmt.returning
                     .as_ref()
-                    .map(|returning| returning.as_expr_unwrap().as_record_unwrap().len())
+                    .map(|returning| returning.as_project_unwrap().as_record_unwrap().len())
             }
             _ => None,
         };

--- a/crates/toasty-sql/src/serializer/statement.rs
+++ b/crates/toasty-sql/src/serializer/statement.rs
@@ -454,7 +454,7 @@ impl ToSql for &stmt::OrderByExpr {
 impl ToSql for &stmt::Returning {
     fn to_sql(self, cx: &ExprContext<'_>, f: &mut super::Formatter<'_>) {
         match self {
-            stmt::Returning::Expr(stmt::Expr::Record(expr_record)) => {
+            stmt::Returning::Project(stmt::Expr::Record(expr_record)) => {
                 let fields = expr_record
                     .fields
                     .iter()
@@ -468,7 +468,7 @@ impl ToSql for &stmt::Returning {
 
                 fmt!(cx, f, Comma(fields));
             }
-            stmt::Returning::Expr(stmt::Expr::Value(stmt::Value::Record(value_record))) => {
+            stmt::Returning::Project(stmt::Expr::Value(stmt::Value::Record(value_record))) => {
                 fmt!(cx, f, Comma(&value_record.fields));
             }
             _ => todo!("returning={self:#?}"),

--- a/crates/toasty-sql/src/stmt.rs
+++ b/crates/toasty-sql/src/stmt.rs
@@ -100,21 +100,25 @@ impl Statement {
             Self::Delete(delete) => delete
                 .returning
                 .as_ref()
-                .map(|ret| ret.as_expr_unwrap().as_record_unwrap().len()),
+                .map(|ret| ret.as_project_unwrap().as_record_unwrap().len()),
             Self::Insert(insert) => insert
                 .returning
                 .as_ref()
-                .map(|ret| ret.as_expr_unwrap().as_record_unwrap().len()),
+                .map(|ret| ret.as_project_unwrap().as_record_unwrap().len()),
             Self::Query(query) => match &query.body {
-                ExprSet::Select(select) => {
-                    Some(select.returning.as_expr_unwrap().as_record_unwrap().len())
-                }
+                ExprSet::Select(select) => Some(
+                    select
+                        .returning
+                        .as_project_unwrap()
+                        .as_record_unwrap()
+                        .len(),
+                ),
                 stmt => todo!("returning_len, stmt={stmt:#?}"),
             },
             Self::Update(update) => update
                 .returning
                 .as_ref()
-                .map(|ret| ret.as_expr_unwrap().as_record_unwrap().len()),
+                .map(|ret| ret.as_project_unwrap().as_record_unwrap().len()),
             _ => None,
         }
     }

--- a/crates/toasty/src/engine/exec/exec_statement.rs
+++ b/crates/toasty/src/engine/exec/exec_statement.rs
@@ -82,7 +82,7 @@ impl Exec<'_> {
 
         debug_assert!(
             stmt.returning()
-                .and_then(|returning| returning.as_expr())
+                .and_then(|returning| returning.as_project())
                 .map(|expr| expr.is_record())
                 .unwrap_or(true),
             "stmt={stmt:#?}"
@@ -282,7 +282,7 @@ impl Exec<'_> {
 
         // Extract the expression from the RETURNING clause and replace ExprReference with ExprArg
         let mut returning_expr = match returning {
-            stmt::Returning::Expr(expr) => expr,
+            stmt::Returning::Project(expr) => expr,
             _ => panic!(
                 "MySQL INSERT with RETURNING must have an Expr, got: {:#?}",
                 returning

--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -539,7 +539,7 @@ impl visit_mut::VisitMut for LowerStatement<'_, '_> {
         // that sub-statements (e.g., child INSERTs for HasOne relations) capture
         // the correct parent row index via scope_statement.
         if matches!(&self.cx, LoweringContext::Insert(..))
-            && let stmt::Returning::Value(stmt::Expr::List(list)) = i
+            && let stmt::Returning::Expr(stmt::Expr::List(list)) = i
         {
             for (index, item) in list.items.iter_mut().enumerate() {
                 self.lower_returning_for_row(index).visit_expr_mut(item);
@@ -596,7 +596,7 @@ impl visit_mut::VisitMut for LowerStatement<'_, '_> {
             lower.constantize_insert_returning(returning, &stmt.source);
 
             if stmt.source.single
-                && let stmt::Returning::Value(expr) = &returning
+                && let stmt::Returning::Expr(expr) = &returning
             {
                 // Not strictly true, but there is nothing that needs to
                 // return a list at this point for a "single" query. If this

--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -283,12 +283,12 @@ impl visit_mut::VisitMut for LowerStatement<'_, '_> {
                     let maybe_res = self.lower_expr_binary_op(
                         stmt::BinaryOp::Eq,
                         &mut e.expr,
-                        e.query.returning_mut_unwrap().as_expr_mut_unwrap(),
+                        e.query.returning_mut_unwrap().as_project_mut_unwrap(),
                     );
 
                     assert!(maybe_res.is_none(), "TODO");
 
-                    let returning = e.query.returning_mut_unwrap().as_expr_mut_unwrap();
+                    let returning = e.query.returning_mut_unwrap().as_project_mut_unwrap();
 
                     if !returning.is_record() {
                         *returning = stmt::Expr::record([returning.take()]);
@@ -313,7 +313,7 @@ impl visit_mut::VisitMut for LowerStatement<'_, '_> {
                     let maybe_res = self.lower_expr_binary_op(
                         stmt::BinaryOp::Eq,
                         &mut e.expr,
-                        e.query.returning_mut_unwrap().as_expr_mut_unwrap(),
+                        e.query.returning_mut_unwrap().as_project_mut_unwrap(),
                     );
 
                     assert!(maybe_res.is_none(), "TODO");
@@ -532,7 +532,7 @@ impl visit_mut::VisitMut for LowerStatement<'_, '_> {
                 self.build_include_subquery(&mut returning, field, &nested);
             }
 
-            *i = stmt::Returning::Expr(returning);
+            *i = stmt::Returning::Project(returning);
         }
 
         // For multi-row INSERT returning, visit each row with its row index so
@@ -663,7 +663,7 @@ impl visit_mut::VisitMut for LowerStatement<'_, '_> {
                 }
 
                 // Step 2 — build the returning expression.
-                *returning = stmt::Returning::Expr(build_update_returning(
+                *returning = stmt::Returning::Project(build_update_returning(
                     model.id,
                     None,
                     &mapping.fields,

--- a/crates/toasty/src/engine/lower/insert.rs
+++ b/crates/toasty/src/engine/lower/insert.rs
@@ -161,7 +161,7 @@ impl LowerStatement<'_, '_> {
         single: bool,
     ) {
         // If there is no returning statement, there is nothing to convert
-        let Some(stmt::Returning::Expr(projection)) = returning else {
+        let Some(stmt::Returning::Project(projection)) = returning else {
             return;
         };
 

--- a/crates/toasty/src/engine/lower/insert.rs
+++ b/crates/toasty/src/engine/lower/insert.rs
@@ -202,7 +202,7 @@ impl LowerStatement<'_, '_> {
             converted.push(converted_row);
         }
 
-        *returning = Some(stmt::Returning::Value(if single {
+        *returning = Some(stmt::Returning::Expr(if single {
             assert!(converted.len() == 1);
             converted.into_iter().next().unwrap()
         } else {

--- a/crates/toasty/src/engine/lower/relation.rs
+++ b/crates/toasty/src/engine/lower/relation.rs
@@ -301,7 +301,7 @@ impl LowerStatement<'_, '_> {
                 let stmt::ExprSet::Select(select) = &mut query.body else {
                     todo!()
                 };
-                select.returning = stmt::Returning::Expr(stmt::Expr::record([1]));
+                select.returning = stmt::Returning::Project(stmt::Expr::record([1]));
                 query
             }));
         }
@@ -529,7 +529,7 @@ impl LowerStatement<'_, '_> {
 
                 // Previous value of returning does nothing in this
                 // context
-                insert.returning = Some(stmt::Returning::Expr(stmt::Expr::record(
+                insert.returning = Some(stmt::Returning::Project(stmt::Expr::record(
                     belongs_to
                         .foreign_key
                         .fields
@@ -792,7 +792,7 @@ impl RelationSource for UpdateRelationSource<'_> {
     fn set_returning_field(&mut self, field: FieldId, expr: stmt::Expr) {
         debug_assert!(self.returning_changed, "TODO");
 
-        let Some(stmt::Returning::Expr(stmt::Expr::Cast(expr_cast))) = self.returning else {
+        let Some(stmt::Returning::Project(stmt::Expr::Cast(expr_cast))) = self.returning else {
             todo!("UpdateRelationSource={self:#?}")
         };
 
@@ -843,7 +843,7 @@ impl RelationSource for InsertRelationSource<'_> {
 
     fn set_returning_field(&mut self, field: FieldId, expr: stmt::Expr) {
         let record = match self.returning {
-            Some(stmt::Returning::Expr(stmt::Expr::Record(record))) => record,
+            Some(stmt::Returning::Project(stmt::Expr::Record(record))) => record,
             Some(stmt::Returning::Value(stmt::Expr::List(rows))) => {
                 rows.items[self.index].as_record_mut_unwrap()
             }

--- a/crates/toasty/src/engine/lower/relation.rs
+++ b/crates/toasty/src/engine/lower/relation.rs
@@ -301,7 +301,7 @@ impl LowerStatement<'_, '_> {
                 let stmt::ExprSet::Select(select) = &mut query.body else {
                     todo!()
                 };
-                select.returning = stmt::Expr::record([1]).into();
+                select.returning = stmt::Returning::Expr(stmt::Expr::record([1]));
                 query
             }));
         }
@@ -529,16 +529,13 @@ impl LowerStatement<'_, '_> {
 
                 // Previous value of returning does nothing in this
                 // context
-                insert.returning = Some(
-                    stmt::Expr::record(
-                        belongs_to
-                            .foreign_key
-                            .fields
-                            .iter()
-                            .map(|fk_field| stmt::Expr::ref_self_field(fk_field.target)),
-                    )
-                    .into(),
-                );
+                insert.returning = Some(stmt::Returning::Expr(stmt::Expr::record(
+                    belongs_to
+                        .foreign_key
+                        .fields
+                        .iter()
+                        .map(|fk_field| stmt::Expr::ref_self_field(fk_field.target)),
+                )));
 
                 let target_id = self.new_dependency(insert);
                 let stmt_info = &self.state.hir[target_id];

--- a/crates/toasty/src/engine/lower/relation.rs
+++ b/crates/toasty/src/engine/lower/relation.rs
@@ -543,7 +543,7 @@ impl LowerStatement<'_, '_> {
                 let returning = stmt_info.stmt.as_ref().unwrap().returning().expect("bug");
 
                 let expr = match returning {
-                    stmt::Returning::Value(expr) if expr.is_const() => expr.clone(),
+                    stmt::Returning::Expr(expr) if expr.is_const() => expr.clone(),
                     _ => {
                         // Make sure the source statement returns a single record
                         debug_assert!(match &**stmt_info.stmt.as_ref().unwrap() {
@@ -844,10 +844,10 @@ impl RelationSource for InsertRelationSource<'_> {
     fn set_returning_field(&mut self, field: FieldId, expr: stmt::Expr) {
         let record = match self.returning {
             Some(stmt::Returning::Project(stmt::Expr::Record(record))) => record,
-            Some(stmt::Returning::Value(stmt::Expr::List(rows))) => {
+            Some(stmt::Returning::Expr(stmt::Expr::List(rows))) => {
                 rows.items[self.index].as_record_mut_unwrap()
             }
-            Some(stmt::Returning::Value(stmt::Expr::Record(record))) => record,
+            Some(stmt::Returning::Expr(stmt::Expr::Record(record))) => record,
             _ => todo!("InsertRelationSource={self:#?}"),
         };
 

--- a/crates/toasty/src/engine/lower/returning.rs
+++ b/crates/toasty/src/engine/lower/returning.rs
@@ -43,7 +43,7 @@ impl LowerStatement<'_, '_> {
     ///
     /// Can be constantized to:
     /// ```text
-    /// stmt::Returning::Value(vec![
+    /// stmt::Returning::Expr(vec![
     ///     Record { id: '123', name: 'Alice' },
     ///     Record { id: '456', name: 'Bob' },
     /// ])
@@ -68,7 +68,7 @@ impl LowerStatement<'_, '_> {
     ///    - This produces a `stmt::Value` for each row
     ///
     /// 3. **Replace** `stmt::Returning::Project(projection)` with
-    ///    `stmt::Returning::Value(values)`
+    ///    `stmt::Returning::Expr(values)`
     ///    - Single-row inserts return a single value
     ///    - Multi-row inserts return a list of values
     ///
@@ -96,7 +96,7 @@ impl LowerStatement<'_, '_> {
                     *returning = xformed_returning;
                 }
             }
-            stmt::Returning::Value(expr) => self.constantize_insert_returning_expr(expr, source),
+            stmt::Returning::Expr(expr) => self.constantize_insert_returning_expr(expr, source),
             _ => {}
         }
     }
@@ -215,7 +215,7 @@ impl LowerStatement<'_, '_> {
             }
 
             // Replace the expression-based RETURNING with a constant value
-            Some(stmt::Returning::Value(if source.single {
+            Some(stmt::Returning::Expr(if source.single {
                 // Single row insert: return just the one value
                 constantized
                     .into_iter()

--- a/crates/toasty/src/engine/lower/returning.rs
+++ b/crates/toasty/src/engine/lower/returning.rs
@@ -67,7 +67,7 @@ impl LowerStatement<'_, '_> {
     ///    - For each INSERT row, evaluate the RETURNING projection
     ///    - This produces a `stmt::Value` for each row
     ///
-    /// 3. **Replace** `stmt::Returning::Expr(projection)` with
+    /// 3. **Replace** `stmt::Returning::Project(projection)` with
     ///    `stmt::Returning::Value(values)`
     ///    - Single-row inserts return a single value
     ///    - Multi-row inserts return a list of values
@@ -89,7 +89,7 @@ impl LowerStatement<'_, '_> {
         source: &stmt::Query,
     ) {
         match returning {
-            stmt::Returning::Expr(project) => {
+            stmt::Returning::Project(project) => {
                 if let Some(xformed_returning) =
                     self.constantize_insert_returning_projection(project, source)
                 {
@@ -306,7 +306,7 @@ impl LowerStatement<'_, '_> {
             source: ConstantizeSource::UpdateAssignments { assignments },
         };
 
-        let stmt::Returning::Expr(project) = returning else {
+        let stmt::Returning::Project(project) = returning else {
             // Already a constant value (e.g., empty record for batch
             // unit-returning); nothing to constantize.
             return;
@@ -315,7 +315,7 @@ impl LowerStatement<'_, '_> {
         project.substitute(input);
 
         if let Ok(row) = project.eval_const() {
-            *returning = stmt::Returning::Expr(row.into());
+            *returning = stmt::Returning::Project(row.into());
         }
     }
 }

--- a/crates/toasty/src/engine/plan/nested_merge.rs
+++ b/crates/toasty/src/engine/plan/nested_merge.rs
@@ -290,7 +290,7 @@ impl NestedMergePlanner<'_> {
                         let child_returning = child_stmt.returning_unwrap();
 
                         match child_returning {
-                            stmt::Returning::Value(returning_expr) if returning_expr.is_const() => {
+                            stmt::Returning::Expr(returning_expr) if returning_expr.is_const() => {
                                 match child_stmt {
                                     stmt::Statement::Query(query) if query.single => {
                                         let stmt::Expr::Value(v) = returning_expr else {

--- a/crates/toasty/src/engine/plan/nested_merge.rs
+++ b/crates/toasty/src/engine/plan/nested_merge.rs
@@ -186,7 +186,7 @@ impl NestedMergePlanner<'_> {
 
         // Map the returning clause to projection expression
         let projection = match returning {
-            stmt::Returning::Expr(expr) => {
+            stmt::Returning::Project(expr) => {
                 let (s, _) = self
                     .inputs
                     .insert_full(stmt_state.load_data_statement.get().unwrap());

--- a/crates/toasty/src/engine/plan/statement.rs
+++ b/crates/toasty/src/engine/plan/statement.rs
@@ -196,7 +196,7 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
             && let stmt::Statement::Query(query) = &mut stmt
             && let stmt::ExprSet::Values(values) = &mut query.body
         {
-            returning = Some(stmt::Returning::Value(if query.single {
+            returning = Some(stmt::Returning::Expr(if query.single {
                 assert_eq!(1, values.rows.len());
                 values.rows.drain(..).next().unwrap()
             } else {
@@ -278,7 +278,7 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
 
         let is_returning_projection = matches!(returning, Some(stmt::Returning::Project(..)));
         debug_assert!(
-            is_returning_projection || matches!(returning, None | Some(stmt::Returning::Value(..)))
+            is_returning_projection || matches!(returning, None | Some(stmt::Returning::Expr(..)))
         );
 
         visit_mut::for_each_expr_mut(returning, |expr| {
@@ -1613,7 +1613,7 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
         // Then handle returning clause
         if let Some(clause) = returning.clause {
             match clause {
-                stmt::Returning::Value(expr) => {
+                stmt::Returning::Expr(expr) => {
                     // Value variant contains a constant expression that can be evaluated
                     if let Ok(value) = expr.eval_const() {
                         let ty = value.infer_ty();

--- a/crates/toasty/src/engine/plan/statement.rs
+++ b/crates/toasty/src/engine/plan/statement.rs
@@ -276,7 +276,7 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
     ) -> IndexSet<mir::NodeId> {
         let mut inputs = IndexSet::new();
 
-        let is_returning_projection = matches!(returning, Some(stmt::Returning::Expr(..)));
+        let is_returning_projection = matches!(returning, Some(stmt::Returning::Project(..)));
         debug_assert!(
             is_returning_projection || matches!(returning, None | Some(stmt::Returning::Value(..)))
         );
@@ -581,7 +581,7 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
         assert!(tables.len() <= 1, "TODO: handle more complicated cases");
 
         let sub_query = stmt::Select {
-            returning: stmt::Returning::Expr(stmt::Expr::record([1])),
+            returning: stmt::Returning::Project(stmt::Expr::record([1])),
             source: stmt::Source::Table(stmt::SourceTable {
                 tables,
                 from: vec![stmt::TableWithJoins {
@@ -767,7 +767,7 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
 
         // Set returning clause with all columns (including added ORDER BY columns)
         if !self.load_data.select_items.is_empty() {
-            stmt.set_returning(stmt::Returning::Expr(stmt::Expr::record(
+            stmt.set_returning(stmt::Returning::Project(stmt::Expr::record(
                 self.load_data
                     .select_items
                     .iter()
@@ -807,7 +807,7 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
         } else {
             debug_assert!(
                 stmt.returning()
-                    .and_then(|returning| returning.as_expr())
+                    .and_then(|returning| returning.as_project())
                     .map(|expr| expr.is_record())
                     .unwrap_or(true),
                 "stmt={stmt:#?}"
@@ -995,7 +995,7 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
         ctes.push(stmt::Cte {
             query: stmt::Query::builder(target)
                 .filter(filter.clone())
-                .returning(stmt::Returning::Expr(stmt::Expr::record_from_vec(vec![
+                .returning(stmt::Returning::Project(stmt::Expr::record_from_vec(vec![
                     stmt::Expr::count_star(),
                     stmt::FuncCount {
                         arg: None,
@@ -1007,7 +1007,7 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
         });
 
         let returning_len = match &stmt.returning {
-            Some(stmt::Returning::Expr(expr)) => {
+            Some(stmt::Returning::Project(expr)) => {
                 let stmt::Expr::Record(expr_record) = expr else {
                     panic!("returning must be a record");
                 };
@@ -1033,7 +1033,7 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
                         }
                         .into(),
                         filter: true.into(),
-                        returning: stmt::Returning::Expr(stmt::Expr::record_from_vec(vec![
+                        returning: stmt::Returning::Project(stmt::Expr::record_from_vec(vec![
                             stmt::Expr::eq(
                                 stmt::ExprColumn {
                                     nesting: 0,
@@ -1054,7 +1054,7 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
                     stmt.returning
                         // TODO: hax
                         .unwrap_or_else(|| {
-                            stmt::Returning::Expr(stmt::Expr::record_from_vec(vec![
+                            stmt::Returning::Project(stmt::Expr::record_from_vec(vec![
                                 stmt::Expr::from("hello"),
                             ]))
                         }),
@@ -1104,7 +1104,7 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
                 },
             ),
             filter: stmt::Filter::new(true),
-            returning: stmt::Returning::Expr(stmt::Expr::record_from_vec(columns)),
+            returning: stmt::Returning::Project(stmt::Expr::record_from_vec(columns)),
         })
         .with(ctes)
         .build()
@@ -1144,7 +1144,7 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
 
         let read = stmt::Query::builder(target)
             .filter(filter.clone())
-            .returning(stmt::Returning::Expr(stmt::Expr::record_from_vec(vec![
+            .returning(stmt::Returning::Project(stmt::Expr::record_from_vec(vec![
                 stmt::Expr::count_star(),
                 stmt::FuncCount {
                     arg: None,
@@ -1637,7 +1637,7 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
                         node_id
                     }
                 }
-                stmt::Returning::Expr(projection) => {
+                stmt::Returning::Project(projection) => {
                     if let Some(position) = returning.inputs.get_index_of(&data_load_node_id) {
                         self.insert_mir_with_deps(mir::Eval {
                             inputs: returning.inputs,

--- a/crates/toasty/src/engine/plan/statement.rs
+++ b/crates/toasty/src/engine/plan/statement.rs
@@ -767,15 +767,12 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
 
         // Set returning clause with all columns (including added ORDER BY columns)
         if !self.load_data.select_items.is_empty() {
-            stmt.set_returning(
-                stmt::Expr::record(
-                    self.load_data
-                        .select_items
-                        .iter()
-                        .map(|item| item.to_expr()),
-                )
-                .into(),
-            );
+            stmt.set_returning(stmt::Returning::Expr(stmt::Expr::record(
+                self.load_data
+                    .select_items
+                    .iter()
+                    .map(|item| item.to_expr()),
+            )));
         }
 
         let input_args: Vec<_> = self
@@ -998,14 +995,14 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
         ctes.push(stmt::Cte {
             query: stmt::Query::builder(target)
                 .filter(filter.clone())
-                .returning(vec![
+                .returning(stmt::Returning::Expr(stmt::Expr::record_from_vec(vec![
                     stmt::Expr::count_star(),
                     stmt::FuncCount {
                         arg: None,
                         filter: Some(Box::new(condition)),
                     }
                     .into(),
-                ])
+                ])))
                 .build(),
         });
 
@@ -1147,14 +1144,14 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
 
         let read = stmt::Query::builder(target)
             .filter(filter.clone())
-            .returning(vec![
+            .returning(stmt::Returning::Expr(stmt::Expr::record_from_vec(vec![
                 stmt::Expr::count_star(),
                 stmt::FuncCount {
                     arg: None,
                     filter: Some(Box::new(condition)),
                 }
                 .into(),
-            ])
+            ])))
             .locks(if self.planner.engine.capability().select_for_update {
                 vec![stmt::Lock::Update]
             } else {

--- a/crates/toasty/src/engine/plan/statement.rs
+++ b/crates/toasty/src/engine/plan/statement.rs
@@ -767,12 +767,12 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
 
         // Set returning clause with all columns (including added ORDER BY columns)
         if !self.load_data.select_items.is_empty() {
-            stmt.set_returning(stmt::Returning::Project(stmt::Expr::record(
+            stmt.set_returning_project(stmt::Expr::record(
                 self.load_data
                     .select_items
                     .iter()
                     .map(|item| item.to_expr()),
-            )));
+            ));
         }
 
         let input_args: Vec<_> = self
@@ -995,14 +995,14 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
         ctes.push(stmt::Cte {
             query: stmt::Query::builder(target)
                 .filter(filter.clone())
-                .returning(stmt::Returning::Project(stmt::Expr::record_from_vec(vec![
+                .returning_project(stmt::Expr::record_from_vec(vec![
                     stmt::Expr::count_star(),
                     stmt::FuncCount {
                         arg: None,
                         filter: Some(Box::new(condition)),
                     }
                     .into(),
-                ])))
+                ]))
                 .build(),
         });
 
@@ -1144,14 +1144,14 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
 
         let read = stmt::Query::builder(target)
             .filter(filter.clone())
-            .returning(stmt::Returning::Project(stmt::Expr::record_from_vec(vec![
+            .returning_project(stmt::Expr::record_from_vec(vec![
                 stmt::Expr::count_star(),
                 stmt::FuncCount {
                     arg: None,
                     filter: Some(Box::new(condition)),
                 }
                 .into(),
-            ])))
+            ]))
             .locks(if self.planner.engine.capability().select_for_update {
                 vec![stmt::Lock::Update]
             } else {

--- a/crates/toasty/src/engine/simplify/lift_in_subquery.rs
+++ b/crates/toasty/src/engine/simplify/lift_in_subquery.rs
@@ -119,7 +119,7 @@ impl Simplify<'_> {
             let mut subquery = query.clone();
 
             subquery.body.as_select_mut_unwrap().returning =
-                stmt::Returning::Expr(stmt::Expr::ref_self_field(fk_fields.target));
+                stmt::Returning::Project(stmt::Expr::ref_self_field(fk_fields.target));
 
             Some(stmt::Expr::in_subquery(
                 stmt::Expr::ref_self_field(fk_fields.source),
@@ -166,7 +166,8 @@ impl Simplify<'_> {
 
         match &mut subquery.body {
             stmt::ExprSet::Select(select) => {
-                select.returning = stmt::Returning::Expr(stmt::Expr::ref_self_field(child_field));
+                select.returning =
+                    stmt::Returning::Project(stmt::Expr::ref_self_field(child_field));
             }
             _ => todo!(),
         }

--- a/crates/toasty/src/stmt/into_statement.rs
+++ b/crates/toasty/src/stmt/into_statement.rs
@@ -69,11 +69,11 @@ impl_into_statement_for_tuple!(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8; 8; 0, 1, 2, 3, 4,
 ///
 /// Mutation statements (delete, update) without a returning clause default to
 /// returning a count. In a batch, every sub-statement must produce a value, so
-/// we set an empty record returning (`Returning::Value(Expr::record([]))`)
+/// we set an empty record returning (`Returning::Expr(Expr::record([]))`)
 /// which represents unit.
 fn ensure_batch_returning(stmt: &mut stmt::Statement) {
     if !stmt.is_query() && stmt.returning().is_none() {
-        stmt.set_returning(stmt::Returning::Value(stmt::Expr::record::<stmt::Expr>([])));
+        stmt.set_returning(stmt::Returning::Expr(stmt::Expr::record::<stmt::Expr>([])));
     }
 }
 

--- a/crates/toasty/src/stmt/into_statement.rs
+++ b/crates/toasty/src/stmt/into_statement.rs
@@ -73,7 +73,7 @@ impl_into_statement_for_tuple!(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8; 8; 0, 1, 2, 3, 4,
 /// which represents unit.
 fn ensure_batch_returning(stmt: &mut stmt::Statement) {
     if !stmt.is_query() && stmt.returning().is_none() {
-        stmt.set_returning(stmt::Returning::Expr(stmt::Expr::record::<stmt::Expr>([])));
+        stmt.set_returning_expr(stmt::Expr::record::<stmt::Expr>([]));
     }
 }
 

--- a/crates/toasty/src/stmt/query.rs
+++ b/crates/toasty/src/stmt/query.rs
@@ -450,7 +450,7 @@ impl<M: Model> Query<List<M>> {
     /// ```
     pub fn count(mut self) -> Query<u64> {
         // Set the returning clause to COUNT(*)
-        *self.untyped.returning_mut_unwrap() = Returning::Expr(stmt::Expr::count_star());
+        *self.untyped.returning_mut_unwrap() = Returning::Project(stmt::Expr::count_star());
         self.untyped.single = true;
 
         Query::from_untyped(self.untyped)

--- a/docs/dev/architecture/query-engine.md
+++ b/docs/dev/architecture/query-engine.md
@@ -127,7 +127,7 @@ This lowering phase handles:
 Lowering transforms model-level statements to table-level statements through a visitor pattern that rewrites each part of the statement AST:
 
 1. **Table Resolution**: `InsertTarget::Model`, `UpdateTarget::Model`, etc. become their corresponding table references
-2. **Returning Clause Transformation**: `Returning::Model` is replaced with `Returning::Expr` containing the expanded column expressions
+2. **Returning Clause Transformation**: `Returning::Model` is replaced with `Returning::Project` containing the expanded column expressions
 3. **Field Reference Resolution**: Model field references are converted to table column references
 4. **Include Expansion**: Association includes become subqueries in the returning clause
 


### PR DESCRIPTION
## Summary

Rename `Returning::Expr` → `Returning::Project` (per-row projection) and `Returning::Value` → `Returning::Expr` (fixed expression). Closes #240.

The old names were misleading: the per-row variant was called `Expr` even though every variant carries an `Expr`, and the fixed-expression variant was called `Value` despite holding an `Expr` (not a `stmt::Value`).

To avoid silently miscompiling call sites during the rename, the prep commit drops three ambiguous `From<*> for Returning` impls — each of which used to map its input into the old `Expr` variant via `.into()`. The follow-up commit re-adds that ergonomics as variant-typed helpers: `set_returning_project` / `set_returning_expr` on `Statement`, and `returning_project` / `returning_expr` on `QueryBuilder`.

## Type of change

- [x] Small / obvious change — internal cleanup

## Checklist

- [x] PR title uses Conventional Commits format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

Recommended commit-by-commit review:

1. `463e7360` — drop ambiguous `From` impls for `Returning` (no rename yet; surfaces the explicit variant choice at every construction site)
2. `f50fe0c2` — `Returning::Expr` → `Returning::Project` (mechanical rename, including helper methods)
3. `09ce74a8` — `Returning::Value` → `Returning::Expr` (mechanical rename)
4. `842dab6e` — add variant-typed helpers and adopt them at the four sites that needed explicit wrapping