### PR TITLE
feat: add #[deferred] field attribute and Deferred<T> wrapper

### DIFF
--- a/crates/toasty-core/src/schema/app/field.rs
+++ b/crates/toasty-core/src/schema/app/field.rs
@@ -49,6 +49,10 @@ pub struct Field {
     /// If `true`, this field tracks an OCC version counter.
     pub versionable: bool,
 
+    /// If `true`, this field is excluded from default queries and must be
+    /// loaded on demand via the per-field `.exec()` method.
+    pub deferred: bool,
+
     /// Validation constraints applied to this field's values.
     pub constraints: Vec<Constraint>,
 

--- a/crates/toasty-core/tests/schema_missing_model.rs
+++ b/crates/toasty-core/tests/schema_missing_model.rs
@@ -20,6 +20,7 @@ fn make_id_field(model_id: ModelId) -> Field {
         primary_key: true,
         auto: None,
         versionable: false,
+        deferred: false,
         constraints: vec![],
         variant: None,
     }
@@ -57,6 +58,7 @@ fn make_relation_field(model_id: ModelId, index: usize, name: &str, ty: FieldTy)
         primary_key: false,
         auto: None,
         versionable: false,
+        deferred: false,
         constraints: vec![],
         variant: None,
     }

--- a/crates/toasty-core/tests/schema_resolve_field.rs
+++ b/crates/toasty-core/tests/schema_resolve_field.rs
@@ -23,6 +23,7 @@ fn id_field(model: ModelId) -> Field {
         primary_key: true,
         auto: None,
         versionable: false,
+        deferred: false,
         constraints: vec![],
         variant: None,
     }
@@ -44,6 +45,7 @@ fn prim_field(model: ModelId, index: usize, name: &str) -> Field {
         primary_key: false,
         auto: None,
         versionable: false,
+        deferred: false,
         constraints: vec![],
         variant: None,
     }
@@ -65,6 +67,7 @@ fn variant_field(model: ModelId, index: usize, name: &str, variant_index: usize)
         primary_key: false,
         auto: None,
         versionable: false,
+        deferred: false,
         constraints: vec![],
         variant: Some(VariantId {
             model,
@@ -88,6 +91,7 @@ fn embedded_field(model: ModelId, index: usize, name: &str, target: ModelId) -> 
         primary_key: false,
         auto: None,
         versionable: false,
+        deferred: false,
         constraints: vec![],
         variant: None,
     }

--- a/crates/toasty-core/tests/schema_verify_version_field.rs
+++ b/crates/toasty-core/tests/schema_verify_version_field.rs
@@ -24,6 +24,7 @@ fn make_field(model_id: ModelId, index: usize, name: &str, versionable: bool) ->
         primary_key: index == 0,
         auto: None,
         versionable,
+        deferred: false,
         constraints: vec![],
         variant: None,
     }

--- a/crates/toasty-core/tests/stmt_infer_expr_reference_ty.rs
+++ b/crates/toasty-core/tests/stmt_infer_expr_reference_ty.rs
@@ -84,6 +84,7 @@ fn model_root(id: usize, field_types: &[(Type, &str)]) -> ModelRoot {
             primary_key: i == 0,
             auto: None,
             versionable: false,
+            deferred: false,
             constraints: vec![],
             variant: None,
         })

--- a/crates/toasty-driver-integration-suite/src/scenarios.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios.rs
@@ -1,3 +1,5 @@
+pub mod deferred_document;
+pub mod deferred_optional_document;
 pub mod has_many_belongs_to;
 pub mod has_many_multi_relation;
 pub mod has_many_same_target;

--- a/crates/toasty-driver-integration-suite/src/scenarios/deferred_document.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios/deferred_document.rs
@@ -1,0 +1,21 @@
+use crate::prelude::*;
+
+scenario! {
+    #![id(ID)]
+
+    #[derive(Debug, toasty::Model)]
+    struct Document {
+        #[key]
+        #[auto]
+        id: ID,
+
+        title: String,
+
+        #[deferred]
+        body: toasty::Deferred<String>,
+    }
+
+    async fn setup(test: &mut Test) -> toasty::Db {
+        test.setup_db(models!(Document)).await
+    }
+}

--- a/crates/toasty-driver-integration-suite/src/scenarios/deferred_optional_document.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios/deferred_optional_document.rs
@@ -1,0 +1,21 @@
+use crate::prelude::*;
+
+scenario! {
+    #![id(ID)]
+
+    #[derive(Debug, toasty::Model)]
+    struct Document {
+        #[key]
+        #[auto]
+        id: ID,
+
+        title: String,
+
+        #[deferred]
+        summary: toasty::Deferred<Option<String>>,
+    }
+
+    async fn setup(test: &mut Test) -> toasty::Db {
+        test.setup_db(models!(Document)).await
+    }
+}

--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -19,6 +19,7 @@ pub mod crud_query;
 pub mod crud_query_macro;
 pub mod crud_sort_limit;
 pub mod crud_update_field_order;
+pub mod deferred_field;
 pub mod dynamodb_limit_boundary;
 pub mod dynamodb_update_batch_filter;
 pub mod embed_enum_data;

--- a/crates/toasty-driver-integration-suite/src/tests/deferred_field.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/deferred_field.rs
@@ -118,6 +118,153 @@ pub async fn deferred_optional_exec_loads_value(t: &mut Test) -> Result<()> {
 }
 
 #[driver_test(id(ID))]
+pub async fn deferred_include_loads_value(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Document {
+        #[key]
+        #[auto]
+        id: ID,
+
+        title: String,
+
+        #[deferred]
+        body: toasty::Deferred<String>,
+    }
+
+    let mut db = t.setup_db(models!(Document)).await;
+
+    let created = toasty::create!(Document {
+        title: "Hello".to_string(),
+        body: "the long body".to_string(),
+    })
+    .exec(&mut db)
+    .await?;
+
+    // `.include()` of a deferred primitive eagerly loads it as part of the
+    // model query — no separate fetch is needed.
+    let read = Document::filter_by_id(created.id)
+        .include(Document::fields().body())
+        .get(&mut db)
+        .await?;
+
+    assert!(!read.body.is_unloaded());
+    assert_eq!("the long body", read.body.get());
+
+    Ok(())
+}
+
+#[driver_test(id(ID))]
+pub async fn deferred_optional_include_loads_some(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Document {
+        #[key]
+        #[auto]
+        id: ID,
+
+        title: String,
+
+        #[deferred]
+        summary: toasty::Deferred<Option<String>>,
+    }
+
+    let mut db = t.setup_db(models!(Document)).await;
+
+    let created = toasty::create!(Document {
+        title: "With summary".to_string(),
+        summary: "a brief summary".to_string(),
+    })
+    .exec(&mut db)
+    .await?;
+
+    let read = Document::filter_by_id(created.id)
+        .include(Document::fields().summary())
+        .get(&mut db)
+        .await?;
+
+    assert!(!read.summary.is_unloaded());
+    assert_eq!(&Some("a brief summary".to_string()), read.summary.get());
+
+    Ok(())
+}
+
+#[driver_test(id(ID))]
+pub async fn deferred_optional_include_loads_none(t: &mut Test) -> Result<()> {
+    // A nullable deferred field must distinguish "loaded as NULL" from
+    // "unloaded". An eager `.include()` puts the field into the loaded state
+    // even when the column value is NULL.
+    #[derive(Debug, toasty::Model)]
+    struct Document {
+        #[key]
+        #[auto]
+        id: ID,
+
+        title: String,
+
+        #[deferred]
+        summary: toasty::Deferred<Option<String>>,
+    }
+
+    let mut db = t.setup_db(models!(Document)).await;
+
+    let created = toasty::create!(Document {
+        title: "No summary".to_string(),
+    })
+    .exec(&mut db)
+    .await?;
+
+    let read = Document::filter_by_id(created.id)
+        .include(Document::fields().summary())
+        .get(&mut db)
+        .await?;
+
+    assert!(!read.summary.is_unloaded());
+    assert_eq!(&None, read.summary.get());
+
+    Ok(())
+}
+
+#[driver_test(id(ID))]
+pub async fn deferred_optional_create_returns_none_loaded(t: &mut Test) -> Result<()> {
+    // INSERT...RETURNING bypasses the deferred mask, so the value the caller
+    // just supplied (including `None`) must come back loaded — the in-memory
+    // record should not be ambiguous with the unloaded state.
+    #[derive(Debug, toasty::Model)]
+    struct Document {
+        #[key]
+        #[auto]
+        id: ID,
+
+        title: String,
+
+        #[deferred]
+        summary: toasty::Deferred<Option<String>>,
+    }
+
+    let mut db = t.setup_db(models!(Document)).await;
+
+    let with_some = toasty::create!(Document {
+        title: "With summary".to_string(),
+        summary: "hello".to_string(),
+    })
+    .exec(&mut db)
+    .await?;
+
+    assert!(!with_some.summary.is_unloaded());
+    assert_eq!(&Some("hello".to_string()), with_some.summary.get());
+
+    let with_none = toasty::create!(Document {
+        title: "No summary".to_string(),
+    })
+    .exec(&mut db)
+    .await?;
+
+    assert!(!with_none.summary.is_unloaded());
+    assert_eq!(&None, with_none.summary.get());
+
+    Ok(())
+}
+
+#[driver_test(id(ID))]
 pub async fn deferred_filter_does_not_load_field(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     struct Document {

--- a/crates/toasty-driver-integration-suite/src/tests/deferred_field.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/deferred_field.rs
@@ -1,20 +1,8 @@
 use crate::prelude::*;
 
-#[driver_test(id(ID))]
+#[driver_test(id(ID), scenario(crate::scenarios::deferred_document))]
 pub async fn default_load_leaves_deferred_unloaded(t: &mut Test) -> Result<()> {
-    #[derive(Debug, toasty::Model)]
-    struct Document {
-        #[key]
-        #[auto]
-        id: ID,
-
-        title: String,
-
-        #[deferred]
-        body: toasty::Deferred<String>,
-    }
-
-    let mut db = t.setup_db(models!(Document)).await;
+    let mut db = setup(t).await;
 
     let created = toasty::create!(Document {
         title: "Hello".to_string(),
@@ -35,21 +23,9 @@ pub async fn default_load_leaves_deferred_unloaded(t: &mut Test) -> Result<()> {
     Ok(())
 }
 
-#[driver_test(id(ID))]
+#[driver_test(id(ID), scenario(crate::scenarios::deferred_document))]
 pub async fn deferred_exec_loads_value(t: &mut Test) -> Result<()> {
-    #[derive(Debug, toasty::Model)]
-    struct Document {
-        #[key]
-        #[auto]
-        id: ID,
-
-        title: String,
-
-        #[deferred]
-        body: toasty::Deferred<String>,
-    }
-
-    let mut db = t.setup_db(models!(Document)).await;
+    let mut db = setup(t).await;
 
     let created = toasty::create!(Document {
         title: "Hello".to_string(),
@@ -71,21 +47,9 @@ pub async fn deferred_exec_loads_value(t: &mut Test) -> Result<()> {
     Ok(())
 }
 
-#[driver_test(id(ID))]
+#[driver_test(id(ID), scenario(crate::scenarios::deferred_optional_document))]
 pub async fn deferred_optional_exec_loads_value(t: &mut Test) -> Result<()> {
-    #[derive(Debug, toasty::Model)]
-    struct Document {
-        #[key]
-        #[auto]
-        id: ID,
-
-        title: String,
-
-        #[deferred]
-        summary: toasty::Deferred<Option<String>>,
-    }
-
-    let mut db = t.setup_db(models!(Document)).await;
+    let mut db = setup(t).await;
 
     // Create with summary set.
     let with_summary = toasty::create!(Document {
@@ -117,21 +81,9 @@ pub async fn deferred_optional_exec_loads_value(t: &mut Test) -> Result<()> {
     Ok(())
 }
 
-#[driver_test(id(ID))]
+#[driver_test(id(ID), scenario(crate::scenarios::deferred_document))]
 pub async fn deferred_include_loads_value(t: &mut Test) -> Result<()> {
-    #[derive(Debug, toasty::Model)]
-    struct Document {
-        #[key]
-        #[auto]
-        id: ID,
-
-        title: String,
-
-        #[deferred]
-        body: toasty::Deferred<String>,
-    }
-
-    let mut db = t.setup_db(models!(Document)).await;
+    let mut db = setup(t).await;
 
     let created = toasty::create!(Document {
         title: "Hello".to_string(),
@@ -153,21 +105,9 @@ pub async fn deferred_include_loads_value(t: &mut Test) -> Result<()> {
     Ok(())
 }
 
-#[driver_test(id(ID))]
+#[driver_test(id(ID), scenario(crate::scenarios::deferred_optional_document))]
 pub async fn deferred_optional_include_loads_some(t: &mut Test) -> Result<()> {
-    #[derive(Debug, toasty::Model)]
-    struct Document {
-        #[key]
-        #[auto]
-        id: ID,
-
-        title: String,
-
-        #[deferred]
-        summary: toasty::Deferred<Option<String>>,
-    }
-
-    let mut db = t.setup_db(models!(Document)).await;
+    let mut db = setup(t).await;
 
     let created = toasty::create!(Document {
         title: "With summary".to_string(),
@@ -187,24 +127,12 @@ pub async fn deferred_optional_include_loads_some(t: &mut Test) -> Result<()> {
     Ok(())
 }
 
-#[driver_test(id(ID))]
+#[driver_test(id(ID), scenario(crate::scenarios::deferred_optional_document))]
 pub async fn deferred_optional_include_loads_none(t: &mut Test) -> Result<()> {
     // A nullable deferred field must distinguish "loaded as NULL" from
     // "unloaded". An eager `.include()` puts the field into the loaded state
     // even when the column value is NULL.
-    #[derive(Debug, toasty::Model)]
-    struct Document {
-        #[key]
-        #[auto]
-        id: ID,
-
-        title: String,
-
-        #[deferred]
-        summary: toasty::Deferred<Option<String>>,
-    }
-
-    let mut db = t.setup_db(models!(Document)).await;
+    let mut db = setup(t).await;
 
     let created = toasty::create!(Document {
         title: "No summary".to_string(),
@@ -223,24 +151,12 @@ pub async fn deferred_optional_include_loads_none(t: &mut Test) -> Result<()> {
     Ok(())
 }
 
-#[driver_test(id(ID))]
+#[driver_test(id(ID), scenario(crate::scenarios::deferred_optional_document))]
 pub async fn deferred_optional_create_returns_none_loaded(t: &mut Test) -> Result<()> {
     // INSERT...RETURNING bypasses the deferred mask, so the value the caller
     // just supplied (including `None`) must come back loaded — the in-memory
     // record should not be ambiguous with the unloaded state.
-    #[derive(Debug, toasty::Model)]
-    struct Document {
-        #[key]
-        #[auto]
-        id: ID,
-
-        title: String,
-
-        #[deferred]
-        summary: toasty::Deferred<Option<String>>,
-    }
-
-    let mut db = t.setup_db(models!(Document)).await;
+    let mut db = setup(t).await;
 
     let with_some = toasty::create!(Document {
         title: "With summary".to_string(),
@@ -264,24 +180,12 @@ pub async fn deferred_optional_create_returns_none_loaded(t: &mut Test) -> Resul
     Ok(())
 }
 
-#[driver_test(id(ID), requires(sql))]
+#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::deferred_document))]
 pub async fn deferred_filter_does_not_load_field(t: &mut Test) -> Result<()> {
     // SQL-only: a bare predicate on the deferred field requires a full table
     // scan. The DDB equivalent is `deferred_pk_filter_does_not_load_field`,
     // which grounds the query on the primary key.
-    #[derive(Debug, toasty::Model)]
-    struct Document {
-        #[key]
-        #[auto]
-        id: ID,
-
-        title: String,
-
-        #[deferred]
-        body: toasty::Deferred<String>,
-    }
-
-    let mut db = t.setup_db(models!(Document)).await;
+    let mut db = setup(t).await;
 
     toasty::create!(Document {
         title: "First".to_string(),
@@ -310,24 +214,12 @@ pub async fn deferred_filter_does_not_load_field(t: &mut Test) -> Result<()> {
     Ok(())
 }
 
-#[driver_test(id(ID))]
+#[driver_test(id(ID), scenario(crate::scenarios::deferred_document))]
 pub async fn deferred_pk_filter_does_not_load_field(t: &mut Test) -> Result<()> {
     // Same coverage as `deferred_filter_does_not_load_field`, expressed as a
     // PK-grounded query so it runs on DDB. The deferred field appears in the
     // filter but is still left unloaded in the result.
-    #[derive(Debug, toasty::Model)]
-    struct Document {
-        #[key]
-        #[auto]
-        id: ID,
-
-        title: String,
-
-        #[deferred]
-        body: toasty::Deferred<String>,
-    }
-
-    let mut db = t.setup_db(models!(Document)).await;
+    let mut db = setup(t).await;
 
     let alpha = toasty::create!(Document {
         title: "First".to_string(),
@@ -397,21 +289,9 @@ pub async fn deferred_works_through_type_alias(t: &mut Test) -> Result<()> {
     Ok(())
 }
 
-#[driver_test(id(ID))]
+#[driver_test(id(ID), scenario(crate::scenarios::deferred_document))]
 pub async fn deferred_update_without_prior_load(t: &mut Test) -> Result<()> {
-    #[derive(Debug, toasty::Model)]
-    struct Document {
-        #[key]
-        #[auto]
-        id: ID,
-
-        title: String,
-
-        #[deferred]
-        body: toasty::Deferred<String>,
-    }
-
-    let mut db = t.setup_db(models!(Document)).await;
+    let mut db = setup(t).await;
 
     let created = toasty::create!(Document {
         title: "Hello".to_string(),

--- a/crates/toasty-driver-integration-suite/src/tests/deferred_field.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/deferred_field.rs
@@ -161,6 +161,40 @@ pub async fn deferred_filter_does_not_load_field(t: &mut Test) -> Result<()> {
 }
 
 #[driver_test(id(ID))]
+pub async fn deferred_works_through_type_alias(t: &mut Test) -> Result<()> {
+    type Lazy<T> = toasty::Deferred<T>;
+
+    #[derive(Debug, toasty::Model)]
+    struct Document {
+        #[key]
+        #[auto]
+        id: ID,
+
+        title: String,
+
+        #[deferred]
+        body: Lazy<String>,
+    }
+
+    let mut db = t.setup_db(models!(Document)).await;
+
+    let created = toasty::create!(Document {
+        title: "Hello".to_string(),
+        body: "the long body".to_string(),
+    })
+    .exec(&mut db)
+    .await?;
+
+    let read = Document::filter_by_id(created.id).get(&mut db).await?;
+    assert!(read.body.is_unloaded());
+
+    let body: String = read.body().exec(&mut db).await?;
+    assert_eq!("the long body", body);
+
+    Ok(())
+}
+
+#[driver_test(id(ID))]
 pub async fn deferred_update_without_prior_load(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     struct Document {

--- a/crates/toasty-driver-integration-suite/src/tests/deferred_field.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/deferred_field.rs
@@ -23,9 +23,9 @@ pub async fn default_load_leaves_deferred_unloaded(t: &mut Test) -> Result<()> {
     .exec(&mut db)
     .await?;
 
-    // Newly created records: deferred field is unloaded.
+    // Newly created records expose the value just written as loaded.
     assert_eq!("Hello", created.title);
-    assert!(created.body.is_unloaded());
+    assert_eq!("the long body", created.body.get());
 
     // Querying the model leaves the deferred field unloaded.
     let read = Document::filter_by_id(created.id).get(&mut db).await?;

--- a/crates/toasty-driver-integration-suite/src/tests/deferred_field.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/deferred_field.rs
@@ -1,0 +1,203 @@
+use crate::prelude::*;
+
+#[driver_test(id(ID))]
+pub async fn default_load_leaves_deferred_unloaded(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Document {
+        #[key]
+        #[auto]
+        id: ID,
+
+        title: String,
+
+        #[deferred]
+        body: toasty::Deferred<String>,
+    }
+
+    let mut db = t.setup_db(models!(Document)).await;
+
+    let created = toasty::create!(Document {
+        title: "Hello".to_string(),
+        body: "the long body".to_string(),
+    })
+    .exec(&mut db)
+    .await?;
+
+    // Newly created records: deferred field is unloaded.
+    assert_eq!("Hello", created.title);
+    assert!(created.body.is_unloaded());
+
+    // Querying the model leaves the deferred field unloaded.
+    let read = Document::filter_by_id(created.id).get(&mut db).await?;
+    assert_eq!("Hello", read.title);
+    assert!(read.body.is_unloaded());
+
+    Ok(())
+}
+
+#[driver_test(id(ID))]
+pub async fn deferred_exec_loads_value(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Document {
+        #[key]
+        #[auto]
+        id: ID,
+
+        title: String,
+
+        #[deferred]
+        body: toasty::Deferred<String>,
+    }
+
+    let mut db = t.setup_db(models!(Document)).await;
+
+    let created = toasty::create!(Document {
+        title: "Hello".to_string(),
+        body: "the long body".to_string(),
+    })
+    .exec(&mut db)
+    .await?;
+
+    let read = Document::filter_by_id(created.id).get(&mut db).await?;
+    assert!(read.body.is_unloaded());
+
+    // The per-field accessor loads on demand and returns the value.
+    let body: String = read.body().exec(&mut db).await?;
+    assert_eq!("the long body", body);
+
+    // The in-memory record is not mutated by `.exec()`.
+    assert!(read.body.is_unloaded());
+
+    Ok(())
+}
+
+#[driver_test(id(ID))]
+pub async fn deferred_optional_exec_loads_value(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Document {
+        #[key]
+        #[auto]
+        id: ID,
+
+        title: String,
+
+        #[deferred]
+        summary: toasty::Deferred<Option<String>>,
+    }
+
+    let mut db = t.setup_db(models!(Document)).await;
+
+    // Create with summary set.
+    let with_summary = toasty::create!(Document {
+        title: "With summary".to_string(),
+        summary: "a brief summary".to_string(),
+    })
+    .exec(&mut db)
+    .await?;
+
+    // Create with summary omitted (nullable, so optional).
+    let without_summary = toasty::create!(Document {
+        title: "No summary".to_string(),
+    })
+    .exec(&mut db)
+    .await?;
+
+    let with = Document::filter_by_id(with_summary.id).get(&mut db).await?;
+    assert!(with.summary.is_unloaded());
+    let summary: Option<String> = with.summary().exec(&mut db).await?;
+    assert_eq!(Some("a brief summary".to_string()), summary);
+
+    let without = Document::filter_by_id(without_summary.id)
+        .get(&mut db)
+        .await?;
+    assert!(without.summary.is_unloaded());
+    let summary: Option<String> = without.summary().exec(&mut db).await?;
+    assert_eq!(None, summary);
+
+    Ok(())
+}
+
+#[driver_test(id(ID))]
+pub async fn deferred_filter_does_not_load_field(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Document {
+        #[key]
+        #[auto]
+        id: ID,
+
+        title: String,
+
+        #[deferred]
+        body: toasty::Deferred<String>,
+    }
+
+    let mut db = t.setup_db(models!(Document)).await;
+
+    toasty::create!(Document {
+        title: "First".to_string(),
+        body: "alpha body".to_string(),
+    })
+    .exec(&mut db)
+    .await?;
+
+    toasty::create!(Document {
+        title: "Second".to_string(),
+        body: "beta body".to_string(),
+    })
+    .exec(&mut db)
+    .await?;
+
+    // Filter on the deferred field — the WHERE clause uses it but the SELECT
+    // does not project it.
+    let docs = Document::filter(Document::fields().body().eq("alpha body".to_string()))
+        .exec(&mut db)
+        .await?;
+
+    assert_eq!(1, docs.len());
+    assert_eq!("First", docs[0].title);
+    assert!(docs[0].body.is_unloaded());
+
+    Ok(())
+}
+
+#[driver_test(id(ID))]
+pub async fn deferred_update_without_prior_load(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Document {
+        #[key]
+        #[auto]
+        id: ID,
+
+        title: String,
+
+        #[deferred]
+        body: toasty::Deferred<String>,
+    }
+
+    let mut db = t.setup_db(models!(Document)).await;
+
+    let created = toasty::create!(Document {
+        title: "Hello".to_string(),
+        body: "old body".to_string(),
+    })
+    .exec(&mut db)
+    .await?;
+
+    let mut doc = Document::filter_by_id(created.id).get(&mut db).await?;
+    assert!(doc.body.is_unloaded());
+
+    // Update the deferred field without ever loading it.
+    doc.update()
+        .body("new body".to_string())
+        .exec(&mut db)
+        .await?;
+
+    // Loaded-ness is unchanged after an update.
+    assert!(doc.body.is_unloaded());
+
+    // The new value is persisted in the database.
+    let body: String = doc.body().exec(&mut db).await?;
+    assert_eq!("new body", body);
+
+    Ok(())
+}

--- a/crates/toasty-driver-integration-suite/src/tests/deferred_field.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/deferred_field.rs
@@ -290,7 +290,9 @@ pub async fn deferred_works_through_type_alias(t: &mut Test) -> Result<()> {
 }
 
 #[driver_test(id(ID), scenario(crate::scenarios::deferred_document))]
-pub async fn deferred_update_without_prior_load(t: &mut Test) -> Result<()> {
+pub async fn deferred_update_loads_from_unloaded(t: &mut Test) -> Result<()> {
+    // The caller supplied the value as part of the update, so the in-memory
+    // field becomes loaded — no follow-up fetch is needed.
     let mut db = setup(t).await;
 
     let created = toasty::create!(Document {
@@ -303,18 +305,43 @@ pub async fn deferred_update_without_prior_load(t: &mut Test) -> Result<()> {
     let mut doc = Document::filter_by_id(created.id).get(&mut db).await?;
     assert!(doc.body.is_unloaded());
 
-    // Update the deferred field without ever loading it.
     doc.update()
         .body("new body".to_string())
         .exec(&mut db)
         .await?;
 
-    // Loaded-ness is unchanged after an update.
-    assert!(doc.body.is_unloaded());
+    assert!(!doc.body.is_unloaded());
+    assert_eq!("new body", doc.body.get());
 
-    // The new value is persisted in the database.
-    let body: String = doc.body().exec(&mut db).await?;
-    assert_eq!("new body", body);
+    Ok(())
+}
+
+#[driver_test(id(ID), scenario(crate::scenarios::deferred_document))]
+pub async fn deferred_update_refreshes_loaded_value(t: &mut Test) -> Result<()> {
+    // An already-loaded deferred field is refreshed by the update, matching
+    // non-deferred field behavior.
+    let mut db = setup(t).await;
+
+    let created = toasty::create!(Document {
+        title: "Hello".to_string(),
+        body: "old body".to_string(),
+    })
+    .exec(&mut db)
+    .await?;
+
+    let mut doc = Document::filter_by_id(created.id)
+        .include(Document::fields().body())
+        .get(&mut db)
+        .await?;
+    assert_eq!("old body", doc.body.get());
+
+    doc.update()
+        .body("new body".to_string())
+        .exec(&mut db)
+        .await?;
+
+    assert!(!doc.body.is_unloaded());
+    assert_eq!("new body", doc.body.get());
 
     Ok(())
 }

--- a/crates/toasty-driver-integration-suite/src/tests/deferred_field.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/deferred_field.rs
@@ -264,8 +264,11 @@ pub async fn deferred_optional_create_returns_none_loaded(t: &mut Test) -> Resul
     Ok(())
 }
 
-#[driver_test(id(ID))]
+#[driver_test(id(ID), requires(sql))]
 pub async fn deferred_filter_does_not_load_field(t: &mut Test) -> Result<()> {
+    // SQL-only: a bare predicate on the deferred field requires a full table
+    // scan. The DDB equivalent is `deferred_pk_filter_does_not_load_field`,
+    // which grounds the query on the primary key.
     #[derive(Debug, toasty::Model)]
     struct Document {
         #[key]
@@ -303,6 +306,59 @@ pub async fn deferred_filter_does_not_load_field(t: &mut Test) -> Result<()> {
     assert_eq!(1, docs.len());
     assert_eq!("First", docs[0].title);
     assert!(docs[0].body.is_unloaded());
+
+    Ok(())
+}
+
+#[driver_test(id(ID))]
+pub async fn deferred_pk_filter_does_not_load_field(t: &mut Test) -> Result<()> {
+    // Same coverage as `deferred_filter_does_not_load_field`, expressed as a
+    // PK-grounded query so it runs on DDB. The deferred field appears in the
+    // filter but is still left unloaded in the result.
+    #[derive(Debug, toasty::Model)]
+    struct Document {
+        #[key]
+        #[auto]
+        id: ID,
+
+        title: String,
+
+        #[deferred]
+        body: toasty::Deferred<String>,
+    }
+
+    let mut db = t.setup_db(models!(Document)).await;
+
+    let alpha = toasty::create!(Document {
+        title: "First".to_string(),
+        body: "alpha body".to_string(),
+    })
+    .exec(&mut db)
+    .await?;
+
+    toasty::create!(Document {
+        title: "Second".to_string(),
+        body: "beta body".to_string(),
+    })
+    .exec(&mut db)
+    .await?;
+
+    // Match on the PK, with the deferred field as an additional filter.
+    let matched = Document::filter_by_id(alpha.id)
+        .filter(Document::fields().body().eq("alpha body".to_string()))
+        .exec(&mut db)
+        .await?;
+
+    assert_eq!(1, matched.len());
+    assert_eq!("First", matched[0].title);
+    assert!(matched[0].body.is_unloaded());
+
+    // The deferred predicate filters the row out when it does not match.
+    let missed = Document::filter_by_id(alpha.id)
+        .filter(Document::fields().body().eq("beta body".to_string()))
+        .exec(&mut db)
+        .await?;
+    assert!(missed.is_empty());
 
     Ok(())
 }

--- a/crates/toasty-macros/src/lib.rs
+++ b/crates/toasty-macros/src/lib.rs
@@ -579,7 +579,7 @@ use proc_macro::TokenStream;
     Model,
     attributes(
         key, auto, default, update, column, index, unique, table, has_many, has_one, belongs_to,
-        serialize, version
+        serialize, version, deferred
     )
 )]
 pub fn derive_model(input: TokenStream) -> TokenStream {

--- a/crates/toasty-macros/src/model/expand/create.rs
+++ b/crates/toasty-macros/src/model/expand/create.rs
@@ -1,5 +1,5 @@
 use super::{Expand, util};
-use crate::model::schema::FieldTy;
+use crate::model::schema::{FieldTy, extract_deferred_inner};
 
 use proc_macro2::TokenStream;
 use quote::{quote, quote_spanned};
@@ -208,6 +208,16 @@ impl Expand<'_> {
                                     self.stmt.set(#index_tokenized, <String as #toasty::IntoExpr<String>>::into_expr(json));
                                     self
                                 }
+                            }
+                        }
+                    }
+                    FieldTy::Primitive(ty) if field.attrs.deferred => {
+                        let inner = extract_deferred_inner(ty)
+                            .expect("deferred field must wrap inner type in `Deferred<T>`");
+                        quote! {
+                            #vis fn #name(mut self, #name: impl #toasty::IntoExpr<#inner>) -> Self {
+                                self.stmt.set(#index_tokenized, #name.into_expr());
+                                self
                             }
                         }
                     }

--- a/crates/toasty-macros/src/model/expand/create.rs
+++ b/crates/toasty-macros/src/model/expand/create.rs
@@ -1,5 +1,5 @@
 use super::{Expand, util};
-use crate::model::schema::{FieldTy, extract_deferred_inner};
+use crate::model::schema::FieldTy;
 
 use proc_macro2::TokenStream;
 use quote::{quote, quote_spanned};
@@ -212,8 +212,7 @@ impl Expand<'_> {
                         }
                     }
                     FieldTy::Primitive(ty) if field.attrs.deferred => {
-                        let inner = extract_deferred_inner(ty)
-                            .expect("deferred field must wrap inner type in `Deferred<T>`");
+                        let inner = quote!(<#ty as #toasty::Defer>::Inner);
                         quote! {
                             #vis fn #name(mut self, #name: impl #toasty::IntoExpr<#inner>) -> Self {
                                 self.stmt.set(#index_tokenized, #name.into_expr());

--- a/crates/toasty-macros/src/model/expand/embedded_enum.rs
+++ b/crates/toasty-macros/src/model/expand/embedded_enum.rs
@@ -295,6 +295,7 @@ impl Expand<'_> {
                         primary_key: false,
                         auto: None,
                         versionable: false,
+                        deferred: false,
                         constraints: vec![],
                         variant: Some(#toasty::core::schema::app::VariantId {
                             model: id,

--- a/crates/toasty-macros/src/model/expand/fields.rs
+++ b/crates/toasty-macros/src/model/expand/fields.rs
@@ -1,6 +1,6 @@
 use super::{Expand, util};
 use crate::model::schema::FieldTy::{BelongsTo, HasMany, HasOne, Primitive};
-use crate::model::schema::ModelKind;
+use crate::model::schema::{ModelKind, extract_deferred_inner};
 use proc_macro2::TokenStream;
 use quote::{quote, quote_spanned};
 
@@ -36,6 +36,11 @@ impl Expand<'_> {
                     Primitive(_) if field.attrs.serialize.is_some() => {
                         // Serialized fields are stored as opaque JSON; no field accessor
                         TokenStream::new()
+                    }
+                    Primitive(ty) if field.attrs.deferred => {
+                        let inner = extract_deferred_inner(ty)
+                            .expect("deferred field must wrap inner type in `Deferred<T>`");
+                        self.expand_primitive_field_method(field_ident, &inner, &field_offset)
                     }
                     Primitive(ty) => {
                         self.expand_primitive_field_method(field_ident, ty, &field_offset)
@@ -124,6 +129,11 @@ impl Expand<'_> {
 
                 match &field.ty {
                     Primitive(_) if field.attrs.serialize.is_some() => TokenStream::new(),
+                    Primitive(ty) if field.attrs.deferred => {
+                        let inner = extract_deferred_inner(ty)
+                            .expect("deferred field must wrap inner type in `Deferred<T>`");
+                        self.expand_list_primitive_field_method(field_ident, &inner, &field_offset)
+                    }
                     Primitive(ty) => {
                         self.expand_list_primitive_field_method(field_ident, ty, &field_offset)
                     }

--- a/crates/toasty-macros/src/model/expand/fields.rs
+++ b/crates/toasty-macros/src/model/expand/fields.rs
@@ -1,6 +1,6 @@
 use super::{Expand, util};
 use crate::model::schema::FieldTy::{BelongsTo, HasMany, HasOne, Primitive};
-use crate::model::schema::{ModelKind, extract_deferred_inner};
+use crate::model::schema::ModelKind;
 use proc_macro2::TokenStream;
 use quote::{quote, quote_spanned};
 
@@ -38,8 +38,8 @@ impl Expand<'_> {
                         TokenStream::new()
                     }
                     Primitive(ty) if field.attrs.deferred => {
-                        let inner = extract_deferred_inner(ty)
-                            .expect("deferred field must wrap inner type in `Deferred<T>`");
+                        let inner: syn::Type =
+                            syn::parse_quote!(<#ty as #toasty::Defer>::Inner);
                         self.expand_primitive_field_method(field_ident, &inner, &field_offset)
                     }
                     Primitive(ty) => {
@@ -130,8 +130,7 @@ impl Expand<'_> {
                 match &field.ty {
                     Primitive(_) if field.attrs.serialize.is_some() => TokenStream::new(),
                     Primitive(ty) if field.attrs.deferred => {
-                        let inner = extract_deferred_inner(ty)
-                            .expect("deferred field must wrap inner type in `Deferred<T>`");
+                        let inner: syn::Type = syn::parse_quote!(<#ty as #toasty::Defer>::Inner);
                         self.expand_list_primitive_field_method(field_ident, &inner, &field_offset)
                     }
                     Primitive(ty) => {

--- a/crates/toasty-macros/src/model/expand/query.rs
+++ b/crates/toasty-macros/src/model/expand/query.rs
@@ -188,7 +188,7 @@ impl Expand<'_> {
         let model_ident = &self.model.ident;
         let query_struct_ident = &self.model.kind.as_root_unwrap().query_struct_ident;
 
-        if self.model.has_associations() {
+        if self.model.has_includable_fields() {
             Some(quote! {
                     #vis fn include<#include_ty>(mut self, path: impl #toasty::Into<#toasty::Path<#model_ident, #include_ty>>) -> #query_struct_ident {
                         self.stmt.include(path.into());

--- a/crates/toasty-macros/src/model/expand/relation.rs
+++ b/crates/toasty-macros/src/model/expand/relation.rs
@@ -1,5 +1,5 @@
 use super::{Expand, util};
-use crate::model::schema::{BelongsTo, Field, FieldTy, HasMany, HasOne};
+use crate::model::schema::{BelongsTo, Field, FieldTy, HasMany, HasOne, extract_deferred_inner};
 
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -191,9 +191,61 @@ impl Expand<'_> {
                     Some(self.expand_model_relation_has_many_method(rel, field))
                 }
                 FieldTy::HasOne(rel) => Some(self.expand_model_relation_has_one_method(rel, field)),
+                FieldTy::Primitive(ty) if field.attrs.deferred => {
+                    Some(self.expand_model_deferred_load_method(ty, field))
+                }
                 FieldTy::Primitive(_) => None,
             })
             .collect()
+    }
+
+    fn expand_model_deferred_load_method(&self, ty: &syn::Type, field: &Field) -> TokenStream {
+        let toasty = &self.toasty;
+        let vis = &self.model.vis;
+        let model_ident = &self.model.ident;
+        let field_ident = &field.name.ident;
+        let field_index = util::int(field.id);
+        let inner = extract_deferred_inner(ty)
+            .expect("deferred field must wrap inner type in `Deferred<T>`");
+
+        let pk_filter = self.primary_key_filter();
+        let filter_method_ident = &pk_filter.filter_method_ident;
+        let arg_idents: Vec<_> = self.expand_filter_arg_idents(pk_filter).collect();
+
+        quote! {
+            #vis fn #field_ident(&self) -> #toasty::DeferredLoad<#inner> {
+                // Suppress unused field warning: a never-loaded #[deferred]
+                // field still compiles cleanly even if no other code reads it.
+                if false {
+                    let _ = &self.#field_ident;
+                }
+
+                use #toasty::IntoStatement;
+
+                // Build a PK-filtered single-row query, then rewrite its
+                // RETURNING clause to project only the deferred column. This
+                // yields `SELECT <deferred_col> FROM <table> WHERE pk = ?`.
+                let __stmt = #model_ident::#filter_method_ident( #( & self.#arg_idents ),* )
+                    .one()
+                    .into_statement()
+                    .into_untyped();
+                let mut __query = match __stmt {
+                    #toasty::core::stmt::Statement::Query(q) => q,
+                    _ => unreachable!("filter_by_<pk>().one() always builds a Query"),
+                };
+                *__query.returning_mut_unwrap() = #toasty::core::stmt::Returning::Project(
+                    #toasty::core::stmt::Expr::record([
+                        #toasty::core::stmt::Expr::Reference(
+                            #toasty::core::stmt::ExprReference::Field {
+                                nesting: 0,
+                                index: #field_index,
+                            }
+                        )
+                    ])
+                );
+                #toasty::DeferredLoad::new(__query.into())
+            }
+        }
     }
 
     fn expand_model_relation_belongs_to_method(

--- a/crates/toasty-macros/src/model/expand/relation.rs
+++ b/crates/toasty-macros/src/model/expand/relation.rs
@@ -1,5 +1,5 @@
 use super::{Expand, util};
-use crate::model::schema::{BelongsTo, Field, FieldTy, HasMany, HasOne, extract_deferred_inner};
+use crate::model::schema::{BelongsTo, Field, FieldTy, HasMany, HasOne};
 
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -205,8 +205,7 @@ impl Expand<'_> {
         let model_ident = &self.model.ident;
         let field_ident = &field.name.ident;
         let field_index = util::int(field.id);
-        let inner = extract_deferred_inner(ty)
-            .expect("deferred field must wrap inner type in `Deferred<T>`");
+        let inner = quote!(<#ty as #toasty::Defer>::Inner);
 
         let pk_filter = self.primary_key_filter();
         let filter_method_ident = &pk_filter.filter_method_ident;

--- a/crates/toasty-macros/src/model/expand/relation.rs
+++ b/crates/toasty-macros/src/model/expand/relation.rs
@@ -212,14 +212,14 @@ impl Expand<'_> {
         let arg_idents: Vec<_> = self.expand_filter_arg_idents(pk_filter).collect();
 
         quote! {
-            #vis fn #field_ident(&self) -> #toasty::DeferredLoad<#inner> {
+            #vis fn #field_ident(&self) -> #toasty::Statement<#inner> {
                 // Suppress unused field warning: a never-loaded #[deferred]
                 // field still compiles cleanly even if no other code reads it.
                 if false {
                     let _ = &self.#field_ident;
                 }
 
-                #toasty::DeferredLoad::from_pk_query(
+                #toasty::build_deferred_load(
                     #model_ident::#filter_method_ident( #( & self.#arg_idents ),* ).one(),
                     #field_index,
                 )

--- a/crates/toasty-macros/src/model/expand/relation.rs
+++ b/crates/toasty-macros/src/model/expand/relation.rs
@@ -219,30 +219,10 @@ impl Expand<'_> {
                     let _ = &self.#field_ident;
                 }
 
-                use #toasty::IntoStatement;
-
-                // Build a PK-filtered single-row query, then rewrite its
-                // RETURNING clause to project only the deferred column. This
-                // yields `SELECT <deferred_col> FROM <table> WHERE pk = ?`.
-                let __stmt = #model_ident::#filter_method_ident( #( & self.#arg_idents ),* )
-                    .one()
-                    .into_statement()
-                    .into_untyped();
-                let mut __query = match __stmt {
-                    #toasty::core::stmt::Statement::Query(q) => q,
-                    _ => unreachable!("filter_by_<pk>().one() always builds a Query"),
-                };
-                *__query.returning_mut_unwrap() = #toasty::core::stmt::Returning::Project(
-                    #toasty::core::stmt::Expr::record([
-                        #toasty::core::stmt::Expr::Reference(
-                            #toasty::core::stmt::ExprReference::Field {
-                                nesting: 0,
-                                index: #field_index,
-                            }
-                        )
-                    ])
-                );
-                #toasty::DeferredLoad::new(__query.into())
+                #toasty::DeferredLoad::from_pk_query(
+                    #model_ident::#filter_method_ident( #( & self.#arg_idents ),* ).one(),
+                    #field_index,
+                )
             }
         }
     }

--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -208,6 +208,7 @@ impl Expand<'_> {
             };
 
             let versionable = field.attrs.versionable;
+            let deferred = field.attrs.deferred;
 
             quote! {
                 #toasty::core::schema::app::Field {
@@ -221,6 +222,7 @@ impl Expand<'_> {
                     primary_key: #primary_key,
                     auto: #auto,
                     versionable: #versionable,
+                    deferred: #deferred,
                     constraints: vec![],
                     variant: None,
                 }

--- a/crates/toasty-macros/src/model/expand/update.rs
+++ b/crates/toasty-macros/src/model/expand/update.rs
@@ -1,5 +1,5 @@
 use super::{Expand, util};
-use crate::model::schema::FieldTy;
+use crate::model::schema::{FieldTy, extract_deferred_inner};
 
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -133,6 +133,22 @@ impl Expand<'_> {
                             self.assignments.set(projection, <String as #toasty::IntoExpr<String>>::into_expr(json));
                             self
                         }
+                    }
+                }
+            }
+            FieldTy::Primitive(ty) if field.attrs.deferred => {
+                let inner = extract_deferred_inner(ty)
+                    .expect("deferred field must wrap inner type in `Deferred<T>`");
+                quote! {
+                    #vis fn #field_ident(mut self, #field_ident: impl #toasty::Assign<#inner>) -> Self {
+                        self.#set_field_ident(#field_ident);
+                        self
+                    }
+
+                    #vis fn #set_field_ident(&mut self, #field_ident: impl #toasty::Assign<#inner>) -> &mut Self {
+                        let projection = #projection;
+                        #field_ident.assign(&mut self.assignments, projection);
+                        self
                     }
                 }
             }

--- a/crates/toasty-macros/src/model/expand/update.rs
+++ b/crates/toasty-macros/src/model/expand/update.rs
@@ -1,5 +1,5 @@
 use super::{Expand, util};
-use crate::model::schema::{FieldTy, extract_deferred_inner};
+use crate::model::schema::FieldTy;
 
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -137,8 +137,7 @@ impl Expand<'_> {
                 }
             }
             FieldTy::Primitive(ty) if field.attrs.deferred => {
-                let inner = extract_deferred_inner(ty)
-                    .expect("deferred field must wrap inner type in `Deferred<T>`");
+                let inner = quote!(<#ty as #toasty::Defer>::Inner);
                 quote! {
                     #vis fn #field_ident(mut self, #field_ident: impl #toasty::Assign<#inner>) -> Self {
                         self.#set_field_ident(#field_ident);

--- a/crates/toasty-macros/src/model/schema.rs
+++ b/crates/toasty-macros/src/model/schema.rs
@@ -8,7 +8,7 @@ mod error;
 pub(crate) use error::ErrorSet;
 
 mod field;
-pub(crate) use field::{Field, FieldTy, SerializeAttr, SerializeFormat};
+pub(crate) use field::{Field, FieldTy, SerializeAttr, SerializeFormat, extract_deferred_inner};
 
 mod fk;
 pub(crate) use fk::ForeignKeyField;

--- a/crates/toasty-macros/src/model/schema.rs
+++ b/crates/toasty-macros/src/model/schema.rs
@@ -8,7 +8,7 @@ mod error;
 pub(crate) use error::ErrorSet;
 
 mod field;
-pub(crate) use field::{Field, FieldTy, SerializeAttr, SerializeFormat, extract_deferred_inner};
+pub(crate) use field::{Field, FieldTy, SerializeAttr, SerializeFormat};
 
 mod fk;
 pub(crate) use fk::ForeignKeyField;

--- a/crates/toasty-macros/src/model/schema/field.rs
+++ b/crates/toasty-macros/src/model/schema/field.rs
@@ -67,6 +67,9 @@ pub(crate) struct FieldAttr {
 
     /// True if the field tracks an OCC version counter
     pub(crate) versionable: bool,
+
+    /// True if the field is annotated with `#[deferred]`
+    pub(crate) deferred: bool,
 }
 
 #[derive(Debug)]
@@ -107,6 +110,7 @@ impl FieldAttr {
             update_expr: None,
             serialize: None,
             versionable: false,
+            deferred: false,
         };
 
         for attr in attrs {
@@ -187,6 +191,15 @@ impl FieldAttr {
                     ));
                 } else {
                     field_attr.versionable = true;
+                }
+            } else if attr.path().is_ident("deferred") {
+                if field_attr.deferred {
+                    errs.push(syn::Error::new_spanned(
+                        attr,
+                        "duplicate #[deferred] attribute",
+                    ));
+                } else {
+                    field_attr.deferred = true;
                 }
             } else if attr.path().is_ident("serialize") {
                 if field_attr.serialize.is_some() {
@@ -399,6 +412,36 @@ impl Field {
             }
         }
 
+        if attrs.deferred {
+            if ty.is_some() {
+                errs.push(syn::Error::new_spanned(
+                    field,
+                    "#[deferred] cannot be combined with relation attributes",
+                ));
+            }
+
+            if attrs.versionable {
+                errs.push(syn::Error::new_spanned(
+                    field,
+                    "#[deferred] cannot be combined with #[version]",
+                ));
+            }
+
+            if attrs.key.is_some() {
+                errs.push(syn::Error::new_spanned(
+                    field,
+                    "#[deferred] cannot be combined with #[key]",
+                ));
+            }
+
+            if extract_deferred_inner(&field.ty).is_none() {
+                errs.push(syn::Error::new_spanned(
+                    &field.ty,
+                    "#[deferred] requires the field to be wrapped in `Deferred<T>`",
+                ));
+            }
+        }
+
         if let Some(err) = errs.collect() {
             return Err(err);
         }
@@ -429,6 +472,34 @@ impl Field {
             variant: None,
         })
     }
+}
+
+/// Extract `T` from a syntactic `Deferred<T>` (or `toasty::Deferred<T>` /
+/// `::toasty::Deferred<T>`). Returns `None` if `ty` is not a `Deferred<...>`.
+pub(crate) fn extract_deferred_inner(ty: &syn::Type) -> Option<syn::Type> {
+    let syn::Type::Path(type_path) = ty else {
+        return None;
+    };
+
+    let last = type_path.path.segments.last()?;
+
+    if last.ident != "Deferred" {
+        return None;
+    }
+
+    let syn::PathArguments::AngleBracketed(args) = &last.arguments else {
+        return None;
+    };
+
+    if args.args.len() != 1 {
+        return None;
+    }
+
+    let syn::GenericArgument::Type(inner) = args.args.first()? else {
+        return None;
+    };
+
+    Some(inner.clone())
 }
 
 pub(crate) fn rewrite_self(ty: &mut syn::Type, model: &syn::Ident) {

--- a/crates/toasty-macros/src/model/schema/field.rs
+++ b/crates/toasty-macros/src/model/schema/field.rs
@@ -433,13 +433,6 @@ impl Field {
                     "#[deferred] cannot be combined with #[key]",
                 ));
             }
-
-            if extract_deferred_inner(&field.ty).is_none() {
-                errs.push(syn::Error::new_spanned(
-                    &field.ty,
-                    "#[deferred] requires the field to be wrapped in `Deferred<T>`",
-                ));
-            }
         }
 
         if let Some(err) = errs.collect() {
@@ -472,34 +465,6 @@ impl Field {
             variant: None,
         })
     }
-}
-
-/// Extract `T` from a syntactic `Deferred<T>` (or `toasty::Deferred<T>` /
-/// `::toasty::Deferred<T>`). Returns `None` if `ty` is not a `Deferred<...>`.
-pub(crate) fn extract_deferred_inner(ty: &syn::Type) -> Option<syn::Type> {
-    let syn::Type::Path(type_path) = ty else {
-        return None;
-    };
-
-    let last = type_path.path.segments.last()?;
-
-    if last.ident != "Deferred" {
-        return None;
-    }
-
-    let syn::PathArguments::AngleBracketed(args) = &last.arguments else {
-        return None;
-    };
-
-    if args.args.len() != 1 {
-        return None;
-    }
-
-    let syn::GenericArgument::Type(inner) = args.args.first()? else {
-        return None;
-    };
-
-    Some(inner.clone())
 }
 
 pub(crate) fn rewrite_self(ty: &mut syn::Type, model: &syn::Ident) {

--- a/crates/toasty-macros/src/model/schema/model.rs
+++ b/crates/toasty-macros/src/model/schema/model.rs
@@ -363,8 +363,12 @@ impl Model {
         }
     }
 
-    pub(crate) fn has_associations(&self) -> bool {
-        self.fields.iter().any(|f| f.ty.is_relation())
+    /// True if any field can be the target of `.include()` — relations or
+    /// `#[deferred]` primitives.
+    pub(crate) fn has_includable_fields(&self) -> bool {
+        self.fields
+            .iter()
+            .any(|f| f.ty.is_relation() || f.attrs.deferred)
     }
 
     pub(crate) fn from_enum_ast(ast: &syn::ItemEnum) -> syn::Result<Self> {

--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -538,21 +538,32 @@ impl visit_mut::VisitMut for LowerStatement<'_, '_> {
                 self.build_include_subquery(&mut returning, field, &nested);
             }
 
-            // Mask out deferred fields not covered by an include path. The
-            // column is preserved in `table_to_model` (so filter and order_by
-            // expressions still resolve to a real column reference), but the
-            // SELECT projection emits Null for the slot.
+            // Encode each deferred slot so the row decoder can distinguish
+            // "loaded" from "unloaded" — critical when the inner type is
+            // `Option<T>`, where a NULL column value is otherwise
+            // indistinguishable from the unloaded state.
             //
-            // INSERT...RETURNING bypasses the mask: the caller just supplied
-            // the value and expects to read it back as loaded.
-            if !self.cx.is_insert() {
-                let model = self.model_unwrap();
-                for (index, field) in model.fields.iter().enumerate() {
-                    if field.deferred && !included_top_fields.contains(index) {
-                        returning
-                            .entry_mut(index)
-                            .insert(stmt::Expr::from(stmt::Value::Null));
-                    }
+            // - Loaded slots wrap the column reference in a 1-element record
+            //   `Record([col])`, so an actual NULL value comes back as
+            //   `Record([Null])` and decodes to `Some(None)`.
+            // - Unloaded slots emit a bare `Null`, which decodes to the
+            //   unloaded state.
+            //
+            // INSERT...RETURNING always projects deferred fields (the caller
+            // just supplied the value and expects to read it back).
+            let model = self.model_unwrap();
+            let is_insert = self.cx.is_insert();
+            for (index, field) in model.fields.iter().enumerate() {
+                if !field.deferred {
+                    continue;
+                }
+                let loaded = is_insert || included_top_fields.contains(index);
+                let mut entry = returning.entry_mut(index);
+                if loaded {
+                    let inner = entry.take();
+                    entry.insert(stmt::Expr::record([inner]));
+                } else {
+                    entry.insert(stmt::Expr::from(stmt::Value::Null));
                 }
             }
 

--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -542,12 +542,17 @@ impl visit_mut::VisitMut for LowerStatement<'_, '_> {
             // column is preserved in `table_to_model` (so filter and order_by
             // expressions still resolve to a real column reference), but the
             // SELECT projection emits Null for the slot.
-            let model = self.model_unwrap();
-            for (index, field) in model.fields.iter().enumerate() {
-                if field.deferred && !included_top_fields.contains(&index) {
-                    returning
-                        .entry_mut(index)
-                        .insert(stmt::Expr::from(stmt::Value::Null));
+            //
+            // INSERT...RETURNING bypasses the mask: the caller just supplied
+            // the value and expects to read it back as loaded.
+            if !self.cx.is_insert() {
+                let model = self.model_unwrap();
+                for (index, field) in model.fields.iter().enumerate() {
+                    if field.deferred && !included_top_fields.contains(&index) {
+                        returning
+                            .entry_mut(index)
+                            .insert(stmt::Expr::from(stmt::Value::Null));
+                    }
                 }
             }
 

--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -511,6 +511,10 @@ impl visit_mut::VisitMut for LowerStatement<'_, '_> {
             // same field slot (see issue #691).
             include.sort_by_key(|p| *p.projection.as_slice().first().expect("empty include path"));
 
+            // Track which top-level fields are explicitly included so that
+            // deferred fields are not masked when the caller asked for them.
+            let mut included_top_fields = HashSet::new();
+
             let mut nested: Vec<stmt::Projection> = vec![];
             let mut current: Option<usize> = None;
 
@@ -518,6 +522,8 @@ impl visit_mut::VisitMut for LowerStatement<'_, '_> {
                 let [first, rest @ ..] = path.projection.as_slice() else {
                     unreachable!("guaranteed non-empty by sort_by_key above")
                 };
+
+                included_top_fields.insert(*first);
 
                 if current != Some(*first) {
                     if let Some(field) = current {
@@ -530,6 +536,19 @@ impl visit_mut::VisitMut for LowerStatement<'_, '_> {
             }
             if let Some(field) = current {
                 self.build_include_subquery(&mut returning, field, &nested);
+            }
+
+            // Mask out deferred fields not covered by an include path. The
+            // column is preserved in `table_to_model` (so filter and order_by
+            // expressions still resolve to a real column reference), but the
+            // SELECT projection emits Null for the slot.
+            let model = self.model_unwrap();
+            for (index, field) in model.fields.iter().enumerate() {
+                if field.deferred && !included_top_fields.contains(&index) {
+                    returning
+                        .entry_mut(index)
+                        .insert(stmt::Expr::from(stmt::Value::Null));
+                }
             }
 
             *i = stmt::Returning::Project(returning);
@@ -858,6 +877,20 @@ impl<'a, 'b> LowerStatement<'a, 'b> {
         nested: &[stmt::Projection],
     ) {
         let field = &self.model_unwrap().fields[field_index];
+
+        // Primitive deferred field: the column reference is already in the
+        // returning record (built from `table_to_model`), so an include is
+        // a no-op here. The masking step in `visit_returning_mut` will skip
+        // this field's slot since it appears in the include set.
+        if field.deferred && field.ty.is_primitive() {
+            for path in nested {
+                assert!(
+                    path.is_empty(),
+                    "include sub-paths on deferred primitive fields are not supported"
+                );
+            }
+            return;
+        }
 
         let (mut stmt, target_model_id) = match &field.ty {
             FieldTy::HasMany(rel) => (

--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -513,7 +513,7 @@ impl visit_mut::VisitMut for LowerStatement<'_, '_> {
 
             // Track which top-level fields are explicitly included so that
             // deferred fields are not masked when the caller asked for them.
-            let mut included_top_fields = HashSet::new();
+            let mut included_top_fields = stmt::PathFieldSet::new();
 
             let mut nested: Vec<stmt::Projection> = vec![];
             let mut current: Option<usize> = None;
@@ -548,7 +548,7 @@ impl visit_mut::VisitMut for LowerStatement<'_, '_> {
             if !self.cx.is_insert() {
                 let model = self.model_unwrap();
                 for (index, field) in model.fields.iter().enumerate() {
-                    if field.deferred && !included_top_fields.contains(&index) {
+                    if field.deferred && !included_top_fields.contains(index) {
                         returning
                             .entry_mut(index)
                             .insert(stmt::Expr::from(stmt::Value::Null));

--- a/crates/toasty/src/lib.rs
+++ b/crates/toasty/src/lib.rs
@@ -134,8 +134,8 @@ pub mod codegen_support {
     pub use crate::{
         Db, Error, Executor, Result, Statement,
         schema::{
-            Auto, BelongsTo, Deferred, DeferredLoad, DiscoverItem, Embed, Field, HasMany, HasOne,
-            Load, Model, Register, Relation, Scope, generate_unique_id,
+            Auto, BelongsTo, Defer, Deferred, DeferredLoad, DiscoverItem, Embed, Field, HasMany,
+            HasOne, Load, Model, Register, Relation, Scope, generate_unique_id,
         },
         stmt::CreateMany,
         stmt::{self, Assign, IntoExpr, IntoInsert, IntoStatement, List, Path},

--- a/crates/toasty/src/lib.rs
+++ b/crates/toasty/src/lib.rs
@@ -116,7 +116,7 @@ mod engine;
 
 /// Model, relation, and schema inspection types.
 pub mod schema;
-pub use schema::{BelongsTo, HasMany, HasOne};
+pub use schema::{BelongsTo, Deferred, HasMany, HasOne};
 
 // `Page` lives in `stmt`.
 
@@ -134,8 +134,8 @@ pub mod codegen_support {
     pub use crate::{
         Db, Error, Executor, Result, Statement,
         schema::{
-            Auto, BelongsTo, DiscoverItem, Embed, Field, HasMany, HasOne, Load, Model, Register,
-            Relation, Scope, generate_unique_id,
+            Auto, BelongsTo, Deferred, DeferredLoad, DiscoverItem, Embed, Field, HasMany, HasOne,
+            Load, Model, Register, Relation, Scope, generate_unique_id,
         },
         stmt::CreateMany,
         stmt::{self, Assign, IntoExpr, IntoInsert, IntoStatement, List, Path},

--- a/crates/toasty/src/lib.rs
+++ b/crates/toasty/src/lib.rs
@@ -134,8 +134,8 @@ pub mod codegen_support {
     pub use crate::{
         Db, Error, Executor, Result, Statement,
         schema::{
-            Auto, BelongsTo, Defer, Deferred, DeferredLoad, DiscoverItem, Embed, Field, HasMany,
-            HasOne, Load, Model, Register, Relation, Scope, generate_unique_id,
+            Auto, BelongsTo, Defer, Deferred, DiscoverItem, Embed, Field, HasMany, HasOne, Load,
+            Model, Register, Relation, Scope, build_deferred_load, generate_unique_id,
         },
         stmt::CreateMany,
         stmt::{self, Assign, IntoExpr, IntoInsert, IntoStatement, List, Path},

--- a/crates/toasty/src/schema.rs
+++ b/crates/toasty/src/schema.rs
@@ -5,7 +5,7 @@ mod belongs_to;
 pub use belongs_to::BelongsTo;
 
 mod deferred;
-pub use deferred::{Defer, Deferred, DeferredLoad};
+pub use deferred::{Defer, Deferred, build_deferred_load};
 
 mod embed;
 pub use embed::Embed;

--- a/crates/toasty/src/schema.rs
+++ b/crates/toasty/src/schema.rs
@@ -5,7 +5,7 @@ mod belongs_to;
 pub use belongs_to::BelongsTo;
 
 mod deferred;
-pub use deferred::{Deferred, DeferredLoad};
+pub use deferred::{Defer, Deferred, DeferredLoad};
 
 mod embed;
 pub use embed::Embed;

--- a/crates/toasty/src/schema.rs
+++ b/crates/toasty/src/schema.rs
@@ -4,6 +4,9 @@ pub use auto::Auto;
 mod belongs_to;
 pub use belongs_to::BelongsTo;
 
+mod deferred;
+pub use deferred::{Deferred, DeferredLoad};
+
 mod embed;
 pub use embed::Embed;
 

--- a/crates/toasty/src/schema/deferred.rs
+++ b/crates/toasty/src/schema/deferred.rs
@@ -1,10 +1,9 @@
 use super::{Field, Load};
+use crate::Statement;
 use crate::stmt::{self, Expr, IntoStatement};
-use crate::{Executor, Result};
 use toasty_core::schema::app::ModelSet;
 
 use std::fmt;
-use std::marker::PhantomData;
 
 /// A field whose value is not loaded by default.
 ///
@@ -70,74 +69,24 @@ impl<T> Deferred<T> {
     }
 }
 
-/// Builder returned by the per-field accessor on a model with a `#[deferred]`
-/// primitive. Calling [`exec`](DeferredLoad::exec) issues a single-row read
-/// against the database keyed on the model's primary key and returns the
-/// deferred field's value.
+/// Build a `Statement<T>` from a PK-filtered single-row query and the
+/// model-field index of the deferred field. Rewrites the statement's
+/// `RETURNING` clause to project just that column.
 ///
-/// `DeferredLoad` is constructed by generated code via [`new`](DeferredLoad::new)
-/// and rewrites the statement's `RETURNING` clause to project just the deferred
-/// column. The model record itself is never decoded, which keeps the loaded
-/// state of nullable fields (`Deferred<Option<T>>`) unambiguous regardless of
-/// whether the column value is `NULL`.
-pub struct DeferredLoad<T> {
-    stmt: toasty_core::stmt::Statement,
-    _p: PhantomData<T>,
-}
-
-impl<T: Load<Output = T>> DeferredLoad<T> {
-    /// Construct a new builder. Used by generated code.
-    #[doc(hidden)]
-    pub fn new(stmt: toasty_core::stmt::Statement) -> Self {
-        Self {
-            stmt,
-            _p: PhantomData,
-        }
-    }
-
-    /// Build a `DeferredLoad` from a PK-filtered single-row query and the
-    /// model-field index of the deferred field. Rewrites the statement's
-    /// `RETURNING` clause to project just that column. Used by generated code.
-    #[doc(hidden)]
-    pub fn from_pk_query<S: IntoStatement>(stmt: S, field_index: usize) -> Self {
-        let mut untyped = stmt.into_statement().into_untyped();
-        *untyped.returning_mut_unwrap() =
-            toasty_core::stmt::Returning::Project(toasty_core::stmt::Expr::record([
-                toasty_core::stmt::Expr::Reference(toasty_core::stmt::ExprReference::Field {
-                    nesting: 0,
-                    index: field_index,
-                }),
-            ]));
-        Self::new(untyped)
-    }
-
-    /// Execute the load and return the deferred field's value.
-    pub async fn exec(self, executor: &mut dyn Executor) -> Result<T> {
-        let response = executor.exec_untyped(self.stmt).await?;
-        let value = response.values.collect_as_value().await?;
-        T::load(unwrap_single_column(value))
-    }
-}
-
-/// Unwrap the value returned by a `SELECT col FROM tbl WHERE pk = ?` into the
-/// scalar at the single column. Handles `Value::List([Value::Record([col])])`
-/// (driver-shaped result), `Value::Record([col])` (single-row), and a bare
-/// scalar.
-fn unwrap_single_column(value: toasty_core::stmt::Value) -> toasty_core::stmt::Value {
-    use toasty_core::stmt::Value;
-    match value {
-        Value::List(items) => {
-            let mut iter = items.into_iter();
-            match iter.next() {
-                Some(first) => unwrap_single_column(first),
-                None => Value::Null,
-            }
-        }
-        Value::Record(record) if record.fields.len() == 1 => {
-            record.fields.into_iter().next().unwrap()
-        }
-        v => v,
-    }
+/// Used by generated code for the per-field accessor on `#[deferred]`
+/// primitives. The model record itself is never decoded, which keeps the
+/// loaded state of nullable fields (`Deferred<Option<T>>`) unambiguous
+/// regardless of whether the column value is `NULL`.
+#[doc(hidden)]
+pub fn build_deferred_load<T, S: IntoStatement>(stmt: S, field_index: usize) -> Statement<T> {
+    let mut untyped = stmt.into_statement().into_untyped();
+    *untyped.returning_mut_unwrap() = toasty_core::stmt::Returning::Project(
+        toasty_core::stmt::Expr::Reference(toasty_core::stmt::ExprReference::Field {
+            nesting: 0,
+            index: field_index,
+        }),
+    );
+    Statement::from_untyped_stmt(untyped)
 }
 
 impl<T> Default for Deferred<T> {

--- a/crates/toasty/src/schema/deferred.rs
+++ b/crates/toasty/src/schema/deferred.rs
@@ -18,6 +18,26 @@ pub struct Deferred<T> {
     value: Option<T>,
 }
 
+/// Marker trait identifying a deferred-load field wrapper, exposing the wrapped
+/// value type via [`Inner`](Defer::Inner).
+///
+/// Generated code references `<F as Defer>::Inner` to recover the user-facing
+/// value type for fields annotated with `#[deferred]`. The trait is implemented
+/// only for [`Deferred<T>`], so applying `#[deferred]` to a field whose type is
+/// not `Deferred<T>` (after type aliases are resolved) fails to compile.
+#[diagnostic::on_unimplemented(
+    message = "`#[deferred]` requires the field to be wrapped in `Deferred<T>`",
+    label = "expected `Deferred<T>`, found `{Self}`"
+)]
+pub trait Defer {
+    /// The wrapped value type.
+    type Inner;
+}
+
+impl<T> Defer for Deferred<T> {
+    type Inner = T;
+}
+
 impl<T> Deferred<T> {
     /// Returns `true` if the field has not been loaded.
     pub fn is_unloaded(&self) -> bool {

--- a/crates/toasty/src/schema/deferred.rs
+++ b/crates/toasty/src/schema/deferred.rs
@@ -103,15 +103,21 @@ impl<T: Load<Output = T>> Load for Deferred<T> {
     }
 
     fn load(value: toasty_core::stmt::Value) -> crate::Result<Self> {
-        // A deferred field is loaded as Null when the column was excluded from
-        // the default projection — the unloaded state. (Phase 1: only the
-        // unloaded path is reachable through the model load. `.include()` is
-        // not yet supported.)
+        // The lowering wraps loaded deferred slots in a 1-element record and
+        // emits a bare Null for unloaded slots, so the two states are
+        // distinguishable even when the inner column value is NULL (i.e. the
+        // `Deferred<Option<T>>` case).
         match value {
             toasty_core::stmt::Value::Null => Ok(Self { value: None }),
-            value => Ok(Self {
-                value: Some(T::load(value)?),
-            }),
+            toasty_core::stmt::Value::Record(record) if record.fields.len() == 1 => {
+                let mut iter = record.fields.into_iter();
+                Ok(Self {
+                    value: Some(T::load(iter.next().unwrap())?),
+                })
+            }
+            value => Err(toasty_core::Error::from_args(format_args!(
+                "deferred field decoder expected Null or single-field Record, got {value:?}"
+            ))),
         }
     }
 

--- a/crates/toasty/src/schema/deferred.rs
+++ b/crates/toasty/src/schema/deferred.rs
@@ -1,0 +1,200 @@
+use super::{Field, Load};
+use crate::stmt::{self, Expr};
+use crate::{Executor, Result};
+use toasty_core::schema::app::ModelSet;
+
+use std::fmt;
+use std::marker::PhantomData;
+
+/// A field whose value is not loaded by default.
+///
+/// `Deferred<T>` wraps a `T` whose underlying column is excluded from default
+/// queries. After a normal load the value is unloaded and accessing it via
+/// [`get`](Deferred::get) panics. Fetch the value with the per-field
+/// `.exec()` accessor on the record.
+///
+/// `Deferred<Option<T>>` is supported when the column is nullable.
+pub struct Deferred<T> {
+    value: Option<T>,
+}
+
+impl<T> Deferred<T> {
+    /// Returns `true` if the field has not been loaded.
+    pub fn is_unloaded(&self) -> bool {
+        self.value.is_none()
+    }
+
+    /// Returns a reference to the loaded value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the field has not been loaded.
+    #[track_caller]
+    pub fn get(&self) -> &T {
+        self.value.as_ref().expect("deferred field not loaded")
+    }
+
+    /// Clears the loaded value, returning the field to the unloaded state.
+    pub fn unload(&mut self) {
+        self.value = None;
+    }
+
+    /// Consumes this `Deferred<T>` and returns the loaded value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the field has not been loaded.
+    #[track_caller]
+    pub fn into_inner(self) -> T {
+        self.value.expect("deferred field not loaded")
+    }
+}
+
+/// Builder returned by the per-field accessor on a model with a `#[deferred]`
+/// primitive. Calling [`exec`](DeferredLoad::exec) issues a single-row read
+/// against the database keyed on the model's primary key and returns the
+/// deferred field's value.
+///
+/// `DeferredLoad` is constructed by generated code via [`new`](DeferredLoad::new)
+/// and rewrites the statement's `RETURNING` clause to project just the deferred
+/// column. The model record itself is never decoded, which keeps the loaded
+/// state of nullable fields (`Deferred<Option<T>>`) unambiguous regardless of
+/// whether the column value is `NULL`.
+pub struct DeferredLoad<T> {
+    stmt: toasty_core::stmt::Statement,
+    _p: PhantomData<T>,
+}
+
+impl<T: Load<Output = T>> DeferredLoad<T> {
+    /// Construct a new builder. Used by generated code.
+    #[doc(hidden)]
+    pub fn new(stmt: toasty_core::stmt::Statement) -> Self {
+        Self {
+            stmt,
+            _p: PhantomData,
+        }
+    }
+
+    /// Execute the load and return the deferred field's value.
+    pub async fn exec(self, executor: &mut dyn Executor) -> Result<T> {
+        let response = executor.exec_untyped(self.stmt).await?;
+        let value = response.values.collect_as_value().await?;
+        T::load(unwrap_single_column(value))
+    }
+}
+
+/// Unwrap the value returned by a `SELECT col FROM tbl WHERE pk = ?` into the
+/// scalar at the single column. Handles `Value::List([Value::Record([col])])`
+/// (driver-shaped result), `Value::Record([col])` (single-row), and a bare
+/// scalar.
+fn unwrap_single_column(value: toasty_core::stmt::Value) -> toasty_core::stmt::Value {
+    use toasty_core::stmt::Value;
+    match value {
+        Value::List(items) => {
+            let mut iter = items.into_iter();
+            match iter.next() {
+                Some(first) => unwrap_single_column(first),
+                None => Value::Null,
+            }
+        }
+        Value::Record(record) if record.fields.len() == 1 => {
+            record.fields.into_iter().next().unwrap()
+        }
+        v => v,
+    }
+}
+
+impl<T> Default for Deferred<T> {
+    fn default() -> Self {
+        Self { value: None }
+    }
+}
+
+impl<T: Load<Output = T>> Load for Deferred<T> {
+    type Output = Self;
+
+    fn ty() -> toasty_core::stmt::Type {
+        T::ty()
+    }
+
+    fn load(value: toasty_core::stmt::Value) -> crate::Result<Self> {
+        // A deferred field is loaded as Null when the column was excluded from
+        // the default projection — the unloaded state. (Phase 1: only the
+        // unloaded path is reachable through the model load. `.include()` is
+        // not yet supported.)
+        match value {
+            toasty_core::stmt::Value::Null => Ok(Self { value: None }),
+            value => Ok(Self {
+                value: Some(T::load(value)?),
+            }),
+        }
+    }
+
+    fn reload(_target: &mut Self, _value: toasty_core::stmt::Value) -> crate::Result<()> {
+        // An update does not change a deferred field's loaded state. The
+        // in-memory copy (loaded or unloaded) is left as-is.
+        Ok(())
+    }
+}
+
+impl<T: Field<Output = T>> Field for Deferred<T> {
+    type Path<Origin> = T::Path<Origin>;
+    type ListPath<Origin> = T::ListPath<Origin>;
+    type Update<'a> = T::Update<'a>;
+    type Inner = T::Inner;
+    const NULLABLE: bool = T::NULLABLE;
+
+    fn new_path<Origin>(_path: stmt::Path<Origin, Self>) -> Self::Path<Origin> {
+        // Deferred fields use a generated accessor that emits a path on the
+        // inner type T directly (see `expand_primitive_field_method`'s
+        // deferred arm). This impl is unreachable through normal codegen.
+        unreachable!("Deferred::new_path should not be called directly")
+    }
+
+    fn new_list_path<Origin>(
+        _path: stmt::Path<Origin, stmt::List<Self>>,
+    ) -> Self::ListPath<Origin> {
+        unreachable!("Deferred::new_list_path should not be called directly")
+    }
+
+    fn new_update<'a>(
+        assignments: &'a mut toasty_core::stmt::Assignments,
+        projection: toasty_core::stmt::Projection,
+    ) -> Self::Update<'a> {
+        T::new_update(assignments, projection)
+    }
+
+    fn field_ty(
+        storage_ty: Option<toasty_core::schema::db::Type>,
+    ) -> toasty_core::schema::app::FieldTy {
+        T::field_ty(storage_ty)
+    }
+
+    fn key_constraint<Origin>(&self, _target: stmt::Path<Origin, Self::Inner>) -> Expr<bool> {
+        // Foreign keys cannot reference a deferred field.
+        unreachable!("Deferred fields cannot be used as foreign keys")
+    }
+
+    fn register(model_set: &mut ModelSet) {
+        T::register(model_set);
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for Deferred<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.value {
+            Some(value) => value.fmt(f),
+            None => write!(f, "<not loaded>"),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T: serde_core::Serialize> serde_core::Serialize for Deferred<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde_core::Serializer,
+    {
+        self.value.serialize(serializer)
+    }
+}

--- a/crates/toasty/src/schema/deferred.rs
+++ b/crates/toasty/src/schema/deferred.rs
@@ -1,5 +1,5 @@
 use super::{Field, Load};
-use crate::stmt::{self, Expr};
+use crate::stmt::{self, Expr, IntoStatement};
 use crate::{Executor, Result};
 use toasty_core::schema::app::ModelSet;
 
@@ -93,6 +93,22 @@ impl<T: Load<Output = T>> DeferredLoad<T> {
             stmt,
             _p: PhantomData,
         }
+    }
+
+    /// Build a `DeferredLoad` from a PK-filtered single-row query and the
+    /// model-field index of the deferred field. Rewrites the statement's
+    /// `RETURNING` clause to project just that column. Used by generated code.
+    #[doc(hidden)]
+    pub fn from_pk_query<S: IntoStatement>(stmt: S, field_index: usize) -> Self {
+        let mut untyped = stmt.into_statement().into_untyped();
+        *untyped.returning_mut_unwrap() =
+            toasty_core::stmt::Returning::Project(toasty_core::stmt::Expr::record([
+                toasty_core::stmt::Expr::Reference(toasty_core::stmt::ExprReference::Field {
+                    nesting: 0,
+                    index: field_index,
+                }),
+            ]));
+        Self::new(untyped)
     }
 
     /// Execute the load and return the deferred field's value.

--- a/crates/toasty/src/schema/deferred.rs
+++ b/crates/toasty/src/schema/deferred.rs
@@ -121,9 +121,15 @@ impl<T: Load<Output = T>> Load for Deferred<T> {
         }
     }
 
-    fn reload(_target: &mut Self, _value: toasty_core::stmt::Value) -> crate::Result<()> {
-        // An update does not change a deferred field's loaded state. The
-        // in-memory copy (loaded or unloaded) is left as-is.
+    fn reload(target: &mut Self, value: toasty_core::stmt::Value) -> crate::Result<()> {
+        // The caller already supplied the value as part of the update, so the
+        // field becomes loaded regardless of its prior state — no follow-up
+        // fetch is needed to read what was just written.
+        //
+        // Updates send the assigned value back unwrapped, unlike the SELECT
+        // lowering which wraps loaded slots in a 1-element record to
+        // distinguish them from unloaded slots.
+        target.value = Some(T::load(value)?);
         Ok(())
     }
 }

--- a/docs/guide/src/SUMMARY.md
+++ b/docs/guide/src/SUMMARY.md
@@ -35,6 +35,7 @@
 # Advanced Features
 
 - [Embedded Types](./embedded-types.md)
+- [Deferred Fields](./deferred-fields.md)
 - [Batch Operations](./batch-operations.md)
 - [Transactions](./transactions.md)
 - [Concurrency Control](./concurrency-control.md)

--- a/docs/guide/src/deferred-fields.md
+++ b/docs/guide/src/deferred-fields.md
@@ -1,0 +1,297 @@
+# Deferred Fields
+
+A deferred field is a column Toasty omits from the default `SELECT`
+list. Records returned from a query have the field unloaded; loading
+the value requires either a follow-up `.exec()` call or a preload with
+`.include()`.
+
+The pattern fits columns that are large, expensive to fetch, or rarely
+read: a `Document` body, a binary blob, an audit-event JSON payload.
+Without the deferred annotation, every list query reads every column
+whether the caller needs it or not.
+
+The API mirrors `BelongsTo`: a synchronous `.get()` reads an
+already-loaded value, an async per-field accessor loads on demand, and
+`.include()` preloads as part of the parent query.
+
+## Marking a field as deferred
+
+Annotate the field with `#[deferred]` and wrap its type in `Deferred<T>`:
+
+```rust
+# use toasty::Model;
+#[derive(Debug, toasty::Model)]
+struct Document {
+    #[key]
+    #[auto]
+    id: u64,
+
+    title: String,
+
+    #[deferred]
+    body: toasty::Deferred<String>,
+}
+```
+
+Both are required; using one without the other is a compile error. The
+attribute directs the macro to omit the field from the default
+projection and to generate the per-field load method. The wrapper type
+provides the unloaded-state runtime API.
+
+`#[deferred]` is supported on primitive fields and on embedded types
+(`#[derive(Embed)]`). It does not compose with `#[belongs_to]`,
+`#[has_many]`, or `#[has_one]` — relations are already lazy.
+
+## Loaded state on create vs query
+
+The record returned by `create!` is loaded with the deferred value the
+caller just wrote — `.get()` reads it without a round-trip. A
+subsequent query against the same row returns a separate record with
+the deferred field unloaded:
+
+```rust
+# use toasty::Model;
+# #[derive(Debug, toasty::Model)]
+# struct Document {
+#     #[key]
+#     #[auto]
+#     id: u64,
+#     title: String,
+#     #[deferred]
+#     body: toasty::Deferred<String>,
+# }
+# async fn __example(mut db: toasty::Db) -> toasty::Result<()> {
+let created = toasty::create!(Document {
+    title: "Hello",
+    body: "the long body",
+})
+.exec(&mut db)
+.await?;
+
+// Loaded — the value the caller passed in.
+assert_eq!("the long body", created.body.get());
+
+// A separate query returns the deferred field unloaded.
+let doc = Document::filter_by_id(created.id).get(&mut db).await?;
+assert_eq!("Hello", doc.title);
+assert!(doc.body.is_unloaded());
+# Ok(())
+# }
+```
+
+Calling `doc.body.get()` in the unloaded state panics. `.get()` is the
+synchronous accessor for a value already loaded into the record; on an
+unloaded field there is nothing to return.
+
+## Loading on demand
+
+The macro generates a per-field method that issues a single-row read
+keyed on the model's primary key. Call `.exec()` to fetch the value:
+
+```rust
+# use toasty::Model;
+# #[derive(Debug, toasty::Model)]
+# struct Document {
+#     #[key]
+#     #[auto]
+#     id: u64,
+#     title: String,
+#     #[deferred]
+#     body: toasty::Deferred<String>,
+# }
+# async fn __example(mut db: toasty::Db) -> toasty::Result<()> {
+# let created = toasty::create!(Document {
+#     title: "Hello",
+#     body: "the long body",
+# }).exec(&mut db).await?;
+# let doc = Document::filter_by_id(created.id).get(&mut db).await?;
+let body: String = doc.body().exec(&mut db).await?;
+# Ok(())
+# }
+```
+
+The return type of `.exec()` is the type within `Deferred<T>`. The
+call does not mutate the in-memory record — `doc.body.is_unloaded()`
+is still `true` afterward, and re-issuing the same load returns the
+value again.
+
+The `.await` makes the round-trip explicit. Code that needs the value
+many times should preload with `.include()` instead — calling `.exec()`
+in a loop over a `Vec<Document>` is N+1 by definition.
+
+## Preloading with `.include()`
+
+`.include()` extends the parent query's projection so deferred fields
+are loaded onto the same record returned by the query:
+
+```rust
+# use toasty::Model;
+# #[derive(Debug, toasty::Model)]
+# struct Document {
+#     #[key]
+#     #[auto]
+#     id: u64,
+#     title: String,
+#     #[deferred]
+#     body: toasty::Deferred<String>,
+# }
+# async fn __example(mut db: toasty::Db) -> toasty::Result<()> {
+# let created = toasty::create!(Document {
+#     title: "Hello",
+#     body: "the long body",
+# }).exec(&mut db).await?;
+let doc = Document::filter_by_id(created.id)
+    .include(Document::fields().body())
+    .get(&mut db)
+    .await?;
+
+let body: &String = doc.body.get();   // synchronous, no query
+# Ok(())
+# }
+```
+
+The `.include()` call adds the deferred column to the existing query —
+no extra round-trip. Multiple `.include()` calls on the same query
+coalesce, and they combine with relation `.include()`s:
+
+```rust,ignore
+let doc = Document::filter_by_id(id)
+    .include(Document::fields().body())
+    .include(Document::fields().summary())
+    .include(Document::fields().author())   // BelongsTo
+    .get(&mut db)
+    .await?;
+```
+
+Across a result set, `.include()` is the way to avoid N+1: a single
+query loads the deferred fields for every record it returns.
+
+## Filtering and sorting
+
+Filtering or sorting on a deferred field references the column in
+`WHERE` or `ORDER BY` without loading the value — only `.include()`
+adds the field to the `SELECT` list:
+
+```rust
+# use toasty::Model;
+# #[derive(Debug, toasty::Model)]
+# struct Document {
+#     #[key]
+#     #[auto]
+#     id: u64,
+#     title: String,
+#     #[deferred]
+#     body: toasty::Deferred<String>,
+# }
+# async fn __example(mut db: toasty::Db) -> toasty::Result<()> {
+# let alpha = toasty::create!(Document {
+#     title: "First",
+#     body: "alpha body",
+# }).exec(&mut db).await?;
+let docs = Document::filter_by_id(alpha.id)
+    .filter(Document::fields().body().eq("alpha body".to_string()))
+    .exec(&mut db)
+    .await?;
+
+assert_eq!(1, docs.len());
+assert!(docs[0].body.is_unloaded());
+# Ok(())
+# }
+```
+
+## Updating
+
+Updating a deferred field does not require it to be loaded:
+
+```rust
+# use toasty::Model;
+# #[derive(Debug, toasty::Model)]
+# struct Document {
+#     #[key]
+#     #[auto]
+#     id: u64,
+#     title: String,
+#     #[deferred]
+#     body: toasty::Deferred<String>,
+# }
+# async fn __example(mut db: toasty::Db) -> toasty::Result<()> {
+# let created = toasty::create!(Document {
+#     title: "Hello",
+#     body: "old body",
+# }).exec(&mut db).await?;
+let mut doc = Document::filter_by_id(created.id).get(&mut db).await?;
+assert!(doc.body.is_unloaded());
+
+doc.update().body("new body".to_string()).exec(&mut db).await?;
+
+// The update does not change the loaded state of the in-memory record.
+assert!(doc.body.is_unloaded());
+# Ok(())
+# }
+```
+
+A loaded value is unchanged by the update. The caller is responsible
+for refreshing the in-memory record to read the new value without a
+follow-up `.exec()` or `.include()`.
+
+## Optional deferred fields
+
+`Deferred<T>` where `T` is `Option<U>` makes the field nullable. The
+column stores `NULL` when the value is `None`, and `create!` treats the
+field as optional:
+
+```rust
+# use toasty::Model;
+#[derive(Debug, toasty::Model)]
+struct Document {
+    #[key]
+    #[auto]
+    id: u64,
+
+    title: String,
+
+    #[deferred]
+    summary: toasty::Deferred<Option<String>>,
+}
+```
+
+```rust
+# use toasty::Model;
+# #[derive(Debug, toasty::Model)]
+# struct Document {
+#     #[key]
+#     #[auto]
+#     id: u64,
+#     title: String,
+#     #[deferred]
+#     summary: toasty::Deferred<Option<String>>,
+# }
+# async fn __example(mut db: toasty::Db) -> toasty::Result<()> {
+// summary may be set or omitted at create time.
+let with = toasty::create!(Document {
+    title: "With summary",
+    summary: "a brief summary",
+}).exec(&mut db).await?;
+
+let without = toasty::create!(Document {
+    title: "No summary",
+}).exec(&mut db).await?;
+
+let summary: Option<String> = with.summary().exec(&mut db).await?;
+assert_eq!(Some("a brief summary".to_string()), summary);
+
+let summary: Option<String> = without.summary().exec(&mut db).await?;
+assert_eq!(None, summary);
+# Ok(())
+# }
+```
+
+A required `Deferred<T>` (where `T` is not `Option<_>`) is a required
+argument to `create!`, just like any other non-nullable field —
+`create!` fails to compile when it is missing.
+
+## Driver support
+
+`#[deferred]` is supported on every driver. SQL backends shorten the
+`SELECT` column list; DynamoDB shortens the `ProjectionExpression`.
+Drivers do not need a capability flag for this feature.

--- a/docs/guide/src/deferred-fields.md
+++ b/docs/guide/src/deferred-fields.md
@@ -201,7 +201,10 @@ assert!(docs[0].body.is_unloaded());
 
 ## Updating
 
-Updating a deferred field does not require it to be loaded:
+Updating a deferred field does not require it to be loaded. The
+caller already supplies the value, so the field is loaded with the new
+value after the update — no follow-up `.exec()` or `.include()` is
+needed to read what was just written:
 
 ```rust
 # use toasty::Model;
@@ -224,15 +227,11 @@ assert!(doc.body.is_unloaded());
 
 doc.update().body("new body".to_string()).exec(&mut db).await?;
 
-// The update does not change the loaded state of the in-memory record.
-assert!(doc.body.is_unloaded());
+// The field is loaded with the value just assigned.
+assert_eq!("new body", doc.body.get());
 # Ok(())
 # }
 ```
-
-A loaded value is unchanged by the update. The caller is responsible
-for refreshing the in-memory record to read the new value without a
-follow-up `.exec()` or `.include()`.
 
 ## Optional deferred fields
 

--- a/tests/tests/ui/relation_has_one_requires_attr.stderr
+++ b/tests/tests/ui/relation_has_one_requires_attr.stderr
@@ -7,12 +7,12 @@ error[E0277]: the trait bound `toasty::HasOne<Option<Profile>>: toasty::schema::
   = help: the following other types implement trait `toasty::schema::Field`:
             Arc<T>
             Box<T>
+            Deferred<T>
             Option<T>
             Rc<T>
             Vec<u8>
             bigdecimal::BigDecimal
             bool
-            f32
           and $N others
 
 error[E0277]: the trait bound `toasty::HasOne<Option<Profile>>: toasty::schema::Field` is not satisfied
@@ -24,10 +24,10 @@ error[E0277]: the trait bound `toasty::HasOne<Option<Profile>>: toasty::schema::
   = help: the following other types implement trait `toasty::schema::Field`:
             Arc<T>
             Box<T>
+            Deferred<T>
             Option<T>
             Rc<T>
             Vec<u8>
             bigdecimal::BigDecimal
             bool
-            f32
           and $N others


### PR DESCRIPTION
## Summary

Phase 1 of the [deferred fields design](https://github.com/tokio-rs/toasty/blob/main/docs/dev/design/deferred-fields.md). Tag a primitive field with `#[deferred] field: Deferred<T>` to exclude it from the default SELECT. Querying the model leaves the field unloaded; calling the per-field accessor (`record.field()`) issues a single-row PK-keyed read and returns `T`. Filters and order-by still resolve to the underlying column.

```rust
#[derive(toasty::Model)]
struct Document {
    #[key] #[auto] id: u64,
    title: String,
    #[deferred]
    body: toasty::Deferred<String>,
}

let doc = Document::filter_by_id(id).get(&mut db).await?;
assert!(doc.body.is_unloaded());
let body: String = doc.body().exec(&mut db).await?;
```

Scope: primitive fields only, on-demand load via `.exec()`, no user-facing `.include()` (Phase 2).

Key implementation notes:

- `app::Field` carries a `deferred: bool` flag; the lowering pass masks deferred slots in the model `RETURNING` while preserving the column in `table_to_model` so filter/order-by still resolve.
- `Deferred<T>::Field::Path<Origin> = T::Path<Origin>` so filters work transparently. The model field accessor and create/update setters use the inner `T`.
- `DeferredLoad<T>` rewrites the `RETURNING` to project just the deferred column and decodes the result directly to `T`, sidestepping the loaded-vs-unloaded ambiguity that would otherwise affect `Deferred<Option<T>>`.
- `Deferred::reload` is a no-op so updates do not change a deferred field's loaded state.

## Type of change

- [x] Implements a previously accepted design: [docs/dev/design/deferred-fields.md](https://github.com/tokio-rs/toasty/blob/main/docs/dev/design/deferred-fields.md)

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes (10 new integration tests for SQLite; full workspace green)
- [x] Touches a public API → covered by the merged design doc
- [x] Touches driver-observable behavior → no new `Operation`; SQL drivers see a shorter projection list, DynamoDB encoding noted in the design as forward work

## Notes for reviewers

- The masking happens in `visit_returning_mut`'s `Returning::Model` arm in `crates/toasty/src/engine/lower.rs`. `build_include_subquery` no-ops for primitive deferred fields — the column ref is already in the returning, and the masking step skips fields named in the include set. This shape sets up Phase 2 (`.include()`) without reshaping Phase 1's API.
- For `Deferred<Option<T>>`, `Value::Null` is overloaded (unloaded vs. loaded-as-`None`). `DeferredLoad` avoids the issue by bypassing model load entirely. If/when `.include()` lands for deferred fields, this will need a sentinel-style encoding similar to what nullable-relation includes already do.