### PR TITLE
fix(toasty-cli): write default config if none exists

### DIFF
--- a/crates/toasty-cli/Cargo.toml
+++ b/crates/toasty-cli/Cargo.toml
@@ -30,5 +30,8 @@ toml.workspace = true
 toml_edit = { workspace = true, features = ["serde"] }
 url.workspace = true
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [lints]
 workspace = true

--- a/crates/toasty-cli/src/config.rs
+++ b/crates/toasty-cli/src/config.rs
@@ -27,7 +27,7 @@ use std::path::Path;
 ///     std::path::PathBuf::from("db/migrations"),
 /// );
 /// ```
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Config {
     /// Migration-related configuration
     pub migration: MigrationConfig,
@@ -41,15 +41,55 @@ impl Config {
 
     /// Load configuration from Toasty.toml in the project root
     pub fn load() -> Result<Self> {
-        let path = Path::new("Toasty.toml");
+        Self::load_from(Path::new("Toasty.toml"))
+    }
+
+    /// Load configuration from a specific path.
+    pub fn load_from(path: &Path) -> Result<Self> {
         let contents = fs::read_to_string(path)?;
         let config: Config = toml::from_str(&contents)?;
         Ok(config)
+    }
+
+    /// Load configuration from `<project_root>/Toasty.toml`, creating it with
+    /// default contents if the file does not exist.
+    pub fn load_or_default(project_root: &Path) -> Result<Self> {
+        let path = project_root.join("Toasty.toml");
+        if path.exists() {
+            Self::load_from(&path)
+        } else {
+            let config = Self::default();
+            let toml = toml::to_string_pretty(&config)?;
+            fs::write(&path, toml)?;
+            Ok(config)
+        }
     }
 
     /// Set the migration configuration
     pub fn migration(mut self, migration: MigrationConfig) -> Self {
         self.migration = migration;
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn load_or_default_creates_toasty_toml_when_missing() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("Toasty.toml");
+        assert!(!path.exists());
+
+        Config::load_or_default(dir.path()).unwrap();
+
+        assert!(path.exists(), "Toasty.toml should be created on first load");
+        let contents = fs::read_to_string(&path).unwrap();
+        let reparsed: Config = toml::from_str(&contents).unwrap();
+        let default = Config::default();
+
+        assert_eq!(reparsed, default);
     }
 }

--- a/crates/toasty-cli/src/migration/config.rs
+++ b/crates/toasty-cli/src/migration/config.rs
@@ -33,7 +33,7 @@ use std::path::PathBuf;
 ///     std::path::PathBuf::from("my_app/db/history.toml"),
 /// );
 /// ```
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct MigrationConfig {
     /// Path to the migrations folder
     pub path: PathBuf,


### PR DESCRIPTION
## Summary

Currently when using the toasty-cli it doesn't write out the config when creating your first migration. In this pr a new method is added (`load_or_default`) that writes the default config if it doesn't exist.

<!-- What does this change and why? Link the issue it closes. -->

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers
none
