### PR TITLE
ci: allow docs-sync workflow to read docs/ files

### DIFF
--- a/.github/workflows/claude-docs-sync.yml
+++ b/.github/workflows/claude-docs-sync.yml
@@ -187,4 +187,4 @@ jobs:
 
             Keep the review terse. Prefer fewer words over more.
           claude_args: |
-            --allowed-tools "Bash(gh pr view:*),Bash(gh pr diff:*),mcp__github__pull_request_read,mcp__github__pull_request_review_write,mcp__github__resolve_review_thread"
+            --allowed-tools "Bash(gh pr view:*),Bash(gh pr diff:*),Read(docs/**),Glob(docs/**),mcp__github__pull_request_read,mcp__github__pull_request_review_write,mcp__github__resolve_review_thread"


### PR DESCRIPTION
## Summary

The Claude Docs Sync workflow's prompt instructs the agent to read `docs/dev/roadmap.md`, design docs under `docs/dev/design/`, and pages under `docs/guide/src/`, but `Read` and `Glob` were not in the `--allowed-tools` list. Every read was denied (recent runs showed 9 permission denials per invocation), so Rule A and Rule B were being evaluated without the inputs they depend on. Add `Read(docs/**)` and `Glob(docs/**)`, scoped to `docs/` so the `pull_request_target` safety boundary still holds — no PR code outside `docs/` becomes readable.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format