### PR TITLE
feat: add ilike() filter method

### DIFF
--- a/crates/toasty-core/src/stmt/expr_like.rs
+++ b/crates/toasty-core/src/stmt/expr_like.rs
@@ -23,6 +23,9 @@ pub struct ExprLike {
     /// pattern make the following `%`, `_`, or `c` match literally, and the
     /// serializer emits an `ESCAPE 'c'` clause.
     pub escape: Option<char>,
+
+    /// Whether the match is case-insensitive.
+    pub case_insensitive: bool,
 }
 
 impl Expr {
@@ -32,6 +35,18 @@ impl Expr {
             expr: Box::new(expr.into()),
             pattern: Box::new(pattern.into()),
             escape: None,
+            case_insensitive: false,
+        }
+        .into()
+    }
+
+    /// Creates a `expr ILIKE pattern` expression with no escape character.
+    pub fn ilike(expr: impl Into<Self>, pattern: impl Into<Self>) -> Self {
+        ExprLike {
+            expr: Box::new(expr.into()),
+            pattern: Box::new(pattern.into()),
+            escape: None,
+            case_insensitive: true,
         }
         .into()
     }

--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -39,6 +39,7 @@ pub mod field_column_name;
 pub mod field_column_type;
 pub mod field_default_and_update;
 pub mod field_version;
+pub mod filter_ilike;
 pub mod filter_like;
 pub mod float_fields;
 pub mod index_composite;

--- a/crates/toasty-driver-integration-suite/src/tests/filter_ilike.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/filter_ilike.rs
@@ -1,0 +1,119 @@
+use crate::prelude::*;
+
+#[derive(Debug, toasty::Model)]
+struct Item {
+    #[key]
+    id: i64,
+    name: String,
+}
+
+async fn setup(test: &mut Test) -> toasty::Db {
+    let mut db = test.setup_db(models!(Item)).await;
+
+    toasty::create!(Item::[
+        { id: 1_i64, name: "Alice"   },
+        { id: 2_i64, name: "ALICIA"  },
+        { id: 3_i64, name: "alfred"  },
+        { id: 4_i64, name: "Bob"     },
+        { id: 5_i64, name: "BARRY"   },
+    ])
+    .exec(&mut db)
+    .await
+    .unwrap();
+
+    db
+}
+
+/// ILIKE with an uppercase pattern matches rows regardless of their case.
+/// On PostgreSQL this requires `ILIKE`; on SQLite/MySQL plain `LIKE` is already
+/// case-insensitive for ASCII, so the same query works.
+#[driver_test(requires(sql))]
+pub async fn ilike_uppercase_pattern(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let mut items: Vec<Item> = Item::filter(Item::fields().name().ilike("AL%".to_string()))
+        .exec(&mut db)
+        .await?;
+
+    items.sort_by_key(|i| i.id);
+
+    assert_eq!(items.len(), 3);
+    assert_eq!(items[0].name, "Alice");
+    assert_eq!(items[1].name, "ALICIA");
+    assert_eq!(items[2].name, "alfred");
+
+    Ok(())
+}
+
+/// ILIKE with a lowercase pattern — symmetric to the uppercase case. Catches
+/// the inverse bug if the serializer accidentally emitted a case-sensitive op.
+#[driver_test(requires(sql))]
+pub async fn ilike_lowercase_pattern(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let mut items: Vec<Item> = Item::filter(Item::fields().name().ilike("al%".to_string()))
+        .exec(&mut db)
+        .await?;
+
+    items.sort_by_key(|i| i.id);
+
+    assert_eq!(items.len(), 3);
+    assert_eq!(items[0].name, "Alice");
+    assert_eq!(items[1].name, "ALICIA");
+    assert_eq!(items[2].name, "alfred");
+
+    Ok(())
+}
+
+/// ILIKE with a pattern that matches nothing — returns empty result.
+#[driver_test(requires(sql))]
+pub async fn ilike_no_match(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let items: Vec<Item> = Item::filter(Item::fields().name().ilike("ZZ%".to_string()))
+        .exec(&mut db)
+        .await?;
+
+    assert_eq!(items.len(), 0);
+
+    Ok(())
+}
+
+/// ILIKE on an `Option<String>` field — matches non-null values regardless of
+/// case; rows with NULL values are excluded since `NULL ILIKE pattern` is
+/// unknown.
+#[driver_test(requires(sql))]
+pub async fn ilike_optional_field(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct OptItem {
+        #[key]
+        id: i64,
+        nickname: Option<String>,
+    }
+
+    let mut db = test.setup_db(models!(OptItem)).await;
+
+    toasty::create!(OptItem::[
+        { id: 1_i64, nickname: Some("Alice".to_string())   },
+        { id: 2_i64, nickname: Some("ALICIA".to_string())  },
+        { id: 3_i64, nickname: Some("alfred".to_string())  },
+        { id: 4_i64, nickname: Some("Bob".to_string())     },
+        { id: 5_i64, nickname: None                        },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let mut items: Vec<OptItem> =
+        OptItem::filter(OptItem::fields().nickname().ilike("al%".to_string()))
+            .exec(&mut db)
+            .await?;
+
+    items.sort_by_key(|i| i.id);
+
+    assert_eq!(items.len(), 3);
+    assert_eq!(items[0].nickname.as_deref(), Some("Alice"));
+    assert_eq!(items[1].nickname.as_deref(), Some("ALICIA"));
+    assert_eq!(items[2].nickname.as_deref(), Some("alfred"));
+
+    Ok(())
+}

--- a/crates/toasty-sql/src/serializer/expr.rs
+++ b/crates/toasty-sql/src/serializer/expr.rs
@@ -49,7 +49,13 @@ impl ToSql for &stmt::Expr {
                 fmt!(cx, f, expr.expr " IS NULL");
             }
             stmt::Expr::Like(expr) => {
-                fmt!(cx, f, expr.expr " LIKE " expr.pattern);
+                let op =
+                    if expr.case_insensitive && matches!(f.serializer.flavor, Flavor::Postgresql) {
+                        " ILIKE "
+                    } else {
+                        " LIKE "
+                    };
+                fmt!(cx, f, expr.expr op expr.pattern);
                 if let Some(escape) = expr.escape {
                     let escape = &stmt::Value::String(escape.to_string());
                     fmt!(cx, f, " ESCAPE " escape);

--- a/crates/toasty/src/engine/lower/expr_pattern.rs
+++ b/crates/toasty/src/engine/lower/expr_pattern.rs
@@ -43,6 +43,7 @@ impl LowerStatement<'_, '_> {
             expr: Box::new(*e.expr),
             pattern: Box::new(stmt::Expr::Value(stmt::Value::String(pattern))),
             escape,
+            case_insensitive: false,
         }
         .into();
     }

--- a/crates/toasty/src/stmt/path.rs
+++ b/crates/toasty/src/stmt/path.rs
@@ -567,6 +567,34 @@ where
             _p: PhantomData,
         }
     }
+
+    /// Case-insensitive variant of [`like`](Self::like).
+    ///
+    /// On PostgreSQL this serializes to `ILIKE`. On SQLite and MySQL it
+    /// serializes to plain `LIKE`, since both engines are already
+    /// case-insensitive for ASCII by default — note that Unicode case-folding
+    /// behavior depends on locale (PostgreSQL) or column collation (MySQL),
+    /// and SQLite's `LIKE` is ASCII-only without the ICU extension. Not
+    /// supported by the DynamoDB driver.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[derive(Debug, toasty::Model)]
+    /// # struct User {
+    /// #     #[key]
+    /// #     id: i64,
+    /// #     name: String,
+    /// # }
+    /// // Matches "Alice", "ALICIA", and "alfred".
+    /// let filter = User::fields().name().ilike("al%".to_string());
+    /// ```
+    pub fn ilike(self, pattern: impl IntoExpr<String>) -> Expr<bool> {
+        Expr {
+            untyped: stmt::Expr::ilike(self.untyped.into_stmt(), pattern.into_expr().untyped),
+            _p: PhantomData,
+        }
+    }
 }
 
 impl<T, U> Clone for Path<T, U> {


### PR DESCRIPTION
## Summary

Adds `.ilike()` on string fields, mirroring the existing `.like()`. On PostgreSQL, it serializes to `ILIKE`; on SQLite and MySQL, it serializes to plain `LIKE` — both engines are already ASCII case-insensitive by default, so wrapping in `LOWER()` would not improve correctness and would defeat indexes. Not supported by DynamoDB.

Closes #774.

## Type of change

- [x] Small/obvious change — bug fix, docs, internal cleanup, or test

## Checklist

 - [x] `cargo fmt` and `cargo clippy` are clean
 - [x] `cargo test` passes (verified on SQLite and PostgreSQL)

## Notes for reviewers

`ExprLike` grew a `case_insensitive: bool` flag instead of a separate AST variant; the SQL serializer branches on flavor, matching the precedent set by `StartsWith`. Integration tests use mixed-case data (`"ALICIA"`, `"alfred"`) so the `ILIKE` path is actually load-bearing on Postgres — plain `LIKE` would not match those rows.
