### PR TITLE
docs: link query! macro design and roadmap to tracking issue

### DIFF
--- a/docs/dev/design/query-macro.md
+++ b/docs/dev/design/query-macro.md
@@ -18,6 +18,10 @@ let users = User::filter(User::fields().name().eq("Carl")).exec(&mut db).await?;
 The macro eliminates the repetition of the model name in field paths, provides
 infix operators instead of method chains, and reads closer to a query language.
 
+Tracked in [#808] — discussion of the feature happens there.
+
+[#808]: https://github.com/tokio-rs/toasty/issues/808
+
 ## Syntax
 
 ```

--- a/docs/dev/roadmap.md
+++ b/docs/dev/roadmap.md
@@ -138,9 +138,11 @@ the entry lands here.
 
 ## Macros
 
-- `toasty::query!()` — succinct query syntax ([design](design/query-macro.md))
+- `toasty::query!()` — succinct query syntax ([design](design/query-macro.md), [#808])
 - `toasty::create!()` — concise record creation ([design](design/static-assertions-create-macro.md))
 - `toasty::update!()` — concise updates
+
+[#808]: https://github.com/tokio-rs/toasty/issues/808
 
 ## Runtime
 


### PR DESCRIPTION
## Summary

Point the `query!` macro design doc and the roadmap entry at the new tracking issue (#808). The issue is the discussion home for the feature; the design doc continues to be the authoritative reference.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format