### PR TITLE
refactor(engine): use fold for mid-lowering sub-statement canonicalization

### DIFF
--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -20,7 +20,7 @@ use toasty_core::{
     stmt::{self, IntoExprTarget, VisitMut, visit_mut},
 };
 
-use crate::engine::{Engine, HirStatement, hir, simplify::Simplify};
+use crate::engine::{Engine, HirStatement, fold, hir, simplify::Simplify};
 
 impl Engine {
     pub(super) fn lower_stmt(&self, stmt: stmt::Statement) -> Result<HirStatement> {
@@ -415,7 +415,10 @@ impl visit_mut::VisitMut for LowerStatement<'_, '_> {
                     visit_mut::visit_expr_stmt_mut(child, &mut expr_stmt);
                 });
 
-                self.state.engine.simplify_stmt(&mut *expr_stmt.stmt);
+                // Cheap canonicalization is enough here: the parent statement's
+                // post-lowering simplify will recursively visit this embedded
+                // sub-statement and apply the heavyweight rules.
+                fold::fold_stmt(&mut *expr_stmt.stmt);
 
                 *expr = self.new_sub_statement(source_id, target_id, expr_stmt.stmt);
 
@@ -441,7 +444,10 @@ impl visit_mut::VisitMut for LowerStatement<'_, '_> {
                 });
 
                 let mut stmt = stmt::Statement::Query(*expr_exists.subquery);
-                self.state.engine.simplify_stmt(&mut stmt);
+                // Cheap canonicalization is enough here: the parent statement's
+                // post-lowering simplify will recursively visit this embedded
+                // sub-statement and apply the heavyweight rules.
+                fold::fold_stmt(&mut stmt);
 
                 let arg = self.new_sub_statement(source_id, target_id, Box::new(stmt));
 


### PR DESCRIPTION
## Summary

Replace the two `simplify_stmt` calls in `lower.rs` that fire on freshly embedded sub-statements (lines 418, 444) with `fold::fold_stmt`. Both sites embed an `Expr::Stmt` sub-statement into the parent tree via `new_sub_statement`, after which the parent's post-lowering simplify recursively visits and applies the heavyweight rules.

The other two sites named in the design doc remain on `simplify_stmt`:

  - `lower/relation.rs:397` synthesizes a child insert and stitches it onto a `RelationSource` via `set_returning_field`, so the parent's simplify never reaches it. Swapping to `fold` here regressed 125 integration tests (`relation_preload`, `tx_atomic_stmt`, `tx_interactive`) because `lift_in_subquery` and similar app-level rewrites no longer fired.
  - `lower.rs:979` (`build_include_subquery`) is the case the design's Edge Cases section calls out for a recursive `lower_stmt` rewrite.

Both are scoped for a follow-up PR that introduces a recursive `lower_stmt` call on synthesized statements (matching the design's sub-statement-handling section).

## Type of change

<!-- Check one. -->

- [ ] Small / obvious change — bug fix, docs, internal cleanup, or test
- [X] Implements a previously accepted [design](https://github.com/tokio-rs/toasty/blob/worktree-cached-churning-seahorse/docs/dev/design/lower-then-simplify.md)
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [X] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [X] `cargo fmt` and `cargo clippy` are clean
- [X] `cargo test` passes
- [ ] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [ ] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers
N/A
