### PR TITLE
refactor(engine): recursively lower synthesized sub-statements

### DIFF
--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -940,6 +940,48 @@ impl<'a, 'b> LowerStatement<'a, 'b> {
         stmt::Expr::arg(arg)
     }
 
+    /// Run the canonical pipeline (pre-lower simplify, lowering walk, post-lower
+    /// simplify) on a synthesized sub-statement and stitch it onto the parent
+    /// as an `Expr::Arg`.
+    ///
+    /// Used at sites where lowering itself synthesizes a new statement to embed
+    /// in the parent's `Returning` (include subqueries, child inserts for
+    /// relation planning).  Equivalent to a recursive `lower_stmt` call that
+    /// passes through the `Expr::Stmt` arm in `visit_expr_mut`, but expressed
+    /// directly so the synthesized statement does not have to round-trip
+    /// through an `Expr::Stmt` placeholder.
+    fn lower_sub_stmt(&mut self, stmt: stmt::Statement) -> stmt::Expr {
+        let source_id = self.scope_stmt_id();
+        let mut stmt = Box::new(stmt);
+
+        let target_id = self.scope_statement(|child| {
+            // Pre-lower simplify: app-level rewrites (model→PK, lift_in_subquery,
+            // association rewrites) that the lowering visitor expects to have
+            // already fired.
+            Simplify::with_context(child.expr_cx).visit_mut(&mut *stmt);
+            // Lowering walk.
+            child.visit_stmt_mut(&mut stmt);
+            // Post-lower simplify: heavyweight rules on the lowered tree.
+            child.state.engine.simplify_stmt(&mut *stmt);
+        });
+
+        // Sub-statements built via this helper always live in the parent's
+        // Returning clause (include subqueries, child inserts for relation
+        // planning).  Force the new `Arg::Sub`'s `returning` flag accordingly:
+        // `plan_nested_merge` keys off `returning: true` to discover include
+        // subqueries, and the line-399 `Expr::Stmt` arm gets the same flag
+        // because it fires during the parent's Returning walk.
+        let saved_cx = std::mem::replace(&mut self.cx, LoweringContext::Returning(None));
+        let arg = self.new_sub_statement(source_id, target_id, stmt);
+        self.cx = saved_cx;
+
+        if self.state.hir[target_id].independent {
+            self.curr_stmt_info().deps.insert(target_id);
+        }
+
+        arg
+    }
+
     fn schema(&self) -> &'b Schema {
         &self.state.engine.schema
     }

--- a/crates/toasty/src/engine/lower/include.rs
+++ b/crates/toasty/src/engine/lower/include.rs
@@ -39,10 +39,10 @@
 
 use toasty_core::{
     schema::{app, mapping},
-    stmt::{self, VisitMut},
+    stmt,
 };
 
-use crate::engine::{lower::LowerStatement, simplify::Simplify};
+use crate::engine::lower::LowerStatement;
 
 /// The include paths that target a single field, partitioned by whether
 /// they name the field itself or a sub-path within it.
@@ -336,10 +336,10 @@ impl LowerStatement<'_, '_> {
             }
         }
 
-        // Simplify the new stmt to handle relations.
-        Simplify::with_context(self.expr_cx).visit_stmt_query_mut(&mut stmt);
-
-        let mut sub_expr = stmt::Expr::stmt(stmt);
+        // Run the canonical pipeline (pre-lower simplify, lowering walk,
+        // post-lower simplify) on the synthesized subquery, stitching it onto
+        // the parent as an `Expr::Arg`.
+        let mut sub_expr = self.lower_sub_stmt(stmt::Statement::Query(stmt));
 
         // For nullable single relations (HasOne<Option<T>>, BelongsTo<Option<T>>),
         // wrap the sub-expression with a Let + Match to encode the result

--- a/crates/toasty/src/engine/lower/relation.rs
+++ b/crates/toasty/src/engine/lower/relation.rs
@@ -394,8 +394,10 @@ impl LowerStatement<'_, '_> {
             stmt.source.single = false;
         }
 
-        self.state.engine.simplify_stmt(&mut stmt);
-        source.set_returning_field(_field.id, stmt.into());
+        // Run the canonical pipeline on the synthesized child insert and
+        // stitch it onto the parent as an `Expr::Arg`.
+        let arg = self.lower_sub_stmt(stmt::Statement::Insert(stmt));
+        source.set_returning_field(_field.id, arg);
     }
 
     fn plan_mut_belongs_to(


### PR DESCRIPTION
## Summary

PR #3 of the lower-and-simplify epic.  Replace the ad-hoc `Simplify::with_context` and bare `simplify_stmt` calls at the two sites that synthesize a child statement during lowering with a new `lower_sub_stmt` helper that runs the canonical pipeline (pre-lower simplify, lowering walk, post-lower simplify) on the synthesized statement in a fresh scope and stitches it onto the parent as an `Expr::Arg`.

Sites converted:

  - `lower::include::build_include_subquery`: the include subquery now flows through the full pipeline.  The `Expr::Stmt` placeholder round-trip is gone; the helper returns an `Expr::Arg` directly, which the nullable-relation Let+Match wrapper consumes unchanged.
  - `lower::relation::plan_mut_has_n_associate_insert`: the child `INSERT` synthesized for `HasMany` planning now flows through the same pipeline before `set_returning_field`.

The helper temporarily swaps the lowering context to `Returning(None)` around `new_sub_statement` so the new `Arg::Sub`'s `returning` flag matches what the existing `Expr::Stmt` arm sets when it fires during the parent's `Returning` walk. `plan_nested_merge` keys off that flag to discover include subqueries.

No driver, planner, MIR, or test-fixture changes.

## Type of change

<!-- Check one. -->

- [ ] Small / obvious change — bug fix, docs, internal cleanup, or test
- [X] Implements a previously accepted [design](https://github.com/tokio-rs/toasty/pull/787)
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [X] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [X] `cargo fmt` and `cargo clippy` are clean
- [X] `cargo test` passes
- [ ] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [ ] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers
N/A
