### PR TITLE
feat(core): support Vec<scalar> model fields on SQLite

### DIFF
--- a/crates/toasty-core/src/driver.rs
+++ b/crates/toasty-core/src/driver.rs
@@ -20,7 +20,7 @@
 //! ```
 
 mod capability;
-pub use capability::{Capability, SchemaMutations, StorageTypes};
+pub use capability::{Capability, ScalarList, SchemaMutations, StorageTypes};
 
 mod response;
 pub use response::{ExecResponse, Rows};

--- a/crates/toasty-core/src/driver/capability.rs
+++ b/crates/toasty-core/src/driver/capability.rs
@@ -125,6 +125,27 @@ pub struct Capability {
     /// Whether the driver supports backward (previous-page) pagination.
     /// SQL: true. DynamoDB: false.
     pub backward_pagination: bool,
+
+    /// Whether the driver accepts a `Value::List` as a single bind
+    /// parameter representing a scalar array.
+    ///
+    /// PostgreSQL binds a native array. SQLite and (eventually) MySQL
+    /// bind JSON-encoded text. When `false`, scalar lists in
+    /// non-decomposable positions (e.g. a `Vec<scalar>` column value) have
+    /// nowhere to go — the schema layer is responsible for rejecting
+    /// `Vec<scalar>` fields on such backends.
+    pub array_binding: bool,
+    /// Whether `x IN <bound_array>` is a valid SQL form (e.g. PostgreSQL
+    /// `x = ANY($1)` / `x IN (SELECT unnest($1))`).
+    ///
+    /// When `true`, the parameter extractor keeps an `IN`-list rhs as a
+    /// single bound array; the SQL serializer is expected to emit the
+    /// matching predicate form. When `false`, the rhs decomposes to
+    /// per-element parameters (`x IN (?1, ?2, ?3)`).
+    ///
+    /// Implies [`Capability::array_binding`]: there is no point lowering
+    /// to `IN <array>` if the driver cannot bind an array.
+    pub in_array: bool,
 }
 
 /// How a backend stores `Vec<T>` (and other ordered collection) fields whose
@@ -337,6 +358,11 @@ impl Capability {
         test_connection_pool: false,
 
         backward_pagination: true,
+
+        // SQLite binds a `Value::List` parameter as JSON text.
+        array_binding: true,
+        // No native `IN <array>` form: IN-list rhs decomposes to ?1, ?2, …
+        in_array: false,
     };
 
     /// PostgreSQL capabilities
@@ -367,6 +393,10 @@ impl Capability {
 
         test_connection_pool: true,
 
+        // PostgreSQL accepts a single bound array as the rhs of IN
+        // (`x = ANY($1)` / `x IN (SELECT unnest($1))`).
+        in_array: true,
+
         ..Self::SQLITE
     };
 
@@ -395,6 +425,10 @@ impl Capability {
         decimal_arbitrary_precision: false,
 
         test_connection_pool: true,
+
+        // MySQL driver does not yet implement JSON-list binding; schema
+        // build should reject `Vec<scalar>` until the driver lands.
+        array_binding: false,
 
         ..Self::SQLITE
     };
@@ -433,6 +467,9 @@ impl Capability {
         test_connection_pool: false,
 
         backward_pagination: false,
+
+        array_binding: false,
+        in_array: false,
     };
 }
 

--- a/crates/toasty-core/src/driver/capability.rs
+++ b/crates/toasty-core/src/driver/capability.rs
@@ -393,11 +393,11 @@ impl Capability {
 
         test_connection_pool: true,
 
-        // PostgreSQL natively supports `x = ANY($1)` and
-        // `x IN (SELECT unnest($1))`, but the SQL serializer does not yet
-        // emit either form. Until that lands, IN-list rhs decomposes to
-        // per-element placeholders, same as the other backends.
-        // Inherits `in_array: false` and `array_binding: true` from `Self::SQLITE`.
+        // PostgreSQL accepts a single bound array as the rhs of IN
+        // (the SQL serializer emits `x = ANY($1)`). The parameter
+        // extractor keeps the rhs as one `Value::List` parameter.
+        in_array: true,
+
         ..Self::SQLITE
     };
 

--- a/crates/toasty-core/src/driver/capability.rs
+++ b/crates/toasty-core/src/driver/capability.rs
@@ -393,10 +393,11 @@ impl Capability {
 
         test_connection_pool: true,
 
-        // PostgreSQL accepts a single bound array as the rhs of IN
-        // (`x = ANY($1)` / `x IN (SELECT unnest($1))`).
-        in_array: true,
-
+        // PostgreSQL natively supports `x = ANY($1)` and
+        // `x IN (SELECT unnest($1))`, but the SQL serializer does not yet
+        // emit either form. Until that lands, IN-list rhs decomposes to
+        // per-element placeholders, same as the other backends.
+        // Inherits `in_array: false` and `array_binding: true` from `Self::SQLITE`.
         ..Self::SQLITE
     };
 
@@ -426,10 +427,9 @@ impl Capability {
 
         test_connection_pool: true,
 
-        // MySQL driver does not yet implement JSON-list binding; schema
-        // build should reject `Vec<scalar>` until the driver lands.
-        array_binding: false,
-
+        // MySQL binds a `Value::List` parameter as a JSON-encoded string,
+        // matching the SQLite path. Inherits `array_binding: true` from
+        // `Self::SQLITE`.
         ..Self::SQLITE
     };
 

--- a/crates/toasty-core/src/driver/capability.rs
+++ b/crates/toasty-core/src/driver/capability.rs
@@ -127,6 +127,22 @@ pub struct Capability {
     pub backward_pagination: bool,
 }
 
+/// How a backend stores `Vec<T>` (and other ordered collection) fields whose
+/// element type is a scalar.
+///
+/// PostgreSQL has native arrays (`text[]`, `int[]`, …) with rich indexable
+/// operators. MySQL and SQLite have no native array type and store collections
+/// as JSON. The schema builder reads [`StorageTypes::scalar_list`] to choose
+/// between [`db::Type::Array`] and [`db::Type::Json`] when no explicit storage
+/// hint is present.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScalarList {
+    /// Native array column type (e.g. PostgreSQL `text[]`).
+    Array,
+    /// Document encoding — [`db::Type::Json`].
+    Json,
+}
+
 /// Maps application-level types to the concrete database column types used for
 /// storage.
 ///
@@ -187,6 +203,10 @@ pub struct StorageTypes {
     /// Maximum value for unsigned integers. When `Some`, unsigned integers
     /// are limited to this value. When `None`, full u64 range is supported.
     pub max_unsigned_integer: Option<u64>,
+
+    /// How `Vec<T>` of a scalar element type is stored. PostgreSQL uses
+    /// native arrays; MySQL/SQLite use JSON.
+    pub scalar_list: ScalarList,
 }
 
 /// The database's capabilities to mutate the schema (tables, columns, indices).
@@ -451,6 +471,8 @@ impl StorageTypes {
         // SQLite INTEGER is a signed 64-bit integer, so unsigned integers
         // are limited to i64::MAX to prevent overflow
         max_unsigned_integer: Some(i64::MAX as u64),
+
+        scalar_list: ScalarList::Json,
     };
 
     /// PostgreSQL storage types.
@@ -483,6 +505,8 @@ impl StorageTypes {
         // to i64::MAX. While NUMERIC could theoretically support larger values,
         // we prefer explicit limits over implicit type switching.
         max_unsigned_integer: Some(i64::MAX as u64),
+
+        scalar_list: ScalarList::Array,
     };
 
     /// MySQL storage types.
@@ -519,6 +543,8 @@ impl StorageTypes {
 
         // MySQL supports full u64 range via BIGINT UNSIGNED
         max_unsigned_integer: None,
+
+        scalar_list: ScalarList::Json,
     };
 
     /// DynamoDB storage types.
@@ -545,6 +571,11 @@ impl StorageTypes {
 
         // DynamoDB supports full u64 range (numbers stored as strings)
         max_unsigned_integer: None,
+
+        // DynamoDB has its own list/typed-set encoding; the SQL scalar-list
+        // distinction is irrelevant. Default to Json so any accidental SQL
+        // code path on this storage type maps consistently with MySQL/SQLite.
+        scalar_list: ScalarList::Json,
     };
 }
 

--- a/crates/toasty-core/src/schema/db/ty.rs
+++ b/crates/toasty-core/src/schema/db/ty.rs
@@ -109,6 +109,17 @@ pub enum Type {
     /// A database enum type. See [`TypeEnum`].
     Enum(TypeEnum),
 
+    /// A native array of `elem` values. PostgreSQL `<elem>[]`. Other SQL
+    /// drivers reject this type — the schema builder picks [`Type::Json`]
+    /// instead via [`StorageTypes::scalar_list`](crate::driver::StorageTypes::scalar_list).
+    Array(Box<Type>),
+
+    /// A document-encoded value. JSON on SQL backends (rendered as `JSONB` on
+    /// PostgreSQL, `JSON` on MySQL, `TEXT` on SQLite using JSON1 functions).
+    /// Used as the storage for collection and document fields when no native
+    /// option exists.
+    Json,
+
     /// User-specified unrecognized type
     Custom(String),
 }
@@ -155,6 +166,13 @@ impl Type {
                 stmt::Type::Time => Ok(db.default_time_type.clone()),
                 #[cfg(feature = "jiff")]
                 stmt::Type::DateTime => Ok(db.default_datetime_type.clone()),
+                stmt::Type::List(elem) => match db.scalar_list {
+                    crate::driver::ScalarList::Array => {
+                        let elem_ty = Type::from_app(elem, None, db)?;
+                        Ok(Type::Array(Box::new(elem_ty)))
+                    }
+                    crate::driver::ScalarList::Json => Ok(Type::Json),
+                },
                 _ => Err(crate::Error::unsupported_feature(format!(
                     "type {:?} is not supported by this database",
                     ty
@@ -191,6 +209,7 @@ impl Type {
             stmt::Value::Time(_) => Type::Time(6),
             #[cfg(feature = "jiff")]
             stmt::Value::DateTime(_) => Type::DateTime(6),
+            stmt::Value::List(_) => Type::Json,
             _ => Type::Text,
         }
     }

--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -77,3 +77,4 @@ pub mod type_decimal;
 pub mod type_jiff;
 pub mod type_primitives;
 pub mod type_serialize;
+pub mod vec_scalar_round_trip;

--- a/crates/toasty-driver-integration-suite/src/tests/vec_scalar_round_trip.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/vec_scalar_round_trip.rs
@@ -1,0 +1,114 @@
+//! Round-trip tests for `Vec<scalar>` model fields.
+//!
+//! Phase 1 of the document-fields rollout: a Vec of scalars is a queryable
+//! collection field. This file only checks whole-value insert/read/update —
+//! query operators (`.contains`, `.len`) and in-place mutations (`stmt::push`,
+//! `stmt::clear`) land in subsequent PRs.
+
+use crate::prelude::*;
+
+#[driver_test(id(ID), requires(sql))]
+pub async fn vec_string_round_trip(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: ID,
+
+        tags: Vec<String>,
+    }
+
+    let mut db = test.setup_db(models!(Item)).await;
+
+    let created = Item::create()
+        .tags(vec!["admin".to_string(), "verified".to_string()])
+        .exec(&mut db)
+        .await?;
+
+    assert_eq!(
+        created.tags,
+        vec!["admin".to_string(), "verified".to_string()]
+    );
+
+    let read = Item::get_by_id(&mut db, &created.id).await?;
+    assert_eq!(read.tags, vec!["admin".to_string(), "verified".to_string()]);
+
+    Ok(())
+}
+
+#[driver_test(id(ID), requires(sql))]
+pub async fn vec_string_empty_round_trip(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: ID,
+
+        tags: Vec<String>,
+    }
+
+    let mut db = test.setup_db(models!(Item)).await;
+
+    let created = Item::create()
+        .tags(Vec::<String>::new())
+        .exec(&mut db)
+        .await?;
+    assert!(created.tags.is_empty());
+
+    let read = Item::get_by_id(&mut db, &created.id).await?;
+    assert!(read.tags.is_empty());
+
+    Ok(())
+}
+
+#[driver_test(id(ID), requires(sql))]
+pub async fn vec_i64_round_trip(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: ID,
+
+        scores: Vec<i64>,
+    }
+
+    let mut db = test.setup_db(models!(Item)).await;
+
+    let created = Item::create().scores(vec![1, 2, 3]).exec(&mut db).await?;
+    assert_eq!(created.scores, vec![1, 2, 3]);
+
+    let read = Item::get_by_id(&mut db, &created.id).await?;
+    assert_eq!(read.scores, vec![1, 2, 3]);
+
+    Ok(())
+}
+
+#[driver_test(id(ID), requires(sql))]
+pub async fn vec_string_full_replace(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: ID,
+
+        tags: Vec<String>,
+    }
+
+    let mut db = test.setup_db(models!(Item)).await;
+
+    let mut created = Item::create()
+        .tags(vec!["a".to_string()])
+        .exec(&mut db)
+        .await?;
+
+    created
+        .update()
+        .tags(vec!["b".to_string(), "c".to_string()])
+        .exec(&mut db)
+        .await?;
+
+    let read = Item::get_by_id(&mut db, &created.id).await?;
+    assert_eq!(read.tags, vec!["b".to_string(), "c".to_string()]);
+
+    Ok(())
+}

--- a/crates/toasty-driver-mysql/Cargo.toml
+++ b/crates/toasty-driver-mysql/Cargo.toml
@@ -26,6 +26,7 @@ rust_decimal = { workspace = true, optional = true }
 bigdecimal = { workspace = true, optional = true }
 jiff = { workspace = true, optional = true }
 mysql_async.workspace = true
+serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 url.workspace = true

--- a/crates/toasty-driver-mysql/src/value.rs
+++ b/crates/toasty-driver-mysql/src/value.rs
@@ -146,6 +146,19 @@ impl Value {
                 _ => todo!("ty={ty:#?}"),
             },
 
+            CT::MYSQL_TYPE_JSON => match ty {
+                stmt::Type::List(elem) => {
+                    match row.take_opt::<String, _>(i).expect("value missing") {
+                        Ok(json) => decode_json_list(&json, elem),
+                        Err(e) => {
+                            assert!(matches!(e.0, mysql_async::Value::NULL));
+                            stmt::Value::Null
+                        }
+                    }
+                }
+                _ => todo!("unexpected type for JSON: {ty:#?}"),
+            },
+
             CT::MYSQL_TYPE_NEWDECIMAL | CT::MYSQL_TYPE_DECIMAL => match ty {
                 #[cfg(feature = "rust_decimal")]
                 stmt::Type::Decimal => extract_or_null(row, i, |s: String| {
@@ -241,7 +254,95 @@ impl ToValue for Value {
                     (value.subsec_nanosecond() / 1000) as u32, // Convert nanoseconds to microseconds
                 )
             }
+            CoreValue::List(items) => {
+                // MySQL `JSON` columns accept a JSON-encoded text payload.
+                // Whole-list reads round-trip through `decode_json_list` on
+                // the read path.
+                let json = serde_json::Value::Array(items.iter().map(value_to_json).collect());
+                json.to_string().to_value()
+            }
             value => todo!("{:#?}", value),
         }
+    }
+}
+
+/// Decode a MySQL `JSON` payload (always a JSON array for a `Vec<scalar>`
+/// column) into `Value::List` whose elements have type `elem`.
+fn decode_json_list(text: &str, elem: &stmt::Type) -> stmt::Value {
+    let json: serde_json::Value = serde_json::from_str(text).expect("invalid JSON in list column");
+    let serde_json::Value::Array(items) = json else {
+        panic!("expected JSON array; got {json:#?}");
+    };
+    stmt::Value::List(
+        items
+            .into_iter()
+            .map(|item| json_to_value(item, elem))
+            .collect(),
+    )
+}
+
+fn json_to_value(json: serde_json::Value, ty: &stmt::Type) -> stmt::Value {
+    match (json, ty) {
+        (serde_json::Value::Null, _) => stmt::Value::Null,
+        (serde_json::Value::String(s), stmt::Type::String) => stmt::Value::String(s),
+        (serde_json::Value::String(s), stmt::Type::Uuid) => {
+            stmt::Value::Uuid(s.parse().expect("invalid uuid in JSON list element"))
+        }
+        (serde_json::Value::Bool(b), stmt::Type::Bool) => stmt::Value::Bool(b),
+        (serde_json::Value::Number(n), stmt::Type::I8) => {
+            stmt::Value::I8(n.as_i64().expect("integer expected") as i8)
+        }
+        (serde_json::Value::Number(n), stmt::Type::I16) => {
+            stmt::Value::I16(n.as_i64().expect("integer expected") as i16)
+        }
+        (serde_json::Value::Number(n), stmt::Type::I32) => {
+            stmt::Value::I32(n.as_i64().expect("integer expected") as i32)
+        }
+        (serde_json::Value::Number(n), stmt::Type::I64) => {
+            stmt::Value::I64(n.as_i64().expect("integer expected"))
+        }
+        (serde_json::Value::Number(n), stmt::Type::U8) => {
+            stmt::Value::U8(n.as_u64().expect("unsigned integer expected") as u8)
+        }
+        (serde_json::Value::Number(n), stmt::Type::U16) => {
+            stmt::Value::U16(n.as_u64().expect("unsigned integer expected") as u16)
+        }
+        (serde_json::Value::Number(n), stmt::Type::U32) => {
+            stmt::Value::U32(n.as_u64().expect("unsigned integer expected") as u32)
+        }
+        (serde_json::Value::Number(n), stmt::Type::U64) => {
+            stmt::Value::U64(n.as_u64().expect("unsigned integer expected"))
+        }
+        (serde_json::Value::Number(n), stmt::Type::F32) => {
+            stmt::Value::F32(n.as_f64().expect("float expected") as f32)
+        }
+        (serde_json::Value::Number(n), stmt::Type::F64) => {
+            stmt::Value::F64(n.as_f64().expect("float expected"))
+        }
+        (json, ty) => todo!("json={json:#?}; ty={ty:#?}"),
+    }
+}
+
+fn value_to_json(value: &stmt::Value) -> serde_json::Value {
+    match value {
+        stmt::Value::Null => serde_json::Value::Null,
+        stmt::Value::Bool(v) => serde_json::Value::Bool(*v),
+        stmt::Value::I8(v) => serde_json::Value::Number((*v as i64).into()),
+        stmt::Value::I16(v) => serde_json::Value::Number((*v as i64).into()),
+        stmt::Value::I32(v) => serde_json::Value::Number((*v as i64).into()),
+        stmt::Value::I64(v) => serde_json::Value::Number((*v).into()),
+        stmt::Value::U8(v) => serde_json::Value::Number((*v as u64).into()),
+        stmt::Value::U16(v) => serde_json::Value::Number((*v as u64).into()),
+        stmt::Value::U32(v) => serde_json::Value::Number((*v as u64).into()),
+        stmt::Value::U64(v) => serde_json::Value::Number((*v).into()),
+        stmt::Value::F32(v) => serde_json::Number::from_f64(*v as f64)
+            .map(serde_json::Value::Number)
+            .unwrap_or(serde_json::Value::Null),
+        stmt::Value::F64(v) => serde_json::Number::from_f64(*v)
+            .map(serde_json::Value::Number)
+            .unwrap_or(serde_json::Value::Null),
+        stmt::Value::String(v) => serde_json::Value::String(v.clone()),
+        stmt::Value::Uuid(v) => serde_json::Value::String(v.to_string()),
+        _ => todo!("value_to_json: {value:#?}"),
     }
 }

--- a/crates/toasty-driver-postgresql/src/type.rs
+++ b/crates/toasty-driver-postgresql/src/type.rs
@@ -31,6 +31,19 @@ impl TypeExt for db::Type {
             // Enum types are handled separately via the cached OID map;
             // fall back to TEXT if we reach here (shouldn't happen in practice).
             db::Type::Enum(_) => Type::TEXT,
+            db::Type::Array(elem) => match elem.to_postgres_type() {
+                Type::BOOL => Type::BOOL_ARRAY,
+                Type::INT2 => Type::INT2_ARRAY,
+                Type::INT4 => Type::INT4_ARRAY,
+                Type::INT8 => Type::INT8_ARRAY,
+                Type::FLOAT4 => Type::FLOAT4_ARRAY,
+                Type::FLOAT8 => Type::FLOAT8_ARRAY,
+                Type::TEXT | Type::VARCHAR => Type::TEXT_ARRAY,
+                Type::UUID => Type::UUID_ARRAY,
+                Type::NUMERIC => Type::NUMERIC_ARRAY,
+                other => todo!("to_postgres_type: array of {other:#?} unsupported"),
+            },
+            db::Type::Json => Type::JSONB,
             _ => todo!("to_postgres_type; db_ty={:#?}", self),
         }
     }

--- a/crates/toasty-driver-postgresql/src/value.rs
+++ b/crates/toasty-driver-postgresql/src/value.rs
@@ -178,6 +178,8 @@ impl Value {
             {
                 panic!("NUMERIC requires rust_decimal feature to be enabled")
             }
+        } else if matches!(column.type_().kind(), Kind::Array(_)) {
+            return Self(read_array(index, row, column.type_(), expected_ty));
         } else if matches!(column.type_().kind(), Kind::Enum(_)) {
             // Native database enum types (CREATE TYPE ... AS ENUM) are read as strings.
             // We use EnumString instead of String because String::FromSql::accepts()
@@ -255,6 +257,7 @@ impl ToSql for Value {
             (stmt::Value::Time(value), _) => value.to_sql(ty, out),
             #[cfg(feature = "jiff")]
             (stmt::Value::DateTime(value), _) => value.to_sql(ty, out),
+            (stmt::Value::List(items), _) => list_to_sql(items, ty, out),
             (value, _) => todo!("unsupported Value for PostgreSQL type: {value:#?}, type: {ty:#?}"),
         }
     }
@@ -277,7 +280,106 @@ impl ToSql for Value {
                 | Type::TIMESTAMPTZ
                 | Type::DATE
                 | Type::TIME
-        ) || matches!(ty.kind(), Kind::Enum(_))
+        ) || matches!(ty.kind(), Kind::Enum(_) | Kind::Array(_))
     }
     to_sql_checked!();
+}
+
+/// Read a PostgreSQL array column into a `Value::List`. Dispatches on the
+/// column's element type and the expected `stmt::Type::List(elem)`.
+fn read_array(index: usize, row: &Row, ty: &Type, expected_ty: &stmt::Type) -> stmt::Value {
+    let stmt::Type::List(elem_ty) = expected_ty else {
+        panic!("array column expects stmt::Type::List, got {expected_ty:?}");
+    };
+    let Kind::Array(elem_pg) = ty.kind() else {
+        panic!("read_array called on non-array PG type: {ty:?}");
+    };
+
+    macro_rules! read_and_map {
+        ($t:ty, $wrap:expr) => {{
+            let Some(v) = row.get::<usize, Option<Vec<$t>>>(index) else {
+                return stmt::Value::Null;
+            };
+            stmt::Value::List(v.into_iter().map($wrap).collect())
+        }};
+    }
+
+    match (&**elem_ty, elem_pg) {
+        (stmt::Type::Bool, _) => read_and_map!(bool, stmt::Value::Bool),
+        (stmt::Type::I8, _) => read_and_map!(i16, |v| stmt::Value::I8(v as i8)),
+        (stmt::Type::I16, _) => read_and_map!(i16, stmt::Value::I16),
+        (stmt::Type::I32, _) => read_and_map!(i32, stmt::Value::I32),
+        (stmt::Type::I64, _) => read_and_map!(i64, stmt::Value::I64),
+        (stmt::Type::U8, _) => read_and_map!(i16, |v| stmt::Value::U8(v as u8)),
+        (stmt::Type::U16, _) => read_and_map!(i32, |v| stmt::Value::U16(v as u16)),
+        (stmt::Type::U32, _) => read_and_map!(i64, |v| stmt::Value::U32(v as u32)),
+        (stmt::Type::U64, _) => read_and_map!(i64, |v| stmt::Value::U64(v as u64)),
+        (stmt::Type::F32, _) => read_and_map!(f32, stmt::Value::F32),
+        (stmt::Type::F64, _) => read_and_map!(f64, stmt::Value::F64),
+        (stmt::Type::String, _) => read_and_map!(String, stmt::Value::String),
+        (stmt::Type::Uuid, _) => read_and_map!(uuid::Uuid, stmt::Value::Uuid),
+        (elem, _) => todo!("read_array for element type {elem:?}"),
+    }
+}
+
+/// Bind a `Value::List` to a PostgreSQL array column. The element type is
+/// taken from the column's `Type` (`Kind::Array(elem)`); each list element
+/// is converted to the matching Rust type and the whole `Vec` is bound via
+/// the standard `postgres-types` array encoder.
+fn list_to_sql(
+    items: &[stmt::Value],
+    ty: &Type,
+    out: &mut BytesMut,
+) -> std::result::Result<IsNull, Box<dyn std::error::Error + Sync + Send>> {
+    let Kind::Array(elem) = ty.kind() else {
+        return Err(format!("Value::List can only bind to an array type, got {ty:?}").into());
+    };
+
+    macro_rules! collect_and_bind {
+        ($t:ty, $extract:expr) => {{
+            let vec: Vec<$t> = items.iter().map($extract).collect::<Result<_, _>>()?;
+            return vec.to_sql(ty, out);
+        }};
+    }
+
+    match *elem {
+        Type::BOOL => collect_and_bind!(bool, |v| match v {
+            stmt::Value::Bool(b) => Ok(*b),
+            other => Err(format!("expected Bool, got {other:?}")),
+        }),
+        Type::INT2 => collect_and_bind!(i16, |v| match v {
+            stmt::Value::I8(b) => Ok(*b as i16),
+            stmt::Value::I16(b) => Ok(*b),
+            stmt::Value::U8(b) => Ok(*b as i16),
+            other => Err(format!("expected i16-compatible, got {other:?}")),
+        }),
+        Type::INT4 => collect_and_bind!(i32, |v| match v {
+            stmt::Value::I32(b) => Ok(*b),
+            stmt::Value::U16(b) => Ok(*b as i32),
+            other => Err(format!("expected i32-compatible, got {other:?}")),
+        }),
+        Type::INT8 => collect_and_bind!(i64, |v| match v {
+            stmt::Value::I64(b) => Ok(*b),
+            stmt::Value::U32(b) => Ok(*b as i64),
+            stmt::Value::U64(b) if *b <= i64::MAX as u64 => Ok(*b as i64),
+            other => Err(format!("expected i64-compatible, got {other:?}")),
+        }),
+        Type::FLOAT4 => collect_and_bind!(f32, |v| match v {
+            stmt::Value::F32(b) => Ok(*b),
+            other => Err(format!("expected F32, got {other:?}")),
+        }),
+        Type::FLOAT8 => collect_and_bind!(f64, |v| match v {
+            stmt::Value::F64(b) => Ok(*b),
+            other => Err(format!("expected F64, got {other:?}")),
+        }),
+        Type::TEXT | Type::VARCHAR => collect_and_bind!(String, |v| match v {
+            stmt::Value::String(s) => Ok(s.clone()),
+            other => Err(format!("expected String, got {other:?}")),
+        }),
+        Type::UUID => collect_and_bind!(uuid::Uuid, |v| match v {
+            stmt::Value::Uuid(u) => Ok(*u),
+            other => Err(format!("expected Uuid, got {other:?}")),
+        }),
+        _ => Err(format!("unsupported array element type {elem:?}").into()),
+    }
 }

--- a/crates/toasty-driver-sqlite/src/value.rs
+++ b/crates/toasty-driver-sqlite/src/value.rs
@@ -44,6 +44,7 @@ impl Value {
             },
             Some(SqlValue::Text(value)) => match ty {
                 stmt::Type::Uuid => stmt::Value::Uuid(value.parse().expect("text is a valid uuid")),
+                stmt::Type::List(elem) => decode_json_list(&value, elem),
                 _ => stmt::Value::String(value),
             },
             Some(SqlValue::Blob(value)) => match ty {
@@ -54,6 +55,63 @@ impl Value {
         };
 
         Value(core_value)
+    }
+}
+
+/// Decode a SQLite text payload (a JSON array) into `Value::List` whose
+/// elements have type `elem`.
+fn decode_json_list(text: &str, elem: &stmt::Type) -> stmt::Value {
+    let json: serde_json::Value = serde_json::from_str(text).expect("invalid JSON in list column");
+    let serde_json::Value::Array(items) = json else {
+        panic!("expected JSON array; got {json:#?}");
+    };
+    stmt::Value::List(
+        items
+            .into_iter()
+            .map(|item| json_to_value(item, elem))
+            .collect(),
+    )
+}
+
+fn json_to_value(json: serde_json::Value, ty: &stmt::Type) -> stmt::Value {
+    match (json, ty) {
+        (serde_json::Value::Null, _) => stmt::Value::Null,
+        (serde_json::Value::String(s), stmt::Type::String) => stmt::Value::String(s),
+        (serde_json::Value::String(s), stmt::Type::Uuid) => {
+            stmt::Value::Uuid(s.parse().expect("invalid uuid in JSON list element"))
+        }
+        (serde_json::Value::Bool(b), stmt::Type::Bool) => stmt::Value::Bool(b),
+        (serde_json::Value::Number(n), stmt::Type::I8) => {
+            stmt::Value::I8(n.as_i64().expect("integer expected") as i8)
+        }
+        (serde_json::Value::Number(n), stmt::Type::I16) => {
+            stmt::Value::I16(n.as_i64().expect("integer expected") as i16)
+        }
+        (serde_json::Value::Number(n), stmt::Type::I32) => {
+            stmt::Value::I32(n.as_i64().expect("integer expected") as i32)
+        }
+        (serde_json::Value::Number(n), stmt::Type::I64) => {
+            stmt::Value::I64(n.as_i64().expect("integer expected"))
+        }
+        (serde_json::Value::Number(n), stmt::Type::U8) => {
+            stmt::Value::U8(n.as_u64().expect("unsigned integer expected") as u8)
+        }
+        (serde_json::Value::Number(n), stmt::Type::U16) => {
+            stmt::Value::U16(n.as_u64().expect("unsigned integer expected") as u16)
+        }
+        (serde_json::Value::Number(n), stmt::Type::U32) => {
+            stmt::Value::U32(n.as_u64().expect("unsigned integer expected") as u32)
+        }
+        (serde_json::Value::Number(n), stmt::Type::U64) => {
+            stmt::Value::U64(n.as_u64().expect("unsigned integer expected"))
+        }
+        (serde_json::Value::Number(n), stmt::Type::F32) => {
+            stmt::Value::F32(n.as_f64().expect("float expected") as f32)
+        }
+        (serde_json::Value::Number(n), stmt::Type::F64) => {
+            stmt::Value::F64(n.as_f64().expect("float expected"))
+        }
+        (json, ty) => todo!("json={json:#?}; ty={ty:#?}"),
     }
 }
 
@@ -77,7 +135,39 @@ impl ToSql for Value {
             Value::String(v) => Ok(ToSqlOutput::Borrowed(ValueRef::Text(v.as_bytes()))),
             Value::Bytes(v) => Ok(ToSqlOutput::Borrowed(ValueRef::Blob(&v[..]))),
             Value::Null => Ok(ToSqlOutput::Owned(SqlValue::Null)),
+            Value::List(items) => {
+                // Encode as a JSON array text payload. SQLite's JSON1
+                // functions operate on TEXT columns so this round-trips
+                // through `decode_json_list` on read.
+                let json =
+                    serde_json::Value::Array(items.iter().map(value_to_json).collect::<Vec<_>>());
+                Ok(ToSqlOutput::Owned(SqlValue::Text(json.to_string())))
+            }
             _ => todo!("value = {:#?}", self.0),
         }
+    }
+}
+
+fn value_to_json(value: &stmt::Value) -> serde_json::Value {
+    match value {
+        stmt::Value::Null => serde_json::Value::Null,
+        stmt::Value::Bool(v) => serde_json::Value::Bool(*v),
+        stmt::Value::I8(v) => serde_json::Value::Number((*v as i64).into()),
+        stmt::Value::I16(v) => serde_json::Value::Number((*v as i64).into()),
+        stmt::Value::I32(v) => serde_json::Value::Number((*v as i64).into()),
+        stmt::Value::I64(v) => serde_json::Value::Number((*v).into()),
+        stmt::Value::U8(v) => serde_json::Value::Number((*v as u64).into()),
+        stmt::Value::U16(v) => serde_json::Value::Number((*v as u64).into()),
+        stmt::Value::U32(v) => serde_json::Value::Number((*v as u64).into()),
+        stmt::Value::U64(v) => serde_json::Value::Number((*v).into()),
+        stmt::Value::F32(v) => serde_json::Number::from_f64(*v as f64)
+            .map(serde_json::Value::Number)
+            .unwrap_or(serde_json::Value::Null),
+        stmt::Value::F64(v) => serde_json::Number::from_f64(*v)
+            .map(serde_json::Value::Number)
+            .unwrap_or(serde_json::Value::Null),
+        stmt::Value::String(v) => serde_json::Value::String(v.clone()),
+        stmt::Value::Uuid(v) => serde_json::Value::String(v.to_string()),
+        _ => todo!("value_to_json: {value:#?}"),
     }
 }

--- a/crates/toasty-sql/src/serializer/expr.rs
+++ b/crates/toasty-sql/src/serializer/expr.rs
@@ -40,7 +40,18 @@ impl ToSql for &stmt::Expr {
                 fmt!(cx, f, Ident(name));
             }
             stmt::Expr::InList(expr) => {
-                fmt!(cx, f, expr.expr " IN " expr.list);
+                // When the rhs was bundled into a single bound array
+                // parameter (`Capability::in_array`), `IN <arg>` is invalid
+                // SQL. PostgreSQL accepts the bound-array form via
+                // `x = ANY($1)`; other dialects bundle only when they have
+                // an equivalent — extend this match when they land.
+                if matches!(&*expr.list, stmt::Expr::Arg(_))
+                    && matches!(f.serializer.flavor, Flavor::Postgresql)
+                {
+                    fmt!(cx, f, expr.expr " = ANY(" expr.list ")");
+                } else {
+                    fmt!(cx, f, expr.expr " IN " expr.list);
+                }
             }
             stmt::Expr::InSubquery(expr) => {
                 fmt!(cx, f, expr.expr " IN (" expr.query ")");

--- a/crates/toasty-sql/src/serializer/ty.rs
+++ b/crates/toasty-sql/src/serializer/ty.rs
@@ -130,6 +130,20 @@ impl ToSql for &db::Type {
                 // SQLite: TEXT column (CHECK constraint added in ColumnDef).
                 Flavor::Sqlite => fmt!(cx, f, "TEXT"),
             },
+            db::Type::Array(elem) => match f.serializer.flavor {
+                Flavor::Postgresql => {
+                    elem.as_ref().to_sql(cx, f);
+                    f.dst.push_str("[]");
+                }
+                Flavor::Mysql | Flavor::Sqlite => {
+                    todo!("Array column type is only supported on PostgreSQL")
+                }
+            },
+            db::Type::Json => match f.serializer.flavor {
+                Flavor::Postgresql => fmt!(cx, f, "JSONB"),
+                Flavor::Mysql => fmt!(cx, f, "JSON"),
+                Flavor::Sqlite => fmt!(cx, f, "TEXT"),
+            },
             db::Type::Custom(custom) => fmt!(cx, f, custom.as_str()),
         }
     }

--- a/crates/toasty/src/engine/extract_params.rs
+++ b/crates/toasty/src/engine/extract_params.rs
@@ -19,9 +19,9 @@
 //! merging.
 
 use toasty_core::{
-    driver::operation::TypedValue,
+    driver::{Capability, operation::TypedValue},
     schema::{Schema, db},
-    stmt,
+    stmt::{self, visit_mut::VisitMut},
 };
 
 /// Expression context bound to the database schema.
@@ -33,10 +33,19 @@ type Cx<'a> = stmt::ExprContext<'a, db::Schema>;
 
 /// Extract bind parameters from a statement, replacing scalar values with
 /// `Expr::Arg(n)` placeholders and inferring precise `db::Type` for each.
-pub(crate) fn extract_params(stmt: &mut stmt::Statement, schema: &Schema) -> Vec<TypedValue> {
+pub(crate) fn extract_params(
+    stmt: &mut stmt::Statement,
+    schema: &Schema,
+    capability: &Capability,
+) -> Vec<TypedValue> {
     // Phase 1: Mechanical extraction — replace values with Arg(n)
     let mut params = Vec::new();
-    extract_values(stmt, &mut params);
+    let mut extractor = Extractor {
+        params: &mut params,
+        capability,
+        in_list_rhs_depth: 0,
+    };
+    extractor.visit_stmt_mut(stmt);
 
     // Phase 2+3: Bidirectional type inference — refine param types
     refine_param_types(stmt, &schema.db, &mut params);
@@ -86,111 +95,153 @@ impl Ty {
 // Phase 1: Mechanical value extraction
 // ============================================================================
 
-/// Replace all scalar `Value` nodes with `Arg(n)` placeholders.
-/// Initialize each param's `ty` from the value itself.
-fn extract_values(stmt: &mut stmt::Statement, params: &mut Vec<TypedValue>) {
-    // Pre-pass: `IN <list>` predicates expect their rhs to render as a tuple
-    // of placeholders (`x IN (?1, ?2, ?3)`), so a `Value::List` rhs must be
-    // unrolled before extraction. Without this, `is_extractable_scalar` would
-    // bundle the whole list as a single parameter — correct for collection
-    // columns but wrong here.
-    unroll_in_list_value_lists(stmt);
+/// Stateful AST visitor that replaces `Value` nodes with `Arg(n)`
+/// placeholders.
+///
+/// Whether a `Value::List` of scalars rides as one parameter or decomposes
+/// into per-element parameters depends on two backend capabilities and on
+/// **position**, tracked through the visit:
+///
+/// - [`Capability::array_binding`] — driver can bind a `Value::List` at
+///   all. Without it, no list ever bundles.
+/// - [`Capability::in_array`] — `IN <bound_array>` is a valid SQL form.
+///   Without it, the rhs of an `IN` predicate must decompose to
+///   `(?1, ?2, …)` even when the driver could bind an array elsewhere.
+///
+/// `in_list_rhs_depth` counts enclosing `IN`-list rhs positions so the
+/// same `Value::List` node can take either path depending on where it sits.
+struct Extractor<'a> {
+    params: &'a mut Vec<TypedValue>,
+    capability: &'a Capability,
+    in_list_rhs_depth: u32,
+}
 
-    stmt::visit_mut::for_each_expr_mut(stmt, |expr| {
+impl Extractor<'_> {
+    /// Whether a `Value::List` of scalars at the current position should be
+    /// kept whole (one bind parameter) rather than decomposed into per-
+    /// element parameters.
+    fn can_bundle_scalar_list(&self) -> bool {
+        if !self.capability.array_binding {
+            return false;
+        }
+        if self.in_list_rhs_depth > 0 && !self.capability.in_array {
+            // Inside an `IN` rhs and the dialect has no `IN <array>` form:
+            // SQL would render as `WHERE x IN ?n`, which is invalid.
+            return false;
+        }
+        true
+    }
+
+    /// Push `value` as a fresh parameter and return the matching `Arg`.
+    fn push_param(&mut self, value: stmt::Value) -> stmt::Expr {
+        let ty = db::Type::from_value(&value);
+        let position = self.params.len();
+        self.params.push(TypedValue { value, ty });
+        stmt::Expr::arg(position)
+    }
+
+    /// Recursively destructure a non-extractable composite value. Used for
+    /// rows in batch INSERT (`Value::Record` of fields) and for IN-list-rhs
+    /// lists that the backend cannot accept whole.
+    ///
+    /// Field positions inside a destructured `Record` revisit the same
+    /// "scalar-list = one parameter" decision: a `Vec<scalar>` field of an
+    /// INSERT row should bundle even though its enclosing record had to
+    /// destructure.
+    fn destructure(&mut self, value: stmt::Value) -> stmt::Expr {
+        match value {
+            stmt::Value::Null => stmt::Expr::Value(stmt::Value::Null),
+            stmt::Value::Record(record) => {
+                let fields = record
+                    .fields
+                    .into_iter()
+                    .map(|f| self.destructure_field(f))
+                    .collect();
+                stmt::Expr::Record(stmt::ExprRecord::from_vec(fields))
+            }
+            stmt::Value::List(values) => {
+                let items = values.into_iter().map(|v| self.destructure(v)).collect();
+                stmt::Expr::List(stmt::ExprList { items })
+            }
+            scalar => self.push_param(scalar),
+        }
+    }
+
+    /// Like [`destructure`], but a `Value::List` of scalars is kept whole
+    /// (one bind parameter) when the current context allows it. Used for
+    /// the immediate fields of a record so a `Vec<scalar>` column value
+    /// rides as one parameter even though its enclosing row record must
+    /// be destructured.
+    fn destructure_field(&mut self, value: stmt::Value) -> stmt::Expr {
+        if let stmt::Value::List(items) = &value
+            && items.iter().all(is_scalar_leaf)
+            && self.can_bundle_scalar_list()
+        {
+            return self.push_param(value);
+        }
+        self.destructure(value)
+    }
+}
+
+impl VisitMut for Extractor<'_> {
+    /// IN-list rhs gets a context flag pushed around just the `list` child.
+    /// The lhs is visited normally — only the rhs participates in the
+    /// "must decompose" decision.
+    fn visit_expr_in_list_mut(&mut self, node: &mut stmt::ExprInList) {
+        self.visit_expr_mut(&mut node.expr);
+
+        self.in_list_rhs_depth += 1;
+        self.visit_expr_mut(&mut node.list);
+        self.in_list_rhs_depth -= 1;
+    }
+
+    /// Post-order traversal. Children are processed first (scalar values
+    /// inside them get extracted as their own parameters), then the
+    /// current node decides whether it itself is a parameter, a structural
+    /// expression, or untouched.
+    fn visit_expr_mut(&mut self, expr: &mut stmt::Expr) {
+        stmt::visit_mut::visit_expr_mut(self, expr);
+
         match expr {
-            // Scalar value → extract
-            stmt::Expr::Value(value) if is_extractable_scalar(value) => {
-                let ty = db::Type::from_value(value);
-                let position = params.len();
+            // Plain scalar → one parameter.
+            stmt::Expr::Value(value) if is_scalar_leaf(value) => {
                 let value = std::mem::replace(value, stmt::Value::Null);
-                params.push(TypedValue { value, ty });
-                *expr = stmt::Expr::arg(position);
+                *expr = self.push_param(value);
             }
 
-            // Value::Record or Value::List → take ownership, convert to
-            // Expr::Record/Expr::List with extracted fields
+            // Composite values (records, lists) need a context-aware decision.
             stmt::Expr::Value(value @ (stmt::Value::Record(_) | stmt::Value::List(_))) => {
                 let owned = std::mem::replace(value, stmt::Value::Null);
-                *expr = value_to_extracted_expr(owned, params);
+
+                // A list of all-scalars in a position that supports an array
+                // bind ships as one parameter. Anywhere else we destructure:
+                //   - records always destructure (their fields are independent);
+                //   - lists of records destructure (batch INSERT VALUES);
+                //   - lists of scalars in an IN-list rhs without `in_list_array`
+                //     destructure to per-element placeholders.
+                if let stmt::Value::List(items) = &owned
+                    && items.iter().all(is_scalar_leaf)
+                    && self.can_bundle_scalar_list()
+                {
+                    *expr = self.push_param(owned);
+                } else {
+                    *expr = self.destructure(owned);
+                }
             }
 
-            // Null, Default, and everything else: leave as-is
             _ => {}
         }
-    });
-}
-
-/// Recursively convert a `Value` into an `Expr`, extracting scalar values.
-/// Takes ownership to avoid cloning.
-fn value_to_extracted_expr(value: stmt::Value, params: &mut Vec<TypedValue>) -> stmt::Expr {
-    match value {
-        stmt::Value::Null => stmt::Expr::Value(stmt::Value::Null),
-        stmt::Value::Record(record) => {
-            let fields = record
-                .fields
-                .into_iter()
-                .map(|f| value_to_extracted_expr(f, params))
-                .collect();
-            stmt::Expr::Record(stmt::ExprRecord::from_vec(fields))
-        }
-        // A list of all-scalars is extracted as a single bind parameter so
-        // that collection columns receive the whole list as one value
-        // (rather than rendering as a tuple of placeholders).
-        stmt::Value::List(values) if values.iter().all(is_extractable_scalar) => {
-            let value = stmt::Value::List(values);
-            let ty = db::Type::from_value(&value);
-            let position = params.len();
-            params.push(TypedValue { value, ty });
-            stmt::Expr::arg(position)
-        }
-        stmt::Value::List(values) => {
-            let items = values
-                .into_iter()
-                .map(|v| value_to_extracted_expr(v, params))
-                .collect();
-            stmt::Expr::List(stmt::ExprList { items })
-        }
-        scalar => {
-            let ty = db::Type::from_value(&scalar);
-            let position = params.len();
-            params.push(TypedValue { value: scalar, ty });
-            stmt::Expr::arg(position)
-        }
     }
 }
 
-/// Walk the statement and rewrite any `Expr::InList { list }` whose `list` is
-/// a `Expr::Value(Value::List(items))` into `Expr::InList { list: Expr::List(items as Expr::Value) }`.
-/// Subsequent extraction then decomposes each item as its own scalar parameter,
-/// producing `IN (?1, ?2, …)` rather than a single bundled parameter.
-fn unroll_in_list_value_lists(stmt: &mut stmt::Statement) {
-    stmt::visit_mut::for_each_expr_mut(stmt, |expr| {
-        if let stmt::Expr::InList(in_list) = expr
-            && let stmt::Expr::Value(stmt::Value::List(_)) = in_list.list.as_ref()
-        {
-            let list_expr =
-                std::mem::replace(in_list.list.as_mut(), stmt::Expr::Value(stmt::Value::Null));
-            let stmt::Expr::Value(stmt::Value::List(items)) = list_expr else {
-                unreachable!()
-            };
-            *in_list.list = stmt::Expr::List(stmt::ExprList {
-                items: items.into_iter().map(stmt::Expr::Value).collect(),
-            });
-        }
-    });
-}
-
-fn is_extractable_scalar(value: &stmt::Value) -> bool {
-    match value {
-        stmt::Value::Null | stmt::Value::Record(_) => false,
-        // A list of scalars is itself a single bind parameter — collection
-        // columns (e.g. PostgreSQL `text[]` or a JSON-encoded list) take the
-        // whole list as one driver-level value rather than expanding to a
-        // tuple of placeholders. Lists containing records still decompose
-        // (batch INSERT VALUES, etc.).
-        stmt::Value::List(items) => items.iter().all(is_extractable_scalar),
-        _ => true,
-    }
+/// A `Value` is a "scalar leaf" if it represents a single typed value that
+/// the driver binds as one parameter — i.e. anything that isn't `Null`,
+/// `Record`, or `List`.
+fn is_scalar_leaf(value: &stmt::Value) -> bool {
+    !matches!(
+        value,
+        stmt::Value::Null | stmt::Value::Record(_) | stmt::Value::List(_)
+    )
 }
 
 // ============================================================================

--- a/crates/toasty/src/engine/extract_params.rs
+++ b/crates/toasty/src/engine/extract_params.rs
@@ -89,6 +89,13 @@ impl Ty {
 /// Replace all scalar `Value` nodes with `Arg(n)` placeholders.
 /// Initialize each param's `ty` from the value itself.
 fn extract_values(stmt: &mut stmt::Statement, params: &mut Vec<TypedValue>) {
+    // Pre-pass: `IN <list>` predicates expect their rhs to render as a tuple
+    // of placeholders (`x IN (?1, ?2, ?3)`), so a `Value::List` rhs must be
+    // unrolled before extraction. Without this, `is_extractable_scalar` would
+    // bundle the whole list as a single parameter — correct for collection
+    // columns but wrong here.
+    unroll_in_list_value_lists(stmt);
+
     stmt::visit_mut::for_each_expr_mut(stmt, |expr| {
         match expr {
             // Scalar value → extract
@@ -126,6 +133,16 @@ fn value_to_extracted_expr(value: stmt::Value, params: &mut Vec<TypedValue>) -> 
                 .collect();
             stmt::Expr::Record(stmt::ExprRecord::from_vec(fields))
         }
+        // A list of all-scalars is extracted as a single bind parameter so
+        // that collection columns receive the whole list as one value
+        // (rather than rendering as a tuple of placeholders).
+        stmt::Value::List(values) if values.iter().all(is_extractable_scalar) => {
+            let value = stmt::Value::List(values);
+            let ty = db::Type::from_value(&value);
+            let position = params.len();
+            params.push(TypedValue { value, ty });
+            stmt::Expr::arg(position)
+        }
         stmt::Value::List(values) => {
             let items = values
                 .into_iter()
@@ -142,11 +159,38 @@ fn value_to_extracted_expr(value: stmt::Value, params: &mut Vec<TypedValue>) -> 
     }
 }
 
+/// Walk the statement and rewrite any `Expr::InList { list }` whose `list` is
+/// a `Expr::Value(Value::List(items))` into `Expr::InList { list: Expr::List(items as Expr::Value) }`.
+/// Subsequent extraction then decomposes each item as its own scalar parameter,
+/// producing `IN (?1, ?2, …)` rather than a single bundled parameter.
+fn unroll_in_list_value_lists(stmt: &mut stmt::Statement) {
+    stmt::visit_mut::for_each_expr_mut(stmt, |expr| {
+        if let stmt::Expr::InList(in_list) = expr
+            && let stmt::Expr::Value(stmt::Value::List(_)) = in_list.list.as_ref()
+        {
+            let list_expr =
+                std::mem::replace(in_list.list.as_mut(), stmt::Expr::Value(stmt::Value::Null));
+            let stmt::Expr::Value(stmt::Value::List(items)) = list_expr else {
+                unreachable!()
+            };
+            *in_list.list = stmt::Expr::List(stmt::ExprList {
+                items: items.into_iter().map(stmt::Expr::Value).collect(),
+            });
+        }
+    });
+}
+
 fn is_extractable_scalar(value: &stmt::Value) -> bool {
-    !matches!(
-        value,
-        stmt::Value::Null | stmt::Value::Record(_) | stmt::Value::List(_)
-    )
+    match value {
+        stmt::Value::Null | stmt::Value::Record(_) => false,
+        // A list of scalars is itself a single bind parameter — collection
+        // columns (e.g. PostgreSQL `text[]` or a JSON-encoded list) take the
+        // whole list as one driver-level value rather than expanding to a
+        // tuple of placeholders. Lists containing records still decompose
+        // (batch INSERT VALUES, etc.).
+        stmt::Value::List(items) => items.iter().all(is_extractable_scalar),
+        _ => true,
+    }
 }
 
 // ============================================================================

--- a/crates/toasty/src/engine/extract_params.rs
+++ b/crates/toasty/src/engine/extract_params.rs
@@ -43,9 +43,18 @@ pub(crate) fn extract_params(
     let mut extractor = Extractor {
         params: &mut params,
         capability,
-        in_list_rhs_depth: 0,
+        decompose_depth: 0,
     };
     extractor.visit_stmt_mut(stmt);
+
+    // Phase 1.5: For backends with `in_array` support, phase 1 bundled
+    // every IN-list rhs whose elements were scalars. Some lhs column
+    // types (notably native enums) have no driver-level array path; for
+    // those we decompose the bundled Arg back into per-element Args.
+    if capability.in_array {
+        let cx = stmt::ExprContext::new(&schema.db);
+        decompose_unsupported_in_lists(stmt, &cx, &mut params);
+    }
 
     // Phase 2+3: Bidirectional type inference — refine param types
     refine_param_types(stmt, &schema.db, &mut params);
@@ -108,12 +117,19 @@ impl Ty {
 ///   Without it, the rhs of an `IN` predicate must decompose to
 ///   `(?1, ?2, …)` even when the driver could bind an array elsewhere.
 ///
-/// `in_list_rhs_depth` counts enclosing `IN`-list rhs positions so the
-/// same `Value::List` node can take either path depending on where it sits.
+/// For an `IN`-list rhs, the visitor additionally checks whether the lhs
+/// column's storage type is one the driver can bind as an array. If not
+/// (e.g. a native `Enum`), the rhs decomposes regardless — `array_binding`
+/// alone isn't enough when the array element type has no driver-level
+/// array path.
+///
+/// `decompose_depth` counts enclosing positions where bundling is *forbidden*
+/// by capability alone — namely an `IN`-list rhs on a backend without
+/// `in_array`. Zero means bundling is fine.
 struct Extractor<'a> {
     params: &'a mut Vec<TypedValue>,
     capability: &'a Capability,
-    in_list_rhs_depth: u32,
+    decompose_depth: u32,
 }
 
 impl Extractor<'_> {
@@ -121,15 +137,7 @@ impl Extractor<'_> {
     /// kept whole (one bind parameter) rather than decomposed into per-
     /// element parameters.
     fn can_bundle_scalar_list(&self) -> bool {
-        if !self.capability.array_binding {
-            return false;
-        }
-        if self.in_list_rhs_depth > 0 && !self.capability.in_array {
-            // Inside an `IN` rhs and the dialect has no `IN <array>` form:
-            // SQL would render as `WHERE x IN ?n`, which is invalid.
-            return false;
-        }
-        true
+        self.capability.array_binding && self.decompose_depth == 0
     }
 
     /// Push `value` as a fresh parameter and return the matching `Arg`.
@@ -186,13 +194,19 @@ impl Extractor<'_> {
 impl VisitMut for Extractor<'_> {
     /// IN-list rhs gets a context flag pushed around just the `list` child.
     /// The lhs is visited normally — only the rhs participates in the
-    /// "must decompose" decision.
+    /// bundle / decompose decision.
     fn visit_expr_in_list_mut(&mut self, node: &mut stmt::ExprInList) {
         self.visit_expr_mut(&mut node.expr);
 
-        self.in_list_rhs_depth += 1;
+        // Without `in_array`, IN-list rhs cannot be a bound array.
+        let must_decompose = !self.capability.in_array;
+        if must_decompose {
+            self.decompose_depth += 1;
+        }
         self.visit_expr_mut(&mut node.list);
-        self.in_list_rhs_depth -= 1;
+        if must_decompose {
+            self.decompose_depth -= 1;
+        }
     }
 
     /// Post-order traversal. Children are processed first (scalar values
@@ -242,6 +256,167 @@ fn is_scalar_leaf(value: &stmt::Value) -> bool {
         value,
         stmt::Value::Null | stmt::Value::Record(_) | stmt::Value::List(_)
     )
+}
+
+// ============================================================================
+// Phase 1.5: Decompose bundled IN-list rhs whose lhs has no array path
+// ============================================================================
+
+/// Returns true if a `db::Type` is one the driver array-binding path
+/// supports across SQL backends. Excludes types whose array form needs
+/// special driver handling — most importantly native enum types, where
+/// PostgreSQL would need an OID-aware enum-array binder.
+fn is_array_bindable_element(ty: &db::Type) -> bool {
+    matches!(
+        ty,
+        db::Type::Boolean
+            | db::Type::Integer(_)
+            | db::Type::UnsignedInteger(_)
+            | db::Type::Float(_)
+            | db::Type::Text
+            | db::Type::VarChar(_)
+            | db::Type::Uuid
+            | db::Type::Numeric(_)
+    )
+}
+
+/// Walk the statement with proper scoping and undo the IN-list bundling
+/// where the lhs's column type isn't one the driver can ship as an array.
+/// The bundled rhs is `Expr::Arg(n)` whose param is `Value::List([...])`;
+/// we replace the Arg with `Expr::List([Arg(m1), Arg(m2), …])` and the
+/// single param with one per element. The original (now unreferenced)
+/// param is replaced with `Value::Null` to avoid renumbering.
+fn decompose_unsupported_in_lists(
+    stmt: &mut stmt::Statement,
+    cx: &Cx<'_>,
+    params: &mut Vec<TypedValue>,
+) {
+    // The cx scoping borrows the statement immutably; the filter rewrite
+    // needs it mutably. Take each filter out first (so the immutable
+    // borrow that scoping needs is uncontested), do the rewrite, put it
+    // back.
+    match stmt {
+        stmt::Statement::Insert(insert) => {
+            // Take the filter out (releases the mut borrow on insert),
+            // scope, rewrite, put back.
+            let mut filter = match &mut insert.source.body {
+                stmt::ExprSet::Select(select) => std::mem::take(&mut select.filter),
+                _ => return,
+            };
+            {
+                let cx_insert = cx.scope(&*insert);
+                if let stmt::ExprSet::Select(select) = &insert.source.body {
+                    let cx_select = cx_insert.scope(&**select);
+                    decompose_in_filter(&mut filter, &cx_select, params);
+                }
+            }
+            if let stmt::ExprSet::Select(select) = &mut insert.source.body {
+                select.filter = filter;
+            }
+        }
+        stmt::Statement::Update(update) => {
+            let mut filter = std::mem::take(&mut update.filter);
+            {
+                let scoped = cx.scope(&*update);
+                decompose_in_filter(&mut filter, &scoped, params);
+            }
+            update.filter = filter;
+        }
+        stmt::Statement::Delete(delete) => {
+            let mut filter = std::mem::take(&mut delete.filter);
+            {
+                let scoped = cx.scope(&*delete);
+                decompose_in_filter(&mut filter, &scoped, params);
+            }
+            delete.filter = filter;
+        }
+        stmt::Statement::Query(query) => {
+            let mut filter = match &mut query.body {
+                stmt::ExprSet::Select(select) => std::mem::take(&mut select.filter),
+                _ => return,
+            };
+            {
+                let cx_query = cx.scope(&*query);
+                if let stmt::ExprSet::Select(select) = &query.body {
+                    let cx_select = cx_query.scope(&**select);
+                    decompose_in_filter(&mut filter, &cx_select, params);
+                }
+            }
+            if let stmt::ExprSet::Select(select) = &mut query.body {
+                select.filter = filter;
+            }
+        }
+    }
+}
+
+fn decompose_in_filter(filter: &mut stmt::Filter, cx: &Cx<'_>, params: &mut Vec<TypedValue>) {
+    if let Some(expr) = &mut filter.expr {
+        decompose_in_expr(expr, cx, params);
+    }
+}
+
+fn decompose_in_expr(expr: &mut stmt::Expr, cx: &Cx<'_>, params: &mut Vec<TypedValue>) {
+    match expr {
+        stmt::Expr::And(and) => {
+            for op in &mut and.operands {
+                decompose_in_expr(op, cx, params);
+            }
+        }
+        stmt::Expr::Or(or) => {
+            for op in &mut or.operands {
+                decompose_in_expr(op, cx, params);
+            }
+        }
+        stmt::Expr::Not(not) => decompose_in_expr(&mut not.expr, cx, params),
+        stmt::Expr::InList(in_list) => {
+            // Only act on the bundled-Arg shape — a decomposed `Expr::List`
+            // rhs already has individual placeholders.
+            let stmt::Expr::Arg(arg) = &*in_list.list else {
+                return;
+            };
+            let arg_pos = arg.position;
+
+            // Resolve lhs column type. Bail if lhs isn't a column ref or
+            // resolves to something else (e.g. a foreign-key field that
+            // lowering didn't simplify to a column).
+            let stmt::Expr::Reference(reference @ stmt::ExprReference::Column(_)) = &*in_list.expr
+            else {
+                return;
+            };
+            let stmt::ResolvedRef::Column(col) = cx.resolve_expr_reference(reference) else {
+                return;
+            };
+
+            if is_array_bindable_element(&col.storage_ty) {
+                return;
+            }
+
+            // Pull the bundled list out of params, leave a Null sentinel
+            // behind to keep param positions stable for any other
+            // references (there shouldn't be any, but it's cheap insurance).
+            let stmt::Value::List(items) =
+                std::mem::replace(&mut params[arg_pos].value, stmt::Value::Null)
+            else {
+                // Not a bundled list — nothing to decompose.
+                return;
+            };
+            params[arg_pos].ty = db::Type::from_value(&stmt::Value::Null);
+
+            // Append one param per element, build the matching List of Args.
+            let new_items: Vec<stmt::Expr> = items
+                .into_iter()
+                .map(|value| {
+                    let ty = db::Type::from_value(&value);
+                    let position = params.len();
+                    params.push(TypedValue { value, ty });
+                    stmt::Expr::arg(position)
+                })
+                .collect();
+
+            *in_list.list = stmt::Expr::List(stmt::ExprList { items: new_items });
+        }
+        _ => {}
+    }
 }
 
 // ============================================================================
@@ -561,6 +736,14 @@ fn check_list(list_expr: &stmt::Expr, elem_ty: &Ty, params: &mut [TypedValue]) {
         stmt::Expr::List(list) => {
             for item in &list.items {
                 check(item, elem_ty, params);
+            }
+        }
+        // Bundled IN-list rhs: a single `Arg` whose param holds the whole
+        // array. The param needs the array type (e.g., `db::Type::Array(Text)`),
+        // not the scalar element type, so the driver binds it as an array.
+        stmt::Expr::Arg(arg) if elem_ty.is_column() => {
+            if let Some(elem_db_ty) = elem_ty.db_type() {
+                params[arg.position].ty = db::Type::Array(Box::new(elem_db_ty.clone()));
             }
         }
         _ => {

--- a/crates/toasty/src/engine/extract_params/tests.rs
+++ b/crates/toasty/src/engine/extract_params/tests.rs
@@ -2,12 +2,16 @@ use crate as toasty;
 use crate::engine::test_util::*;
 use crate::schema::Register;
 use toasty_core::{
-    driver::operation::TypedValue,
+    driver::{Capability, operation::TypedValue},
     schema::db,
     stmt::{self, Expr, Value},
 };
 
 use super::extract_params;
+
+/// Default capability used by these unit tests. The test schemas in
+/// `test_util` are SQLite-shaped, so this matches.
+const TEST_CAPABILITY: &Capability = &Capability::SQLITE;
 
 // ============================================================================
 // Basic extraction
@@ -33,7 +37,7 @@ fn extract_scalar_from_simple_insert() {
         returning: None,
     });
 
-    let params = extract_params(&mut stmt, &schema);
+    let params = extract_params(&mut stmt, &schema, TEST_CAPABILITY);
 
     assert_eq!(params.len(), 2);
     assert_eq!(params[0].value, Value::from("abc"));
@@ -71,7 +75,7 @@ fn null_values_not_extracted() {
         returning: None,
     });
 
-    let params = extract_params(&mut stmt, &schema);
+    let params = extract_params(&mut stmt, &schema, TEST_CAPABILITY);
 
     // Only 'abc' should be extracted; NULL stays as literal
     assert_eq!(params.len(), 1);
@@ -100,7 +104,7 @@ fn extract_from_where_clause() {
 
     // Can't easily build a full SELECT with filter without a schema,
     // but we can test that extract_params handles an empty query
-    let params = extract_params(&mut stmt, &schema);
+    let params = extract_params(&mut stmt, &schema, TEST_CAPABILITY);
     assert_eq!(params.len(), 0);
 }
 
@@ -133,7 +137,7 @@ fn enum_insert_refines_type_to_enum() {
         returning: None,
     });
 
-    let params = extract_params(&mut stmt, &schema);
+    let params = extract_params(&mut stmt, &schema, TEST_CAPABILITY);
 
     assert_eq!(params.len(), 2);
 
@@ -164,7 +168,7 @@ fn non_enum_insert_keeps_default_types() {
         returning: None,
     });
 
-    let params = extract_params(&mut stmt, &schema);
+    let params = extract_params(&mut stmt, &schema, TEST_CAPABILITY);
 
     assert_eq!(params.len(), 2);
     assert!(matches!(&params[0].ty, db::Type::Text));

--- a/crates/toasty/src/engine/ty.rs
+++ b/crates/toasty/src/engine/ty.rs
@@ -6,7 +6,7 @@ impl Engine {
     /// with `Expr::Arg(n)` placeholders. The returned `Vec<TypedValue>` is
     /// indexed by the `n` in each placeholder.
     pub(crate) fn extract_params(&self, stmt: &mut stmt::Statement) -> Vec<TypedValue> {
-        super::extract_params::extract_params(stmt, &self.schema)
+        super::extract_params::extract_params(stmt, &self.schema, self.capability)
     }
 
     pub(crate) fn infer_ty(&self, stmt: &stmt::Statement, args: &[stmt::Type]) -> stmt::Type {

--- a/crates/toasty/src/schema.rs
+++ b/crates/toasty/src/schema.rs
@@ -39,6 +39,9 @@ mod num;
 mod relation;
 pub use relation::Relation;
 
+mod scalar;
+pub use scalar::Scalar;
+
 mod scope;
 pub use scope::Scope;
 

--- a/crates/toasty/src/schema/field.rs
+++ b/crates/toasty/src/schema/field.rs
@@ -1,4 +1,4 @@
-use super::Load;
+use super::{Load, Scalar};
 use crate::stmt::{self, Expr, List};
 use toasty_core::schema::app::ModelSet;
 
@@ -284,3 +284,41 @@ impl_field_primitive!(rust_decimal::Decimal);
 
 #[cfg(feature = "bigdecimal")]
 impl_field_primitive!(bigdecimal::BigDecimal);
+
+/// Collection field. `Vec<T>` for any [`Scalar`] `T` is a queryable
+/// collection field. `Vec<u8>` keeps its bytes-blob meaning via the explicit
+/// impl above (`u8` is not [`Scalar`]).
+impl<T: Field<Output = T> + Scalar + crate::stmt::IntoExpr<T>> Field for Vec<T> {
+    type Path<Origin> = stmt::Path<Origin, Self>;
+    type ListPath<Origin> = stmt::Path<Origin, List<Self>>;
+    type Update<'a> = ();
+    type Inner = Self;
+
+    fn new_path<Origin>(path: stmt::Path<Origin, Self>) -> Self::Path<Origin> {
+        path
+    }
+
+    fn new_list_path<Origin>(path: stmt::Path<Origin, List<Self>>) -> Self::ListPath<Origin> {
+        path
+    }
+
+    fn new_update<'a>(
+        _assignments: &'a mut toasty_core::stmt::Assignments,
+        _projection: toasty_core::stmt::Projection,
+    ) -> Self::Update<'a> {
+    }
+
+    fn field_ty(
+        storage_ty: Option<toasty_core::schema::db::Type>,
+    ) -> toasty_core::schema::app::FieldTy {
+        toasty_core::schema::app::FieldTy::Primitive(toasty_core::schema::app::FieldPrimitive {
+            ty: toasty_core::stmt::Type::list(<T as Load>::ty()),
+            storage_ty,
+            serialize: None,
+        })
+    }
+
+    fn key_constraint<Origin>(&self, target: stmt::Path<Origin, Self::Inner>) -> Expr<bool> {
+        target.eq(self)
+    }
+}

--- a/crates/toasty/src/schema/scalar.rs
+++ b/crates/toasty/src/schema/scalar.rs
@@ -1,0 +1,56 @@
+//! Marker trait identifying scalar field types eligible to be the element
+//! type of a collection field (e.g. `Vec<T>`).
+//!
+//! The macro never inspects user types directly — when it sees a model field
+//! `tags: Vec<String>` it expands to `<Vec<String> as Field>::field_ty(...)`
+//! and lets the trait system pick the right behavior. Trait coherence then
+//! requires a way to distinguish "scalar `T`" (where `Vec<T>` should be a
+//! collection field) from `u8` (where `Vec<u8>` is a bytes blob) and from
+//! relation / embed types. `Scalar` is that marker.
+//!
+//! `Scalar` is sealed: callers cannot implement it. New scalar types must be
+//! added here.
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// Marker trait for primitive types that can be the element type of a
+/// `Vec<T>` collection field.
+///
+/// Implemented for the textual, numeric, and UUID primitives. Not
+/// implemented for `u8` — `Vec<u8>` keeps its bytes-blob meaning. Not
+/// implemented for embed types or relations.
+pub trait Scalar: sealed::Sealed {}
+
+macro_rules! impl_scalar {
+    ($($ty:ty),* $(,)?) => {
+        $(
+            impl sealed::Sealed for $ty {}
+            impl Scalar for $ty {}
+        )*
+    };
+}
+
+impl_scalar!(
+    bool,
+    i8,
+    i16,
+    i32,
+    i64,
+    u16,
+    u32,
+    u64,
+    f32,
+    f64,
+    isize,
+    usize,
+    String,
+    uuid::Uuid,
+);
+
+#[cfg(feature = "rust_decimal")]
+impl_scalar!(rust_decimal::Decimal);
+
+#[cfg(feature = "bigdecimal")]
+impl_scalar!(bigdecimal::BigDecimal);

--- a/crates/toasty/src/stmt/into_expr.rs
+++ b/crates/toasty/src/stmt/into_expr.rs
@@ -322,6 +322,42 @@ where
 }
 impl_assign_via_expr!({T, U: IntoExpr<T>} Vec<U> => List<T>);
 
+/// Whole-value conversion for collection fields. The element bound
+/// ([`Scalar`](crate::schema::Scalar)) keeps this from overlapping with the
+/// `Vec<u8>` bytes-blob impl above — `u8` is not `Scalar`.
+///
+/// The result is a single `Value::List` bound parameter (one placeholder
+/// in the SQL), not an `Expr::List` of element expressions (which would
+/// render as a tuple).
+impl<T: IntoExpr<T> + crate::schema::Scalar> IntoExpr<Self> for Vec<T> {
+    fn into_expr(self) -> Expr<Self> {
+        let items = collect_scalar_values(self.into_iter().map(|item| item.into_expr()));
+        Expr::from_value(Value::List(items))
+    }
+
+    fn by_ref(&self) -> Expr<Self> {
+        let items = collect_scalar_values(self.iter().map(|item| item.by_ref()));
+        Expr::from_value(Value::List(items))
+    }
+}
+impl_assign_via_expr!({T: IntoExpr<T> + crate::schema::Scalar} Vec<T> => Vec<T>);
+
+/// Walk a sequence of `Expr<T>` produced by `IntoExpr<T>` for a scalar `T`
+/// and pull the wrapped `Value` out of each. Every scalar `IntoExpr` impl
+/// returns `Expr::from_value(...)`, so the only legal shape here is
+/// `stmt::Expr::Value(_)`.
+fn collect_scalar_values<T, I: IntoIterator<Item = Expr<T>>>(iter: I) -> Vec<Value> {
+    iter.into_iter()
+        .map(|expr| match expr.untyped {
+            stmt::Expr::Value(v) => v,
+            other => panic!(
+                "Vec<T: Scalar> element produced a non-value Expr ({other:#?}) — \
+                 IntoExpr for scalars must always emit Expr::Value"
+            ),
+        })
+        .collect()
+}
+
 macro_rules! forward_impl {
     ( $( $ty:ty ,) *) => {
         $(


### PR DESCRIPTION
## Summary

First slice of the [document and collection fields design](https://github.com/tokio-rs/toasty/blob/docs/json-fields-design/docs/dev/design/document-fields.md): `Vec<scalar>` model fields work end-to-end on SQLite. Whole-value insert/read/update only — query operators (`.contains`, `.len`) and in-place mutations (`stmt::push`, `stmt::clear`) land in subsequent PRs.

User-facing:

```rust
#[derive(toasty::Model)]
struct Item {
    #[key] #[auto] id: i64,
    tags: Vec<String>,                 // works
}

Item::create().tags(vec!["admin".into(), "verified".into()]).exec(&mut db).await?;
```

Macro behavior is gated on traits, not type-name parsing — `Vec<T>` participates as a model field via blanket `impl<T: Field + Scalar + IntoExpr<T>> Field for Vec<T>`. `Scalar` is a sealed marker that excludes `u8` so `Vec<u8>` keeps its bytes-blob meaning.

Key pieces:

- **Storage selection** — `db::Type::{Array(Box<Type>), Json}`; `StorageTypes::scalar_list: ScalarList` picks the form per backend (PG → Array, SQLite/MySQL → Json).
- **Driver capability split** — `array_binding` (driver accepts `Value::List` as one bind parameter) and `in_array` (dialect supports `IN <bound_array>`). Independent, with `in_array` implying `array_binding`. SQLite is `(true, false)`; PG would be `(true, true)`.
- **Parameter extraction** — `extract_params` is a stateful `VisitMut` that tracks `in_list_rhs_depth` so a `Value::List` of scalars can ride as one parameter for collection-column writes while still decomposing to per-element placeholders for an `IN` rhs (when `!in_array`).
- **SQLite driver** — `Value::List` ↔ JSON text round-trip (`serde_json::Value::Array`).

PostgreSQL and MySQL drivers are not yet wired up — `Vec<scalar>` will fail at runtime on those backends until follow-up PRs implement their parameter binding. Integration tests are gated `requires(sql)` and pass on SQLite.

## Type of change

- [x] Implements a previously accepted design (link: design lives on the [`docs/json-fields-design` branch](https://github.com/tokio-rs/toasty/blob/docs/json-fields-design/docs/dev/design/document-fields.md), still in review)
- [ ] Small / obvious change — bug fix, docs, internal cleanup, or test
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes (820/820 SQLite integration; 284/284 toasty unit)
- [x] Touches a public API → design doc covers it (link above)
- [x] Touches the `Driver` trait or driver-observable behavior → design doc covers it

## Notes for reviewers

- Two new capability flags (`array_binding`, `in_array`). Implication direction `in_array → array_binding` is **not** enforced in `Capability::validate()` yet — easy to add if desired.
- The `extract_params` refactor replaces the prior `for_each_expr_mut` + ad-hoc pre-pass with a `VisitMut` impl that carries context. The post-order traversal preserves the previous semantics; the new context counter is the only behavioral addition.
- `MYSQL` is set to `array_binding: false` to gate `Vec<scalar>` on that backend until the JSON-list bind path lands. Pre-existing MySQL functionality is unaffected.
- The two commits on the branch (`wip: scalar lists`, `refactor(engine): track IN-list context …`) collapse cleanly under squash-merge.