### PR TITLE
feat: add per-call .select() column projection

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -69,6 +69,7 @@ pub mod relation_has_many_same_target;
 pub mod relation_has_many_scoped_query;
 pub mod relation_has_one_crud;
 pub mod relation_preload;
+pub mod select_projection;
 pub mod starts_with;
 pub mod tx_atomic_stmt;
 pub mod tx_interactive;

--- a/crates/toasty-driver-integration-suite/src/tests/select_projection.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/select_projection.rs
@@ -1,0 +1,124 @@
+use crate::prelude::*;
+
+#[derive(Debug, toasty::Model)]
+struct Item {
+    #[key]
+    id: i64,
+    name: String,
+    quantity: i64,
+}
+
+async fn setup(test: &mut Test) -> toasty::Db {
+    let mut db = test.setup_db(models!(Item)).await;
+
+    toasty::create!(Item::[
+        { id: 1_i64, name: "Alice",   quantity: 7_i64  },
+        { id: 2_i64, name: "Bob",     quantity: 3_i64  },
+        { id: 3_i64, name: "Charlie", quantity: 11_i64 },
+    ])
+    .exec(&mut db)
+    .await
+    .unwrap();
+
+    db
+}
+
+/// `.select(field)` on a `Query<List<Item>>` returns a `Query<List<String>>`
+/// whose `.exec()` produces a `Vec<String>` of the projected column.
+#[driver_test(requires(sql))]
+pub async fn select_single_field(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let mut names: Vec<String> = Item::all()
+        .select(Item::fields().name())
+        .exec(&mut db)
+        .await?;
+
+    names.sort();
+
+    assert_eq!(
+        names,
+        vec![
+            "Alice".to_string(),
+            "Bob".to_string(),
+            "Charlie".to_string()
+        ]
+    );
+
+    Ok(())
+}
+
+/// `.select((f1, f2))` returns a `Query<List<(T1, T2)>>` whose `.exec()`
+/// produces a `Vec` of tuples.
+#[driver_test(requires(sql))]
+pub async fn select_tuple(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let mut pairs: Vec<(i64, String)> = Item::all()
+        .select((Item::fields().id(), Item::fields().name()))
+        .exec(&mut db)
+        .await?;
+
+    pairs.sort_by_key(|(id, _)| *id);
+
+    assert_eq!(
+        pairs,
+        vec![
+            (1_i64, "Alice".to_string()),
+            (2_i64, "Bob".to_string()),
+            (3_i64, "Charlie".to_string()),
+        ]
+    );
+
+    Ok(())
+}
+
+/// `.select(...)` composes with `.filter(...)`: the projection sees only rows
+/// matching the filter expression.
+#[driver_test(requires(sql))]
+pub async fn select_with_filter(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let mut names: Vec<String> = Item::filter(Item::fields().quantity().gt(5_i64))
+        .select(Item::fields().name())
+        .exec(&mut db)
+        .await?;
+
+    names.sort();
+
+    assert_eq!(names, vec!["Alice".to_string(), "Charlie".to_string()]);
+
+    Ok(())
+}
+
+/// `.select(...).first()` lifts the outer container to `Option<T>`.
+#[driver_test(requires(sql))]
+pub async fn select_first(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let name: Option<String> = Item::filter(Item::fields().id().eq(2_i64))
+        .select(Item::fields().name())
+        .first()
+        .exec(&mut db)
+        .await?;
+
+    assert_eq!(name.as_deref(), Some("Bob"));
+
+    Ok(())
+}
+
+/// `.select(...).first()` returns `None` when no rows match.
+#[driver_test(requires(sql))]
+pub async fn select_first_no_match(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let name: Option<String> = Item::filter(Item::fields().id().eq(999_i64))
+        .select(Item::fields().name())
+        .first()
+        .exec(&mut db)
+        .await?;
+
+    assert_eq!(name, None);
+
+    Ok(())
+}

--- a/crates/toasty-macros/src/model/expand/query.rs
+++ b/crates/toasty-macros/src/model/expand/query.rs
@@ -53,6 +53,17 @@ impl Expand<'_> {
                     self.stmt.count()
                 }
 
+                #vis fn select<__E, __T>(
+                    self,
+                    projection: __E,
+                ) -> #toasty::stmt::Query<#toasty::List<__T>>
+                where
+                    __E: #toasty::IntoExpr<__T>,
+                    __T: #toasty::Load,
+                {
+                    self.stmt.select(projection)
+                }
+
                 #vis fn delete(self) -> #toasty::stmt::Delete<()> {
                     self.stmt.delete()
                 }

--- a/crates/toasty/src/stmt/query.rs
+++ b/crates/toasty/src/stmt/query.rs
@@ -1,4 +1,4 @@
-use super::{Delete, Expr, IntoStatement, List, Statement, Value};
+use super::{Delete, Expr, IntoExpr, IntoStatement, List, Statement, Value};
 use crate::{
     Executor, Result,
     schema::{Load, Model},
@@ -453,6 +453,55 @@ impl<M: Model> Query<List<M>> {
         // Set the returning clause to COUNT(*)
         *self.untyped.returning_mut_unwrap() = Returning::Project(stmt::Expr::count_star());
         self.untyped.single = true;
+
+        Query::from_untyped(self.untyped)
+    }
+
+    /// Project this list query onto an expression, narrowing the returned
+    /// shape from `M` to `T`.
+    ///
+    /// `projection` can be any expression source: a single field path
+    /// (returning `Vec<T>` for the field's Rust type), a tuple of field paths
+    /// (returning `Vec` of a tuple), or any other type that implements
+    /// `IntoExpr<T>`.  The default model projection is replaced wholesale by
+    /// the columns the projection expression references.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # tokio::runtime::Runtime::new().unwrap().block_on(async {
+    /// # #[derive(Debug, toasty::Model)]
+    /// # struct User {
+    /// #     #[key]
+    /// #     id: i64,
+    /// #     name: String,
+    /// # }
+    /// # let driver = toasty_driver_sqlite::Sqlite::in_memory();
+    /// # let mut db = toasty::Db::builder().models(toasty::models!(User)).build(driver).await.unwrap();
+    /// # db.push_schema().await.unwrap();
+    /// use toasty::stmt::{List, Query};
+    ///
+    /// // Single-field projection: returns `Vec<String>`.
+    /// let names: Vec<String> = Query::<List<User>>::all()
+    ///     .select(User::fields().name())
+    ///     .exec(&mut db)
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// // Tuple projection: returns `Vec<(i64, String)>`.
+    /// let pairs: Vec<(i64, String)> = Query::<List<User>>::all()
+    ///     .select((User::fields().id(), User::fields().name()))
+    ///     .exec(&mut db)
+    ///     .await
+    ///     .unwrap();
+    /// # });
+    /// ```
+    pub fn select<E, T>(mut self, projection: E) -> Query<List<T>>
+    where
+        E: IntoExpr<T>,
+        T: Load,
+    {
+        *self.untyped.returning_mut_unwrap() = Returning::Project(projection.into_expr().untyped);
 
         Query::from_untyped(self.untyped)
     }


### PR DESCRIPTION
## Summary

Implements PR #1 of the per-call column projection design (#811).  Adds `.select(projection)` to the macro-generated query builder for each model.  The method takes any `IntoExpr<T>` and returns `Query<List<T>>`, replacing the default model projection with the columns the projection expression references.

This iteration covers single-field and tuple projections (arities 1-8, matching the existing `Load` tuple impls):

  - `User::all().select(User::fields().name()).exec(...)` returns `Vec<String>`.
  - `User::all().select((User::fields().id(), User::fields().name())).exec(...)` returns `Vec<(i64, String)>`.

Composes with `.filter(...)` and `.first()` per the design.

Deferred to follow-on PRs:
  - Relation field projections (BelongsTo, HasOne, HasMany).
  - Field-path projections through embedded types.

The engine plumbing (`Returning::Project` from PR #790, the deferred-field path from PR #793) is reused unchanged; this PR adds only the user-facing wiring on `Query<List<M>>` and the matching delegate on the macro-generated `*Query` struct.

## Type of change

<!-- Check one. -->

- [ ] Small / obvious change — bug fix, docs, internal cleanup, or test
- [X] Implements a previously accepted [design](https://github.com/tokio-rs/toasty/blob/main/docs/dev/design/column-projection.md)
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [X] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [X] `cargo fmt` and `cargo clippy` are clean
- [X] `cargo test` passes
- [ ] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [X] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers

N/A
