### PR TITLE
fix: reverse OrderByExpr direction correctly for backward pagination

### DIFF
--- a/crates/toasty-core/src/stmt/order_by_expr.rs
+++ b/crates/toasty-core/src/stmt/order_by_expr.rs
@@ -26,12 +26,11 @@ pub struct OrderByExpr {
 }
 
 impl OrderByExpr {
-    /// Flips the sort direction. `Desc` becomes default (ascending); default
-    /// and `Asc` become `Asc` (explicit ascending, since the default changed).
+    /// Flips the sort direction. `Asc` becomes `Desc` and `Desc` becomes default (ascending).
     pub fn reverse(&mut self) {
         self.order = match self.order {
-            Some(Direction::Desc) => None,
-            _ => Some(Direction::Asc),
+            Some(Direction::Asc) => Some(Direction::Desc),
+            _ => None,
         }
     }
 }

--- a/crates/toasty-core/src/stmt/order_by_expr.rs
+++ b/crates/toasty-core/src/stmt/order_by_expr.rs
@@ -26,11 +26,12 @@ pub struct OrderByExpr {
 }
 
 impl OrderByExpr {
-    /// Flips the sort direction. `Asc` becomes `Desc` and `Desc` becomes default (ascending).
+    /// Flips the sort direction. `Desc` becomes `Asc`; default (ascending)
+    /// and `Asc` become `Desc`.
     pub fn reverse(&mut self) {
         self.order = match self.order {
-            Some(Direction::Asc) => Some(Direction::Desc),
-            _ => None,
+            Some(Direction::Desc) => Some(Direction::Asc),
+            _ => Some(Direction::Desc),
         }
     }
 }

--- a/crates/toasty-driver-integration-suite/src/tests/crud_composite_key_pagination.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/crud_composite_key_pagination.rs
@@ -367,6 +367,51 @@ pub async fn paginate_composite_key_prev(test: &mut Test) -> Result<()> {
     let prev: Option<Page<_>> = page2.prev(&mut db).await?;
     assert!(prev.is_some());
 
+    // Check the number and order of the items in the previous page
+    let prev_page = prev.unwrap();
+    assert_eq!(prev_page.len(), 10);
+    for i in 0..10 {
+        assert_eq!(prev_page[i].seq, i as i64);
+    }
+
+    Ok(())
+}
+
+#[driver_test(requires(backward_pagination))]
+pub async fn paginate_composite_key_prev_desc(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    #[key(partition = kind, local = seq)]
+    struct Event {
+        kind: String,
+        seq: i64,
+    }
+
+    let mut db = test.setup_db(models!(Event)).await;
+
+    for i in 0..20 {
+        Event::create().kind("info").seq(i).exec(&mut db).await?;
+    }
+
+    test.log().clear();
+
+    // Retrieve two pages in descending order
+    let page1: Page<_> = Event::filter_by_kind("info")
+        .order_by(Event::fields().seq().desc())
+        .paginate(10)
+        .exec(&mut db)
+        .await?;
+    let page2: Page<_> = page1.next(&mut db).await?.unwrap();
+
+    // Check the number and order of the items in the previous page
+    assert!(page2.has_prev());
+    let prev: Option<Page<_>> = page2.prev(&mut db).await?;
+    assert!(prev.is_some());
+    let prev_page: Page<Event> = prev.unwrap();
+    assert_eq!(prev_page.len(), 10);
+    for (i, expected) in (10..20).rev().enumerate() {
+        assert_eq!(prev_page[i].seq, expected);
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
<!--
PR title uses Conventional Commits, e.g.
    feat: add upsert support
    fix: handle composite key in IN-list rewrite
See CONTRIBUTING.md for the full process.
-->

## Summary

<!-- What does this change and why? Link the issue it closes. -->

- Fix `OrderByExpr::reverse` not changing `Asc` to `Desc`.
- Modified `crud_composite_key_pagination::paginate_composite_key_prev` test to check the number and order of items in the previous page (this covers previous pages in `Asc` order).
- Added `crud_composite_key_pagination::paginate_composite_key_prev_desc` test to cover previous pages in `Desc` order.

Closes #804 

## Type of change

<!-- Check one. -->

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

<!-- Anything reviewers should focus on. -->
