### PR TITLE
test: cover embed sub-field projection

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -70,6 +70,7 @@ pub mod relation_has_many_scoped_query;
 pub mod relation_has_one_crud;
 pub mod relation_preload;
 pub mod select_projection;
+pub mod select_projection_embed;
 pub mod starts_with;
 pub mod tx_atomic_stmt;
 pub mod tx_interactive;

--- a/crates/toasty-driver-integration-suite/src/tests/select_projection_embed.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/select_projection_embed.rs
@@ -1,0 +1,44 @@
+//! `.select(...)` projection through embedded sub-fields. Field paths
+//! into an embed flow through the existing `Path<T, U>: IntoExpr<U>`
+//! chain, so no production code change is required for this case to
+//! work end-to-end; this file is the integration coverage.
+
+use crate::prelude::*;
+
+#[derive(Debug, toasty::Embed)]
+struct Address {
+    street: String,
+    city: String,
+}
+
+#[derive(Debug, toasty::Model)]
+struct Customer {
+    #[key]
+    id: i64,
+    name: String,
+    address: Address,
+}
+
+#[driver_test(requires(sql))]
+pub async fn select_embed_subfield(test: &mut Test) -> Result<()> {
+    let mut db = test.setup_db(models!(Customer)).await;
+
+    Customer::create()
+        .id(1_i64)
+        .name("Alice")
+        .address(Address {
+            street: "123 Main St".to_string(),
+            city: "Springfield".to_string(),
+        })
+        .exec(&mut db)
+        .await?;
+
+    let cities: Vec<String> = Customer::all()
+        .select(Customer::fields().address().city())
+        .exec(&mut db)
+        .await?;
+
+    assert_eq!(cities, vec!["Springfield".to_string()]);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Confirm `.select(Customer::fields().address().city())` works end-to-end on the existing `Path<T, U>: IntoExpr<U>` infrastructure.  The column-projection design (#811) listed this case as supported but no test exercised it.

## Type of change

<!-- Check one. -->

- [X] Small / obvious change — bug fix, docs, internal cleanup, or test
- [ ] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`):
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [X] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [X] `cargo fmt` and `cargo clippy` are clean
- [X] `cargo test` passes
- [ ] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [ ] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers

N/A
