### PR TITLE
docs: track #828 in macros roadmap

### DIFF
--- a/docs/dev/roadmap.md
+++ b/docs/dev/roadmap.md
@@ -141,8 +141,10 @@ the entry lands here.
 - `toasty::query!()` — succinct query syntax ([design](design/query-macro.md), [#808])
 - `toasty::create!()` — concise record creation ([design](design/static-assertions-create-macro.md))
 - `toasty::update!()` — concise updates
+- Derive macro for populating a struct from a query result ([#828])
 
 [#808]: https://github.com/tokio-rs/toasty/issues/808
+[#828]: https://github.com/tokio-rs/toasty/issues/828
 
 ## Runtime
 


### PR DESCRIPTION
## Summary

Adds a roadmap entry under Macros pointing at [#828] — a derive macro for populating a struct from a query result. Phrased to capture the concept without committing to attribute syntax or other API specifics.

## Type of change

- [X] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [X] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format

[#828]: https://github.com/tokio-rs/toasty/issues/828