### PR TITLE
feat(macros): support custom index names via `name = "..."`

### DIFF
--- a/crates/toasty-core/src/schema/app/index.rs
+++ b/crates/toasty-core/src/schema/app/index.rs
@@ -18,6 +18,7 @@ use crate::schema::db::{IndexOp, IndexScope};
 ///
 /// let index = Index {
 ///     id: IndexId { model: ModelId(0), index: 0 },
+///     name: None,
 ///     fields: vec![IndexField {
 ///         field: ModelId(0).field(0),
 ///         op: IndexOp::Eq,
@@ -33,6 +34,11 @@ use crate::schema::db::{IndexOp, IndexScope};
 pub struct Index {
     /// Uniquely identifies this index within the schema.
     pub id: IndexId,
+
+    /// User-provided index name from `#[index(name = "...", ...)]` or
+    /// `#[key(name = "...", ...)]`. When `None`, the schema builder generates
+    /// a name automatically.
+    pub name: Option<String>,
 
     /// Fields included in the index, in order.
     pub fields: Vec<IndexField>,

--- a/crates/toasty-core/src/schema/builder/table.rs
+++ b/crates/toasty-core/src/schema/builder/table.rs
@@ -227,7 +227,7 @@ impl BuildTableFromModels<'_> {
                     table: self.table.id,
                     index: out.len(),
                 },
-                name: String::new(),
+                name: app_index.name.clone().unwrap_or_default(),
                 on: self.table.id,
                 columns: vec![],
                 unique: app_index.unique,
@@ -358,6 +358,11 @@ impl BuildTableFromModels<'_> {
 
     fn update_index_names(&mut self) {
         for index in &mut self.table.indices {
+            // Preserve user-provided names from `#[index(name = "...", ...)]`.
+            if !index.name.is_empty() {
+                continue;
+            }
+
             index.name = format!("index_{}_by", self.table.name);
 
             for (i, index_column) in index.columns.iter().enumerate() {

--- a/crates/toasty-core/tests/schema_verify_version_field.rs
+++ b/crates/toasty-core/tests/schema_verify_version_field.rs
@@ -47,6 +47,7 @@ fn build_model(fields: Vec<Field>, version_field: Option<FieldId>) -> Model {
         table_name: None,
         indices: vec![Index {
             id: pk_index_id,
+            name: None,
             fields: vec![IndexField {
                 field: id.field(0),
                 op: IndexOp::Eq,

--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -43,6 +43,7 @@ pub mod filter_ilike;
 pub mod filter_like;
 pub mod float_fields;
 pub mod index_composite;
+pub mod index_custom_name;
 pub mod infra_connection_per_clone;
 pub mod infra_missing_registrations;
 pub mod infra_pool_config;

--- a/crates/toasty-driver-integration-suite/src/tests/index_custom_name.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/index_custom_name.rs
@@ -1,0 +1,105 @@
+use crate::prelude::*;
+
+/// `#[index(name = "...", ...)]` overrides the auto-generated index name
+/// in the DB schema, and the index is still usable for queries.
+#[driver_test]
+pub async fn index_custom_name_overrides_default(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    #[index(name = "tournament_region_idx", tournament_id, region)]
+    struct Match {
+        #[key]
+        id: String,
+        tournament_id: String,
+        region: String,
+    }
+
+    let mut db = t.setup_db(models!(Match)).await;
+
+    // Schema carries the user-provided name (not the auto-generated form).
+    let table = &db.schema().db.tables[0];
+    let custom_idx = table
+        .indices
+        .iter()
+        .find(|i| !i.primary_key)
+        .expect("non-PK index should exist");
+    assert_eq!(custom_idx.name, "tournament_region_idx");
+
+    // The auto-generated form must NOT be present.
+    assert!(
+        !table
+            .indices
+            .iter()
+            .any(|i| i.name == "index_matches_by_tournament_id_and_region"),
+        "auto-generated name should not coexist with the custom name"
+    );
+
+    toasty::create!(Match::[
+        { id: "m1", tournament_id: "WINTER2024", region: "NA-EAST" },
+        { id: "m2", tournament_id: "WINTER2024", region: "EU-WEST" },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let matches: Vec<Match> = Match::filter_by_tournament_id("WINTER2024")
+        .exec(&mut db)
+        .await?;
+    assert_eq!(matches.len(), 2);
+
+    Ok(())
+}
+
+/// Without `name = "..."`, the schema builder still produces the
+/// auto-generated `index_<table>_by_<cols>` form. Sanity check that the
+/// custom-name path doesn't accidentally suppress all auto-naming.
+#[driver_test]
+pub async fn index_custom_name_default_unchanged(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    #[index(category)]
+    struct Product {
+        #[key]
+        id: String,
+        category: String,
+    }
+
+    let db = t.setup_db(models!(Product)).await;
+    let table = &db.schema().db.tables[0];
+
+    let auto_idx = table
+        .indices
+        .iter()
+        .find(|i| !i.primary_key)
+        .expect("non-PK index should exist");
+    // Suite prefixes the table name; assert the structural form, not the literal.
+    assert!(
+        auto_idx.name.starts_with("index_") && auto_idx.name.ends_with("_by_category"),
+        "expected auto-generated `index_<table>_by_category`, got: {}",
+        auto_idx.name
+    );
+
+    Ok(())
+}
+
+/// `#[key(name = "...", ...)]` records the custom name on the primary-key
+/// index in the DB schema. SQL backends emit primary keys inline today, so
+/// this verifies the schema-internal wiring rather than DDL output.
+#[driver_test]
+pub async fn key_custom_name_recorded_on_pk_index(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    #[key(name = "player_pk", partition = team, local = name)]
+    struct Player {
+        team: String,
+        name: String,
+    }
+
+    let db = t.setup_db(models!(Player)).await;
+    let table = &db.schema().db.tables[0];
+
+    let pk_index = table
+        .indices
+        .iter()
+        .find(|i| i.primary_key)
+        .expect("PK index should exist");
+    assert_eq!(pk_index.name, "player_pk");
+
+    Ok(())
+}

--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -283,6 +283,10 @@ impl Expand<'_> {
                 let index_tokenized = util::int(index);
                 let unique = &model_index.unique;
                 let primary_key = &model_index.primary_key;
+                let name = match &model_index.name {
+                    Some(value) => quote!(Some(#value.to_string())),
+                    None => quote!(None),
+                };
 
                 let fields = model_index.fields.iter().map(|index_field| {
                     let field_tokenized = util::int(index_field.field);
@@ -311,6 +315,7 @@ impl Expand<'_> {
                             model: id,
                             index: #index_tokenized,
                         },
+                        name: #name,
                         fields: vec![ #( #fields ),* ],
                         unique: #unique,
                         primary_key: #primary_key,

--- a/crates/toasty-macros/src/model/schema/index.rs
+++ b/crates/toasty-macros/src/model/schema/index.rs
@@ -8,6 +8,11 @@ pub(crate) struct Index {
 
     /// True when the index is the primary key
     pub(crate) primary_key: bool,
+
+    /// User-provided index name from `#[index(name = "...", ...)]` or
+    /// `#[key(name = "...", ...)]`. When `None`, the schema builder generates
+    /// a name automatically.
+    pub(crate) name: Option<String>,
 }
 
 #[derive(Debug)]

--- a/crates/toasty-macros/src/model/schema/key_attr.rs
+++ b/crates/toasty-macros/src/model/schema/key_attr.rs
@@ -2,6 +2,7 @@
 pub(crate) struct KeyAttr {
     pub(crate) partition: Vec<syn::Ident>,
     pub(crate) local: Vec<syn::Ident>,
+    pub(crate) name: Option<String>,
 }
 
 impl KeyAttr {
@@ -9,9 +10,35 @@ impl KeyAttr {
         let mut partition = vec![];
         let mut local = vec![];
         let mut simple_fields = vec![];
+        let mut name: Option<String> = None;
         let mut has_named = false;
 
         attr.parse_nested_meta(|meta| {
+            // `name = "..."` — explicit override for the generated index name.
+            // Disambiguates from a model field literally called `name` by
+            // requiring the `=` token; bare `name` still parses as a field ref.
+            if meta.path.is_ident("name") && meta.input.peek(syn::Token![=]) {
+                if name.is_some() {
+                    return Err(syn::Error::new_spanned(
+                        &meta.path,
+                        "`name` specified more than once",
+                    ));
+                }
+
+                let value: syn::LitStr = meta.value()?.parse()?;
+                let value_str = value.value();
+
+                if value_str.is_empty() {
+                    return Err(syn::Error::new_spanned(
+                        &value,
+                        "`name` must be a non-empty string",
+                    ));
+                }
+
+                name = Some(value_str);
+                return Ok(());
+            }
+
             if meta.path.is_ident("partition") || meta.path.is_ident("local") {
                 if !simple_fields.is_empty() {
                     return Err(syn::Error::new_spanned(
@@ -106,6 +133,10 @@ impl KeyAttr {
             }
         }
 
-        Ok(Self { partition, local })
+        Ok(Self {
+            partition,
+            local,
+            name,
+        })
     }
 }

--- a/crates/toasty-macros/src/model/schema/model.rs
+++ b/crates/toasty-macros/src/model/schema/model.rs
@@ -254,6 +254,7 @@ impl Model {
                 fields: pk_index_fields,
                 unique: true,
                 primary_key: true,
+                name: model_attr.key.as_ref().and_then(|k| k.name.clone()),
             });
 
             // Iterate all extras rather than bailing on the first so every
@@ -334,6 +335,7 @@ impl Model {
                 fields: index_fields,
                 unique: false,
                 primary_key: false,
+                name: index_attr.name.clone(),
             });
         }
 
@@ -575,6 +577,7 @@ fn collect_field_indices(fields: &[Field], indices: &mut Vec<Index>) {
                 }],
                 unique: field.attrs.unique,
                 primary_key: false,
+                name: None,
             });
         }
     }


### PR DESCRIPTION
## Summary

Closes #658.

Add `name = "..."` support to `#[index(...)]` and `#[key(...)]`, letting
users override the auto-generated `index_<table>_by_<cols>` form:

```rust
#[index(name = "tournament_region_idx", partition = [tournament_id, region], local = [round])]
```

The custom name is stored on `app::Index.name`, propagated to
`db::Index.name`, and emitted by the SQL DDL serializer (`CREATE INDEX
<name> ...`). Without `name = "..."`, auto-generation is unchanged.

`#[key(name = "...")]` is parsed and recorded on the PK index but does
not yet rewrite the inline `CREATE TABLE` PK clause — left as a
follow-up if named PK constraints are desired.

## Type of change

- [x] Other: small user-facing macro extension; no design doc — see notes.

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

- Backward-compat: `#[index(name)]` (bare ident) still parses as a field
  reference; only `name = "..."` (with `=`) is the new syntax. The
  parser uses `peek(Token![=])` to disambiguate.
- The duplicate-name uniqueness check in `schema/verify.rs` already
  covers collisions for free; no extra validation needed.
- Tests cover: custom name overrides default and remains queryable;
  default auto-naming unchanged when `name` is omitted; `#[key(name =
  ...)]` recorded on the PK index.
- This touches public macro syntax but is small enough I skipped a
  design doc — happy to add one if you'd prefer.