### PR TITLE
chore: drop renovate weekly schedule

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,7 +2,6 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
     "config:recommended",
-    "schedule:weekly",
     "group:allNonMajor",
   ],
   // The Rust stable toolchain is pinned in two places:


### PR DESCRIPTION
## Summary

The `schedule:weekly` extends restricts Renovate to a narrow Monday window. The dependency dashboard ([#700](https://github.com/tokio-rs/toasty/issues/700)) currently has a grouped non-major bump and several major action bumps that have been stuck in "Awaiting Schedule" for ~3 weeks. Drop the schedule extends so updates open as Renovate detects them; `group:allNonMajor` still keeps churn down by bundling minor/patch bumps into one PR.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format

## Notes for reviewers

The Rust toolchain custom manager and its `automerge` rule are unchanged.