### PR TITLE
fix(macros): validate explicit `#[auto(...)]` strategies via the type checker

### DIFF
--- a/crates/toasty-macros/src/model/expand.rs
+++ b/crates/toasty-macros/src/model/expand.rs
@@ -38,6 +38,7 @@ impl Expand<'_> {
         let relation_structs = self.expand_relation_structs();
         let validate_create_impls = self.expand_validate_create_impls();
         let storage_compat_checks = self.expand_storage_compat_checks();
+        let auto_compat_checks = self.expand_auto_compat_checks();
 
         wrap_in_const(quote! {
             #model_impls
@@ -49,6 +50,7 @@ impl Expand<'_> {
             #relation_structs
             #validate_create_impls
             #storage_compat_checks
+            #auto_compat_checks
         })
     }
 }

--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -374,6 +374,45 @@ impl Expand<'_> {
         quote! { #( #checks )* }
     }
 
+    /// Emit one obligation per field with an explicit `#[auto(...)]` strategy
+    /// that the field's Rust type implements
+    /// `codegen_support::auto::AutoCompatible<Tag>` for the matching tag.
+    ///
+    /// The bare `#[auto]` form already gets a `T: Auto` obligation from the
+    /// `STRATEGY` const lookup in `expand_model_fields`, so it does not need
+    /// a separate check here.
+    pub(super) fn expand_auto_compat_checks(&self) -> TokenStream {
+        let toasty = &self.toasty;
+
+        let checks = self.model.fields.iter().filter_map(|field| {
+            let auto = field.attrs.auto.as_ref()?;
+
+            let FieldTy::Primitive(ty) = &field.ty else {
+                return None;
+            };
+
+            let tag = match auto {
+                AutoStrategy::Unspecified => return None,
+                AutoStrategy::Uuid(_) => quote! { #toasty::auto::tag::Uuid },
+                AutoStrategy::Increment => quote! { #toasty::auto::tag::Increment },
+            };
+
+            // Pin the diagnostic at the field type's span so the error lands
+            // on the user's declaration, not the derive call site.
+            Some(quote_spanned! { ty.span()=>
+                const _: () = {
+                    fn _check<__T>()
+                    where
+                        __T: #toasty::auto::AutoCompatible<#tag>,
+                    {}
+                    let _ = _check::<#ty>;
+                };
+            })
+        });
+
+        quote! { #( #checks )* }
+    }
+
     /// Generate calls to register all models reachable from this model's fields.
     ///
     /// For primitive fields, no call is emitted (the default `Field::register`

--- a/crates/toasty/src/codegen_support.rs
+++ b/crates/toasty/src/codegen_support.rs
@@ -4,6 +4,7 @@
 
 #![doc(hidden)]
 
+pub mod auto;
 pub mod newtype;
 pub mod storage;
 

--- a/crates/toasty/src/codegen_support/auto.rs
+++ b/crates/toasty/src/codegen_support/auto.rs
@@ -1,0 +1,69 @@
+//! Compile-time validation for explicit `#[auto(...)]` strategies.
+//!
+//! When `#[derive(Model)]` sees an explicit strategy on a field
+//! (`#[auto(uuid)]`, `#[auto(uuid(v4))]`, `#[auto(uuid(v7))]`,
+//! `#[auto(increment)]`), the generated code emits a one-shot obligation that
+//! the field's Rust type implements `AutoCompatible<Tag>` for the matching
+//! marker `Tag`. The bare `#[auto]` form already gets a `T: Auto` obligation
+//! via the `STRATEGY` const lookup, so it does not need this trait.
+//!
+//! Mirrors the pattern in [`crate::codegen_support::storage`]: tag types are
+//! zero-sized markers, the trait carries a `#[diagnostic::on_unimplemented]`
+//! message, and the macro names tags by absolute path so user-side type
+//! aliases or shadowing cannot defeat the check.
+
+/// Marker types for each `#[auto(...)]` strategy.
+///
+/// These types are zero-sized and only ever appear as the `Strategy`
+/// parameter to [`AutoCompatible`]. Macro-generated code names them by
+/// absolute path.
+#[allow(missing_docs)]
+pub mod tag {
+    pub struct Uuid;
+    pub struct Increment;
+}
+
+/// Asserts that a Rust field type can carry an auto-generated value of the
+/// given strategy.
+///
+/// Macro-generated code emits a `_check::<FieldType>()` call where `_check`
+/// is bounded by `AutoCompatible<Tag>`. The bound is checked against the
+/// resolved field type, so type aliases and newtype embeds compose naturally.
+#[diagnostic::on_unimplemented(
+    message = "field type `{Self}` is not compatible with the requested auto strategy `{Strategy}`",
+    label = "incompatible Rust type for `#[auto(...)]`",
+    note = "see `toasty::codegen_support::auto` for the compatibility table"
+)]
+pub trait AutoCompatible<Strategy> {}
+
+// `Option<T>` is compatible with the same strategies as `T`. Auto-populated
+// fields are typically non-nullable, but the schema tracks nullability
+// separately so the strategy check is unaffected by the option wrapper.
+impl<T, S> AutoCompatible<S> for Option<T> where T: AutoCompatible<S> {}
+
+impl AutoCompatible<tag::Increment> for i8 {}
+impl AutoCompatible<tag::Increment> for i16 {}
+impl AutoCompatible<tag::Increment> for i32 {}
+impl AutoCompatible<tag::Increment> for i64 {}
+impl AutoCompatible<tag::Increment> for u8 {}
+impl AutoCompatible<tag::Increment> for u16 {}
+impl AutoCompatible<tag::Increment> for u32 {}
+impl AutoCompatible<tag::Increment> for u64 {}
+impl AutoCompatible<tag::Increment> for isize {}
+impl AutoCompatible<tag::Increment> for usize {}
+
+impl AutoCompatible<tag::Uuid> for uuid::Uuid {}
+
+// A tuple-newtype embed is compatible with whatever its inner type is
+// compatible with. Mirrors the `Auto` blanket in
+// [`crate::codegen_support::newtype`].
+//
+// `do_not_recommend` keeps the blanket out of suggestion lists so the
+// `AutoCompatible` `#[diagnostic::on_unimplemented]` message wins.
+#[diagnostic::do_not_recommend]
+impl<T, S> AutoCompatible<S> for T
+where
+    T: super::newtype::NewtypeOf,
+    <T as super::newtype::NewtypeOf>::Inner: AutoCompatible<S>,
+{
+}

--- a/tests/tests/ui/auto_increment_on_uuid.rs
+++ b/tests/tests/ui/auto_increment_on_uuid.rs
@@ -1,0 +1,12 @@
+// `#[auto(increment)]` on a UUID field is a strategy/type mismatch — `Uuid`
+// is `AutoCompatible<tag::Uuid>`, not `tag::Increment`.
+
+#[derive(Debug, toasty::Model)]
+struct Doc {
+    #[key]
+    #[auto(increment)]
+    id: uuid::Uuid,
+    title: String,
+}
+
+fn main() {}

--- a/tests/tests/ui/auto_increment_on_uuid.stderr
+++ b/tests/tests/ui/auto_increment_on_uuid.stderr
@@ -1,0 +1,23 @@
+error[E0277]: field type `uuid::Uuid` is not compatible with the requested auto strategy `toasty::codegen_support::auto::tag::Increment`
+ --> tests/ui/auto_increment_on_uuid.rs:8:9
+  |
+8 |     id: uuid::Uuid,
+  |         ^^^^^^^^^^ incompatible Rust type for `#[auto(...)]`
+  |
+  = note: see `toasty::codegen_support::auto` for the compatibility table
+help: the trait `AutoCompatible<toasty::codegen_support::auto::tag::Increment>` is not implemented for `uuid::Uuid`
+      but trait `AutoCompatible<toasty::codegen_support::auto::tag::Uuid>` is implemented for it
+ --> $WORKSPACE/crates/toasty/src/codegen_support/auto.rs
+  |
+  | impl AutoCompatible<tag::Uuid> for uuid::Uuid {}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  = help: for that trait implementation, expected `toasty::codegen_support::auto::tag::Uuid`, found `toasty::codegen_support::auto::tag::Increment`
+note: required by a bound in `_check`
+ --> tests/ui/auto_increment_on_uuid.rs:4:17
+  |
+4 | #[derive(Debug, toasty::Model)]
+  |                 ^^^^^^^^^^^^^ required by this bound in `_check`
+...
+8 |     id: uuid::Uuid,
+  |         ---- required by a bound in this function
+  = note: this error originates in the derive macro `toasty::Model` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/tests/ui/auto_uuid_on_bool.rs
+++ b/tests/tests/ui/auto_uuid_on_bool.rs
@@ -1,0 +1,13 @@
+// `#[auto(uuid)]` requires a UUID-compatible field type. `bool` is rejected
+// at compile time by the `AutoCompatible<tag::Uuid>` obligation rather than
+// silently compiling and panicking at insert time.
+
+#[derive(Debug, toasty::Model)]
+struct Doc {
+    #[key]
+    #[auto(uuid(v7))]
+    id: bool,
+    title: String,
+}
+
+fn main() {}

--- a/tests/tests/ui/auto_uuid_on_bool.stderr
+++ b/tests/tests/ui/auto_uuid_on_bool.stderr
@@ -1,0 +1,27 @@
+error[E0277]: field type `bool` is not compatible with the requested auto strategy `toasty::codegen_support::auto::tag::Uuid`
+ --> tests/ui/auto_uuid_on_bool.rs:9:9
+  |
+9 |     id: bool,
+  |         ^^^^ incompatible Rust type for `#[auto(...)]`
+  |
+  = help: the trait `toasty::codegen_support::auto::AutoCompatible<toasty::codegen_support::auto::tag::Uuid>` is not implemented for `bool`
+  = note: see `toasty::codegen_support::auto` for the compatibility table
+  = help: the following other types implement trait `toasty::codegen_support::auto::AutoCompatible<Strategy>`:
+            `Option<T>` implements `toasty::codegen_support::auto::AutoCompatible<S>`
+            `i16` implements `toasty::codegen_support::auto::AutoCompatible<toasty::codegen_support::auto::tag::Increment>`
+            `i32` implements `toasty::codegen_support::auto::AutoCompatible<toasty::codegen_support::auto::tag::Increment>`
+            `i64` implements `toasty::codegen_support::auto::AutoCompatible<toasty::codegen_support::auto::tag::Increment>`
+            `i8` implements `toasty::codegen_support::auto::AutoCompatible<toasty::codegen_support::auto::tag::Increment>`
+            `isize` implements `toasty::codegen_support::auto::AutoCompatible<toasty::codegen_support::auto::tag::Increment>`
+            `u16` implements `toasty::codegen_support::auto::AutoCompatible<toasty::codegen_support::auto::tag::Increment>`
+            `u32` implements `toasty::codegen_support::auto::AutoCompatible<toasty::codegen_support::auto::tag::Increment>`
+          and $N others
+note: required by a bound in `_check`
+ --> tests/ui/auto_uuid_on_bool.rs:5:17
+  |
+5 | #[derive(Debug, toasty::Model)]
+  |                 ^^^^^^^^^^^^^ required by this bound in `_check`
+...
+9 |     id: bool,
+  |         ---- required by a bound in this function
+  = note: this error originates in the derive macro `toasty::Model` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/tests/ui/auto_uuid_on_int.rs
+++ b/tests/tests/ui/auto_uuid_on_int.rs
@@ -1,0 +1,13 @@
+// `#[auto(uuid)]` on an integer field is a strategy/type mismatch — `i64`
+// is `AutoCompatible<tag::Increment>`, not `tag::Uuid`. Caught at compile
+// time so the user sees the wrong choice instead of a runtime panic.
+
+#[derive(Debug, toasty::Model)]
+struct Doc {
+    #[key]
+    #[auto(uuid(v7))]
+    id: i64,
+    title: String,
+}
+
+fn main() {}

--- a/tests/tests/ui/auto_uuid_on_int.stderr
+++ b/tests/tests/ui/auto_uuid_on_int.stderr
@@ -1,0 +1,23 @@
+error[E0277]: field type `i64` is not compatible with the requested auto strategy `toasty::codegen_support::auto::tag::Uuid`
+ --> tests/ui/auto_uuid_on_int.rs:9:9
+  |
+9 |     id: i64,
+  |         ^^^ incompatible Rust type for `#[auto(...)]`
+  |
+  = note: see `toasty::codegen_support::auto` for the compatibility table
+help: the trait `AutoCompatible<toasty::codegen_support::auto::tag::Uuid>` is not implemented for `i64`
+      but trait `AutoCompatible<toasty::codegen_support::auto::tag::Increment>` is implemented for it
+ --> $WORKSPACE/crates/toasty/src/codegen_support/auto.rs
+  |
+  | impl AutoCompatible<tag::Increment> for i64 {}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  = help: for that trait implementation, expected `toasty::codegen_support::auto::tag::Increment`, found `toasty::codegen_support::auto::tag::Uuid`
+note: required by a bound in `_check`
+ --> tests/ui/auto_uuid_on_int.rs:5:17
+  |
+5 | #[derive(Debug, toasty::Model)]
+  |                 ^^^^^^^^^^^^^ required by this bound in `_check`
+...
+9 |     id: i64,
+  |         --- required by a bound in this function
+  = note: this error originates in the derive macro `toasty::Model` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
## Summary

Bare `#[auto]` already gets a `T: Auto` obligation through the
`<T as Auto>::STRATEGY` lookup, but explicit forms (`#[auto(uuid)]`,
`#[auto(uuid(v4))]`, `#[auto(uuid(v7))]`, `#[auto(increment)]`) skipped that
check and emitted the strategy literally — so mismatches like
`#[auto(uuid)] id: bool` or `#[auto(uuid)] id: i64` compiled and panicked
at insert time.

Add `codegen_support::auto::{tag, AutoCompatible}` mirroring the storage
compat-check pattern (`codegen_support::storage`): tag markers per
strategy, a trait with `#[diagnostic::on_unimplemented]`, impls for the
integer primitives + `Uuid`, and `Option<T>` / `NewtypeOf` blanket impls
so option-wrapped and tuple-newtype embeds compose. The macro emits a
one-shot `_check::<T>()` obligation against the matching tag for explicit
strategies. The legitimate `#[auto(uuid(v4))]` override on a `Uuid` field
still works since v4 and v7 both map to `tag::Uuid`.

Resolves #840.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

The compile-time errors live in `tests/tests/ui/auto_*.stderr`. The
strategy-mismatch cases (`auto_uuid_on_int`, `auto_increment_on_uuid`)
benefit from rustc's "but trait `AutoCompatible<X>` is implemented for it"
hint, which points at the right strategy without us having to spell it
out in the diagnostic.