### PR TITLE
ci: auto-merge low-risk Renovate PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -36,5 +36,15 @@
       automerge: true,
       platformAutomerge: true,
     },
+    {
+      matchUpdateTypes: ["minor", "patch", "pin", "digest"],
+      automerge: true,
+      platformAutomerge: true,
+    },
+    {
+      matchDepTypes: ["devDependencies"],
+      automerge: true,
+      platformAutomerge: true,
+    },
   ],
 }


### PR DESCRIPTION
## Summary

Extend `.github/renovate.json5` so Renovate auto-merges low-risk updates once required CI checks pass:

- minor / patch / pin / digest updates across all managers
- any `devDependencies` update (including major)

Major updates to runtime dependencies still open a PR for manual review. `platformAutomerge` is used so GitHub's native auto-merge handles the wait — repo settings already permit it and `main` has required-check branch protection.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format

## Notes for reviewers

The two new rules sit after the existing Rust toolchain rule. Rules merge in order, so if a dep matches more than one (e.g. a `devDependencies` patch), they all set the same flag — no conflict.