### PR TITLE
chore: release v0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,20 +65,20 @@ unsafe_code = "deny"
 
 [workspace.dependencies]
 # Toasty crates
-toasty = { version = "0.5.0", path = "crates/toasty" }
-toasty-cli = { version = "0.5.0", path = "crates/toasty-cli" }
-toasty-core = { version = "0.5.0", path = "crates/toasty-core" }
-toasty-macros = { version = "0.5.0", path = "crates/toasty-macros" }
-toasty-sql = { version = "0.5.0", path = "crates/toasty-sql" }
+toasty = { version = "0.6.0", path = "crates/toasty" }
+toasty-cli = { version = "0.6.0", path = "crates/toasty-cli" }
+toasty-core = { version = "0.6.0", path = "crates/toasty-core" }
+toasty-macros = { version = "0.6.0", path = "crates/toasty-macros" }
+toasty-sql = { version = "0.6.0", path = "crates/toasty-sql" }
 # Driver implementations
-toasty-driver-dynamodb = { version = "0.5.0", path = "crates/toasty-driver-dynamodb" }
-toasty-driver-mysql = { version = "0.5.0", path = "crates/toasty-driver-mysql" }
-toasty-driver-postgresql = { version = "0.5.0", path = "crates/toasty-driver-postgresql" }
-toasty-driver-sqlite = { version = "0.5.0", path = "crates/toasty-driver-sqlite" }
+toasty-driver-dynamodb = { version = "0.6.0", path = "crates/toasty-driver-dynamodb" }
+toasty-driver-mysql = { version = "0.6.0", path = "crates/toasty-driver-mysql" }
+toasty-driver-postgresql = { version = "0.6.0", path = "crates/toasty-driver-postgresql" }
+toasty-driver-sqlite = { version = "0.6.0", path = "crates/toasty-driver-sqlite" }
 
 # Driver integration test suite dependencies
-toasty-driver-integration-suite = { version = "0.5.0", path = "crates/toasty-driver-integration-suite" }
-toasty-driver-integration-suite-macros = { version = "0.5.0", path = "crates/toasty-driver-integration-suite-macros" }
+toasty-driver-integration-suite = { version = "0.6.0", path = "crates/toasty-driver-integration-suite" }
+toasty-driver-integration-suite-macros = { version = "0.6.0", path = "crates/toasty-driver-integration-suite-macros" }
 
 # Other crates
 assert-struct = "0.4.2"

--- a/crates/toasty-cli/CHANGELOG.md
+++ b/crates/toasty-cli/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-cli-v0.5.0...toasty-cli-v0.6.0) - 2026-05-14
+
+### Fixed
+
+- CLI automatically creates a default config if none exists ([#795])
+
+[#795]: https://github.com/tokio-rs/toasty/pull/795
+
 ## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-cli-v0.4.0...toasty-cli-v0.5.0) - 2026-04-27
 
 ### Added

--- a/crates/toasty-cli/Cargo.toml
+++ b/crates/toasty-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-cli"
-version = "0.5.0"
+version = "0.6.0"
 description = "Command-line interface for Toasty schema management"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-core/CHANGELOG.md
+++ b/crates/toasty-core/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-core-v0.5.0...toasty-core-v0.6.0) - 2026-05-14
+
+### Added
+
+- Add Vec<scalar> model fields with push, extend, clear, pop, remove_at, and remove methods on PostgreSQL, MySQL, SQLite, and DynamoDB ([#866], [#880], [#887], [#872])
+- Improve connection pool reliability by detecting broken connections before the next query and evicting them after backend restart ([#874], [#867])
+- Support custom index names via `name = "..."` in macros ([#842])
+- Proxy Auto through tuple-newtype Embed types ([#836])
+- Add .select() projection through BelongsTo relations ([#827])
+- Optimize IN-list queries on PostgreSQL by binding as a single array parameter ([#818])
+- Add full-table scan support for DynamoDB ([#821])
+- Add #[deferred] field attribute and Deferred<T> wrapper, with support for embedded types ([#793], [#799])
+- Add backward pagination driver capability ([#757])
+- Add ilike() filter method ([#801])
+
+### Changed
+
+- [**breaking**] Rename Returning enum variants (Expr→Project, Value→Expr) ([#790])
+
+[#757]: https://github.com/tokio-rs/toasty/pull/757
+[#790]: https://github.com/tokio-rs/toasty/pull/790
+[#793]: https://github.com/tokio-rs/toasty/pull/793
+[#799]: https://github.com/tokio-rs/toasty/pull/799
+[#801]: https://github.com/tokio-rs/toasty/pull/801
+[#818]: https://github.com/tokio-rs/toasty/pull/818
+[#821]: https://github.com/tokio-rs/toasty/pull/821
+[#827]: https://github.com/tokio-rs/toasty/pull/827
+[#836]: https://github.com/tokio-rs/toasty/pull/836
+[#842]: https://github.com/tokio-rs/toasty/pull/842
+[#866]: https://github.com/tokio-rs/toasty/pull/866
+[#867]: https://github.com/tokio-rs/toasty/pull/867
+[#872]: https://github.com/tokio-rs/toasty/pull/872
+[#874]: https://github.com/tokio-rs/toasty/pull/874
+[#880]: https://github.com/tokio-rs/toasty/pull/880
+[#887]: https://github.com/tokio-rs/toasty/pull/887
+
 ## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-core-v0.4.0...toasty-core-v0.5.0) - 2026-04-27
 
 ### Added

--- a/crates/toasty-core/Cargo.toml
+++ b/crates/toasty-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-core"
-version = "0.5.0"
+version = "0.6.0"
 description = "Core types, schema representations, and driver interface for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-dynamodb/CHANGELOG.md
+++ b/crates/toasty-driver-dynamodb/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-dynamodb-v0.5.0...toasty-driver-dynamodb-v0.6.0) - 2026-05-14
+
+### Added
+
+- Add push, pop, extend, clear, remove_at, remove operations for vector scalar fields ([#887], [#880])
+- Add vector scalar field support on MySQL, SQLite, and DynamoDB ([#872])
+- Add full-table scan support for DynamoDB ([#821])
+
+[#821]: https://github.com/tokio-rs/toasty/pull/821
+[#872]: https://github.com/tokio-rs/toasty/pull/872
+[#880]: https://github.com/tokio-rs/toasty/pull/880
+[#887]: https://github.com/tokio-rs/toasty/pull/887
+
 ## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-dynamodb-v0.4.0...toasty-driver-dynamodb-v0.5.0) - 2026-04-27
 
 ### Added

--- a/crates/toasty-driver-dynamodb/Cargo.toml
+++ b/crates/toasty-driver-dynamodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-dynamodb"
-version = "0.5.0"
+version = "0.6.0"
 description = "Amazon DynamoDB driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-integration-suite-macros/CHANGELOG.md
+++ b/crates/toasty-driver-integration-suite-macros/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-macros-v0.5.0...toasty-driver-integration-suite-macros-v0.6.0) - 2026-05-14
+
+- Internal improvements only
+
 ## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-macros-v0.4.0...toasty-driver-integration-suite-macros-v0.5.0) - 2026-04-27
 
 - Internal improvements only

--- a/crates/toasty-driver-integration-suite-macros/Cargo.toml
+++ b/crates/toasty-driver-integration-suite-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-integration-suite-macros"
-version = "0.5.0"
+version = "0.6.0"
 description = "Proc macros for the Toasty driver integration test suite"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-integration-suite/CHANGELOG.md
+++ b/crates/toasty-driver-integration-suite/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-v0.5.0...toasty-driver-integration-suite-v0.6.0) - 2026-05-14
+
+### Added
+
+- Statement operations (push, extend, clear, pop, remove_at, remove) for Vec<scalar> fields ([#880], [#887])
+- Vec<scalar> support across PostgreSQL, MySQL, SQLite, and DynamoDB ([#866], [#872])
+- Connection pool automatically detects and recovers from broken connections and backend restarts ([#867], [#874])
+- Custom index names via the index macro ([#842])
+- Auto ID proxying for embedded tuple-newtype types ([#836])
+- .select() column projection through model relations ([#820], [#827])
+- Optimized IN-list binding as array parameters on PostgreSQL ([#818])
+- Full-table scan support for DynamoDB ([#821])
+- #[deferred] attribute for lazy-loaded fields in models and embedded types ([#793], [#799])
+- Backward pagination support ([#757])
+- Case-insensitive pattern matching with ilike() ([#801])
+- latest_by() query to fetch the most recent record by a field ([#707])
+- Filter queries by fields on associated models ([#781])
+- all() filter method for associations ([#784])
+
+### Fixed
+
+- Record equality and comparison operations now work correctly with cast rules ([#838])
+
+[#707]: https://github.com/tokio-rs/toasty/pull/707
+[#757]: https://github.com/tokio-rs/toasty/pull/757
+[#781]: https://github.com/tokio-rs/toasty/pull/781
+[#784]: https://github.com/tokio-rs/toasty/pull/784
+[#793]: https://github.com/tokio-rs/toasty/pull/793
+[#799]: https://github.com/tokio-rs/toasty/pull/799
+[#801]: https://github.com/tokio-rs/toasty/pull/801
+[#818]: https://github.com/tokio-rs/toasty/pull/818
+[#820]: https://github.com/tokio-rs/toasty/pull/820
+[#821]: https://github.com/tokio-rs/toasty/pull/821
+[#827]: https://github.com/tokio-rs/toasty/pull/827
+[#836]: https://github.com/tokio-rs/toasty/pull/836
+[#838]: https://github.com/tokio-rs/toasty/pull/838
+[#842]: https://github.com/tokio-rs/toasty/pull/842
+[#866]: https://github.com/tokio-rs/toasty/pull/866
+[#867]: https://github.com/tokio-rs/toasty/pull/867
+[#872]: https://github.com/tokio-rs/toasty/pull/872
+[#874]: https://github.com/tokio-rs/toasty/pull/874
+[#880]: https://github.com/tokio-rs/toasty/pull/880
+[#887]: https://github.com/tokio-rs/toasty/pull/887
+
 ## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-v0.4.0...toasty-driver-integration-suite-v0.5.0) - 2026-04-27
 
 ### Added

--- a/crates/toasty-driver-integration-suite/Cargo.toml
+++ b/crates/toasty-driver-integration-suite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-integration-suite"
-version = "0.5.0"
+version = "0.6.0"
 description = "Integration test suite for Toasty database drivers"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-mysql/CHANGELOG.md
+++ b/crates/toasty-driver-mysql/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-mysql-v0.5.0...toasty-driver-mysql-v0.6.0) - 2026-05-14
+
+### Added
+
+- Support for Vec<scalar> fields on MySQL, SQLite, and DynamoDB ([#872])
+- Detect and recover from broken pool connections before executing queries ([#874])
+- Automatically evict stale pooled connections after backend restart ([#867])
+
+[#867]: https://github.com/tokio-rs/toasty/pull/867
+[#872]: https://github.com/tokio-rs/toasty/pull/872
+[#874]: https://github.com/tokio-rs/toasty/pull/874
+
 ## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-mysql-v0.4.0...toasty-driver-mysql-v0.5.0) - 2026-04-27
 
 ### Added

--- a/crates/toasty-driver-mysql/Cargo.toml
+++ b/crates/toasty-driver-mysql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-mysql"
-version = "0.5.0"
+version = "0.6.0"
 description = "MySQL driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-postgresql/CHANGELOG.md
+++ b/crates/toasty-driver-postgresql/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-postgresql-v0.5.0...toasty-driver-postgresql-v0.6.0) - 2026-05-14
+
+### Added
+
+- Add Vec<scalar> model field support to MySQL, SQLite, and DynamoDB ([#872])
+- Add Vec<scalar> support to PostgreSQL using native array storage ([#866])
+- Detect broken pool connections before the next query ([#874])
+- Automatically evict stale connections after backend restart ([#867])
+- Improve PostgreSQL IN-list query performance by using array parameter binding ([#818])
+
+[#818]: https://github.com/tokio-rs/toasty/pull/818
+[#866]: https://github.com/tokio-rs/toasty/pull/866
+[#867]: https://github.com/tokio-rs/toasty/pull/867
+[#872]: https://github.com/tokio-rs/toasty/pull/872
+[#874]: https://github.com/tokio-rs/toasty/pull/874
+
 ## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-postgresql-v0.4.0...toasty-driver-postgresql-v0.5.0) - 2026-04-27
 
 ### Added

--- a/crates/toasty-driver-postgresql/Cargo.toml
+++ b/crates/toasty-driver-postgresql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-postgresql"
-version = "0.5.0"
+version = "0.6.0"
 description = "PostgreSQL driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-sqlite/CHANGELOG.md
+++ b/crates/toasty-driver-sqlite/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-sqlite-v0.5.0...toasty-driver-sqlite-v0.6.0) - 2026-05-14
+
+### Added
+
+- Vec<scalar> field support on MySQL, SQLite, and DynamoDB ([#872])
+
+[#872]: https://github.com/tokio-rs/toasty/pull/872
+
 ## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-sqlite-v0.4.0...toasty-driver-sqlite-v0.5.0) - 2026-04-27
 
 ### Added

--- a/crates/toasty-driver-sqlite/Cargo.toml
+++ b/crates/toasty-driver-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-sqlite"
-version = "0.5.0"
+version = "0.6.0"
 description = "SQLite driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-macros/CHANGELOG.md
+++ b/crates/toasty-macros/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-macros-v0.5.0...toasty-macros-v0.6.0) - 2026-05-14
+
+### Added
+
+- Add Vec<scalar> model fields with PostgreSQL native array storage ([#866])
+- Support custom index names via `name = "..."` ([#842])
+- Proxy Auto through tuple-newtype Embed types ([#836])
+- Add .select() column projection, including through BelongsTo relations ([#820], [#827])
+- Validate column storage types via type checker ([#832])
+- Add compile-time validation for create! macro field sets ([#648])
+- Add #[deferred] field attribute and Deferred<T> wrapper, with support for embedded types ([#793], [#799])
+- Add latest_by query ([#707])
+- Add all filter for associations ([#784])
+
+### Fixed
+
+- Validate explicit `#[auto(...)]` strategies via type checker ([#851])
+
+[#648]: https://github.com/tokio-rs/toasty/pull/648
+[#707]: https://github.com/tokio-rs/toasty/pull/707
+[#784]: https://github.com/tokio-rs/toasty/pull/784
+[#793]: https://github.com/tokio-rs/toasty/pull/793
+[#799]: https://github.com/tokio-rs/toasty/pull/799
+[#820]: https://github.com/tokio-rs/toasty/pull/820
+[#827]: https://github.com/tokio-rs/toasty/pull/827
+[#832]: https://github.com/tokio-rs/toasty/pull/832
+[#836]: https://github.com/tokio-rs/toasty/pull/836
+[#842]: https://github.com/tokio-rs/toasty/pull/842
+[#851]: https://github.com/tokio-rs/toasty/pull/851
+[#866]: https://github.com/tokio-rs/toasty/pull/866
+
 ## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-macros-v0.4.0...toasty-macros-v0.5.0) - 2026-04-27
 
 ### Added

--- a/crates/toasty-macros/Cargo.toml
+++ b/crates/toasty-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-macros"
-version = "0.5.0"
+version = "0.6.0"
 description = "Derive macros for Toasty models and embeds"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-sql/CHANGELOG.md
+++ b/crates/toasty-sql/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-sql-v0.5.0...toasty-sql-v0.6.0) - 2026-05-14
+
+### Added
+
+- Add Vec<scalar> field support on PostgreSQL, MySQL, SQLite, and DynamoDB ([#866], [#872])
+- Add mutating methods for Vec<scalar> fields: push, extend, clear, pop, remove_at, remove ([#880], [#887])
+- Bind IN-list as a single array parameter on PostgreSQL ([#818])
+- Add ilike() filter method ([#801])
+
+[#801]: https://github.com/tokio-rs/toasty/pull/801
+[#818]: https://github.com/tokio-rs/toasty/pull/818
+[#866]: https://github.com/tokio-rs/toasty/pull/866
+[#872]: https://github.com/tokio-rs/toasty/pull/872
+[#880]: https://github.com/tokio-rs/toasty/pull/880
+[#887]: https://github.com/tokio-rs/toasty/pull/887
+
 ## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-sql-v0.4.0...toasty-sql-v0.5.0) - 2026-04-27
 
 ### Added

--- a/crates/toasty-sql/Cargo.toml
+++ b/crates/toasty-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-sql"
-version = "0.5.0"
+version = "0.6.0"
 description = "SQL serialization layer for Toasty database drivers"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty/CHANGELOG.md
+++ b/crates/toasty/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-v0.5.0...toasty-v0.6.0) - 2026-05-14
+
+### Added
+
+- Vec<scalar> model fields with push, extend, clear, pop, remove_at, and remove operations on PostgreSQL, MySQL, SQLite, and DynamoDB ([#866], [#872], [#880], [#887])
+- Connection pooling improvements: lifetime capping, idle time limits, and automatic broken connection detection and eviction ([#879], [#882], [#874], [#867])
+- Query capabilities: .select() projection through BelongsTo relations, per-call column projection, ilike() filter method, filtering by associated model fields, all-condition filters for associations, and latest_by queries ([#827], [#820], [#801], [#781], [#784], [#707])
+- Compile-time validation for column storage types and create! macro field sets ([#832], [#648])
+- Auto proxying through tuple-newtype Embed types ([#836])
+- #[deferred] field attribute and Deferred<T> wrapper with embedded type support ([#793], [#799])
+- Backward pagination driver capability ([#757])
+- Full-table scan support on DynamoDB ([#821])
+- IN-list parameter optimization for PostgreSQL ([#818])
+
+### Fixed
+
+- Compile-time validation for explicit auto strategies ([#851])
+- Record equality comparisons now properly apply type casting rules ([#838])
+
+[#648]: https://github.com/tokio-rs/toasty/pull/648
+[#707]: https://github.com/tokio-rs/toasty/pull/707
+[#757]: https://github.com/tokio-rs/toasty/pull/757
+[#781]: https://github.com/tokio-rs/toasty/pull/781
+[#784]: https://github.com/tokio-rs/toasty/pull/784
+[#793]: https://github.com/tokio-rs/toasty/pull/793
+[#799]: https://github.com/tokio-rs/toasty/pull/799
+[#801]: https://github.com/tokio-rs/toasty/pull/801
+[#818]: https://github.com/tokio-rs/toasty/pull/818
+[#820]: https://github.com/tokio-rs/toasty/pull/820
+[#821]: https://github.com/tokio-rs/toasty/pull/821
+[#827]: https://github.com/tokio-rs/toasty/pull/827
+[#832]: https://github.com/tokio-rs/toasty/pull/832
+[#836]: https://github.com/tokio-rs/toasty/pull/836
+[#838]: https://github.com/tokio-rs/toasty/pull/838
+[#851]: https://github.com/tokio-rs/toasty/pull/851
+[#866]: https://github.com/tokio-rs/toasty/pull/866
+[#867]: https://github.com/tokio-rs/toasty/pull/867
+[#872]: https://github.com/tokio-rs/toasty/pull/872
+[#874]: https://github.com/tokio-rs/toasty/pull/874
+[#879]: https://github.com/tokio-rs/toasty/pull/879
+[#880]: https://github.com/tokio-rs/toasty/pull/880
+[#882]: https://github.com/tokio-rs/toasty/pull/882
+[#887]: https://github.com/tokio-rs/toasty/pull/887
+
 ## [0.5.0](https://github.com/tokio-rs/toasty/compare/toasty-v0.4.0...toasty-v0.5.0) - 2026-04-27
 
 ### Added

--- a/crates/toasty/Cargo.toml
+++ b/crates/toasty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty"
-version = "0.5.0"
+version = "0.6.0"
 description = "An async ORM for Rust supporting SQL and NoSQL databases"
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `toasty-core`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)
* `toasty-driver-dynamodb`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `toasty-sql`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `toasty-driver-mysql`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)
* `toasty-driver-postgresql`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `toasty-driver-sqlite`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `toasty-macros`: 0.5.0 -> 0.6.0
* `toasty`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `toasty-cli`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `toasty-driver-integration-suite-macros`: 0.5.0 -> 0.6.0
* `toasty-driver-integration-suite`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)

### ⚠ `toasty-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field FieldStruct.default_returning in /tmp/.tmpTqYwvz/toasty/crates/toasty-core/src/schema/mapping/field.rs:239
  field Index.name in /tmp/.tmpTqYwvz/toasty/crates/toasty-core/src/schema/app/index.rs:41
  field Capability.scan in /tmp/.tmpTqYwvz/toasty/crates/toasty-core/src/driver/capability.rs:134
  field Capability.scan_supports_sort in /tmp/.tmpTqYwvz/toasty/crates/toasty-core/src/driver/capability.rs:143
  field Capability.backward_pagination in /tmp/.tmpTqYwvz/toasty/crates/toasty-core/src/driver/capability.rs:172
  field Capability.bind_list_param in /tmp/.tmpTqYwvz/toasty/crates/toasty-core/src/driver/capability.rs:178
  field Capability.predicate_match_any in /tmp/.tmpTqYwvz/toasty/crates/toasty-core/src/driver/capability.rs:183
  field Capability.native_array in /tmp/.tmpTqYwvz/toasty/crates/toasty-core/src/driver/capability.rs:195
  field Capability.vec_scalar in /tmp/.tmpTqYwvz/toasty/crates/toasty-core/src/driver/capability.rs:201
  field Capability.native_array_set_predicates in /tmp/.tmpTqYwvz/toasty/crates/toasty-core/src/driver/capability.rs:216
  field Capability.vec_remove in /tmp/.tmpTqYwvz/toasty/crates/toasty-core/src/driver/capability.rs:224
  field Capability.vec_pop in /tmp/.tmpTqYwvz/toasty/crates/toasty-core/src/driver/capability.rs:233
  field Capability.vec_remove_at in /tmp/.tmpTqYwvz/toasty/crates/toasty-core/src/driver/capability.rs:241
  field Model.default_returning in /tmp/.tmpTqYwvz/toasty/crates/toasty-core/src/schema/mapping/model.rs:76
  field FieldEnum.default_returning in /tmp/.tmpTqYwvz/toasty/crates/toasty-core/src/schema/mapping/field.rs:279
  field ExprLike.case_insensitive in /tmp/.tmpTqYwvz/toasty/crates/toasty-core/src/stmt/expr_like.rs:28
  field FieldPrimitive.column_expr in /tmp/.tmpTqYwvz/toasty/crates/toasty-core/src/schema/mapping/field.rs:190
  field Field.deferred in /tmp/.tmpTqYwvz/toasty/crates/toasty-core/src/schema/app/field.rs:54

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_missing.ron

Failed in:
  enum toasty_core::driver::operation::QueryPkLimit, previously in file /tmp/.tmpwaBXJU/toasty-core/src/driver/operation/query_pk.rs:9

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_added.ron

Failed in:
  variant Expr:AllOp in /tmp/.tmpTqYwvz/toasty/crates/toasty-core/src/stmt/expr.rs:39
  variant Expr:AnyOp in /tmp/.tmpTqYwvz/toasty/crates/toasty-core/src/stmt/expr.rs:48
  variant Expr:Intersects in /tmp/.tmpTqYwvz/toasty/crates/toasty-core/src/stmt/expr.rs:89
  variant Expr:IsSuperset in /tmp/.tmpTqYwvz/toasty/crates/toasty-core/src/stmt/expr.rs:97
  variant Expr:Length in /tmp/.tmpTqYwvz/toasty/crates/toasty-core/src/stmt/expr.rs:104
  variant Type:List in /tmp/.tmpTqYwvz/toasty/crates/toasty-core/src/schema/db/ty.rs:115
  variant Assignment:Append in /tmp/.tmpTqYwvz/toasty/crates/toasty-core/src/stmt/assignments.rs:60
  variant Assignment:Pop in /tmp/.tmpTqYwvz/toasty/crates/toasty-core/src/stmt/assignments.rs:65
  variant Assignment:RemoveAt in /tmp/.tmpTqYwvz/toasty/crates/toasty-core/src/stmt/assignments.rs:71
  variant Operation:Scan in /tmp/.tmpTqYwvz/toasty/crates/toasty-core/src/driver/operation.rs:92
  variant Operation:Scan in /tmp/.tmpTqYwvz/toasty/crates/toasty-core/src/driver/operation.rs:92
  variant Returning:Project in /tmp/.tmpTqYwvz/toasty/crates/toasty-core/src/stmt/returning.rs:29

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_missing.ron

Failed in:
  variant Returning::Value, previously in file /tmp/.tmpwaBXJU/toasty-core/src/stmt/returning.rs:32

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/inherent_method_missing.ron

Failed in:
  Returning::from_expr_iter, previously in file /tmp/.tmpwaBXJU/toasty-core/src/stmt/returning.rs:38
  Returning::as_expr, previously in file /tmp/.tmpwaBXJU/toasty-core/src/stmt/returning.rs:84
  Returning::as_expr_unwrap, previously in file /tmp/.tmpwaBXJU/toasty-core/src/stmt/returning.rs:97
  Returning::as_expr_mut, previously in file /tmp/.tmpwaBXJU/toasty-core/src/stmt/returning.rs:104
  Returning::as_expr_mut_unwrap, previously in file /tmp/.tmpwaBXJU/toasty-core/src/stmt/returning.rs:117
  Returning::set_expr, previously in file /tmp/.tmpwaBXJU/toasty-core/src/stmt/returning.rs:126
  Returning::is_value, previously in file /tmp/.tmpwaBXJU/toasty-core/src/stmt/returning.rs:131
  Type::from_value, previously in file /tmp/.tmpwaBXJU/toasty-core/src/schema/db/ty.rs:170
```

### ⚠ `toasty-driver-mysql` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type Connection is no longer Sync, in /tmp/.tmpTqYwvz/toasty/crates/toasty-driver-mysql/src/lib.rs:178
```

### ⚠ `toasty-driver-integration-suite` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/function_missing.ron

Failed in:
  function toasty_driver_integration_suite::tests::dynamodb_limit_boundary::limit_offset_spans_page_boundary, previously in file /tmp/.tmpwaBXJU/toasty-driver-integration-suite/src/tests/dynamodb_limit_boundary.rs:55
  function toasty_driver_integration_suite::tests::dynamodb_limit_boundary::limit_spans_page_boundary, previously in file /tmp/.tmpwaBXJU/toasty-driver-integration-suite/src/tests/dynamodb_limit_boundary.rs:19
  function toasty_driver_integration_suite::tests::dynamodb_limit_boundary::limit_offset_spans_page_boundary_gsi, previously in file /tmp/.tmpwaBXJU/toasty-driver-integration-suite/src/tests/dynamodb_limit_boundary.rs:134
  function toasty_driver_integration_suite::tests::dynamodb_limit_boundary::limit_spans_page_boundary_gsi, previously in file /tmp/.tmpwaBXJU/toasty-driver-integration-suite/src/tests/dynamodb_limit_boundary.rs:94

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/module_missing.ron

Failed in:
  mod toasty_driver_integration_suite::tests::dynamodb_limit_boundary, previously in file /tmp/.tmpwaBXJU/toasty-driver-integration-suite/src/tests/dynamodb_limit_boundary.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/struct_missing.ron

Failed in:
  struct toasty_driver_integration_suite::LoggingDriver, previously in file /tmp/.tmpwaBXJU/toasty-driver-integration-suite/src/logging_driver.rs:13
  struct toasty_driver_integration_suite::ExecLog, previously in file /tmp/.tmpwaBXJU/toasty-driver-integration-suite/src/exec_log.rs:9
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `toasty-core`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-core-v0.5.0...toasty-core-v0.6.0) - 2026-05-14

### Added

- Add Vec<scalar> model fields with push, extend, clear, pop, remove_at, and remove methods on PostgreSQL, MySQL, SQLite, and DynamoDB ([#866], [#880], [#887], [#872])
- Improve connection pool reliability by detecting broken connections before the next query and evicting them after backend restart ([#874], [#867])
- Support custom index names via `name = "..."` in macros ([#842])
- Proxy Auto through tuple-newtype Embed types ([#836])
- Add .select() projection through BelongsTo relations ([#827])
- Optimize IN-list queries on PostgreSQL by binding as a single array parameter ([#818])
- Add full-table scan support for DynamoDB ([#821])
- Add #[deferred] field attribute and Deferred<T> wrapper, with support for embedded types ([#793], [#799])
- Add backward pagination driver capability ([#757])
- Add ilike() filter method ([#801])

### Changed

- [**breaking**] Rename Returning enum variants (Expr→Project, Value→Expr) ([#790])

[#757]: https://github.com/tokio-rs/toasty/pull/757
[#790]: https://github.com/tokio-rs/toasty/pull/790
[#793]: https://github.com/tokio-rs/toasty/pull/793
[#799]: https://github.com/tokio-rs/toasty/pull/799
[#801]: https://github.com/tokio-rs/toasty/pull/801
[#818]: https://github.com/tokio-rs/toasty/pull/818
[#821]: https://github.com/tokio-rs/toasty/pull/821
[#827]: https://github.com/tokio-rs/toasty/pull/827
[#836]: https://github.com/tokio-rs/toasty/pull/836
[#842]: https://github.com/tokio-rs/toasty/pull/842
[#866]: https://github.com/tokio-rs/toasty/pull/866
[#867]: https://github.com/tokio-rs/toasty/pull/867
[#872]: https://github.com/tokio-rs/toasty/pull/872
[#874]: https://github.com/tokio-rs/toasty/pull/874
[#880]: https://github.com/tokio-rs/toasty/pull/880
[#887]: https://github.com/tokio-rs/toasty/pull/887
</blockquote>

## `toasty-driver-dynamodb`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-dynamodb-v0.5.0...toasty-driver-dynamodb-v0.6.0) - 2026-05-14

### Added

- Add push, pop, extend, clear, remove_at, remove operations for vector scalar fields ([#887], [#880])
- Add vector scalar field support on MySQL, SQLite, and DynamoDB ([#872])
- Add full-table scan support for DynamoDB ([#821])

[#821]: https://github.com/tokio-rs/toasty/pull/821
[#872]: https://github.com/tokio-rs/toasty/pull/872
[#880]: https://github.com/tokio-rs/toasty/pull/880
[#887]: https://github.com/tokio-rs/toasty/pull/887
</blockquote>

## `toasty-sql`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-sql-v0.5.0...toasty-sql-v0.6.0) - 2026-05-14

### Added

- Add Vec<scalar> field support on PostgreSQL, MySQL, SQLite, and DynamoDB ([#866], [#872])
- Add mutating methods for Vec<scalar> fields: push, extend, clear, pop, remove_at, remove ([#880], [#887])
- Bind IN-list as a single array parameter on PostgreSQL ([#818])
- Add ilike() filter method ([#801])

[#801]: https://github.com/tokio-rs/toasty/pull/801
[#818]: https://github.com/tokio-rs/toasty/pull/818
[#866]: https://github.com/tokio-rs/toasty/pull/866
[#872]: https://github.com/tokio-rs/toasty/pull/872
[#880]: https://github.com/tokio-rs/toasty/pull/880
[#887]: https://github.com/tokio-rs/toasty/pull/887
</blockquote>

## `toasty-driver-mysql`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-mysql-v0.5.0...toasty-driver-mysql-v0.6.0) - 2026-05-14

### Added

- Support for Vec<scalar> fields on MySQL, SQLite, and DynamoDB ([#872])
- Detect and recover from broken pool connections before executing queries ([#874])
- Automatically evict stale pooled connections after backend restart ([#867])

[#867]: https://github.com/tokio-rs/toasty/pull/867
[#872]: https://github.com/tokio-rs/toasty/pull/872
[#874]: https://github.com/tokio-rs/toasty/pull/874
</blockquote>

## `toasty-driver-postgresql`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-postgresql-v0.5.0...toasty-driver-postgresql-v0.6.0) - 2026-05-14

### Added

- Add Vec<scalar> model field support to MySQL, SQLite, and DynamoDB ([#872])
- Add Vec<scalar> support to PostgreSQL using native array storage ([#866])
- Detect broken pool connections before the next query ([#874])
- Automatically evict stale connections after backend restart ([#867])
- Improve PostgreSQL IN-list query performance by using array parameter binding ([#818])

[#818]: https://github.com/tokio-rs/toasty/pull/818
[#866]: https://github.com/tokio-rs/toasty/pull/866
[#867]: https://github.com/tokio-rs/toasty/pull/867
[#872]: https://github.com/tokio-rs/toasty/pull/872
[#874]: https://github.com/tokio-rs/toasty/pull/874
</blockquote>

## `toasty-driver-sqlite`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-sqlite-v0.5.0...toasty-driver-sqlite-v0.6.0) - 2026-05-14

### Added

- Vec<scalar> field support on MySQL, SQLite, and DynamoDB ([#872])

[#872]: https://github.com/tokio-rs/toasty/pull/872
</blockquote>

## `toasty-macros`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-macros-v0.5.0...toasty-macros-v0.6.0) - 2026-05-14

### Added

- Add Vec<scalar> model fields with PostgreSQL native array storage ([#866])
- Support custom index names via `name = "..."` ([#842])
- Proxy Auto through tuple-newtype Embed types ([#836])
- Add .select() column projection, including through BelongsTo relations ([#820], [#827])
- Validate column storage types via type checker ([#832])
- Add compile-time validation for create! macro field sets ([#648])
- Add #[deferred] field attribute and Deferred<T> wrapper, with support for embedded types ([#793], [#799])
- Add latest_by query ([#707])
- Add all filter for associations ([#784])

### Fixed

- Validate explicit `#[auto(...)]` strategies via type checker ([#851])

[#648]: https://github.com/tokio-rs/toasty/pull/648
[#707]: https://github.com/tokio-rs/toasty/pull/707
[#784]: https://github.com/tokio-rs/toasty/pull/784
[#793]: https://github.com/tokio-rs/toasty/pull/793
[#799]: https://github.com/tokio-rs/toasty/pull/799
[#820]: https://github.com/tokio-rs/toasty/pull/820
[#827]: https://github.com/tokio-rs/toasty/pull/827
[#832]: https://github.com/tokio-rs/toasty/pull/832
[#836]: https://github.com/tokio-rs/toasty/pull/836
[#842]: https://github.com/tokio-rs/toasty/pull/842
[#851]: https://github.com/tokio-rs/toasty/pull/851
[#866]: https://github.com/tokio-rs/toasty/pull/866
</blockquote>

## `toasty`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-v0.5.0...toasty-v0.6.0) - 2026-05-14

### Added

- Vec<scalar> model fields with push, extend, clear, pop, remove_at, and remove operations on PostgreSQL, MySQL, SQLite, and DynamoDB ([#866], [#872], [#880], [#887])
- Connection pooling improvements: lifetime capping, idle time limits, and automatic broken connection detection and eviction ([#879], [#882], [#874], [#867])
- Query capabilities: .select() projection through BelongsTo relations, per-call column projection, ilike() filter method, filtering by associated model fields, all-condition filters for associations, and latest_by queries ([#827], [#820], [#801], [#781], [#784], [#707])
- Compile-time validation for column storage types and create! macro field sets ([#832], [#648])
- Auto proxying through tuple-newtype Embed types ([#836])
- #[deferred] field attribute and Deferred<T> wrapper with embedded type support ([#793], [#799])
- Backward pagination driver capability ([#757])
- Full-table scan support on DynamoDB ([#821])
- IN-list parameter optimization for PostgreSQL ([#818])

### Fixed

- Compile-time validation for explicit auto strategies ([#851])
- Record equality comparisons now properly apply type casting rules ([#838])

[#648]: https://github.com/tokio-rs/toasty/pull/648
[#707]: https://github.com/tokio-rs/toasty/pull/707
[#757]: https://github.com/tokio-rs/toasty/pull/757
[#781]: https://github.com/tokio-rs/toasty/pull/781
[#784]: https://github.com/tokio-rs/toasty/pull/784
[#793]: https://github.com/tokio-rs/toasty/pull/793
[#799]: https://github.com/tokio-rs/toasty/pull/799
[#801]: https://github.com/tokio-rs/toasty/pull/801
[#818]: https://github.com/tokio-rs/toasty/pull/818
[#820]: https://github.com/tokio-rs/toasty/pull/820
[#821]: https://github.com/tokio-rs/toasty/pull/821
[#827]: https://github.com/tokio-rs/toasty/pull/827
[#832]: https://github.com/tokio-rs/toasty/pull/832
[#836]: https://github.com/tokio-rs/toasty/pull/836
[#838]: https://github.com/tokio-rs/toasty/pull/838
[#851]: https://github.com/tokio-rs/toasty/pull/851
[#866]: https://github.com/tokio-rs/toasty/pull/866
[#867]: https://github.com/tokio-rs/toasty/pull/867
[#872]: https://github.com/tokio-rs/toasty/pull/872
[#874]: https://github.com/tokio-rs/toasty/pull/874
[#879]: https://github.com/tokio-rs/toasty/pull/879
[#880]: https://github.com/tokio-rs/toasty/pull/880
[#882]: https://github.com/tokio-rs/toasty/pull/882
[#887]: https://github.com/tokio-rs/toasty/pull/887
</blockquote>

## `toasty-cli`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-cli-v0.5.0...toasty-cli-v0.6.0) - 2026-05-14

### Fixed

- CLI automatically creates a default config if none exists ([#795])

[#795]: https://github.com/tokio-rs/toasty/pull/795
</blockquote>

## `toasty-driver-integration-suite-macros`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-macros-v0.5.0...toasty-driver-integration-suite-macros-v0.6.0) - 2026-05-14

- Internal improvements only
</blockquote>

## `toasty-driver-integration-suite`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-v0.5.0...toasty-driver-integration-suite-v0.6.0) - 2026-05-14

### Added

- Statement operations (push, extend, clear, pop, remove_at, remove) for Vec<scalar> fields ([#880], [#887])
- Vec<scalar> support across PostgreSQL, MySQL, SQLite, and DynamoDB ([#866], [#872])
- Connection pool automatically detects and recovers from broken connections and backend restarts ([#867], [#874])
- Custom index names via the index macro ([#842])
- Auto ID proxying for embedded tuple-newtype types ([#836])
- .select() column projection through model relations ([#820], [#827])
- Optimized IN-list binding as array parameters on PostgreSQL ([#818])
- Full-table scan support for DynamoDB ([#821])
- #[deferred] attribute for lazy-loaded fields in models and embedded types ([#793], [#799])
- Backward pagination support ([#757])
- Case-insensitive pattern matching with ilike() ([#801])
- latest_by() query to fetch the most recent record by a field ([#707])
- Filter queries by fields on associated models ([#781])
- all() filter method for associations ([#784])

### Fixed

- Record equality and comparison operations now work correctly with cast rules ([#838])

[#707]: https://github.com/tokio-rs/toasty/pull/707
[#757]: https://github.com/tokio-rs/toasty/pull/757
[#781]: https://github.com/tokio-rs/toasty/pull/781
[#784]: https://github.com/tokio-rs/toasty/pull/784
[#793]: https://github.com/tokio-rs/toasty/pull/793
[#799]: https://github.com/tokio-rs/toasty/pull/799
[#801]: https://github.com/tokio-rs/toasty/pull/801
[#818]: https://github.com/tokio-rs/toasty/pull/818
[#820]: https://github.com/tokio-rs/toasty/pull/820
[#821]: https://github.com/tokio-rs/toasty/pull/821
[#827]: https://github.com/tokio-rs/toasty/pull/827
[#836]: https://github.com/tokio-rs/toasty/pull/836
[#838]: https://github.com/tokio-rs/toasty/pull/838
[#842]: https://github.com/tokio-rs/toasty/pull/842
[#866]: https://github.com/tokio-rs/toasty/pull/866
[#867]: https://github.com/tokio-rs/toasty/pull/867
[#872]: https://github.com/tokio-rs/toasty/pull/872
[#874]: https://github.com/tokio-rs/toasty/pull/874
[#880]: https://github.com/tokio-rs/toasty/pull/880
[#887]: https://github.com/tokio-rs/toasty/pull/887
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).