### PR TITLE
docs: correct DynamoDB uniqueness enforcement claim

### DIFF
--- a/docs/guide/src/indexes-and-unique-constraints.md
+++ b/docs/guide/src/indexes-and-unique-constraints.md
@@ -6,13 +6,12 @@ generated.
 
 ## Unique fields
 
-Add `#[unique]` to a field to create a unique index. On databases that support
-unique constraints (SQLite, PostgreSQL, MySQL), the database enforces that no
-two records can have the same value for this field. Toasty applies the
-constraint on a best-effort basis — if the underlying database does not support
-unique indexes (e.g., DynamoDB on non-key attributes), the `#[unique]` attribute
-still generates the same query methods but uniqueness is not enforced at the
-storage level.
+Add `#[unique]` to a field to create a unique index. Toasty enforces uniqueness
+on all supported databases. SQL databases (SQLite, PostgreSQL, MySQL) use a
+native unique index. DynamoDB uses a separate index table keyed on the unique
+attribute; inserts and updates write to both tables in a single
+`TransactWriteItems` call with an `attribute_not_exists` condition that rejects
+duplicates.
 
 ```rust
 # use toasty::Model;


### PR DESCRIPTION
The DynamoDB driver creates a separate index table per unique index and
writes to it inside a TransactWriteItems call with an
attribute_not_exists condition, so duplicate inserts are rejected. The
previous wording described uniqueness as best-effort and unenforced on
DynamoDB, which contradicts both the driver implementation and the
duplicate-insert example shown immediately below.

https://claude.ai/code/session_012UscmanfUzAMX9mi6kbQz1