### PR TITLE
feat: pre-ping pooled connections on acquire

### DIFF
--- a/crates/toasty/src/db/builder.rs
+++ b/crates/toasty/src/db/builder.rs
@@ -134,6 +134,27 @@ impl Builder {
         self
     }
 
+    /// Validate every connection with an active ping before handing it
+    /// to the caller. Useful for deployments that cannot tolerate even
+    /// one failed user query — a public API behind a flaky network, an
+    /// idempotent worker that does not implement retry. A failing ping
+    /// evicts the connection and the pool reuses another idle slot or
+    /// opens a fresh one; the caller sees either a healthy connection
+    /// or a clean `connection_pool` error if no slot can be opened
+    /// within [`pool_create_timeout`](Self::pool_create_timeout).
+    ///
+    /// The trade-off is one round-trip per checkout. Combine with a
+    /// larger [`max_pool_size`](Self::max_pool_size) if the extra
+    /// latency starts queueing requests. Independent of the background
+    /// sweep — most deployments want one or the other, but enabling
+    /// both is safe.
+    ///
+    /// Defaults to `false`.
+    pub fn pool_pre_ping(&mut self, pre_ping: bool) -> &mut Self {
+        self.pool.pre_ping = pre_ping;
+        self
+    }
+
     /// Build and return the app-level schema from the registered models
     /// without opening a database connection.
     ///

--- a/crates/toasty/src/db/pool.rs
+++ b/crates/toasty/src/db/pool.rs
@@ -32,6 +32,7 @@ pub(crate) struct PoolConfig {
     pub(crate) max_size: usize,
     pub(crate) timeouts: Timeouts,
     pub(crate) health_check_interval: Option<Duration>,
+    pub(crate) pre_ping: bool,
 }
 
 impl Default for PoolConfig {
@@ -40,6 +41,7 @@ impl Default for PoolConfig {
             max_size: get_default_pool_max_size(),
             timeouts: Default::default(),
             health_check_interval: Some(Duration::from_secs(60)),
+            pre_ping: false,
         }
     }
 }
@@ -91,6 +93,7 @@ impl Pool {
             driver: Box::new(driver),
             engine,
             sweep_waker: sweep_waker.clone(),
+            pre_ping: config.pre_ping,
         })
         .runtime(deadpool::Runtime::Tokio1)
         .max_size(effective_max)
@@ -157,6 +160,7 @@ pub(super) struct Manager {
     driver: Box<dyn Driver>,
     engine: Engine,
     sweep_waker: Arc<SweepWaker>,
+    pre_ping: bool,
 }
 
 impl std::fmt::Debug for Manager {
@@ -193,6 +197,30 @@ impl deadpool::managed::Manager for Manager {
             return Err(deadpool::managed::RecycleError::message(
                 "background task is no longer running",
             ));
+        }
+        if self.pre_ping {
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            if obj.in_tx.send(ConnectionOperation::Ping { tx }).is_err() {
+                tracing::debug!("pre-ping channel closed; discarding pooled connection");
+                return Err(deadpool::managed::RecycleError::message(
+                    "background task is no longer running",
+                ));
+            }
+            match rx.await {
+                Ok(Ok(())) => {}
+                Ok(Err(err)) => {
+                    tracing::debug!(error = %err, "pre-ping failed; discarding pooled connection");
+                    return Err(deadpool::managed::RecycleError::Backend(err));
+                }
+                Err(_) => {
+                    tracing::debug!(
+                        "pre-ping response channel dropped; discarding pooled connection"
+                    );
+                    return Err(deadpool::managed::RecycleError::message(
+                        "background task exited during pre-ping",
+                    ));
+                }
+            }
         }
         tracing::trace!("recycling pooled connection");
         Ok(())

--- a/crates/toasty/tests/pool_sweep.rs
+++ b/crates/toasty/tests/pool_sweep.rs
@@ -147,6 +147,7 @@ impl Connection for MockConnection {
 async fn build_db(
     max_pool_size: usize,
     health_check_interval: Option<Duration>,
+    pre_ping: bool,
 ) -> (toasty::Db, Arc<MockState>) {
     let driver = MockDriver::new();
     let state = driver.state();
@@ -155,6 +156,7 @@ async fn build_db(
         .models(toasty::models!(User))
         .max_pool_size(max_pool_size)
         .pool_health_check_interval(health_check_interval)
+        .pool_pre_ping(pre_ping)
         .build(driver)
         .await
         .unwrap();
@@ -168,7 +170,7 @@ async fn build_db(
 /// path in isolation.
 #[tokio::test(start_paused = true)]
 async fn pool_recovers_after_connection_lost() {
-    let (mut db, state) = build_db(1, None).await;
+    let (mut db, state) = build_db(1, None, false).await;
 
     toasty::create!(User {
         name: "alice",
@@ -205,7 +207,7 @@ async fn pool_recovers_after_connection_lost() {
 /// needing a user query to trip it.
 #[tokio::test(start_paused = true)]
 async fn sweep_evicts_dead_idle_connection() {
-    let (mut db, state) = build_db(1, Some(Duration::from_millis(50))).await;
+    let (mut db, state) = build_db(1, Some(Duration::from_millis(50)), false).await;
 
     // Force the pool to open its one connection.
     toasty::create!(User {
@@ -246,7 +248,7 @@ async fn eager_escalation_after_observed_loss() {
     // 60-second interval so the periodic tick cannot fire during the
     // test — only the notify-driven escalation path can drain the
     // queued faults here.
-    let (mut db, state) = build_db(3, Some(Duration::from_secs(60))).await;
+    let (mut db, state) = build_db(3, Some(Duration::from_secs(60)), false).await;
 
     let c1 = db.connection().await.unwrap();
     let c2 = db.connection().await.unwrap();
@@ -310,7 +312,7 @@ async fn eager_escalation_after_observed_loss() {
 /// idle connection.
 #[tokio::test(start_paused = true)]
 async fn periodic_failure_does_not_redundantly_escalate() {
-    let (db, state) = build_db(3, Some(Duration::from_secs(1))).await;
+    let (db, state) = build_db(3, Some(Duration::from_secs(1)), false).await;
 
     let c1 = db.connection().await.unwrap();
     let c2 = db.connection().await.unwrap();
@@ -331,4 +333,78 @@ async fn periodic_failure_does_not_redundantly_escalate() {
         3,
         "expected one escalation pass (1 fail + 2 healthy); redundant escalate would have raised this to 5",
     );
+}
+
+/// Pre-ping catches a silently-broken idle connection on checkout
+/// and the caller never sees the failure. Sweep is disabled so the
+/// only path that can drain the dead slot before the user's query
+/// goes out is `Manager::recycle`'s active ping.
+#[tokio::test(start_paused = true)]
+async fn pre_ping_evicts_silently_broken_idle_connection() {
+    let (mut db, state) = build_db(1, None, true).await;
+
+    toasty::create!(User {
+        name: "alice",
+        age: 30
+    })
+    .exec(&mut db)
+    .await
+    .unwrap();
+    assert_eq!(db.pool().status().size, 1);
+
+    let pings_before = state.pings.load(Ordering::Relaxed);
+    state.ping_fail_tokens.store(1, Ordering::Relaxed);
+
+    // Recycle pings, the ping fails, deadpool drops the slot and
+    // opens a fresh one before the user's exec runs.
+    toasty::create!(User {
+        name: "bob",
+        age: 30
+    })
+    .exec(&mut db)
+    .await
+    .unwrap();
+
+    assert_eq!(state.pings.load(Ordering::Relaxed) - pings_before, 1);
+    assert_eq!(state.ping_fail_tokens.load(Ordering::Relaxed), 0);
+    assert_eq!(db.pool().status().size, 1);
+}
+
+/// Pre-ping issues a round-trip on every checkout. The first query
+/// after build may or may not recycle (depending on whether the
+/// build-time probe left a slot warm), so we measure pings against a
+/// snapshot taken once the pool is steady-state.
+#[tokio::test(start_paused = true)]
+async fn pre_ping_runs_on_every_checkout() {
+    let (mut db, state) = build_db(1, None, true).await;
+
+    // Warm the pool past any setup-driven acquires.
+    toasty::create!(User {
+        name: "alice",
+        age: 30
+    })
+    .exec(&mut db)
+    .await
+    .unwrap();
+
+    let pings_before = state.pings.load(Ordering::Relaxed);
+
+    // Two more checkouts — each must recycle the lone idle slot and
+    // therefore fire exactly one pre-ping.
+    toasty::create!(User {
+        name: "bob",
+        age: 30
+    })
+    .exec(&mut db)
+    .await
+    .unwrap();
+    toasty::create!(User {
+        name: "carol",
+        age: 30
+    })
+    .exec(&mut db)
+    .await
+    .unwrap();
+
+    assert_eq!(state.pings.load(Ordering::Relaxed) - pings_before, 2);
 }

--- a/docs/dev/design/connection-pool-resilience.md
+++ b/docs/dev/design/connection-pool-resilience.md
@@ -587,15 +587,15 @@ Tracked in [#678]. The design lands in slices.
   with default `true`; PostgreSQL and MySQL connection-lost classifiers;
   the pool evicts a connection whose task observes `!is_valid()` after
   an `exec`. SQLite and DynamoDB stay on trait defaults.
+- **Background sweep with eager escalation** — PR [#874]. Adds
+  `Connection::ping()` to the driver trait, the
+  `pool_health_check_interval` builder option (default `Some(60s)`), the
+  sweep tokio task spawned by `Pool`, and the eager-escalation path
+  triggered by an observed `Error::connection_lost`. PostgreSQL and MySQL
+  drivers implement `ping`; SQLite and DynamoDB stay on the default no-op.
 
 **Remaining**
 
-- **Background sweep with eager escalation.** Adds `Connection::ping()`
-  to the driver trait, the `pool_health_check_interval` builder option,
-  the sweep tokio task spawned by `Pool`, and the eager-escalation path
-  triggered by an observed `Error::connection_lost`. This is the largest
-  user-visible win still outstanding — it closes the "first query after
-  a restart fails" gap.
 - **Per-acquire pre-ping.** Adds `pool_pre_ping(bool)`. Off by default.
   Reuses `Connection::ping()` from the slice above.
 - **Connection lifetime caps.** Adds `pool_max_connection_lifetime` and
@@ -605,3 +605,4 @@ Tracked in [#678]. The design lands in slices.
 When the last slice lands, delete this doc per the project convention.
 
 [#867]: https://github.com/tokio-rs/toasty/pull/867
+[#874]: https://github.com/tokio-rs/toasty/pull/874

--- a/docs/dev/design/connection-pool-resilience.md
+++ b/docs/dev/design/connection-pool-resilience.md
@@ -593,11 +593,16 @@ Tracked in [#678]. The design lands in slices.
   sweep tokio task spawned by `Pool`, and the eager-escalation path
   triggered by an observed `Error::connection_lost`. PostgreSQL and MySQL
   drivers implement `ping`; SQLite and DynamoDB stay on the default no-op.
+- **Per-acquire pre-ping** — PR [#879]. Adds the `pool_pre_ping(bool)`
+  builder option (default `false`). When enabled, `Manager::recycle`
+  sends `Connection::ping()` after the passive `is_valid` check and
+  treats a failing ping like a connection-lost error so deadpool drops
+  the slot and tries another. The ping reuses the
+  `ConnectionOperation::Ping` plumbing from the sweep slice; no
+  driver-trait surface change.
 
 **Remaining**
 
-- **Per-acquire pre-ping.** Adds `pool_pre_ping(bool)`. Off by default.
-  Reuses `Connection::ping()` from the slice above.
 - **Connection lifetime caps.** Adds `pool_max_connection_lifetime` and
   `pool_max_connection_idle_time`. Pure `recycle`-time checks; no driver
   surface change.
@@ -606,3 +611,4 @@ When the last slice lands, delete this doc per the project convention.
 
 [#867]: https://github.com/tokio-rs/toasty/pull/867
 [#874]: https://github.com/tokio-rs/toasty/pull/874
+[#879]: https://github.com/tokio-rs/toasty/pull/879


### PR DESCRIPTION
## Summary

Adds `pool_pre_ping(bool)` to validate every pooled connection with an active ping before handing it to the caller. For deployments that cannot tolerate even one failed query, this catches a silently-broken connection (LB-closed socket, killed session) that the passive `is_valid` check misses. Off by default; reuses the `Connection::ping()` plumbing from the background sweep and runs inside the existing `recycle_timeout` budget.

The design doc's implementation-status section is also corrected: the background-sweep slice was implemented in #874 but the status section (added in the same PR) still listed it under Remaining. Moves it to Shipped with a link to #874.

Implements the per-acquire pre-ping slice in [`docs/dev/design/connection-pool-resilience.md`](../blob/worktree-shiny-frolicking-comet/docs/dev/design/connection-pool-resilience.md). Remaining slice after this lands: connection lifetime caps.

## Type of change

- [x] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`):
      [docs/dev/design/connection-pool-resilience.md](../blob/worktree-shiny-frolicking-comet/docs/dev/design/connection-pool-resilience.md)

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers

Two new tests in `crates/toasty/tests/pool_sweep.rs` exercise the failure path (silently broken idle slot gets drained without surfacing to the caller) and the steady-state cost (one ping per checkout). Both use deltas off a warm-pool snapshot to avoid coupling to setup-driven acquires.