### PR TITLE
refactor: introduce IntoScope<M> trait for Insert::set_scope

### DIFF
--- a/crates/toasty-macros/src/model/expand/query.rs
+++ b/crates/toasty-macros/src/model/expand/query.rs
@@ -123,6 +123,20 @@ impl Expand<'_> {
                 }
             }
 
+            impl #toasty::stmt::IntoScope<#model_ident> for #query_struct_ident {
+                fn into_scope(self) -> #toasty::Statement<#toasty::List<#model_ident>> {
+                    use #toasty::stmt::IntoScope;
+                    self.stmt.into_scope()
+                }
+            }
+
+            impl #toasty::stmt::IntoScope<#model_ident> for &#query_struct_ident {
+                fn into_scope(self) -> #toasty::Statement<#toasty::List<#model_ident>> {
+                    use #toasty::stmt::IntoScope;
+                    self.stmt.clone().into_scope()
+                }
+            }
+
             impl #toasty::Default for #query_struct_ident {
                 fn default() -> #query_struct_ident {
                     #query_struct_ident { stmt: #toasty::stmt::Query::all() }

--- a/crates/toasty-macros/src/model/expand/relation.rs
+++ b/crates/toasty-macros/src/model/expand/relation.rs
@@ -26,7 +26,7 @@ impl Expand<'_> {
             }
 
             #vis struct OptionOne {
-                stmt: #toasty::stmt::Query<#toasty::List<#model_ident>>,
+                stmt: #toasty::stmt::Query<#toasty::Option<#model_ident>>,
             }
 
             impl Many {
@@ -105,7 +105,7 @@ impl Expand<'_> {
 
             impl OptionOne {
                 pub fn from_stmt(stmt: #toasty::stmt::Query<#toasty::List<#model_ident>>) -> OptionOne {
-                    OptionOne { stmt }
+                    OptionOne { stmt: stmt.first() }
                 }
 
                 /// Create a new associated record
@@ -116,7 +116,7 @@ impl Expand<'_> {
                 }
 
                 #vis async fn exec(self, executor: &mut dyn #toasty::Executor) -> #toasty::Result<#toasty::Option<#model_ident>> {
-                    self.stmt.first().exec(executor).await
+                    self.stmt.exec(executor).await
                 }
             }
 

--- a/crates/toasty/src/stmt.rs
+++ b/crates/toasty/src/stmt.rs
@@ -46,6 +46,9 @@ use crate::{Executor, schema::Load};
 mod query;
 pub use query::Query;
 
+mod scope;
+pub use scope::IntoScope;
+
 mod update;
 pub use update::Update;
 

--- a/crates/toasty/src/stmt/association.rs
+++ b/crates/toasty/src/stmt/association.rs
@@ -1,4 +1,4 @@
-use super::{IntoExpr, IntoStatement, List, Path, Statement};
+use super::{IntoExpr, IntoScope, IntoStatement, List, Path, Statement};
 use crate::schema::Model;
 use std::{fmt, marker::PhantomData};
 use toasty_core::stmt;
@@ -212,6 +212,12 @@ impl<T: Model> IntoStatement for Association<List<T>> {
     }
 }
 
+impl<M: Model> IntoScope<M> for Association<List<M>> {
+    fn into_scope(self) -> Statement<List<M>> {
+        self.into_statement()
+    }
+}
+
 impl<M: Model> Association<M> {
     /// Create a has-one or belongs-to association from `source` following
     /// `path`.
@@ -265,6 +271,12 @@ impl<T: Model> IntoStatement for Association<T> {
         })
         .build();
         Statement::from_untyped_stmt(query.into())
+    }
+}
+
+impl<M: Model> IntoScope<M> for Association<M> {
+    fn into_scope(self) -> Statement<List<M>> {
+        self.into_statement()
     }
 }
 

--- a/crates/toasty/src/stmt/insert.rs
+++ b/crates/toasty/src/stmt/insert.rs
@@ -1,4 +1,4 @@
-use super::{Expr, IntoStatement, List};
+use super::{Expr, IntoScope, List};
 use crate::schema::Model;
 use std::{fmt, marker::PhantomData};
 use toasty_core::stmt;
@@ -119,10 +119,10 @@ impl<M: Model> Insert<M> {
     /// ```
     pub fn set_scope<S>(&mut self, scope: S)
     where
-        S: IntoStatement<Returning = List<M>>,
+        S: IntoScope<M>,
     {
         self.untyped.target =
-            stmt::InsertTarget::Scope(Box::new(scope.into_statement().into_untyped_query()));
+            stmt::InsertTarget::Scope(Box::new(scope.into_scope().into_untyped_query()));
     }
 
     /// Set the value of the field at `field` index in the current record.

--- a/crates/toasty/src/stmt/scope.rs
+++ b/crates/toasty/src/stmt/scope.rs
@@ -1,0 +1,52 @@
+use super::{List, Query, Statement};
+
+/// Convert a query into a scope statement over model `M`.
+///
+/// `IntoScope<M>` captures "this is a query targeting model `M`, regardless of
+/// cardinality." It admits the three forms a relation accessor can produce —
+/// `Query<List<M>>`, `Query<Option<M>>`, and `Query<M>` — and lowers each to a
+/// `Statement<List<M>>` suitable for use as an insert scope (see
+/// [`Insert::set_scope`](crate::stmt::Insert::set_scope)).
+///
+/// Compare to [`IntoStatement`](crate::stmt::IntoStatement), which preserves the
+/// query's returning type and so distinguishes the three forms above. `IntoScope`
+/// erases that distinction, since the scope of an insert only cares about which
+/// rows the query addresses, not how many it would return on execution.
+///
+/// For `Query<Option<M>>` and `Query<M>` — produced by [`Query::first`] and
+/// [`Query::one`] respectively — the `single` flag and the paired `LIMIT 1`
+/// added by those narrowing methods are cleared, since `Statement<List<M>>`
+/// would otherwise be self-contradictory ("a list that returns one row").
+///
+/// [`Query::first`]: crate::stmt::Query::first
+/// [`Query::one`]: crate::stmt::Query::one
+pub trait IntoScope<M> {
+    /// Lower `self` into a `Statement<List<M>>` for use as an insert scope.
+    fn into_scope(self) -> Statement<List<M>>;
+}
+
+impl<M> IntoScope<M> for Query<List<M>> {
+    fn into_scope(self) -> Statement<List<M>> {
+        Statement::from_untyped_stmt(self.untyped.into())
+    }
+}
+
+impl<M> IntoScope<M> for Query<Option<M>> {
+    fn into_scope(self) -> Statement<List<M>> {
+        Statement::from_untyped_stmt(widen(self.untyped).into())
+    }
+}
+
+impl<M> IntoScope<M> for Query<M> {
+    fn into_scope(self) -> Statement<List<M>> {
+        Statement::from_untyped_stmt(widen(self.untyped).into())
+    }
+}
+
+fn widen(mut query: toasty_core::stmt::Query) -> toasty_core::stmt::Query {
+    if query.single {
+        query.single = false;
+        query.limit = None;
+    }
+    query
+}

--- a/crates/toasty/tests/stmt_into_scope.rs
+++ b/crates/toasty/tests/stmt_into_scope.rs
@@ -1,0 +1,68 @@
+use toasty::stmt::{IntoScope, IntoStatement, List, Query};
+use toasty_core::stmt as core_stmt;
+
+#[derive(Debug, toasty::Model)]
+struct User {
+    #[key]
+    id: i64,
+    name: String,
+}
+
+fn untyped_query<T>(stmt: toasty::Statement<T>) -> core_stmt::Query {
+    stmt.into_untyped().into_query_unwrap()
+}
+
+#[test]
+fn into_scope_from_list_preserves_query() {
+    let q: Query<List<User>> = Query::all();
+    let original = untyped_query(q.clone().into_statement());
+
+    let widened = untyped_query(IntoScope::<User>::into_scope(q));
+
+    assert_eq!(widened, original);
+    assert!(!widened.single);
+    assert!(widened.limit.is_none());
+}
+
+#[test]
+fn into_scope_from_option_clears_single_and_limit() {
+    let q: Query<Option<User>> = Query::<List<User>>::all().first();
+
+    // Sanity: .first() applied both `single = true` and `LIMIT 1`.
+    let pre = untyped_query(q.clone().into_statement());
+    assert!(pre.single);
+    assert!(pre.limit.is_some());
+
+    let widened = untyped_query(IntoScope::<User>::into_scope(q));
+
+    assert!(!widened.single);
+    assert!(widened.limit.is_none());
+}
+
+#[test]
+fn into_scope_from_one_clears_single_and_limit() {
+    let q: Query<User> = Query::<List<User>>::all().one();
+
+    let pre = untyped_query(q.clone().into_statement());
+    assert!(pre.single);
+    assert!(pre.limit.is_some());
+
+    let widened = untyped_query(IntoScope::<User>::into_scope(q));
+
+    assert!(!widened.single);
+    assert!(widened.limit.is_none());
+}
+
+#[test]
+fn into_scope_preserves_filter_body() {
+    // The body (source + filter) should round-trip identically through
+    // widening — only `single` / `limit` get reset.
+    let list_q: Query<List<User>> = Query::filter(User::fields().name().eq("alice"));
+    let from_list = untyped_query(IntoScope::<User>::into_scope(list_q.clone()));
+
+    let from_option = untyped_query(IntoScope::<User>::into_scope(list_q.clone().first()));
+    let from_one = untyped_query(IntoScope::<User>::into_scope(list_q.one()));
+
+    assert_eq!(from_list.body, from_option.body);
+    assert_eq!(from_list.body, from_one.body);
+}


### PR DESCRIPTION
## Summary

`Insert::set_scope` previously required `IntoStatement<Returning = List<M>>`,
which admitted `Query<List<M>>` but excluded the narrowed `Query<Option<M>>`
and `Query<M>` forms produced by `.first()` / `.one()`. That forced the
generated `OptionOne` relation struct to hold its query as
`Query<List<M>>` even though it semantically represents an at-most-one
result.

Introduce `IntoScope<M>` — "this is a query targeting model `M`,
regardless of cardinality" — and re-bound `set_scope` on it. The
narrowed forms widen back: `single` and the paired `LIMIT 1` are
cleared so the resulting `Statement<List<M>>` is internally consistent.
With that in place, the generated `OptionOne.stmt` is narrowed to
`Query<Option<M>>` to match the struct's name and `exec` signature.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses Conventional Commits format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

The two commits are split for clarity: the first lands the trait and
re-bounds `set_scope`; the second narrows the macro-generated
`OptionOne.stmt` and adds an `IntoScope<M>` impl to the generated query
struct so `Model::all()` still composes.