### PR TITLE
docs: add examples for deferred field loading patterns

### DIFF
--- a/docs/guide/src/deferred-fields.md
+++ b/docs/guide/src/deferred-fields.md
@@ -38,6 +38,66 @@ attribute directs the macro to omit the field from the default
 projection and to generate the per-field load method. The wrapper type
 provides the unloaded-state runtime API.
 
+A record from an ordinary query has `body` unloaded. Load it explicitly
+with a follow-up read keyed on the primary key:
+
+```rust
+# use toasty::Model;
+# #[derive(Debug, toasty::Model)]
+# struct Document {
+#     #[key]
+#     #[auto]
+#     id: u64,
+#     title: String,
+#     #[deferred]
+#     body: toasty::Deferred<String>,
+# }
+# async fn __example(mut db: toasty::Db) -> toasty::Result<()> {
+# let created = toasty::create!(Document {
+#     title: "Hello",
+#     body: "the long body",
+# }).exec(&mut db).await?;
+let doc = Document::filter_by_id(created.id).get(&mut db).await?;
+assert!(doc.body.is_unloaded());
+
+// Issue a follow-up read for just the deferred column.
+let body: String = doc.body().exec(&mut db).await?;
+# Ok(())
+# }
+```
+
+Or preload it with `.include()` so the value arrives on the record the
+query returns — no second round-trip:
+
+```rust
+# use toasty::Model;
+# #[derive(Debug, toasty::Model)]
+# struct Document {
+#     #[key]
+#     #[auto]
+#     id: u64,
+#     title: String,
+#     #[deferred]
+#     body: toasty::Deferred<String>,
+# }
+# async fn __example(mut db: toasty::Db) -> toasty::Result<()> {
+# let created = toasty::create!(Document {
+#     title: "Hello",
+#     body: "the long body",
+# }).exec(&mut db).await?;
+let doc = Document::filter_by_id(created.id)
+    .include(Document::fields().body())
+    .get(&mut db)
+    .await?;
+
+let body: &String = doc.body.get();   // synchronous, no query
+# Ok(())
+# }
+```
+
+Both mechanisms are covered in full below; the rest of this section
+first describes where `#[deferred]` can be applied.
+
 `#[deferred]` is supported on primitive fields and on embedded types
 (`#[derive(Embed)]` structs and enums). It does not compose with
 `#[belongs_to]`, `#[has_many]`, or `#[has_one]` — relations are already

--- a/docs/guide/src/deferred-fields.md
+++ b/docs/guide/src/deferred-fields.md
@@ -95,9 +95,6 @@ let body: &String = doc.body.get();   // synchronous, no query
 # }
 ```
 
-Both mechanisms are covered in full below; the rest of this section
-first describes where `#[deferred]` can be applied.
-
 `#[deferred]` is supported on primitive fields and on embedded types
 (`#[derive(Embed)]` structs and enums). It does not compose with
 `#[belongs_to]`, `#[has_many]`, or `#[has_one]` — relations are already


### PR DESCRIPTION
## Summary

Adds two practical code examples to the deferred fields documentation showing the two main patterns for working with deferred fields:

1. **Explicit follow-up load**: Using the per-field load method (`.body().exec()`) to fetch a deferred field in a separate query
2. **Preload with `.include()`**: Using `.include(Document::fields().body())` to fetch the deferred field in the initial query, avoiding a second round-trip

These examples demonstrate both the unloaded-state runtime API and the practical trade-offs between the two approaches. The examples are placed before the detailed reference section to help users quickly understand the two main usage patterns.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Documentation is clear and includes runnable examples

## Notes for reviewers

The examples use the existing `#[deferred]` attribute and query builder API (`filter_by_id`, `include`, per-field load methods) that are already implemented. These are documentation-only additions showing how to use existing functionality.

https://claude.ai/code/session_01RNPYC4GxR8sErUVRmXwB57