### PR TITLE
refactor(macros): give One and OptionOne precise query types

### DIFF
--- a/crates/toasty-macros/src/model/expand/relation.rs
+++ b/crates/toasty-macros/src/model/expand/relation.rs
@@ -22,7 +22,7 @@ impl Expand<'_> {
             }
 
             #vis struct One {
-                stmt: #toasty::stmt::Query<#toasty::List<#model_ident>>,
+                stmt: #toasty::stmt::Query<#model_ident>,
             }
 
             #vis struct OptionOne {
@@ -79,7 +79,7 @@ impl Expand<'_> {
 
             impl One {
                 #vis fn from_stmt(stmt: #toasty::stmt::Query<#toasty::List<#model_ident>>) -> One {
-                    One { stmt }
+                    One { stmt: stmt.one() }
                 }
 
                 /// Create a new associated record
@@ -90,14 +90,14 @@ impl Expand<'_> {
                 }
 
                 #vis async fn exec(self, executor: &mut dyn #toasty::Executor) -> #toasty::Result<#model_ident> {
-                    self.stmt.one().exec(executor).await
+                    self.stmt.exec(executor).await
                 }
             }
 
             impl #toasty::IntoStatement for One {
-                type Returning = #toasty::List<#model_ident>;
+                type Returning = #model_ident;
 
-                fn into_statement(self) -> #toasty::Statement<#toasty::List<#model_ident>> {
+                fn into_statement(self) -> #toasty::Statement<#model_ident> {
                     use #toasty::IntoStatement;
                     self.stmt.into_statement()
                 }


### PR DESCRIPTION
## Summary

The generated `One` and `OptionOne` relation structs both held a
`Query<List<M>>` internally, narrowing to a single row only at `exec()`.
They now hold `Query<M>` and `Query<Option<M>>` respectively, so the type
reflects the actual result from `from_stmt` onward — through `exec`,
`IntoStatement`, and `set_scope`.

`from_stmt` keeps a uniform `Query<List<M>>` input (narrowing happens
inside it), because the shared `<T as Relation>::One::from_stmt` call
site resolves to `One::from_stmt` for non-nullable relations and
`OptionOne::from_stmt` for nullable ones — both must accept the same
argument type.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

Behavioral change: `IntoStatement for One` now reports `Returning = M`
instead of `List<M>`, so passing a has-one/belongs-to accessor to
`Db::exec` resolves to `M` rather than `Vec<M>`. This is the correct
type for a single-row relation; the existing relation `.exec()` tests
all pass. Flagged as `BREAKING CHANGE` in the commit footer.