### PR TITLE
chore: release v0.6.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,20 +65,20 @@ unsafe_code = "deny"
 
 [workspace.dependencies]
 # Toasty crates
-toasty = { version = "0.6.0", path = "crates/toasty" }
-toasty-cli = { version = "0.6.0", path = "crates/toasty-cli" }
-toasty-core = { version = "0.6.0", path = "crates/toasty-core" }
-toasty-macros = { version = "0.6.0", path = "crates/toasty-macros" }
-toasty-sql = { version = "0.6.0", path = "crates/toasty-sql" }
+toasty = { version = "0.6.1", path = "crates/toasty" }
+toasty-cli = { version = "0.6.1", path = "crates/toasty-cli" }
+toasty-core = { version = "0.6.1", path = "crates/toasty-core" }
+toasty-macros = { version = "0.6.1", path = "crates/toasty-macros" }
+toasty-sql = { version = "0.6.1", path = "crates/toasty-sql" }
 # Driver implementations
-toasty-driver-dynamodb = { version = "0.6.0", path = "crates/toasty-driver-dynamodb" }
-toasty-driver-mysql = { version = "0.6.0", path = "crates/toasty-driver-mysql" }
-toasty-driver-postgresql = { version = "0.6.0", path = "crates/toasty-driver-postgresql" }
-toasty-driver-sqlite = { version = "0.6.0", path = "crates/toasty-driver-sqlite" }
+toasty-driver-dynamodb = { version = "0.6.1", path = "crates/toasty-driver-dynamodb" }
+toasty-driver-mysql = { version = "0.6.1", path = "crates/toasty-driver-mysql" }
+toasty-driver-postgresql = { version = "0.6.1", path = "crates/toasty-driver-postgresql" }
+toasty-driver-sqlite = { version = "0.6.1", path = "crates/toasty-driver-sqlite" }
 
 # Driver integration test suite dependencies
-toasty-driver-integration-suite = { version = "0.6.0", path = "crates/toasty-driver-integration-suite" }
-toasty-driver-integration-suite-macros = { version = "0.6.0", path = "crates/toasty-driver-integration-suite-macros" }
+toasty-driver-integration-suite = { version = "0.6.1", path = "crates/toasty-driver-integration-suite" }
+toasty-driver-integration-suite-macros = { version = "0.6.1", path = "crates/toasty-driver-integration-suite-macros" }
 
 # Other crates
 assert-struct = "0.4.2"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <div align="center">
   <h3>The cozy, easy ORM for Rust</h3>
-  <a href="https://tokio-rs.github.io/toasty/0.6.0/guide/">Guide</a> •
+  <a href="https://tokio-rs.github.io/toasty/0.6.1/guide/">Guide</a> •
   <a href="https://docs.rs/toasty">API Docs</a> •
   <a href="https://crates.io/crates/toasty">Crates.io</a> •
   <a href="https://discord.gg/tokio">Discord</a>

--- a/crates/toasty-cli/CHANGELOG.md
+++ b/crates/toasty-cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-cli-v0.6.0...toasty-cli-v0.6.1) - 2026-05-16
+
+- Internal improvements only.
+
 ## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-cli-v0.5.0...toasty-cli-v0.6.0) - 2026-05-14
 
 ### Fixed

--- a/crates/toasty-cli/Cargo.toml
+++ b/crates/toasty-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-cli"
-version = "0.6.0"
+version = "0.6.1"
 description = "Command-line interface for Toasty schema management"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-core/CHANGELOG.md
+++ b/crates/toasty-core/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-core-v0.6.0...toasty-core-v0.6.1) - 2026-05-16
+
+### Added
+
+- Field-level `#[index]` attributes now reject arguments ([#909])
+- Support ordering by multiple fields ([#901])
+
+### Fixed
+
+- Fixed equality operations with composite keys ([#906])
+- Improved `belongs_to` syntax and error messages for composite keys ([#905])
+
+[#901]: https://github.com/tokio-rs/toasty/pull/901
+[#905]: https://github.com/tokio-rs/toasty/pull/905
+[#906]: https://github.com/tokio-rs/toasty/pull/906
+[#909]: https://github.com/tokio-rs/toasty/pull/909
+
 ## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-core-v0.5.0...toasty-core-v0.6.0) - 2026-05-14
 
 ### Added

--- a/crates/toasty-core/Cargo.toml
+++ b/crates/toasty-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-core"
-version = "0.6.0"
+version = "0.6.1"
 description = "Core types, schema representations, and driver interface for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-dynamodb/CHANGELOG.md
+++ b/crates/toasty-driver-dynamodb/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-driver-dynamodb-v0.6.0...toasty-driver-dynamodb-v0.6.1) - 2026-05-16
+
+- Internal improvements only.
+
 ## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-dynamodb-v0.5.0...toasty-driver-dynamodb-v0.6.0) - 2026-05-14
 
 ### Added

--- a/crates/toasty-driver-dynamodb/Cargo.toml
+++ b/crates/toasty-driver-dynamodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-dynamodb"
-version = "0.6.0"
+version = "0.6.1"
 description = "Amazon DynamoDB driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-integration-suite-macros/CHANGELOG.md
+++ b/crates/toasty-driver-integration-suite-macros/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-macros-v0.6.0...toasty-driver-integration-suite-macros-v0.6.1) - 2026-05-16
+
+- Internal improvements only.
+
 ## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-macros-v0.5.0...toasty-driver-integration-suite-macros-v0.6.0) - 2026-05-14
 
 - Internal improvements only

--- a/crates/toasty-driver-integration-suite-macros/Cargo.toml
+++ b/crates/toasty-driver-integration-suite-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-integration-suite-macros"
-version = "0.6.0"
+version = "0.6.1"
 description = "Proc macros for the Toasty driver integration test suite"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-integration-suite/CHANGELOG.md
+++ b/crates/toasty-driver-integration-suite/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-v0.6.0...toasty-driver-integration-suite-v0.6.1) - 2026-05-16
+
+### Added
+
+- .select() projections through HasMany relations ([#894])
+- Chain relation methods on Many for multi-step queries ([#903])
+- Order by multiple fields ([#901])
+
+### Fixed
+
+- Support composite foreign keys in relation-chain queries ([#915])
+- Enable belongs_to with embed-typed primary keys ([#912])
+- Support composite keys in equality comparisons ([#906])
+- Improved syntax and error messages for composite-key belongs_to ([#905])
+- Multiple order_by expressions are now combined instead of replacing ([#899])
+
+[#894]: https://github.com/tokio-rs/toasty/pull/894
+[#899]: https://github.com/tokio-rs/toasty/pull/899
+[#901]: https://github.com/tokio-rs/toasty/pull/901
+[#903]: https://github.com/tokio-rs/toasty/pull/903
+[#905]: https://github.com/tokio-rs/toasty/pull/905
+[#906]: https://github.com/tokio-rs/toasty/pull/906
+[#912]: https://github.com/tokio-rs/toasty/pull/912
+[#915]: https://github.com/tokio-rs/toasty/pull/915
+
 ## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-v0.5.0...toasty-driver-integration-suite-v0.6.0) - 2026-05-14
 
 ### Added

--- a/crates/toasty-driver-integration-suite/Cargo.toml
+++ b/crates/toasty-driver-integration-suite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-integration-suite"
-version = "0.6.0"
+version = "0.6.1"
 description = "Integration test suite for Toasty database drivers"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-mysql/CHANGELOG.md
+++ b/crates/toasty-driver-mysql/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-driver-mysql-v0.6.0...toasty-driver-mysql-v0.6.1) - 2026-05-16
+
+- Internal improvements only.
+
 ## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-mysql-v0.5.0...toasty-driver-mysql-v0.6.0) - 2026-05-14
 
 ### Added

--- a/crates/toasty-driver-mysql/Cargo.toml
+++ b/crates/toasty-driver-mysql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-mysql"
-version = "0.6.0"
+version = "0.6.1"
 description = "MySQL driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-postgresql/CHANGELOG.md
+++ b/crates/toasty-driver-postgresql/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-driver-postgresql-v0.6.0...toasty-driver-postgresql-v0.6.1) - 2026-05-16
+
+- Internal improvements only.
+
 ## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-postgresql-v0.5.0...toasty-driver-postgresql-v0.6.0) - 2026-05-14
 
 ### Added

--- a/crates/toasty-driver-postgresql/Cargo.toml
+++ b/crates/toasty-driver-postgresql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-postgresql"
-version = "0.6.0"
+version = "0.6.1"
 description = "PostgreSQL driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-sqlite/CHANGELOG.md
+++ b/crates/toasty-driver-sqlite/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-driver-sqlite-v0.6.0...toasty-driver-sqlite-v0.6.1) - 2026-05-16
+
+- Internal improvements only.
+
 ## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-sqlite-v0.5.0...toasty-driver-sqlite-v0.6.0) - 2026-05-14
 
 ### Added

--- a/crates/toasty-driver-sqlite/Cargo.toml
+++ b/crates/toasty-driver-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-sqlite"
-version = "0.6.0"
+version = "0.6.1"
 description = "SQLite driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-macros/CHANGELOG.md
+++ b/crates/toasty-macros/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-macros-v0.6.0...toasty-macros-v0.6.1) - 2026-05-16
+
+### Added
+
+- Add `.select()` projection through HasMany relations ([#894])
+- Chain relation methods on `Many` for multi-step queries via paths ([#903])
+- Enforce stricter validation on field-level `#[index]` attributes ([#909])
+- Give `One` and `OptionOne` precise query types ([#889])
+
+### Fixed
+
+- Enable `belongs_to` with embed-typed primary keys ([#912])
+- Improve `belongs_to` syntax and diagnostics for composite keys ([#905])
+
+[#889]: https://github.com/tokio-rs/toasty/pull/889
+[#894]: https://github.com/tokio-rs/toasty/pull/894
+[#903]: https://github.com/tokio-rs/toasty/pull/903
+[#905]: https://github.com/tokio-rs/toasty/pull/905
+[#909]: https://github.com/tokio-rs/toasty/pull/909
+[#912]: https://github.com/tokio-rs/toasty/pull/912
+
 ## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-macros-v0.5.0...toasty-macros-v0.6.0) - 2026-05-14
 
 ### Added

--- a/crates/toasty-macros/Cargo.toml
+++ b/crates/toasty-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-macros"
-version = "0.6.0"
+version = "0.6.1"
 description = "Derive macros for Toasty models and embeds"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-sql/CHANGELOG.md
+++ b/crates/toasty-sql/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-sql-v0.6.0...toasty-sql-v0.6.1) - 2026-05-16
+
+- Internal improvements only
+
 ## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-sql-v0.5.0...toasty-sql-v0.6.0) - 2026-05-14
 
 ### Added

--- a/crates/toasty-sql/Cargo.toml
+++ b/crates/toasty-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-sql"
-version = "0.6.0"
+version = "0.6.1"
 description = "SQL serialization layer for Toasty database drivers"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty/CHANGELOG.md
+++ b/crates/toasty/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-v0.6.0...toasty-v0.6.1) - 2026-05-16
+
+### Added
+
+- Chain relation methods through multiple steps ([#903])
+- Order by multiple fields ([#901])
+
+### Fixed
+
+- Composite foreign keys in relation traversal ([#915])
+- Belongs-to relations with embed-typed primary keys ([#912])
+- Queries with composite keys in equality conditions ([#906])
+- Multiple order_by expressions now stack correctly ([#899])
+
+[#899]: https://github.com/tokio-rs/toasty/pull/899
+[#901]: https://github.com/tokio-rs/toasty/pull/901
+[#903]: https://github.com/tokio-rs/toasty/pull/903
+[#906]: https://github.com/tokio-rs/toasty/pull/906
+[#912]: https://github.com/tokio-rs/toasty/pull/912
+[#915]: https://github.com/tokio-rs/toasty/pull/915
+
 ## [0.6.0](https://github.com/tokio-rs/toasty/compare/toasty-v0.5.0...toasty-v0.6.0) - 2026-05-14
 
 ### Added

--- a/crates/toasty/Cargo.toml
+++ b/crates/toasty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty"
-version = "0.6.0"
+version = "0.6.1"
 description = "An async ORM for Rust supporting SQL and NoSQL databases"
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `toasty-core`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `toasty-driver-dynamodb`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `toasty-sql`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `toasty-driver-mysql`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `toasty-driver-postgresql`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `toasty-driver-sqlite`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `toasty-macros`: 0.6.0 -> 0.6.1
* `toasty`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `toasty-cli`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `toasty-driver-integration-suite-macros`: 0.6.0 -> 0.6.1
* `toasty-driver-integration-suite`: 0.6.0 -> 0.6.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `toasty-core`

<blockquote>

## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-core-v0.6.0...toasty-core-v0.6.1) - 2026-05-16

### Added

- Field-level `#[index]` attributes now reject arguments ([#909])
- Support ordering by multiple fields ([#901])

### Fixed

- Fixed equality operations with composite keys ([#906])
- Improved `belongs_to` syntax and error messages for composite keys ([#905])

[#901]: https://github.com/tokio-rs/toasty/pull/901
[#905]: https://github.com/tokio-rs/toasty/pull/905
[#906]: https://github.com/tokio-rs/toasty/pull/906
[#909]: https://github.com/tokio-rs/toasty/pull/909
</blockquote>

## `toasty-driver-dynamodb`

<blockquote>

## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-driver-dynamodb-v0.6.0...toasty-driver-dynamodb-v0.6.1) - 2026-05-16

- Internal improvements only.
</blockquote>

## `toasty-sql`

<blockquote>

## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-sql-v0.6.0...toasty-sql-v0.6.1) - 2026-05-16

- Internal improvements only
</blockquote>

## `toasty-driver-mysql`

<blockquote>

## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-driver-mysql-v0.6.0...toasty-driver-mysql-v0.6.1) - 2026-05-16

- Internal improvements only.
</blockquote>

## `toasty-driver-postgresql`

<blockquote>

## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-driver-postgresql-v0.6.0...toasty-driver-postgresql-v0.6.1) - 2026-05-16

- Internal improvements only.
</blockquote>

## `toasty-driver-sqlite`

<blockquote>

## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-driver-sqlite-v0.6.0...toasty-driver-sqlite-v0.6.1) - 2026-05-16

- Internal improvements only.
</blockquote>

## `toasty-macros`

<blockquote>

## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-macros-v0.6.0...toasty-macros-v0.6.1) - 2026-05-16

### Added

- Add `.select()` projection through HasMany relations ([#894])
- Chain relation methods on `Many` for multi-step queries via paths ([#903])
- Enforce stricter validation on field-level `#[index]` attributes ([#909])
- Give `One` and `OptionOne` precise query types ([#889])

### Fixed

- Enable `belongs_to` with embed-typed primary keys ([#912])
- Improve `belongs_to` syntax and diagnostics for composite keys ([#905])

[#889]: https://github.com/tokio-rs/toasty/pull/889
[#894]: https://github.com/tokio-rs/toasty/pull/894
[#903]: https://github.com/tokio-rs/toasty/pull/903
[#905]: https://github.com/tokio-rs/toasty/pull/905
[#909]: https://github.com/tokio-rs/toasty/pull/909
[#912]: https://github.com/tokio-rs/toasty/pull/912
</blockquote>

## `toasty`

<blockquote>

## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-v0.6.0...toasty-v0.6.1) - 2026-05-16

### Added

- Chain relation methods through multiple steps ([#903])
- Order by multiple fields ([#901])

### Fixed

- Composite foreign keys in relation traversal ([#915])
- Belongs-to relations with embed-typed primary keys ([#912])
- Queries with composite keys in equality conditions ([#906])
- Multiple order_by expressions now stack correctly ([#899])

[#899]: https://github.com/tokio-rs/toasty/pull/899
[#901]: https://github.com/tokio-rs/toasty/pull/901
[#903]: https://github.com/tokio-rs/toasty/pull/903
[#906]: https://github.com/tokio-rs/toasty/pull/906
[#912]: https://github.com/tokio-rs/toasty/pull/912
[#915]: https://github.com/tokio-rs/toasty/pull/915
</blockquote>

## `toasty-cli`

<blockquote>

## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-cli-v0.6.0...toasty-cli-v0.6.1) - 2026-05-16

- Internal improvements only.
</blockquote>

## `toasty-driver-integration-suite-macros`

<blockquote>

## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-macros-v0.6.0...toasty-driver-integration-suite-macros-v0.6.1) - 2026-05-16

- Internal improvements only.
</blockquote>

## `toasty-driver-integration-suite`

<blockquote>

## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-v0.6.0...toasty-driver-integration-suite-v0.6.1) - 2026-05-16

### Added

- .select() projections through HasMany relations ([#894])
- Chain relation methods on Many for multi-step queries ([#903])
- Order by multiple fields ([#901])

### Fixed

- Support composite foreign keys in relation-chain queries ([#915])
- Enable belongs_to with embed-typed primary keys ([#912])
- Support composite keys in equality comparisons ([#906])
- Improved syntax and error messages for composite-key belongs_to ([#905])
- Multiple order_by expressions are now combined instead of replacing ([#899])

[#894]: https://github.com/tokio-rs/toasty/pull/894
[#899]: https://github.com/tokio-rs/toasty/pull/899
[#901]: https://github.com/tokio-rs/toasty/pull/901
[#903]: https://github.com/tokio-rs/toasty/pull/903
[#905]: https://github.com/tokio-rs/toasty/pull/905
[#906]: https://github.com/tokio-rs/toasty/pull/906
[#912]: https://github.com/tokio-rs/toasty/pull/912
[#915]: https://github.com/tokio-rs/toasty/pull/915
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).