### PR TITLE
feat: add .select() projection through HasMany relations

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -74,6 +74,7 @@ pub mod scan_no_index;
 pub mod select_projection;
 pub mod select_projection_belongs_to;
 pub mod select_projection_embed;
+pub mod select_projection_has_many;
 pub mod select_projection_has_one;
 pub mod starts_with;
 pub mod tx_atomic_stmt;

--- a/crates/toasty-driver-integration-suite/src/tests/select_projection_has_many.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/select_projection_has_many.rs
@@ -1,0 +1,167 @@
+//! `.select(...)` projection through a `HasMany` relation field.
+//!
+//! Field handles for `HasMany` relations return
+//! `<Target as Relation>::ManyField<__Origin>` (the macro-generated
+//! `*FieldList` struct).  An `IntoExpr<List<TargetModel>>` impl on that
+//! struct lets the field handle flow through `.select(...)` the same way
+//! `BelongsTo`/`HasOne` handles do; each parent row projects to a list of
+//! related rows, and the executor decodes the result as `Vec<Vec<Target>>`.
+
+use crate::prelude::*;
+
+#[driver_test(id(ID), requires(sql))]
+pub async fn select_has_many_basic(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+        name: String,
+
+        #[has_many]
+        posts: toasty::HasMany<Post>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Post {
+        #[key]
+        #[auto]
+        id: ID,
+        title: String,
+
+        #[index]
+        user_id: ID,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: toasty::BelongsTo<User>,
+    }
+
+    let mut db = t.setup_db(models!(User, Post)).await;
+
+    toasty::create!(User {
+        name: "Alice",
+        posts: [Post::create().title("alpha"), Post::create().title("beta"),],
+    })
+    .exec(&mut db)
+    .await?;
+
+    let posts_per_user: Vec<Vec<Post>> = User::all()
+        .select(User::fields().posts())
+        .exec(&mut db)
+        .await?;
+
+    assert_eq!(posts_per_user.len(), 1);
+    let mut titles: Vec<String> = posts_per_user[0].iter().map(|p| p.title.clone()).collect();
+    titles.sort();
+    assert_eq!(titles, vec!["alpha".to_string(), "beta".to_string()]);
+
+    Ok(())
+}
+
+#[driver_test(id(ID), requires(sql))]
+pub async fn select_has_many_with_filter(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+        name: String,
+
+        #[has_many]
+        posts: toasty::HasMany<Post>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Post {
+        #[key]
+        #[auto]
+        id: ID,
+        title: String,
+
+        #[index]
+        user_id: ID,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: toasty::BelongsTo<User>,
+    }
+
+    let mut db = t.setup_db(models!(User, Post)).await;
+
+    toasty::create!(User {
+        name: "Alice",
+        posts: [Post::create().title("alpha")],
+    })
+    .exec(&mut db)
+    .await?;
+    toasty::create!(User {
+        name: "Bob",
+        posts: [
+            Post::create().title("beta one"),
+            Post::create().title("beta two"),
+        ],
+    })
+    .exec(&mut db)
+    .await?;
+
+    let posts_per_user: Vec<Vec<Post>> = User::filter(User::fields().name().eq("Bob"))
+        .select(User::fields().posts())
+        .exec(&mut db)
+        .await?;
+
+    assert_eq!(posts_per_user.len(), 1);
+    let mut titles: Vec<String> = posts_per_user[0].iter().map(|p| p.title.clone()).collect();
+    titles.sort();
+    assert_eq!(titles, vec!["beta one".to_string(), "beta two".to_string()]);
+
+    Ok(())
+}
+
+#[driver_test(id(ID), requires(sql))]
+pub async fn select_has_many_first(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+        name: String,
+
+        #[has_many]
+        posts: toasty::HasMany<Post>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Post {
+        #[key]
+        #[auto]
+        id: ID,
+        title: String,
+
+        #[index]
+        user_id: ID,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: toasty::BelongsTo<User>,
+    }
+
+    let mut db = t.setup_db(models!(User, Post)).await;
+
+    toasty::create!(User {
+        name: "Alice",
+        posts: [Post::create().title("alpha"), Post::create().title("beta"),],
+    })
+    .exec(&mut db)
+    .await?;
+
+    let posts: Option<Vec<Post>> = User::filter(User::fields().name().eq("Alice"))
+        .select(User::fields().posts())
+        .first()
+        .exec(&mut db)
+        .await?;
+
+    let posts = posts.expect("first() returned None for a matching user");
+    let mut titles: Vec<String> = posts.iter().map(|p| p.title.clone()).collect();
+    titles.sort();
+    assert_eq!(titles, vec!["alpha".to_string(), "beta".to_string()]);
+
+    Ok(())
+}

--- a/crates/toasty-macros/src/model/expand/fields.rs
+++ b/crates/toasty-macros/src/model/expand/fields.rs
@@ -257,6 +257,16 @@ impl Expand<'_> {
                     self.path
                 }
             }
+
+            impl<__Origin> #toasty::IntoExpr<#toasty::List<#model_ident>> for #field_list_struct_ident<__Origin> {
+                fn into_expr(self) -> #toasty::stmt::Expr<#toasty::List<#model_ident>> {
+                    self.path.into_expr()
+                }
+
+                fn by_ref(&self) -> #toasty::stmt::Expr<#toasty::List<#model_ident>> {
+                    self.path.by_ref()
+                }
+            }
         )
     }
 


### PR DESCRIPTION
## Summary

`User::all().select(User::fields().posts())` returns `Vec<Vec<Post>>`: one inner list per user, populated via the same `build_relation_subquery` HasMany branch that `.include(...)` uses.  Adds `IntoExpr<List<TargetModel>>` for the macro-generated `*FieldList` struct so the field-list handle flows through `.select(...)` the same way the BelongsTo/HasOne `OneField` handle does (per #827, #884).

Three integration tests parameterized over `id(ID)` for both u64 and uuid::Uuid: basic projection, composition with `.filter`, and composition with `.first`.  Mirrors the BelongsTo coverage from #827.

## Type of change

<!-- Check one. -->

- [ ] Small / obvious change — bug fix, docs, internal cleanup, or test
- [X] Implements a previously accepted [design](https://github.com/tokio-rs/toasty/blob/main/docs/dev/design/column-projection.md)
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [X] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [X] `cargo fmt` and `cargo clippy` are clean
- [X] `cargo test` passes
- [ ] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [ ] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers

N/A
