### PR TITLE
fix: update sqlite URL in docs to one that works

### DIFF
--- a/docs/guide/src/database-setup.md
+++ b/docs/guide/src/database-setup.md
@@ -57,7 +57,7 @@ Examples:
 .connect("sqlite::memory:")
 
 // SQLite file
-.connect("sqlite://path/to/db.sqlite")
+.connect("sqlite:./path/to/db.sqlite")
 
 // PostgreSQL
 .connect("postgresql://user:pass@localhost:5432/mydb")


### PR DESCRIPTION
<!--
PR title uses Conventional Commits, e.g.
    feat: add upsert support
    fix: handle composite key in IN-list rewrite
See CONTRIBUTING.md for the full process.
-->

## Summary

Trying to connect to a database with the URL `sqlite://mydb.sqlite`, for example, doesn't work – it doesn't fail, but also doesn't create any database file (because `Url::parse("sqlite://mydb.sqlite")?.path()` is empty). One needs to connect to `sqlite:./mydb.sqlite`. Update the docs to reflect that.

## Type of change

<!-- Check one. -->

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test
- [ ] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`):
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] `cargo fmt` and `cargo clippy` are clean
- [ ] `cargo test` passes
- [ ] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [ ] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers

<!-- Anything reviewers should focus on. -->
