### PR TITLE
chore: rename query to filter

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_multi.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_multi.rs
@@ -108,14 +108,14 @@ pub async fn crud_user_todos_categories(test: &mut Test) -> Result<()> {
 
     let list = category
         .todos()
-        .query(Todo::fields().user().eq(&user))
+        .filter(Todo::fields().user().eq(&user))
         .exec(&mut db)
         .await?;
     check_todo_list(&mut db, &expect, list).await?;
 
     let list = user
         .todos()
-        .query(Todo::fields().category().eq(&category))
+        .filter(Todo::fields().category().eq(&category))
         .exec(&mut db)
         .await?;
     check_todo_list(&mut db, &expect, list).await?;

--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_scoped_query.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_scoped_query.rs
@@ -73,7 +73,7 @@ pub async fn scoped_query_eq(test: &mut Test) -> Result<()> {
     // Query todos scoped by user 1
     let todos = u1
         .todos()
-        .query(Todo::fields().order().eq(0))
+        .filter(Todo::fields().order().eq(0))
         .exec(&mut db)
         .await?;
 
@@ -85,7 +85,7 @@ pub async fn scoped_query_eq(test: &mut Test) -> Result<()> {
     // Querying todos scoped by user 2
     let todos = u2
         .todos()
-        .query(Todo::fields().order().eq(0))
+        .filter(Todo::fields().order().eq(0))
         .exec(&mut db)
         .await?;
 
@@ -106,7 +106,7 @@ pub async fn scoped_query_eq(test: &mut Test) -> Result<()> {
     // Query for order 0 todos again
     let todos = u1
         .todos()
-        .query(Todo::fields().order().eq(0))
+        .filter(Todo::fields().order().eq(0))
         .exec(&mut db)
         .await?;
 
@@ -121,7 +121,7 @@ pub async fn scoped_query_eq(test: &mut Test) -> Result<()> {
     // Query for non-existent TODOs
     let todos = u2
         .todos()
-        .query(Todo::fields().order().eq(1))
+        .filter(Todo::fields().order().eq(1))
         .exec(&mut db)
         .await?;
 
@@ -177,7 +177,7 @@ pub async fn scoped_query_gt(test: &mut Test) -> Result<()> {
     // Find all != 2
     let todos: Vec<_> = user
         .todos()
-        .query(Todo::fields().order().ne(2))
+        .filter(Todo::fields().order().ne(2))
         .exec(&mut db)
         .await?;
 
@@ -193,7 +193,7 @@ pub async fn scoped_query_gt(test: &mut Test) -> Result<()> {
     // Find all greater than 2
     let todos: Vec<_> = user
         .todos()
-        .query(Todo::fields().order().gt(2))
+        .filter(Todo::fields().order().gt(2))
         .exec(&mut db)
         .await?;
 
@@ -205,7 +205,7 @@ pub async fn scoped_query_gt(test: &mut Test) -> Result<()> {
     // Find all greater than or equal to 2
     let todos: Vec<_> = user
         .todos()
-        .query(Todo::fields().order().ge(2))
+        .filter(Todo::fields().order().ge(2))
         .exec(&mut db)
         .await?;
 
@@ -217,7 +217,7 @@ pub async fn scoped_query_gt(test: &mut Test) -> Result<()> {
     // Find all less than to 2
     let todos: Vec<_> = user
         .todos()
-        .query(Todo::fields().order().lt(2))
+        .filter(Todo::fields().order().lt(2))
         .exec(&mut db)
         .await?;
 
@@ -229,7 +229,7 @@ pub async fn scoped_query_gt(test: &mut Test) -> Result<()> {
     // Find all less than or equal to 2
     let todos: Vec<_> = user
         .todos()
-        .query(Todo::fields().order().le(2))
+        .filter(Todo::fields().order().le(2))
         .exec(&mut db)
         .await?;
 

--- a/crates/toasty-macros/src/model/expand/relation.rs
+++ b/crates/toasty-macros/src/model/expand/relation.rs
@@ -42,7 +42,7 @@ impl Expand<'_> {
                     self.into_statement().exec(executor).await
                 }
 
-                #vis fn query(
+                #vis fn filter(
                     self,
                     filter: #toasty::stmt::Expr<bool>
                 ) -> #query_ident {

--- a/docs/guide/src/has-many.md
+++ b/docs/guide/src/has-many.md
@@ -223,13 +223,13 @@ database with a null foreign key.
 The relation accessor supports scoped queries — filtering, updating, and
 deleting within the parent's children.
 
-### Filtering with `.query()`
+### Filtering with `.filter()`
 
 ```rust,ignore
 // Find posts with a specific condition
 let drafts = user
     .posts()
-    .query(Post::fields().published().eq(false))
+    .filter(Post::fields().published().eq(false))
     .exec(&mut db)
     .await?;
 ```
@@ -292,7 +292,7 @@ For a `User` model with `#[has_many] posts: HasMany<Post>`, Toasty generates:
 | `.exec(&mut db)` | `Result<Vec<Post>>` | All posts belonging to this user |
 | `.create()` | Create builder | Create a post with the foreign key pre-filled |
 | `.get_by_id(&mut db, &id)` | `Result<Post>` | Get a post by ID within the scope |
-| `.query(expr)` | Query builder | Filter posts within the scope |
+| `.filter(expr)` | Query builder | Filter posts within the scope |
 | `.insert(&mut db, &post)` | `Result<()>` | Associate an existing post with the user |
 | `.remove(&mut db, &post)` | `Result<()>` | Disassociate a post from the user |
 

--- a/examples/composite-key/src/main.rs
+++ b/examples/composite-key/src/main.rs
@@ -70,7 +70,7 @@ async fn main() -> toasty::Result<()> {
 
     let todos = user
         .todos()
-        .query(Todo::fields().order().eq(1))
+        .filter(Todo::fields().order().eq(1))
         .exec(&mut db)
         .await?;
 


### PR DESCRIPTION
## Summary
It bothered me that the method to add a filter to queries for associations is called `query` so in this pr I renamed it to `filter`. This makes it more consistent with the rest of the api.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers
None
