### PR TITLE
fix: make multiple order_by exprs additive

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/crud_sort_limit.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/crud_sort_limit.rs
@@ -264,6 +264,34 @@ pub async fn first_narrows_to_single_row(t: &mut Test) -> Result<()> {
     Ok(())
 }
 
+#[driver_test(id(ID), scenario(crate::scenarios::user_with_age), requires(sql))]
+pub async fn order_by_multiple_columns_composes(t: &mut Test) -> Result<()> {
+    let mut db = setup(t).await;
+
+    toasty::create!(User::[
+        { name: "Alice", age: 30 },
+        { name: "Carol", age: 20 },
+        { name: "Bob",   age: 30 },
+        { name: "Dave",  age: 20 },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    // Regression for https://github.com/tokio-rs/toasty/issues/803:
+    // chained `.order_by()` calls must compose into a multi-key sort instead
+    // of the later call silently overwriting the earlier one.
+    let users = User::all()
+        .order_by(User::fields().age().asc())
+        .order_by(User::fields().name().desc())
+        .exec(&mut db)
+        .await?;
+
+    let names: Vec<&str> = users.iter().map(|u| u.name.as_str()).collect();
+    assert_eq!(names, ["Dave", "Carol", "Bob", "Alice"]);
+
+    Ok(())
+}
+
 #[driver_test(requires(not(sql)))]
 pub async fn paginate_for_dynamodb(test: &mut Test) -> Result<()> {
     #[derive(toasty::Model)]

--- a/crates/toasty/src/stmt/query.rs
+++ b/crates/toasty/src/stmt/query.rs
@@ -150,10 +150,12 @@ impl<T> Query<T> {
         self
     }
 
-    /// Set the sort order for this query.
+    /// Add a sort order to this query.
     ///
     /// Pass an [`OrderByExpr`](toasty_core::stmt::OrderByExpr) obtained from
-    /// [`Path::asc`] or [`Path::desc`]:
+    /// [`Path::asc`] or [`Path::desc`]. Calling `order_by` multiple times
+    /// appends each expression to the existing order, so later calls act as
+    /// tie-breakers for earlier ones.
     ///
     /// # Examples
     ///
@@ -170,7 +172,11 @@ impl<T> Query<T> {
     /// q.order_by(User::fields().name().desc());
     /// ```
     pub fn order_by(&mut self, order_by: impl Into<stmt::OrderBy>) -> &mut Self {
-        self.untyped.order_by = Some(order_by.into());
+        let order_by = order_by.into();
+        match &mut self.untyped.order_by {
+            Some(existing) => existing.exprs.extend(order_by.exprs),
+            None => self.untyped.order_by = Some(order_by),
+        }
         self
     }
 


### PR DESCRIPTION
## Summary
This pr makes chaining multiple `order_by` calls additive. This is similar to how `filter` works and fixes the open issue (#803).

 We should probably also support ordering based on multiple fields with something like:
```rust
User::all()
  .order_by((User::fields().age().asc(), User::fields().name().desc()))
```
But I'll open a separate pr for this. 

fixes #803

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers
None
