### PR TITLE
feat: order by multiple fields

### DIFF
--- a/crates/toasty-core/src/stmt/order_by.rs
+++ b/crates/toasty-core/src/stmt/order_by.rs
@@ -34,3 +34,93 @@ impl From<OrderByExpr> for OrderBy {
         Self { exprs: vec![value] }
     }
 }
+
+macro_rules! impl_for_tuple {
+    ( $(($T:ident, $idx:tt)),+ ) => {
+        impl<$($T),+> From<($($T,)+)> for OrderBy
+        where
+            $($T: Into<OrderByExpr>,)+
+        {
+            fn from(src: ($($T,)+)) -> Self {
+                Self {
+                    exprs: vec![$(src.$idx.into()),+],
+                }
+            }
+        }
+    };
+}
+
+impl_for_tuple!((T0, 0), (T1, 1));
+impl_for_tuple!((T0, 0), (T1, 1), (T2, 2));
+impl_for_tuple!((T0, 0), (T1, 1), (T2, 2), (T3, 3));
+impl_for_tuple!((T0, 0), (T1, 1), (T2, 2), (T3, 3), (T4, 4));
+impl_for_tuple!((T0, 0), (T1, 1), (T2, 2), (T3, 3), (T4, 4), (T5, 5));
+impl_for_tuple!(
+    (T0, 0),
+    (T1, 1),
+    (T2, 2),
+    (T3, 3),
+    (T4, 4),
+    (T5, 5),
+    (T6, 6)
+);
+impl_for_tuple!(
+    (T0, 0),
+    (T1, 1),
+    (T2, 2),
+    (T3, 3),
+    (T4, 4),
+    (T5, 5),
+    (T6, 6),
+    (T7, 7)
+);
+impl_for_tuple!(
+    (T0, 0),
+    (T1, 1),
+    (T2, 2),
+    (T3, 3),
+    (T4, 4),
+    (T5, 5),
+    (T6, 6),
+    (T7, 7),
+    (T8, 8)
+);
+impl_for_tuple!(
+    (T0, 0),
+    (T1, 1),
+    (T2, 2),
+    (T3, 3),
+    (T4, 4),
+    (T5, 5),
+    (T6, 6),
+    (T7, 7),
+    (T8, 8),
+    (T9, 9)
+);
+impl_for_tuple!(
+    (T0, 0),
+    (T1, 1),
+    (T2, 2),
+    (T3, 3),
+    (T4, 4),
+    (T5, 5),
+    (T6, 6),
+    (T7, 7),
+    (T8, 8),
+    (T9, 9),
+    (T10, 10)
+);
+impl_for_tuple!(
+    (T0, 0),
+    (T1, 1),
+    (T2, 2),
+    (T3, 3),
+    (T4, 4),
+    (T5, 5),
+    (T6, 6),
+    (T7, 7),
+    (T8, 8),
+    (T9, 9),
+    (T10, 10),
+    (T11, 11)
+);

--- a/crates/toasty-driver-integration-suite/src/tests/crud_sort_limit.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/crud_sort_limit.rs
@@ -292,6 +292,32 @@ pub async fn order_by_multiple_columns_composes(t: &mut Test) -> Result<()> {
     Ok(())
 }
 
+#[driver_test(id(ID), scenario(crate::scenarios::user_with_age), requires(sql))]
+pub async fn order_by_tuple(t: &mut Test) -> Result<()> {
+    let mut db = setup(t).await;
+
+    toasty::create!(User::[
+        { name: "Alice", age: 30 },
+        { name: "Carol", age: 20 },
+        { name: "Bob",   age: 30 },
+        { name: "Dave",  age: 20 },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    // A tuple of OrderByExpr sorts by each field in turn, equivalent to
+    // chaining `.order_by()` calls.
+    let users = User::all()
+        .order_by((User::fields().age().asc(), User::fields().name().desc()))
+        .exec(&mut db)
+        .await?;
+
+    let names: Vec<&str> = users.iter().map(|u| u.name.as_str()).collect();
+    assert_eq!(names, ["Dave", "Carol", "Bob", "Alice"]);
+
+    Ok(())
+}
+
 #[driver_test(requires(not(sql)))]
 pub async fn paginate_for_dynamodb(test: &mut Test) -> Result<()> {
     #[derive(toasty::Model)]

--- a/crates/toasty-driver-integration-suite/src/tests/crud_sort_limit.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/crud_sort_limit.rs
@@ -264,6 +264,34 @@ pub async fn first_narrows_to_single_row(t: &mut Test) -> Result<()> {
     Ok(())
 }
 
+#[driver_test(id(ID), scenario(crate::scenarios::user_with_age), requires(sql))]
+pub async fn order_by_multiple_columns_composes(t: &mut Test) -> Result<()> {
+    let mut db = setup(t).await;
+
+    toasty::create!(User::[
+        { name: "Alice", age: 30 },
+        { name: "Carol", age: 20 },
+        { name: "Bob",   age: 30 },
+        { name: "Dave",  age: 20 },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    // Regression for https://github.com/tokio-rs/toasty/issues/803:
+    // chained `.order_by()` calls must compose into a multi-key sort instead
+    // of the later call silently overwriting the earlier one.
+    let users = User::all()
+        .order_by(User::fields().age().asc())
+        .order_by(User::fields().name().desc())
+        .exec(&mut db)
+        .await?;
+
+    let names: Vec<&str> = users.iter().map(|u| u.name.as_str()).collect();
+    assert_eq!(names, ["Dave", "Carol", "Bob", "Alice"]);
+
+    Ok(())
+}
+
 #[driver_test(requires(not(sql)))]
 pub async fn paginate_for_dynamodb(test: &mut Test) -> Result<()> {
     #[derive(toasty::Model)]

--- a/crates/toasty/src/stmt/query.rs
+++ b/crates/toasty/src/stmt/query.rs
@@ -150,10 +150,12 @@ impl<T> Query<T> {
         self
     }
 
-    /// Set the sort order for this query.
+    /// Add a sort order to this query.
     ///
     /// Pass an [`OrderByExpr`](toasty_core::stmt::OrderByExpr) obtained from
-    /// [`Path::asc`] or [`Path::desc`]:
+    /// [`Path::asc`] or [`Path::desc`]. Calling `order_by` multiple times
+    /// appends each expression to the existing order, so later calls act as
+    /// tie-breakers for earlier ones.
     ///
     /// # Examples
     ///
@@ -170,7 +172,11 @@ impl<T> Query<T> {
     /// q.order_by(User::fields().name().desc());
     /// ```
     pub fn order_by(&mut self, order_by: impl Into<stmt::OrderBy>) -> &mut Self {
-        self.untyped.order_by = Some(order_by.into());
+        let order_by = order_by.into();
+        match &mut self.untyped.order_by {
+            Some(existing) => existing.exprs.extend(order_by.exprs),
+            None => self.untyped.order_by = Some(order_by),
+        }
         self
     }
 

--- a/crates/toasty/src/stmt/query.rs
+++ b/crates/toasty/src/stmt/query.rs
@@ -153,9 +153,10 @@ impl<T> Query<T> {
     /// Add a sort order to this query.
     ///
     /// Pass an [`OrderByExpr`](toasty_core::stmt::OrderByExpr) obtained from
-    /// [`Path::asc`] or [`Path::desc`]. Calling `order_by` multiple times
-    /// appends each expression to the existing order, so later calls act as
-    /// tie-breakers for earlier ones.
+    /// [`Path::asc`] or [`Path::desc`], or a tuple of them to sort by several
+    /// fields at once. Calling `order_by` multiple times appends each
+    /// expression to the existing order, so later calls act as tie-breakers
+    /// for earlier ones.
     ///
     /// # Examples
     ///
@@ -165,11 +166,12 @@ impl<T> Query<T> {
     /// #     #[key]
     /// #     id: i64,
     /// #     name: String,
+    /// #     age: i64,
     /// # }
     /// use toasty::stmt::{List, Query};
     ///
     /// let mut q = Query::<List<User>>::all();
-    /// q.order_by(User::fields().name().desc());
+    /// q.order_by((User::fields().age().desc(), User::fields().name().asc()));
     /// ```
     pub fn order_by(&mut self, order_by: impl Into<stmt::OrderBy>) -> &mut Self {
         let order_by = order_by.into();


### PR DESCRIPTION
## Summary
This pr adds support for ordering by multiple fields.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers
This should be merged after #899.
