### PR TITLE
fix: improve composite-key belongs_to syntax and diagnostics

### DIFF
--- a/crates/toasty-core/src/schema/verify.rs
+++ b/crates/toasty-core/src/schema/verify.rs
@@ -28,7 +28,7 @@ impl Verify<'_> {
                 continue;
             };
             for field in &root.fields {
-                self.verify_relations_are_indexed(field);
+                self.verify_relations_are_indexed(model, field)?;
                 self.verify_auto_field_type(field);
             }
         }

--- a/crates/toasty-core/src/schema/verify/relations_are_indexed.rs
+++ b/crates/toasty-core/src/schema/verify/relations_are_indexed.rs
@@ -1,39 +1,66 @@
 use super::Verify;
-use crate::schema::app::{self, Field, FieldId, Model};
+use crate::schema::app::{self, Field, FieldId, Model, ModelRoot};
+use crate::{Error, Result};
+
+/// Returns `true` if `model` declares a single-column non-primary-key index
+/// covering exactly `field`.
+fn has_single_field_index(model: &ModelRoot, field: FieldId) -> bool {
+    model.indices.iter().any(|index| {
+        !index.primary_key && index.fields.len() == 1 && index.fields[0].field == field
+    })
+}
 
 impl Verify<'_> {
     // Iterate each model and make sure there is an index path that enables
     // querying
-    pub(super) fn verify_relations_are_indexed(&self, field: &Field) {
+    pub(super) fn verify_relations_are_indexed(&self, owner: &Model, field: &Field) -> Result<()> {
         use app::FieldTy;
 
         match &field.ty {
             FieldTy::BelongsTo(rel) => self.verify_belongs_to_is_indexed(rel),
-            FieldTy::HasMany(rel) => self.verify_has_many_relation_is_indexed(rel),
-            FieldTy::HasOne(rel) => self.verify_has_one_relation_is_indexed(rel),
-            _ => {}
+            FieldTy::HasMany(rel) => self.verify_has_many_relation_is_indexed(owner, field, rel),
+            FieldTy::HasOne(rel) => self.verify_has_one_relation_is_indexed(owner, field, rel),
+            _ => Ok(()),
         }
     }
 
-    fn verify_belongs_to_is_indexed(&self, _: &app::BelongsTo) {
+    fn verify_belongs_to_is_indexed(&self, _: &app::BelongsTo) -> Result<()> {
         // TODO: Is there any necessary verification here?
+        Ok(())
     }
 
-    fn verify_has_many_relation_is_indexed(&self, rel: &app::HasMany) {
-        self.verify_has_relation_is_indexed(rel.target(&self.schema.app), rel.pair);
+    fn verify_has_many_relation_is_indexed(
+        &self,
+        owner: &Model,
+        field: &Field,
+        rel: &app::HasMany,
+    ) -> Result<()> {
+        self.verify_has_relation_is_indexed(owner, field, rel.target(&self.schema.app), rel.pair)
     }
 
-    fn verify_has_one_relation_is_indexed(&self, rel: &app::HasOne) {
-        self.verify_has_relation_is_indexed(rel.target(&self.schema.app), rel.pair);
+    fn verify_has_one_relation_is_indexed(
+        &self,
+        owner: &Model,
+        field: &Field,
+        rel: &app::HasOne,
+    ) -> Result<()> {
+        self.verify_has_relation_is_indexed(owner, field, rel.target(&self.schema.app), rel.pair)
     }
 
-    fn verify_has_relation_is_indexed(&self, target: &Model, pair: FieldId) {
+    fn verify_has_relation_is_indexed(
+        &self,
+        owner: &Model,
+        field: &Field,
+        target: &Model,
+        pair: FieldId,
+    ) -> Result<()> {
         let belongs_to = self.schema.app.field(pair).ty.as_belongs_to_unwrap();
+        let target_root = target.as_root_unwrap();
 
         // Find an index that starts with the relations pair field and either
         // has no more fields or the next field is of local scope. This ensures
         // the ability to query all associated models.
-        'outer: for index in &target.as_root_unwrap().indices {
+        'outer: for index in &target_root.indices {
             assert!(!index.fields.is_empty());
 
             if index.fields.len() < belongs_to.foreign_key.fields.len() {
@@ -49,7 +76,7 @@ impl Verify<'_> {
             // The first index field matches the foreign key. If there are no
             // more index fields, then the index is an exact match.
             if index.fields.len() == belongs_to.foreign_key.fields.len() {
-                return;
+                return Ok(());
             }
 
             // If the next field is of local scope, then the index can be used.
@@ -57,12 +84,62 @@ impl Verify<'_> {
                 .scope
                 .is_local()
             {
-                return;
+                return Ok(());
             }
 
             // The index is not a match
         }
 
-        panic!("failed to find relation index");
+        // No covering index was found. Build a message that names the offending
+        // relation and suggests what the user needs to add.
+        let owner_name = &owner.name();
+        let target_name = &target_root.name;
+        let rel_field = &field.name;
+        let pair_field = &self.schema.app.field(pair).name;
+
+        let fk_field_names = belongs_to
+            .foreign_key
+            .fields
+            .iter()
+            .map(|fk| self.schema.app.field(fk.source).name.to_string())
+            .collect::<Vec<_>>();
+
+        let hint = if fk_field_names.len() == 1 {
+            format!(
+                "add `#[index]` to field `{}` on model `{}`",
+                fk_field_names[0], target_name,
+            )
+        } else if belongs_to
+            .foreign_key
+            .fields
+            .iter()
+            .all(|fk| has_single_field_index(target_root, fk.source))
+        {
+            // Each FK field has its own single-column index. Two single-column
+            // indexes don't compose into a covering index for a composite
+            // foreign key — the user must replace them with a composite index.
+            format!(
+                "each foreign-key field already has its own `#[index]`, but a \
+                 composite foreign key needs a single covering index. Replace \
+                 the per-field `#[index]` annotations with a model-level \
+                 `#[index({})]` on `{}`",
+                fk_field_names.join(", "),
+                target_name,
+            )
+        } else {
+            format!(
+                "add `#[index({})]` to model `{}`",
+                fk_field_names.join(", "),
+                target_name,
+            )
+        };
+
+        Err(Error::invalid_schema(format!(
+            "relation `{owner_name}::{rel_field}` cannot be queried: \
+             no index on `{target_name}` covers the foreign key \
+             declared by `{target_name}::{pair_field}` (fields: {}). \
+             Hint: {hint}.",
+            fk_field_names.join(", "),
+        )))
     }
 }

--- a/crates/toasty-core/src/schema/verify/relations_are_indexed.rs
+++ b/crates/toasty-core/src/schema/verify/relations_are_indexed.rs
@@ -90,9 +90,20 @@ impl Verify<'_> {
             // The index is not a match
         }
 
-        // No covering index was found. Build a message that names the offending
-        // relation and suggests what the user needs to add.
-        let owner_name = &owner.name();
+        Err(self.missing_relation_index_error(owner, field, target_root, pair, belongs_to))
+    }
+
+    /// Build a helpful `invalid_schema` error explaining that no covering
+    /// index exists for `belongs_to` and suggesting how to add one.
+    fn missing_relation_index_error(
+        &self,
+        owner: &Model,
+        field: &Field,
+        target_root: &ModelRoot,
+        pair: FieldId,
+        belongs_to: &app::BelongsTo,
+    ) -> Error {
+        let owner_name = owner.name();
         let target_name = &target_root.name;
         let rel_field = &field.name;
         let pair_field = &self.schema.app.field(pair).name;
@@ -134,12 +145,12 @@ impl Verify<'_> {
             )
         };
 
-        Err(Error::invalid_schema(format!(
+        Error::invalid_schema(format!(
             "relation `{owner_name}::{rel_field}` cannot be queried: \
              no index on `{target_name}` covers the foreign key \
              declared by `{target_name}::{pair_field}` (fields: {}). \
              Hint: {hint}.",
             fk_field_names.join(", "),
-        )))
+        ))
     }
 }

--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -61,6 +61,7 @@ pub mod relation_belongs_to_self_referential;
 pub mod relation_filter_association;
 pub mod relation_has_many_batch_create;
 pub mod relation_has_many_boxed_fk;
+pub mod relation_has_many_composite_key;
 pub mod relation_has_many_crud;
 pub mod relation_has_many_filter;
 pub mod relation_has_many_link_unlink;

--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs
@@ -1,0 +1,67 @@
+//! Regression tests for `has_many` / `belongs_to` relationships whose
+//! foreign key spans multiple columns.
+//!
+//! See: https://github.com/tokio-rs/toasty/discussions/904
+
+use crate::prelude::*;
+
+/// When a composite-key `belongs_to` has no covering index on the parent
+/// side, schema verification must return a helpful invalid-schema error
+/// rather than panicking with `failed to find relation index`.
+#[driver_test]
+pub async fn composite_belongs_to_missing_index_is_error(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    #[key(id, revision)]
+    struct Parent {
+        id: String,
+        revision: i64,
+
+        #[has_many]
+        children: toasty::HasMany<Child>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Child {
+        #[key]
+        id: String,
+
+        // Two field-level `#[index]` annotations create two separate
+        // single-column indexes — neither covers the composite foreign key.
+        #[index]
+        parent_id: String,
+        #[index]
+        parent_revision: i64,
+
+        #[belongs_to(key = [parent_id, parent_revision], references = [id, revision])]
+        parent: toasty::BelongsTo<Parent>,
+    }
+
+    let err = test
+        .try_setup_db(models!(Parent, Child))
+        .await
+        .expect_err("schema verification should reject this layout");
+
+    assert!(
+        err.is_invalid_schema(),
+        "expected invalid_schema error, got: {err}",
+    );
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("parent_id") && msg.contains("parent_revision"),
+        "error should mention the foreign-key fields, got: {msg}",
+    );
+    assert!(
+        msg.contains("#[index(parent_id, parent_revision)]"),
+        "error should suggest adding a composite index, got: {msg}",
+    );
+    // Both FK fields are individually `#[index]`-annotated, so the verifier
+    // should detect that and explain why two single-column indexes don't
+    // satisfy a composite foreign key.
+    assert!(
+        msg.contains("each foreign-key field already has its own `#[index]`"),
+        "error should call out the per-field `#[index]` annotations, got: {msg}",
+    );
+
+    Ok(())
+}

--- a/crates/toasty-macros/src/lib.rs
+++ b/crates/toasty-macros/src/lib.rs
@@ -365,15 +365,14 @@ use proc_macro::TokenStream;
 /// | `key = <field>` | Local field holding the foreign key value |
 /// | `references = <field>` | Field on the target model being referenced |
 ///
-/// For composite foreign keys, repeat `key`/`references` pairs:
+/// For composite foreign keys, pass arrays to `key` and `references`:
 ///
 /// ```
 /// # use toasty::Model;
 /// # #[derive(Model)]
+/// # #[key(id, tenant_id)]
 /// # struct Org {
-/// #     #[key]
 /// #     id: i64,
-/// #     #[key]
 /// #     tenant_id: i64,
 /// # }
 /// # #[derive(Model)]
@@ -383,13 +382,13 @@ use proc_macro::TokenStream;
 /// #     id: i64,
 /// #     org_id: i64,
 /// #     tenant_id: i64,
-/// #[belongs_to(key = org_id, references = id, key = tenant_id, references = tenant_id)]
+/// #[belongs_to(key = [org_id, tenant_id], references = [id, tenant_id])]
 /// org: toasty::BelongsTo<Org>,
 /// # }
 /// ```
 ///
-/// The number of `key` entries must equal the number of `references`
-/// entries.
+/// The number of fields in `key` must equal the number of fields in
+/// `references`.
 ///
 /// Wrap the target type in `Option` for an optional (nullable) foreign key:
 ///

--- a/crates/toasty-macros/src/model/schema/belongs_to.rs
+++ b/crates/toasty-macros/src/model/schema/belongs_to.rs
@@ -15,45 +15,58 @@ impl BelongsTo {
         ty: &syn::Type,
         names: &[syn::Ident],
     ) -> syn::Result<Self> {
-        let mut fk_sources: Vec<syn::Ident> = vec![];
-        let mut fk_targets: Vec<syn::Ident> = vec![];
-        let mut foreign_key = vec![];
+        let mut fk_sources: Option<Vec<syn::Ident>> = None;
+        let mut fk_targets: Option<Vec<syn::Ident>> = None;
 
         attr.parse_nested_meta(|meta| {
             if meta.path.is_ident("key") {
-                let value = meta.value()?;
-                fk_sources.push(value.parse()?);
+                if fk_sources.is_some() {
+                    return Err(meta.error(
+                        "`key` specified more than once; use `key = [a, b]` for composite foreign keys",
+                    ));
+                }
+                fk_sources = Some(parse_idents(&meta)?);
+                Ok(())
             } else if meta.path.is_ident("references") {
-                let value = meta.value()?;
-                fk_targets.push(value.parse()?);
+                if fk_targets.is_some() {
+                    return Err(meta.error(
+                        "`references` specified more than once; use `references = [a, b]` for composite foreign keys",
+                    ));
+                }
+                fk_targets = Some(parse_idents(&meta)?);
+                Ok(())
             } else {
-                return Err(syn::Error::new_spanned(
-                    &meta.path,
-                    "expected `key` or `references`",
-                ));
+                Err(meta.error("expected `key` or `references`"))
             }
-
-            Ok(())
         })?;
+
+        let fk_sources = fk_sources
+            .ok_or_else(|| syn::Error::new_spanned(attr, "missing `key = ...` attribute"))?;
+        let fk_targets = fk_targets
+            .ok_or_else(|| syn::Error::new_spanned(attr, "missing `references = ...` attribute"))?;
+
+        if fk_sources.is_empty() || fk_targets.is_empty() {
+            return Err(syn::Error::new_spanned(
+                attr,
+                "`key` and `references` must each name at least one field",
+            ));
+        }
 
         if fk_sources.len() != fk_targets.len() {
             return Err(syn::Error::new_spanned(
                 attr,
-                "number of `key` and `references` attributes must match",
+                format!(
+                    "`key` has {} field(s) but `references` has {} field(s); they must match",
+                    fk_sources.len(),
+                    fk_targets.len(),
+                ),
             ));
         }
 
-        if fk_sources.is_empty() {
-            return Err(syn::Error::new_spanned(
-                attr,
-                "expected at least one `key` and `references` attribute",
-            ));
-        }
+        let mut foreign_key = vec![];
 
-        let parts = fk_sources.into_iter().zip(fk_targets);
-
-        for (source, target) in parts {
-            let source = names
+        for (source, target) in fk_sources.into_iter().zip(fk_targets) {
+            let source_idx = names
                 .iter()
                 .position(|name| name == &source)
                 .ok_or_else(|| {
@@ -63,19 +76,29 @@ impl BelongsTo {
                     )
                 })?;
 
-            foreign_key.push(ForeignKeyField { source, target });
+            foreign_key.push(ForeignKeyField {
+                source: source_idx,
+                target,
+            });
         }
-
-        // let syn::Meta::List(list) = &attr.meta else {
-        //     return Err(syn::Error::new_spanned(
-        //         &attr.meta,
-        //         "expected #[relation(key = <field>, references = <field>)]",
-        //     ));
-        // };
 
         Ok(Self {
             ty: ty.clone(),
             foreign_key,
         })
+    }
+}
+
+fn parse_idents(meta: &syn::meta::ParseNestedMeta<'_>) -> syn::Result<Vec<syn::Ident>> {
+    let value = meta.value()?;
+
+    if value.peek(syn::token::Bracket) {
+        let content;
+        syn::bracketed!(content in value);
+        let punctuated =
+            syn::punctuated::Punctuated::<syn::Ident, syn::Token![,]>::parse_terminated(&content)?;
+        Ok(punctuated.into_iter().collect())
+    } else {
+        Ok(vec![value.parse::<syn::Ident>()?])
     }
 }

--- a/tests/tests/ui/belongs_to_repeated_key_flat_form.rs
+++ b/tests/tests/ui/belongs_to_repeated_key_flat_form.rs
@@ -1,0 +1,28 @@
+// The legacy flat form `key = a, references = b, key = c, references = d` is
+// ambiguous for composite foreign keys. The macro must reject it and tell the
+// user to switch to the bracketed list form.
+
+#[derive(toasty::Model)]
+#[key(id, revision)]
+struct Parent {
+    id: uuid::Uuid,
+    revision: i64,
+}
+
+#[derive(toasty::Model)]
+struct Child {
+    #[key]
+    #[auto]
+    id: uuid::Uuid,
+
+    parent_id: uuid::Uuid,
+    parent_revision: i64,
+
+    #[belongs_to(
+        key = parent_id, references = id,
+        key = parent_revision, references = revision,
+    )]
+    parent: toasty::BelongsTo<Parent>,
+}
+
+fn main() {}

--- a/tests/tests/ui/belongs_to_repeated_key_flat_form.stderr
+++ b/tests/tests/ui/belongs_to_repeated_key_flat_form.stderr
@@ -1,0 +1,5 @@
+error: `key` specified more than once; use `key = [a, b]` for composite foreign keys
+  --> tests/ui/belongs_to_repeated_key_flat_form.rs:23:9
+   |
+23 |         key = parent_revision, references = revision,
+   |         ^^^


### PR DESCRIPTION
## Summary

Reported in [#904]: declaring `#[has_many]` on a model with a composite
primary key panics with `failed to find relation index`. Two underlying
issues:

- The flat `key = a, references = b, key = c, references = d` form for
  composite foreign keys is ambiguous.
- The schema verifier panics when no covering index exists for a
  relation, with no hint about how to fix it.

This PR:

- Switches `#[belongs_to]` to `key = [..], references = [..]` for
  composite keys; the repeated flat form is rejected with an error
  pointing at the new syntax.
- Replaces the verifier panic with an `invalid_schema` error that
  names the relation and FK fields, and suggests the right `#[index]`
  annotation. When each FK field already has its own `#[index]`, the
  message explicitly explains that single-column indexes don't compose
  and suggests the model-level composite form.
- Adds an integration test covering the composite-FK error path and a
  trybuild UI test pinning the rejection message for the flat form.

Composite-key relations still hit `todo!` paths in the planner; that's
out of scope for this PR.

Refs [#904].

[#904]: https://github.com/tokio-rs/toasty/discussions/904

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

This is a breaking change for the (likely-rare) users of the flat
composite-key syntax. Documented in the commit footer.