### PR TITLE
fix(engine): handle composite keys in eq-operand rewrite

### DIFF
--- a/crates/toasty-core/src/stmt/entry.rs
+++ b/crates/toasty-core/src/stmt/entry.rs
@@ -141,6 +141,18 @@ impl Entry<'_> {
         )
     }
 
+    /// Returns `true` if this entry holds a record, either as an
+    /// `Expr::Record`, an `Expr::Value(Value::Record)`, or a bare
+    /// `Value::Record`.
+    pub fn is_record(&self) -> bool {
+        match self {
+            Entry::Expr(Expr::Record(_)) => true,
+            Entry::Expr(Expr::Value(value)) => value.is_record(),
+            Entry::Value(value) => value.is_record(),
+            Entry::Expr(_) => false,
+        }
+    }
+
     /// Returns a reference to the contained value, or `None` if this entry
     /// holds a non-value expression.
     pub fn as_value(&self) -> Option<&Value> {

--- a/crates/toasty-core/src/stmt/entry_mut.rs
+++ b/crates/toasty-core/src/stmt/entry_mut.rs
@@ -87,6 +87,18 @@ impl EntryMut<'_> {
         )
     }
 
+    /// Returns `true` if this entry holds a record, either as an
+    /// `Expr::Record`, an `Expr::Value(Value::Record)`, or a bare
+    /// `Value::Record`.
+    pub fn is_record(&self) -> bool {
+        match self {
+            EntryMut::Expr(Expr::Record(_)) => true,
+            EntryMut::Expr(Expr::Value(value)) => value.is_record(),
+            EntryMut::Value(value) => value.is_record(),
+            EntryMut::Expr(_) => false,
+        }
+    }
+
     /// Returns `true` if this entry is `Expr::Default`.
     pub fn is_default(&self) -> bool {
         matches!(self, EntryMut::Expr(Expr::Default))

--- a/crates/toasty-driver-integration-suite/src/scenarios.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios.rs
@@ -1,3 +1,4 @@
+pub mod composite_has_many_belongs_to;
 pub mod deferred_document;
 pub mod deferred_optional_document;
 pub mod has_many_belongs_to;

--- a/crates/toasty-driver-integration-suite/src/scenarios.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios.rs
@@ -1,3 +1,4 @@
+pub mod composite_fk_has_many_belongs_to;
 pub mod composite_has_many_belongs_to;
 pub mod deferred_document;
 pub mod deferred_optional_document;

--- a/crates/toasty-driver-integration-suite/src/scenarios/composite_fk_has_many_belongs_to.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios/composite_fk_has_many_belongs_to.rs
@@ -1,0 +1,37 @@
+use crate::prelude::*;
+
+scenario! {
+    #[derive(Debug, toasty::Model)]
+    #[key(id, revision)]
+    struct User {
+        #[auto]
+        id: uuid::Uuid,
+
+        revision: i64,
+
+        name: String,
+
+        #[has_many]
+        todos: toasty::HasMany<Todo>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    #[index(user_id, user_revision)]
+    struct Todo {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+
+        user_id: uuid::Uuid,
+        user_revision: i64,
+
+        #[belongs_to(key = [user_id, user_revision], references = [id, revision])]
+        user: toasty::BelongsTo<User>,
+
+        title: String,
+    }
+
+    async fn setup(test: &mut Test) -> toasty::Db {
+        test.setup_db(models!(User, Todo)).await
+    }
+}

--- a/crates/toasty-driver-integration-suite/src/scenarios/composite_has_many_belongs_to.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios/composite_has_many_belongs_to.rs
@@ -1,0 +1,37 @@
+use crate::prelude::*;
+
+scenario! {
+    #![id(ID)]
+
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+
+        #[index]
+        name: String,
+
+        #[has_many]
+        todos: toasty::HasMany<Todo>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    #[key(partition = user_id, local = id)]
+    struct Todo {
+        #[auto]
+        id: uuid::Uuid,
+
+        user_id: ID,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: toasty::BelongsTo<User>,
+
+        #[index]
+        title: String,
+    }
+
+    async fn setup(test: &mut Test) -> toasty::Db {
+        test.setup_db(models!(User, Todo)).await
+    }
+}

--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs
@@ -367,7 +367,6 @@ pub async fn composite_associate_new_user_with_todo_on_update_query_via_creation
 }
 
 #[driver_test(id(ID), scenario(crate::scenarios::composite_has_many_belongs_to))]
-#[ignore = "composite keys: unimplemented in engine/lower::rewrite_eq_operand (todo!(\"handle composite keys\"))"]
 pub async fn composite_assign_todo_that_already_has_user_on_create(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -398,7 +397,6 @@ pub async fn composite_assign_todo_that_already_has_user_on_create(test: &mut Te
 }
 
 #[driver_test(id(ID), scenario(crate::scenarios::composite_has_many_belongs_to))]
-#[ignore = "composite keys: unimplemented in engine/lower::rewrite_eq_operand (todo!(\"handle composite keys\"))"]
 pub async fn composite_assign_todo_that_already_has_user_on_update(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -627,7 +625,6 @@ pub async fn composite_remove_add_single_relation_option_belongs_to(test: &mut T
 }
 
 #[driver_test(id(ID), scenario(crate::scenarios::composite_has_many_belongs_to))]
-#[ignore = "composite keys: unimplemented in engine/lower::rewrite_eq_operand (todo!(\"handle composite keys\"))"]
 pub async fn composite_add_remove_single_relation_required_belongs_to(
     test: &mut Test,
 ) -> Result<()> {
@@ -659,7 +656,6 @@ pub async fn composite_add_remove_single_relation_required_belongs_to(
 }
 
 #[driver_test(id(ID), scenario(crate::scenarios::composite_has_many_belongs_to))]
-#[ignore = "composite keys: unimplemented in engine/lower::rewrite_eq_operand (todo!(\"handle composite keys\"))"]
 pub async fn composite_reassign_relation_required_belongs_to(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 

--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs
@@ -2,10 +2,17 @@
 //! multiple columns. These parallel the single-key relation tests so we can
 //! make sure composite-key behavior matches.
 //!
-//! The shared scenario lives in
-//! [`crate::scenarios::composite_has_many_belongs_to`]: a `User` with a
-//! single-column auto PK and a `Todo` whose PK is
-//! `#[key(partition = user_id, local = id)]`.
+//! Two scenarios are used:
+//!
+//! - [`crate::scenarios::composite_has_many_belongs_to`] — `User` with a
+//!   single-column auto PK and a `Todo` whose PK is
+//!   `#[key(partition = user_id, local = id)]`. The FK column is part of
+//!   the child's identity, so reassignment isn't supported on backends that
+//!   can't mutate primary-key columns (DynamoDB).
+//! - [`crate::scenarios::composite_fk_has_many_belongs_to`] — `User` with a
+//!   composite PK `(id, revision)`, and `Todo` with single PK and a
+//!   two-column indexed FK. Used by the reassignment tests, which need the
+//!   FK to be a plain updatable column.
 //!
 //! See: https://github.com/tokio-rs/toasty/discussions/904
 
@@ -319,13 +326,14 @@ pub async fn composite_delete_when_belongs_to_optional(test: &mut Test) -> Resul
     Ok(())
 }
 
-#[driver_test(id(ID), scenario(crate::scenarios::composite_has_many_belongs_to))]
+#[driver_test(scenario(crate::scenarios::composite_fk_has_many_belongs_to))]
 pub async fn composite_associate_new_user_with_todo_on_update_via_creation(
     test: &mut Test,
 ) -> Result<()> {
     let mut db = setup(test).await;
 
     let u1 = User::create()
+        .revision(1)
         .name("User 1")
         .todo(Todo::create().title("hello world"))
         .exec(&mut db)
@@ -336,19 +344,20 @@ pub async fn composite_associate_new_user_with_todo_on_update_via_creation(
     let mut todo = todos.into_iter().next().unwrap();
 
     todo.update()
-        .user(User::create().name("User 2"))
+        .user(User::create().revision(1).name("User 2"))
         .exec(&mut db)
         .await?;
     Ok(())
 }
 
-#[driver_test(id(ID), scenario(crate::scenarios::composite_has_many_belongs_to))]
+#[driver_test(scenario(crate::scenarios::composite_fk_has_many_belongs_to))]
 pub async fn composite_associate_new_user_with_todo_on_update_query_via_creation(
     test: &mut Test,
 ) -> Result<()> {
     let mut db = setup(test).await;
 
     let u1 = User::create()
+        .revision(1)
         .name("User 1")
         .todo(Todo::create().title("a todo"))
         .exec(&mut db)
@@ -358,34 +367,36 @@ pub async fn composite_associate_new_user_with_todo_on_update_query_via_creation
     assert_eq!(1, todos.len());
     let todo = todos.into_iter().next().unwrap();
 
-    Todo::filter_by_user_id_and_id(todo.user_id, todo.id)
+    Todo::filter_by_id(todo.id)
         .update()
-        .user(User::create().name("User 2"))
+        .user(User::create().revision(1).name("User 2"))
         .exec(&mut db)
         .await?;
     Ok(())
 }
 
-#[driver_test(id(ID), scenario(crate::scenarios::composite_has_many_belongs_to))]
+#[driver_test(scenario(crate::scenarios::composite_fk_has_many_belongs_to))]
 pub async fn composite_assign_todo_that_already_has_user_on_create(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
     let todo = Todo::create()
         .title("a todo")
-        .user(User::create().name("User 1"))
+        .user(User::create().revision(1).name("User 1"))
         .exec(&mut db)
         .await?;
 
     let u1 = todo.user().exec(&mut db).await?;
 
     let u2 = User::create()
+        .revision(1)
         .name("User 2")
         .todo(&todo)
         .exec(&mut db)
         .await?;
 
-    let todo_reload = Todo::get_by_user_id_and_id(&mut db, &u2.id, &todo.id).await?;
+    let todo_reload = Todo::get_by_id(&mut db, &todo.id).await?;
     assert_eq!(u2.id, todo_reload.user_id);
+    assert_eq!(u2.revision, todo_reload.user_revision);
 
     let todos: Vec<_> = u1.todos().exec(&mut db).await?;
     assert_eq!(0, todos.len());
@@ -396,27 +407,32 @@ pub async fn composite_assign_todo_that_already_has_user_on_create(test: &mut Te
     Ok(())
 }
 
-#[driver_test(id(ID), scenario(crate::scenarios::composite_has_many_belongs_to))]
+#[driver_test(scenario(crate::scenarios::composite_fk_has_many_belongs_to))]
 pub async fn composite_assign_todo_that_already_has_user_on_update(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
     let todo = Todo::create()
         .title("a todo")
-        .user(User::create().name("User 1"))
+        .user(User::create().revision(1).name("User 1"))
         .exec(&mut db)
         .await?;
 
     let u1 = todo.user().exec(&mut db).await?;
 
-    let mut u2 = User::create().name("User 2").exec(&mut db).await?;
+    let mut u2 = User::create()
+        .revision(1)
+        .name("User 2")
+        .exec(&mut db)
+        .await?;
 
     u2.update()
         .todos(toasty::stmt::insert(&todo))
         .exec(&mut db)
         .await?;
 
-    let todo_reload = Todo::get_by_user_id_and_id(&mut db, &u2.id, &todo.id).await?;
+    let todo_reload = Todo::get_by_id(&mut db, &todo.id).await?;
     assert_eq!(u2.id, todo_reload.user_id);
+    assert_eq!(u2.revision, todo_reload.user_revision);
 
     let todos: Vec<_> = u1.todos().exec(&mut db).await?;
     assert_eq!(0, todos.len());
@@ -427,23 +443,28 @@ pub async fn composite_assign_todo_that_already_has_user_on_update(test: &mut Te
     Ok(())
 }
 
-#[driver_test(id(ID), scenario(crate::scenarios::composite_has_many_belongs_to))]
+#[driver_test(scenario(crate::scenarios::composite_fk_has_many_belongs_to))]
 pub async fn composite_assign_existing_user_to_todo(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
     let mut todo = Todo::create()
         .title("hello")
-        .user(User::create().name("User 1"))
+        .user(User::create().revision(1).name("User 1"))
         .exec(&mut db)
         .await?;
 
     let u1 = todo.user().exec(&mut db).await?;
-    let u2 = User::create().name("User 2").exec(&mut db).await?;
+    let u2 = User::create()
+        .revision(1)
+        .name("User 2")
+        .exec(&mut db)
+        .await?;
 
     todo.update().user(&u2).exec(&mut db).await?;
 
-    let todo_reload = Todo::get_by_user_id_and_id(&mut db, &u2.id, &todo.id).await?;
+    let todo_reload = Todo::get_by_id(&mut db, &todo.id).await?;
     assert_eq!(u2.id, todo_reload.user_id);
+    assert_eq!(u2.revision, todo_reload.user_revision);
 
     let todos: Vec<_> = u1.todos().exec(&mut db).await?;
     assert_eq!(0, todos.len());
@@ -655,12 +676,20 @@ pub async fn composite_add_remove_single_relation_required_belongs_to(
     Ok(())
 }
 
-#[driver_test(id(ID), scenario(crate::scenarios::composite_has_many_belongs_to))]
+#[driver_test(scenario(crate::scenarios::composite_fk_has_many_belongs_to))]
 pub async fn composite_reassign_relation_required_belongs_to(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
-    let u1 = User::create().name("User 1").exec(&mut db).await?;
-    let u2 = User::create().name("User 2").exec(&mut db).await?;
+    let u1 = User::create()
+        .revision(1)
+        .name("User 1")
+        .exec(&mut db)
+        .await?;
+    let u2 = User::create()
+        .revision(1)
+        .name("User 2")
+        .exec(&mut db)
+        .await?;
 
     let t1 = u1.todos().create().title("a todo").exec(&mut db).await?;
 

--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs
@@ -1,9 +1,16 @@
-//! Regression tests for `has_many` / `belongs_to` relationships whose
-//! foreign key spans multiple columns.
+//! Tests for `has_many` / `belongs_to` relationships whose foreign key spans
+//! multiple columns. These parallel the single-key relation tests so we can
+//! make sure composite-key behavior matches.
+//!
+//! The shared scenario lives in
+//! [`crate::scenarios::composite_has_many_belongs_to`]: a `User` with a
+//! single-column auto PK and a `Todo` whose PK is
+//! `#[key(partition = user_id, local = id)]`.
 //!
 //! See: https://github.com/tokio-rs/toasty/discussions/904
 
 use crate::prelude::*;
+use hashbrown::HashMap;
 
 /// When a composite-key `belongs_to` has no covering index on the parent
 /// side, schema verification must return a helpful invalid-schema error
@@ -63,5 +70,958 @@ pub async fn composite_belongs_to_missing_index_is_error(test: &mut Test) -> Res
         "error should call out the per-field `#[index]` annotations, got: {msg}",
     );
 
+    Ok(())
+}
+
+// =====================================================================
+// Tier A — fundamental CRUD on a composite-FK has_many. These mirror the
+// single-key tests in `relation_has_many_crud.rs`.
+// =====================================================================
+
+#[driver_test(id(ID), scenario(crate::scenarios::composite_has_many_belongs_to))]
+pub async fn composite_crud_user_todos(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user = User::create().name("User 1").exec(&mut db).await?;
+
+    assert_eq!(0, user.todos().exec(&mut db).await?.len());
+
+    let todo = user
+        .todos()
+        .create()
+        .title("hello world")
+        .exec(&mut db)
+        .await?;
+
+    // Find the todo by its composite key
+    let list = Todo::filter_by_user_id_and_id(user.id, todo.id)
+        .exec(&mut db)
+        .await?;
+    assert_eq!(1, list.len());
+    assert_eq!(todo.id, list[0].id);
+
+    // Find by partition (user_id) only
+    let list = Todo::filter_by_user_id(user.id).exec(&mut db).await?;
+    assert_eq!(1, list.len());
+    assert_eq!(todo.id, list[0].id);
+
+    // Find the user via the todo's FK
+    let user_reload = User::get_by_id(&mut db, &todo.user_id).await?;
+    assert_eq!(user.id, user_reload.id);
+
+    let mut created = HashMap::new();
+    let mut ids = vec![todo.id];
+    created.insert(todo.id, todo);
+
+    for i in 0..5 {
+        let title = format!("hello world {i}");
+        let todo = if i.is_even() {
+            user.todos().create().title(title).exec(&mut db).await?
+        } else {
+            Todo::create()
+                .user(&user)
+                .title(title)
+                .exec(&mut db)
+                .await?
+        };
+        ids.push(todo.id);
+        assert_none!(created.insert(todo.id, todo));
+    }
+
+    let list = user.todos().exec(&mut db).await?;
+    assert_eq!(6, list.len());
+
+    let loaded: HashMap<_, _> = list.into_iter().map(|t| (t.id, t)).collect();
+    assert_eq!(6, loaded.len());
+    for (id, expect) in &created {
+        assert_eq!(expect.title, loaded[id].title);
+    }
+
+    let list = Todo::filter_by_user_id(user.id).exec(&mut db).await?;
+    assert_eq!(6, list.len());
+
+    let user2 = User::create().name("User 2").exec(&mut db).await?;
+    assert_eq!(0, user2.todos().exec(&mut db).await?.len());
+
+    let u2_todo = user2
+        .todos()
+        .create()
+        .title("user 2 todo")
+        .exec(&mut db)
+        .await?;
+
+    for todo in user.todos().exec(&mut db).await? {
+        assert_ne!(u2_todo.id, todo.id);
+    }
+
+    // Delete a TODO by value (lookup by composite PK)
+    let todo = Todo::get_by_user_id_and_id(&mut db, &user.id, &ids[0]).await?;
+    todo.delete().exec(&mut db).await?;
+    assert_err!(Todo::get_by_user_id_and_id(&mut db, &user.id, &ids[0]).await);
+    assert_err!(user.todos().get_by_id(&mut db, &ids[0]).await);
+
+    // Delete a TODO by scope
+    user.todos()
+        .filter_by_id(ids[1])
+        .delete()
+        .exec(&mut db)
+        .await?;
+    assert_err!(Todo::get_by_user_id_and_id(&mut db, &user.id, &ids[1]).await);
+    assert_err!(user.todos().get_by_id(&mut db, &ids[1]).await);
+
+    // Update a TODO via scope
+    user.todos()
+        .filter_by_id(ids[2])
+        .update()
+        .title("batch update 1")
+        .exec(&mut db)
+        .await?;
+    let todo = Todo::get_by_user_id_and_id(&mut db, &user.id, &ids[2]).await?;
+    assert_eq!(todo.title, "batch update 1");
+
+    // Updating via the wrong user's scope must NOT touch the todo
+    user2
+        .todos()
+        .filter_by_id(ids[2])
+        .update()
+        .title("batch update 2")
+        .exec(&mut db)
+        .await?;
+    let todo = Todo::get_by_user_id_and_id(&mut db, &user.id, &ids[2]).await?;
+    assert_eq!(todo.title, "batch update 1");
+
+    // Deleting the parent deletes its todos
+    let id = user.id;
+    user.delete().exec(&mut db).await?;
+    assert_err!(User::get_by_id(&mut db, &id).await);
+    assert_err!(Todo::get_by_user_id_and_id(&mut db, &id, &ids[2]).await);
+    Ok(())
+}
+
+#[driver_test(id(ID), scenario(crate::scenarios::composite_has_many_belongs_to))]
+pub async fn composite_has_many_insert_on_update(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let mut user = User::create().name("Alice").exec(&mut db).await?;
+    assert!(user.todos().exec(&mut db).await?.is_empty());
+
+    user.update()
+        .name("Bob")
+        .todos(toasty::stmt::insert(Todo::create().title("change name")))
+        .exec(&mut db)
+        .await?;
+
+    assert_eq!("Bob", user.name);
+    let todos: Vec<_> = user.todos().exec(&mut db).await?;
+    assert_eq!(1, todos.len());
+    assert_eq!(todos[0].title, "change name");
+    Ok(())
+}
+
+#[driver_test(id(ID), scenario(crate::scenarios::composite_has_many_belongs_to))]
+pub async fn composite_scoped_find_by_id(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user1 = User::create().name("User 1").exec(&mut db).await?;
+    let user2 = User::create().name("User 2").exec(&mut db).await?;
+
+    let todo = user1
+        .todos()
+        .create()
+        .title("hello world")
+        .exec(&mut db)
+        .await?;
+
+    let reloaded = user1.todos().get_by_id(&mut db, &todo.id).await?;
+    assert_eq!(reloaded.id, todo.id);
+    assert_eq!(reloaded.title, todo.title);
+
+    // Other user's scope: must not find
+    assert_none!(
+        user2
+            .todos()
+            .filter_by_id(todo.id)
+            .first()
+            .exec(&mut db)
+            .await?
+    );
+
+    let reloaded = User::filter_by_id(user1.id)
+        .todos()
+        .get_by_id(&mut db, &todo.id)
+        .await?;
+    assert_eq!(reloaded.id, todo.id);
+
+    // Delete in the wrong scope is a no-op
+    user2
+        .todos()
+        .filter_by_id(todo.id)
+        .delete()
+        .exec(&mut db)
+        .await?;
+    let reloaded = user1.todos().get_by_id(&mut db, &todo.id).await?;
+    assert_eq!(reloaded.id, todo.id);
+    Ok(())
+}
+
+#[driver_test(id(ID), scenario(crate::scenarios::composite_has_many_belongs_to))]
+pub async fn composite_belongs_to_required(test: &mut Test) {
+    let mut db = setup(test).await;
+    assert_err!(Todo::create().title("orphan").exec(&mut db).await);
+}
+
+#[driver_test(id(ID))]
+pub async fn composite_delete_when_belongs_to_optional(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+
+        #[has_many]
+        todos: toasty::HasMany<Todo>,
+    }
+
+    // Composite FK where the FK is *optional* — modeled by leaving the
+    // partition-key column as `Option<ID>`. (NB: keys must still be
+    // populated when inserting, but the nullable FK exercises the
+    // belongs_to-optional codepath after the parent is deleted.)
+    #[derive(Debug, toasty::Model)]
+    struct Todo {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+
+        #[index]
+        user_id: Option<ID>,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: toasty::BelongsTo<Option<User>>,
+    }
+
+    let mut db = test.setup_db(models!(User, Todo)).await;
+
+    let user = User::create().exec(&mut db).await?;
+    let mut ids = vec![];
+
+    for _ in 0..3 {
+        let todo = user.todos().create().exec(&mut db).await?;
+        ids.push(todo.id);
+    }
+
+    user.delete().exec(&mut db).await?;
+
+    // Todos still exist; user_id is None
+    for id in ids {
+        let todo = Todo::get_by_id(&mut db, id).await?;
+        assert_none!(todo.user_id);
+    }
+    Ok(())
+}
+
+#[driver_test(id(ID), scenario(crate::scenarios::composite_has_many_belongs_to))]
+pub async fn composite_associate_new_user_with_todo_on_update_via_creation(
+    test: &mut Test,
+) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let u1 = User::create()
+        .name("User 1")
+        .todo(Todo::create().title("hello world"))
+        .exec(&mut db)
+        .await?;
+
+    let todos: Vec<_> = u1.todos().exec(&mut db).await?;
+    assert_eq!(1, todos.len());
+    let mut todo = todos.into_iter().next().unwrap();
+
+    todo.update()
+        .user(User::create().name("User 2"))
+        .exec(&mut db)
+        .await?;
+    Ok(())
+}
+
+#[driver_test(id(ID), scenario(crate::scenarios::composite_has_many_belongs_to))]
+pub async fn composite_associate_new_user_with_todo_on_update_query_via_creation(
+    test: &mut Test,
+) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let u1 = User::create()
+        .name("User 1")
+        .todo(Todo::create().title("a todo"))
+        .exec(&mut db)
+        .await?;
+
+    let todos: Vec<_> = u1.todos().exec(&mut db).await?;
+    assert_eq!(1, todos.len());
+    let todo = todos.into_iter().next().unwrap();
+
+    Todo::filter_by_user_id_and_id(todo.user_id, todo.id)
+        .update()
+        .user(User::create().name("User 2"))
+        .exec(&mut db)
+        .await?;
+    Ok(())
+}
+
+#[driver_test(id(ID), scenario(crate::scenarios::composite_has_many_belongs_to))]
+#[ignore = "composite keys: unimplemented in engine/lower::rewrite_eq_operand (todo!(\"handle composite keys\"))"]
+pub async fn composite_assign_todo_that_already_has_user_on_create(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let todo = Todo::create()
+        .title("a todo")
+        .user(User::create().name("User 1"))
+        .exec(&mut db)
+        .await?;
+
+    let u1 = todo.user().exec(&mut db).await?;
+
+    let u2 = User::create()
+        .name("User 2")
+        .todo(&todo)
+        .exec(&mut db)
+        .await?;
+
+    let todo_reload = Todo::get_by_user_id_and_id(&mut db, &u2.id, &todo.id).await?;
+    assert_eq!(u2.id, todo_reload.user_id);
+
+    let todos: Vec<_> = u1.todos().exec(&mut db).await?;
+    assert_eq!(0, todos.len());
+
+    let todos: Vec<_> = u2.todos().exec(&mut db).await?;
+    assert_eq!(1, todos.len());
+    assert_eq!(todo.id, todos[0].id);
+    Ok(())
+}
+
+#[driver_test(id(ID), scenario(crate::scenarios::composite_has_many_belongs_to))]
+#[ignore = "composite keys: unimplemented in engine/lower::rewrite_eq_operand (todo!(\"handle composite keys\"))"]
+pub async fn composite_assign_todo_that_already_has_user_on_update(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let todo = Todo::create()
+        .title("a todo")
+        .user(User::create().name("User 1"))
+        .exec(&mut db)
+        .await?;
+
+    let u1 = todo.user().exec(&mut db).await?;
+
+    let mut u2 = User::create().name("User 2").exec(&mut db).await?;
+
+    u2.update()
+        .todos(toasty::stmt::insert(&todo))
+        .exec(&mut db)
+        .await?;
+
+    let todo_reload = Todo::get_by_user_id_and_id(&mut db, &u2.id, &todo.id).await?;
+    assert_eq!(u2.id, todo_reload.user_id);
+
+    let todos: Vec<_> = u1.todos().exec(&mut db).await?;
+    assert_eq!(0, todos.len());
+
+    let todos: Vec<_> = u2.todos().exec(&mut db).await?;
+    assert_eq!(1, todos.len());
+    assert_eq!(todo.id, todos[0].id);
+    Ok(())
+}
+
+#[driver_test(id(ID), scenario(crate::scenarios::composite_has_many_belongs_to))]
+pub async fn composite_assign_existing_user_to_todo(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let mut todo = Todo::create()
+        .title("hello")
+        .user(User::create().name("User 1"))
+        .exec(&mut db)
+        .await?;
+
+    let u1 = todo.user().exec(&mut db).await?;
+    let u2 = User::create().name("User 2").exec(&mut db).await?;
+
+    todo.update().user(&u2).exec(&mut db).await?;
+
+    let todo_reload = Todo::get_by_user_id_and_id(&mut db, &u2.id, &todo.id).await?;
+    assert_eq!(u2.id, todo_reload.user_id);
+
+    let todos: Vec<_> = u1.todos().exec(&mut db).await?;
+    assert_eq!(0, todos.len());
+
+    let todos: Vec<_> = u2.todos().exec(&mut db).await?;
+    assert_eq!(1, todos.len());
+    assert_eq!(todo.id, todos[0].id);
+    Ok(())
+}
+
+#[driver_test(id(ID), scenario(crate::scenarios::composite_has_many_belongs_to))]
+pub async fn composite_assign_todo_to_user_on_update_query(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user = User::create().name("User 1").exec(&mut db).await?;
+
+    User::filter_by_id(user.id)
+        .update()
+        .todos(toasty::stmt::insert(Todo::create().title("hello")))
+        .exec(&mut db)
+        .await?;
+
+    let todos: Vec<_> = user.todos().exec(&mut db).await?;
+    assert_eq!(1, todos.len());
+    assert_eq!("hello", todos[0].title);
+    Ok(())
+}
+
+// =====================================================================
+// Tier B — batch / link / unlink. Mirrors `relation_has_many_batch_create.rs`
+// and `relation_has_many_link_unlink.rs`.
+// =====================================================================
+
+#[driver_test(id(ID), scenario(crate::scenarios::composite_has_many_belongs_to))]
+pub async fn composite_user_batch_create_todos_one_level(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user = User::create()
+        .name("Ann Chovey")
+        .todo(Todo::create().title("Make pizza"))
+        .exec(&mut db)
+        .await?;
+
+    assert_eq!(user.name, "Ann Chovey");
+
+    let todos: Vec<_> = user.todos().exec(&mut db).await?;
+    assert_eq!(1, todos.len());
+    assert_eq!("Make pizza", todos[0].title);
+
+    let todo = Todo::get_by_user_id_and_id(&mut db, &user.id, &todos[0].id).await?;
+    assert_eq!("Make pizza", todo.title);
+    Ok(())
+}
+
+#[driver_test(id(ID), scenario(crate::scenarios::composite_has_many_belongs_to))]
+pub async fn composite_user_batch_create_two_todos_simple(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user = User::create()
+        .name("Ann Chovey")
+        .todo(Todo::create().title("Make pizza"))
+        .todo(Todo::create().title("Sleep"))
+        .exec(&mut db)
+        .await?;
+
+    let todos: Vec<_> = user.todos().exec(&mut db).await?;
+    assert_eq!(2, todos.len());
+
+    let mut titles: Vec<_> = todos.iter().map(|t| &t.title[..]).collect();
+    titles.sort();
+    assert_eq!(titles, vec!["Make pizza", "Sleep"]);
+    Ok(())
+}
+
+#[driver_test(id(ID))]
+pub async fn composite_user_batch_create_todos_with_optional_field(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+
+        name: String,
+
+        #[has_many]
+        todos: toasty::HasMany<Todo>,
+
+        // Optional field exercises the RETURNING/constantize path that
+        // regressed in #user_batch_create_todos_with_optional_field.
+        #[allow(dead_code)]
+        moto: Option<String>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    #[key(partition = user_id, local = id)]
+    struct Todo {
+        #[auto]
+        id: uuid::Uuid,
+
+        user_id: ID,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: toasty::BelongsTo<User>,
+
+        title: String,
+    }
+
+    let mut db = test.setup_db(models!(User, Todo)).await;
+
+    let user = User::create()
+        .name("Ann Chovey")
+        .todo(Todo::create().title("Make pizza"))
+        .todo(Todo::create().title("Sleep"))
+        .exec(&mut db)
+        .await?;
+
+    let todos: Vec<_> = user.todos().exec(&mut db).await?;
+    assert_eq!(2, todos.len());
+
+    let mut titles: Vec<_> = todos.iter().map(|t| &t.title[..]).collect();
+    titles.sort();
+    assert_eq!(titles, vec!["Make pizza", "Sleep"]);
+    Ok(())
+}
+
+#[driver_test(id(ID))]
+pub async fn composite_remove_add_single_relation_option_belongs_to(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+
+        #[has_many]
+        todos: toasty::HasMany<Todo>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Todo {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+
+        #[index]
+        user_id: Option<ID>,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: toasty::BelongsTo<Option<User>>,
+    }
+
+    let mut db = test.setup_db(models!(User, Todo)).await;
+
+    let user = User::create()
+        .todo(Todo::create())
+        .todo(Todo::create())
+        .exec(&mut db)
+        .await?;
+
+    let todos: Vec<_> = user.todos().exec(&mut db).await?;
+    assert_eq!(2, todos.len());
+
+    user.todos().remove(&mut db, &todos[0]).await?;
+
+    let todos_reloaded: Vec<_> = user.todos().exec(&mut db).await?;
+    assert_eq!(1, todos_reloaded.len());
+    assert_eq!(todos[1].id, todos_reloaded[0].id);
+
+    assert_err!(user.todos().get_by_id(&mut db, &todos[0].id).await);
+
+    let todo = Todo::get_by_id(&mut db, todos[0].id).await?;
+    assert_none!(todo.user_id);
+
+    user.todos().insert(&mut db, &todos[0]).await?;
+
+    let todos_reloaded: Vec<_> = user.todos().exec(&mut db).await?;
+    assert!(todos_reloaded.iter().any(|t| t.id == todos[0].id));
+    assert_ok!(user.todos().get_by_id(&mut db, todos[0].id).await);
+    Ok(())
+}
+
+#[driver_test(id(ID), scenario(crate::scenarios::composite_has_many_belongs_to))]
+#[ignore = "composite keys: unimplemented in engine/lower::rewrite_eq_operand (todo!(\"handle composite keys\"))"]
+pub async fn composite_add_remove_single_relation_required_belongs_to(
+    test: &mut Test,
+) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user = User::create().name("User 1").exec(&mut db).await?;
+
+    let t1 = user.todos().create().title("todo 1").exec(&mut db).await?;
+    let t2 = user.todos().create().title("todo 2").exec(&mut db).await?;
+    let t3 = user.todos().create().title("todo 3").exec(&mut db).await?;
+
+    let ids = vec![t1.id, t2.id, t3.id];
+
+    let todos_reloaded: Vec<_> = user.todos().exec(&mut db).await?;
+    assert_eq!(todos_reloaded.len(), 3);
+
+    for id in ids {
+        assert!(todos_reloaded.iter().any(|t| t.id == id));
+    }
+
+    // Unlinking a required belongs_to is a delete
+    user.todos().remove(&mut db, &todos_reloaded[0]).await?;
+
+    assert_err!(Todo::get_by_user_id_and_id(&mut db, &user.id, &todos_reloaded[0].id).await);
+
+    let todos_reloaded: Vec<_> = user.todos().exec(&mut db).await?;
+    assert_eq!(todos_reloaded.len(), 2);
+    Ok(())
+}
+
+#[driver_test(id(ID), scenario(crate::scenarios::composite_has_many_belongs_to))]
+#[ignore = "composite keys: unimplemented in engine/lower::rewrite_eq_operand (todo!(\"handle composite keys\"))"]
+pub async fn composite_reassign_relation_required_belongs_to(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let u1 = User::create().name("User 1").exec(&mut db).await?;
+    let u2 = User::create().name("User 2").exec(&mut db).await?;
+
+    let t1 = u1.todos().create().title("a todo").exec(&mut db).await?;
+
+    u2.todos().insert(&mut db, &t1).await?;
+
+    assert!(u1.todos().exec(&mut db).await?.is_empty());
+
+    let todos = u2.todos().exec(&mut db).await?;
+    assert_eq!(1, todos.len());
+    assert_eq!(t1.id, todos[0].id);
+    Ok(())
+}
+
+#[driver_test(id(ID))]
+pub async fn composite_add_remove_multiple_relation_option_belongs_to(
+    test: &mut Test,
+) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+
+        #[has_many]
+        todos: toasty::HasMany<Todo>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Todo {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+
+        #[index]
+        user_id: Option<ID>,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: toasty::BelongsTo<Option<User>>,
+    }
+
+    let mut db = test.setup_db(models!(User, Todo)).await;
+
+    let user = User::create().exec(&mut db).await?;
+
+    let t1 = Todo::create().exec(&mut db).await?;
+    let t2 = Todo::create().exec(&mut db).await?;
+    let t3 = Todo::create().exec(&mut db).await?;
+
+    let ids = vec![t1.id, t2.id, t3.id];
+
+    user.todos().insert(&mut db, &t1).await?;
+    user.todos().insert(&mut db, &t2).await?;
+    user.todos().insert(&mut db, &t3).await?;
+
+    let todos_reloaded: Vec<_> = user.todos().exec(&mut db).await?;
+    assert_eq!(todos_reloaded.len(), 3);
+
+    for id in ids {
+        assert!(todos_reloaded.iter().any(|t| t.id == id));
+    }
+    Ok(())
+}
+
+// =====================================================================
+// Tier C — preload (.include) over a composite FK. Mirrors
+// `relation_preload.rs`.
+// =====================================================================
+
+#[driver_test(id(ID), scenario(crate::scenarios::composite_has_many_belongs_to))]
+pub async fn composite_basic_has_many_and_belongs_to_preload(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user = User::create()
+        .name("Alice")
+        .todo(Todo::create().title("todo 1"))
+        .todo(Todo::create().title("todo 2"))
+        .todo(Todo::create().title("todo 3"))
+        .exec(&mut db)
+        .await?;
+
+    let user = User::filter_by_id(user.id)
+        .include(User::fields().todos())
+        .get(&mut db)
+        .await?;
+
+    assert_eq!(3, user.todos.get().len());
+
+    let id = user.todos.get()[0].id;
+    let user_id = user.todos.get()[0].user_id;
+
+    let todo = Todo::filter_by_user_id_and_id(user_id, id)
+        .include(Todo::fields().user())
+        .get(&mut db)
+        .await?;
+
+    assert_eq!(user.id, todo.user.get().id);
+    assert_eq!(user.id, todo.user_id);
+    Ok(())
+}
+
+#[driver_test(id(ID), scenario(crate::scenarios::composite_has_many_belongs_to))]
+pub async fn composite_preload_on_empty_query(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    User::create().name("Alice").exec(&mut db).await?;
+
+    let users: Vec<_> = User::filter(User::fields().name().eq("Nope"))
+        .include(User::fields().todos())
+        .exec(&mut db)
+        .await?;
+    assert!(users.is_empty());
+    Ok(())
+}
+
+#[driver_test(id(ID))]
+pub async fn composite_preload_has_many_with_optional_belongs_to(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+
+        name: String,
+
+        #[has_many]
+        todos: toasty::HasMany<Todo>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Todo {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+
+        #[index]
+        user_id: Option<ID>,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: toasty::BelongsTo<Option<User>>,
+
+        title: String,
+    }
+
+    let mut db = test.setup_db(models!(User, Todo)).await;
+
+    let user = User::create()
+        .name("Alice")
+        .todo(Todo::create().title("alpha"))
+        .todo(Todo::create().title("beta"))
+        .exec(&mut db)
+        .await?;
+
+    let user = User::filter_by_id(user.id)
+        .include(User::fields().todos())
+        .get(&mut db)
+        .await?;
+
+    assert_eq!(2, user.todos.get().len());
+    Ok(())
+}
+
+#[driver_test(id(ID), scenario(crate::scenarios::composite_has_many_belongs_to))]
+pub async fn composite_nested_has_many_then_belongs_to_required(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user = User::create()
+        .name("Alice")
+        .todo(Todo::create().title("alpha"))
+        .todo(Todo::create().title("beta"))
+        .exec(&mut db)
+        .await?;
+
+    let user = User::filter_by_id(user.id)
+        .include(User::fields().todos().user())
+        .get(&mut db)
+        .await?;
+
+    let todos = user.todos.get();
+    assert_eq!(2, todos.len());
+    for todo in todos {
+        assert_eq!(user.id, todo.user.get().id);
+        assert_eq!("Alice", todo.user.get().name);
+    }
+    Ok(())
+}
+
+// =====================================================================
+// Tier D — has_one / belongs_to topologies with composite FK on the child.
+// =====================================================================
+
+#[driver_test(id(ID))]
+pub async fn composite_crud_has_one_required(test: &mut Test) -> Result<()> {
+    // User has a single auto-PK and a `has_one` Profile.
+    // Profile's PK is composite (`partition = user_id, local = id`), making the
+    // FK part of the row's key.
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+
+        #[has_one]
+        profile: toasty::HasOne<Option<Profile>>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    #[key(partition = user_id, local = id)]
+    struct Profile {
+        #[auto]
+        id: uuid::Uuid,
+
+        user_id: ID,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: toasty::BelongsTo<User>,
+
+        bio: String,
+    }
+
+    let mut db = test.setup_db(models!(User, Profile)).await;
+
+    let user = User::create()
+        .profile(Profile::create().bio("an apple a day"))
+        .exec(&mut db)
+        .await?;
+
+    let profile = user.profile().exec(&mut db).await?.unwrap();
+    assert_eq!(profile.bio, "an apple a day");
+
+    assert_eq!(user.id, profile.user().exec(&mut db).await?.id);
+
+    // Deleting the user also deletes the profile.
+    user.delete().exec(&mut db).await?;
+    assert_err!(Profile::get_by_user_id_and_id(&mut db, &profile.user_id, &profile.id).await);
+    Ok(())
+}
+
+// =====================================================================
+// Tier E — filters and projections through associations.
+// =====================================================================
+
+#[driver_test(id(ID), requires(sql))]
+pub async fn composite_filter_by_belongs_to_field(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+
+        name: String,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    #[key(partition = user_id, local = id)]
+    struct Profile {
+        #[auto]
+        id: uuid::Uuid,
+
+        user_id: ID,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: toasty::BelongsTo<User>,
+
+        bio: String,
+    }
+
+    let mut db = test.setup_db(models!(User, Profile)).await;
+
+    let alice = User::create().name("alice").exec(&mut db).await?;
+    let bob = User::create().name("bob").exec(&mut db).await?;
+
+    Profile::create()
+        .user(&alice)
+        .bio("alice's bio")
+        .exec(&mut db)
+        .await?;
+    Profile::create()
+        .user(&bob)
+        .bio("bob's bio")
+        .exec(&mut db)
+        .await?;
+
+    let profiles: Vec<Profile> = Profile::filter(Profile::fields().user().name().eq("alice"))
+        .exec(&mut db)
+        .await?;
+    assert_eq!(profiles.len(), 1);
+    assert_eq!(profiles[0].bio, "alice's bio");
+    Ok(())
+}
+
+#[driver_test(
+    id(ID),
+    requires(scan),
+    scenario(crate::scenarios::composite_has_many_belongs_to)
+)]
+pub async fn composite_filter_parent_by_child_field(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let alice = User::create().name("Alice").exec(&mut db).await?;
+    let bob = User::create().name("Bob").exec(&mut db).await?;
+    let carol = User::create().name("Carol").exec(&mut db).await?;
+
+    alice.todos().create().title("urgent").exec(&mut db).await?;
+    bob.todos().create().title("later").exec(&mut db).await?;
+    carol.todos().create().title("urgent").exec(&mut db).await?;
+    carol.todos().create().title("later").exec(&mut db).await?;
+
+    let users: Vec<_> = User::filter(
+        User::fields()
+            .todos()
+            .any(Todo::fields().title().eq("urgent")),
+    )
+    .exec(&mut db)
+    .await?;
+
+    assert_eq_unordered!(users.iter().map(|u| &u.name[..]), ["Alice", "Carol"]);
+    Ok(())
+}
+
+#[driver_test(id(ID), requires(scan))]
+pub async fn composite_select_belongs_to_basic(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+        name: String,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    #[key(partition = user_id, local = id)]
+    struct Post {
+        #[auto]
+        id: uuid::Uuid,
+        title: String,
+
+        user_id: ID,
+
+        #[belongs_to(key = user_id, references = id)]
+        author: toasty::BelongsTo<User>,
+    }
+
+    let mut db = test.setup_db(models!(User, Post)).await;
+
+    let alice = User::create().name("Alice").exec(&mut db).await?;
+    Post::create()
+        .title("Hello")
+        .author(&alice)
+        .exec(&mut db)
+        .await?;
+
+    let users: Vec<User> = Post::all()
+        .select(Post::fields().author())
+        .exec(&mut db)
+        .await?;
+
+    assert_eq!(users.len(), 1);
+    assert_eq!(users[0].name, "Alice");
     Ok(())
 }

--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -968,18 +968,16 @@ impl<'a, 'b> LowerStatement<'a, 'b> {
         if let stmt::Expr::Reference(expr_reference) = operand {
             match &*expr_reference {
                 stmt::ExprReference::Model { nesting } => {
+                    let nesting = *nesting;
                     let model = self
                         .expr_cx
                         .resolve_expr_reference(expr_reference)
                         .as_model_unwrap();
 
-                    let [pk_field] = &model.primary_key.fields[..] else {
-                        todo!("handle composite keys");
-                    };
-
-                    *operand = stmt::Expr::ref_field(*nesting, pk_field);
+                    *operand = key_field_refs(nesting, model.primary_key.fields.iter().copied());
                 }
-                stmt::ExprReference::Field { .. } => {
+                stmt::ExprReference::Field { nesting, .. } => {
+                    let nesting = *nesting;
                     let field = self
                         .expr_cx
                         .resolve_expr_reference(expr_reference)
@@ -989,14 +987,10 @@ impl<'a, 'b> LowerStatement<'a, 'b> {
                         app::FieldTy::Primitive(_) | app::FieldTy::Embedded(_) => {}
                         app::FieldTy::HasMany(_) | app::FieldTy::HasOne(_) => todo!(),
                         app::FieldTy::BelongsTo(rel) => {
-                            let [fk_field] = &rel.foreign_key.fields[..] else {
-                                todo!("handle composite keys");
-                            };
-
-                            let stmt::ExprReference::Field { index, .. } = expr_reference else {
-                                panic!()
-                            };
-                            *index = fk_field.source.index;
+                            *operand = key_field_refs(
+                                nesting,
+                                rel.foreign_key.fields.iter().map(|fk| fk.source),
+                            );
                         }
                     }
                 }
@@ -1600,6 +1594,22 @@ impl LoweringContext<'_> {
 
     fn is_returning(&self) -> bool {
         matches!(self, LoweringContext::Returning(_))
+    }
+}
+
+/// Build the LHS shape of an equality whose RHS is a key value:
+/// a single field reference for a single-column key, a record of field
+/// references for a composite key. The surrounding `==` is then decomposed
+/// into pairwise comparisons by `lower_expr_binary_op`'s `Record == Record`
+/// (or `Record == Value::Record`) handler.
+fn key_field_refs(
+    nesting: usize,
+    mut fields: impl ExactSizeIterator<Item = app::FieldId>,
+) -> stmt::Expr {
+    if fields.len() == 1 {
+        stmt::Expr::ref_field(nesting, fields.next().unwrap())
+    } else {
+        stmt::Expr::record(fields.map(|field| stmt::Expr::ref_field(nesting, field)))
     }
 }
 

--- a/crates/toasty/src/engine/lower/insert.rs
+++ b/crates/toasty/src/engine/lower/insert.rs
@@ -110,18 +110,48 @@ impl LowerStatement<'_, '_> {
         // values
         for field in &model.fields {
             if let app::FieldTy::BelongsTo(rel) = &field.ty {
-                let [fk_field] = &rel.foreign_key.fields[..] else {
-                    todo!()
-                };
-
                 let mut field_expr = expr.entry_mut(field.id.index);
 
-                if !field_expr.is_value() || field_expr.is_value_null() {
+                if field_expr.is_value_null() {
                     continue;
                 }
 
-                let e = field_expr.take();
-                expr.entry_mut(fk_field.source.index).insert(e);
+                if rel.foreign_key.fields.len() == 1 {
+                    if !field_expr.is_value() {
+                        continue;
+                    }
+                    let fk_field = &rel.foreign_key.fields[0];
+                    let e = field_expr.take();
+                    expr.entry_mut(fk_field.source.index).insert(e);
+                } else {
+                    // Composite FK: split the BelongsTo record into per-column
+                    // values. The value is either an `Expr::Record` (when set
+                    // from a model reference, via the tuple `IntoExpr`) or
+                    // `Expr::Value(Value::Record)` (when set from a literal
+                    // record).
+                    let items: Vec<stmt::Expr> = match field_expr.as_expr() {
+                        Some(stmt::Expr::Record(_)) => {
+                            let stmt::Expr::Record(record) = field_expr.take() else {
+                                unreachable!()
+                            };
+                            record.fields
+                        }
+                        Some(stmt::Expr::Value(stmt::Value::Record(_))) => {
+                            let stmt::Expr::Value(stmt::Value::Record(record)) = field_expr.take()
+                            else {
+                                unreachable!()
+                            };
+                            record.into_iter().map(stmt::Expr::Value).collect()
+                        }
+                        _ => continue,
+                    };
+
+                    assert_eq!(items.len(), rel.foreign_key.fields.len());
+
+                    for (fk_field, item) in rel.foreign_key.fields.iter().zip(items) {
+                        expr.entry_mut(fk_field.source.index).insert(item);
+                    }
+                }
             }
         }
 

--- a/crates/toasty/src/engine/lower/insert.rs
+++ b/crates/toasty/src/engine/lower/insert.rs
@@ -116,41 +116,35 @@ impl LowerStatement<'_, '_> {
                     continue;
                 }
 
-                if rel.foreign_key.fields.len() == 1 {
+                let fk_fields = &rel.foreign_key.fields;
+                let is_record = field_expr
+                    .as_expr()
+                    .is_some_and(|e| e.record_len().is_some());
+
+                // Distribute the BelongsTo value into its FK source column(s):
+                //   - composite FK: the value is a record (`Expr::Record` from
+                //     the tuple `IntoExpr` for composite-PK targets, or
+                //     `Expr::Value(Value::Record)` from a literal); one item
+                //     per FK column via `into_record_items`.
+                //   - single FK: the value is a scalar; it goes whole into the
+                //     single FK column.
+                if is_record {
+                    let items = field_expr.take().into_record_items().unwrap();
+                    let mut count = 0;
+                    for (fk_field, item) in fk_fields.iter().zip(items) {
+                        expr.entry_mut(fk_field.source.index).insert(item);
+                        count += 1;
+                    }
+                    assert_eq!(count, fk_fields.len());
+                } else {
                     if !field_expr.is_value() {
                         continue;
                     }
-                    let fk_field = &rel.foreign_key.fields[0];
+                    let [fk_field] = &fk_fields[..] else {
+                        panic!("composite FK expected a record value, got scalar");
+                    };
                     let e = field_expr.take();
                     expr.entry_mut(fk_field.source.index).insert(e);
-                } else {
-                    // Composite FK: split the BelongsTo record into per-column
-                    // values. The value is either an `Expr::Record` (when set
-                    // from a model reference, via the tuple `IntoExpr`) or
-                    // `Expr::Value(Value::Record)` (when set from a literal
-                    // record).
-                    let items: Vec<stmt::Expr> = match field_expr.as_expr() {
-                        Some(stmt::Expr::Record(_)) => {
-                            let stmt::Expr::Record(record) = field_expr.take() else {
-                                unreachable!()
-                            };
-                            record.fields
-                        }
-                        Some(stmt::Expr::Value(stmt::Value::Record(_))) => {
-                            let stmt::Expr::Value(stmt::Value::Record(record)) = field_expr.take()
-                            else {
-                                unreachable!()
-                            };
-                            record.into_iter().map(stmt::Expr::Value).collect()
-                        }
-                        _ => continue,
-                    };
-
-                    assert_eq!(items.len(), rel.foreign_key.fields.len());
-
-                    for (fk_field, item) in rel.foreign_key.fields.iter().zip(items) {
-                        expr.entry_mut(fk_field.source.index).insert(item);
-                    }
                 }
             }
         }

--- a/crates/toasty/src/engine/lower/insert.rs
+++ b/crates/toasty/src/engine/lower/insert.rs
@@ -117,9 +117,6 @@ impl LowerStatement<'_, '_> {
                 }
 
                 let fk_fields = &rel.foreign_key.fields;
-                let is_record = field_expr
-                    .as_expr()
-                    .is_some_and(|e| e.record_len().is_some());
 
                 // Distribute the BelongsTo value into its FK source column(s):
                 //   - composite FK: the value is a record (`Expr::Record` from
@@ -128,7 +125,7 @@ impl LowerStatement<'_, '_> {
                 //     per FK column via `into_record_items`.
                 //   - single FK: the value is a scalar; it goes whole into the
                 //     single FK column.
-                if is_record {
+                if field_expr.is_record() {
                     let items = field_expr.take().into_record_items().unwrap();
                     let mut count = 0;
                     for (fk_field, item) in fk_fields.iter().zip(items) {

--- a/crates/toasty/src/engine/lower/lift_in_subquery.rs
+++ b/crates/toasty/src/engine/lower/lift_in_subquery.rs
@@ -257,12 +257,6 @@ fn lift_belongs_to_in_subquery(
 
     let select = query.body.as_select_unwrap();
 
-    assert_eq!(
-        belongs_to.foreign_key.fields.len(),
-        1,
-        "TODO: composite keys"
-    );
-
     let mut lift = LiftBelongsTo {
         cx: cx.scope(&select.source),
         belongs_to,

--- a/crates/toasty/src/engine/lower/relation.rs
+++ b/crates/toasty/src/engine/lower/relation.rs
@@ -516,6 +516,19 @@ impl LowerStatement<'_, '_> {
 
                 lower.set_relation_field(field, expr, source);
             }
+            // Composite FK: a record whose fields are each a scalar value or
+            // reference — produced by the tuple `IntoExpr` impl when the
+            // target model has a composite primary key. `set_relation_field`
+            // destructures it via `record_len()` / `into_record_items()` and
+            // assigns each component to the matching FK source column.
+            stmt::Expr::Record(record)
+                if record
+                    .fields
+                    .iter()
+                    .all(|f| f.is_value() || f.is_expr_reference()) =>
+            {
+                lower.set_relation_field(field, stmt::Expr::Record(record), source);
+            }
             stmt::Expr::Stmt(expr_stmt) => {
                 lower.plan_mut_belongs_to_associate_stmt(field, *expr_stmt.stmt, source);
             }


### PR DESCRIPTION
## Summary

Two-part sweep to bring composite-key relation behavior up to parity with
single-key. Motivated by [#904].

1. **Test coverage (`test(tests)` commit).** Adds 23 composite-key
   relation tests (45 ID-expansion variants) in
   `relation_has_many_composite_key.rs` covering CRUD, batch, link/unlink,
   preload, has_one, filter, and projection. A shared
   `composite_has_many_belongs_to` scenario backs most of them: single-PK
   `User` + composite-PK (`#[key(partition = user_id, local = id)]`)
   `Todo`. The sweep surfaced four behaviors that hit a single panic.

2. **Engine fix (`fix(engine)` commit).** `engine/lower::rewrite_eq_operand`
   panicked with `todo!(\"handle composite keys\")` whenever lowering
   compared a model reference or a belongs_to field by value against a
   composite-keyed record. It now emits a `Record` of per-key field
   references; the existing `Record == Value::Record` decomposition in
   `lower_expr_binary_op` handles the rest.

Together: 937 tests pass, 0 fail, 0 ignored.

[#904]: https://github.com/tokio-rs/toasty/discussions/904

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] \`cargo fmt\` and \`cargo clippy\` are clean
- [x] \`cargo test\` passes

## Notes for reviewers

Worth eyeballing: the new `key_field_refs` helper at the bottom of
`lower.rs`. The single-element fast path keeps the generated AST shape
identical to before this change; only composite keys take the `Record`
branch.