### PR TITLE
docs: cover array-form composite FKs and multi-field order_by

### DIFF
--- a/docs/guide/src/relationships.md
+++ b/docs/guide/src/relationships.md
@@ -218,58 +218,47 @@ the other?" Put the FK on the dependent model with `BelongsTo`, and declare
 
 ## Composite foreign keys
 
-When a parent model has a composite primary key, the `#[belongs_to]` attribute
-accepts multiple `key`/`references` pairs — one for each column in the composite
-key:
+When a parent model has a composite primary key, the foreign key on the child
+spans the same set of columns. Pass arrays to `key` and `references` to list
+each column:
 
 ```rust
 # use toasty::Model;
 #[derive(Debug, toasty::Model)]
-struct User {
+#[key(org_id, id)]
+struct Team {
+    org_id: u64,
+    id: u64,
+
+    #[has_many]
+    members: toasty::HasMany<Member>,
+}
+
+#[derive(Debug, toasty::Model)]
+#[index(org_id, team_id)]
+struct Member {
     #[key]
     #[auto]
     id: u64,
 
-    #[has_many]
-    todos: toasty::HasMany<Todo>,
-}
+    org_id: u64,
+    team_id: u64,
 
-#[derive(Debug, toasty::Model)]
-#[key(partition = user_id, local = id)]
-struct Todo {
-    #[auto]
-    id: uuid::Uuid,
-
-    user_id: u64,
-
-    #[belongs_to(key = user_id, references = id)]
-    user: toasty::BelongsTo<User>,
-
-    title: String,
+    #[belongs_to(key = [org_id, team_id], references = [org_id, id])]
+    team: toasty::BelongsTo<Team>,
 }
 ```
 
-In this example, `Todo` uses a composite primary key (`user_id` + `id`). The
-`user_id` field serves double duty: it is part of the Todo's own primary key
-*and* the foreign key pointing to `User`.
+The first field in `key` pairs with the first field in `references`, the second
+with the second, and so on, so the two arrays must have the same length. With
+a single-column foreign key, the arrays can be omitted: `key = user_id,
+references = id` is equivalent to `key = [user_id], references = [id]`.
 
-When the parent itself has a composite primary key, list each column pair:
-
-```rust,ignore
-#[belongs_to(key = org_id, references = org_id, key = team_id, references = id)]
-team: toasty::BelongsTo<Team>,
-```
-
-The number of `key` entries must match the number of `references` entries. Toasty
-pairs them positionally: the first `key` maps to the first `references`, the
-second to the second, and so on.
-
-Composite foreign key fields should be indexed together so that Toasty can query
-efficiently:
-
-```rust,ignore
-#[index(fields(org_id, team_id))]
-```
+The foreign key fields need a model-level composite index that covers them in
+order — `#[index(org_id, team_id)]` on the struct, not a separate `#[index]`
+on each field. Two single-column indexes don't compose into a covering index
+for a composite foreign key. Without one, schema verification rejects the
+model and suggests the exact attribute to add.
 
 ## What the following chapters cover
 

--- a/docs/guide/src/sorting-limits-and-pagination.md
+++ b/docs/guide/src/sorting-limits-and-pagination.md
@@ -38,6 +38,45 @@ let items = Item::all()
 `Item::fields().order()` returns a field path. Calling `.asc()` or `.desc()` on
 it produces an ordering expression that `.order_by()` accepts.
 
+### Sorting by multiple fields
+
+Pass a tuple of ordering expressions to sort by several fields at once. Each
+field beyond the first acts as a tie-breaker for the ones before it:
+
+```rust
+# use toasty::Model;
+# #[derive(Debug, toasty::Model)]
+# struct User {
+#     #[key]
+#     #[auto]
+#     id: u64,
+#     name: String,
+#     age: i64,
+# }
+# async fn __example(mut db: toasty::Db) -> toasty::Result<()> {
+// Sort by age ascending; users with the same age are ordered by name descending
+let users = User::all()
+    .order_by((
+        User::fields().age().asc(),
+        User::fields().name().desc(),
+    ))
+    .exec(&mut db)
+    .await?;
+# Ok(())
+# }
+```
+
+Chained `.order_by()` calls behave the same way — each call appends its
+expressions to the existing order rather than replacing them, so the two forms
+below are equivalent:
+
+```rust,ignore
+q.order_by((User::fields().age().asc(), User::fields().name().desc()));
+
+q.order_by(User::fields().age().asc())
+ .order_by(User::fields().name().desc());
+```
+
 Sorting works with filters too:
 
 ```rust
@@ -312,6 +351,7 @@ Methods available on query builders:
 |---|---|
 | `.order_by(field.asc())` | Sort ascending by field |
 | `.order_by(field.desc())` | Sort descending by field |
+| `.order_by((a.asc(), b.desc()))` | Sort by multiple fields; later fields are tie-breakers |
 | `.limit(n)` | Return at most `n` records |
 | `.offset(n)` | Skip first `n` records (requires `.limit()`) |
 | `.paginate(per_page)` | Cursor-based pagination (requires `.order_by()`) |


### PR DESCRIPTION
## Summary

Bring the user guide in sync with two recent code changes:

- **Composite `belongs_to`** (#905) moved from repeated `key`/`references` pairs
  to arrays (`key = [a, b], references = [a, b]`). `docs/guide/src/relationships.md`
  still showed the old form. Updated the example to use the new syntax with a
  `Team`/`Member` pair so the parent itself has a composite primary key, and
  rewrote the indexing note to match the model-level `#[index(a, b)]` form that
  schema verification now requires.
- **Multi-field `order_by`** (#901, #899) added a tuple form and made chained
  calls additive. Added a "Sorting by multiple fields" subsection to
  `docs/guide/src/sorting-limits-and-pagination.md` covering both forms, plus a
  row in the method summary table.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

The `relationships.md` example was retargeted (`Todo` → `Member`/`Team`) so the
parent has a composite primary key, which is the case that needs the new
array syntax. The original `Todo` example was a single-column FK that happened
to live inside a model with a composite PK — fine, but it didn't actually
exercise the composite-FK syntax it was meant to illustrate.

`mdbook build` and `cargo doc --no-deps --workspace` both succeed. `mdbook
test` has pre-existing failures unrelated to these changes (the harness can't
resolve `toasty::` in untouched chapters like `concurrency-control.md`).