### PR TITLE
feat: reject arguments on field-level `#[index]` attribute

### DIFF
--- a/crates/toasty-core/src/schema/verify/relations_are_indexed.rs
+++ b/crates/toasty-core/src/schema/verify/relations_are_indexed.rs
@@ -132,14 +132,14 @@ impl Verify<'_> {
             format!(
                 "each foreign-key field already has its own `#[index]`, but a \
                  composite foreign key needs a single covering index. Replace \
-                 the per-field `#[index]` annotations with a model-level \
-                 `#[index({})]` on `{}`",
+                 the per-field `#[index]` annotations with a struct-level \
+                 `#[index({})]` attribute on `{}`",
                 fk_field_names.join(", "),
                 target_name,
             )
         } else {
             format!(
-                "add `#[index({})]` to model `{}`",
+                "add a struct-level `#[index({})]` attribute to `{}`",
                 fk_field_names.join(", "),
                 target_name,
             )

--- a/crates/toasty-macros/src/model/schema/field.rs
+++ b/crates/toasty-macros/src/model/schema/field.rs
@@ -130,7 +130,14 @@ impl FieldAttr {
                     field_attr.unique = true;
                 }
             } else if attr.path().is_ident("index") {
-                if field_attr.index {
+                if !matches!(attr.meta, syn::Meta::Path(_)) {
+                    errs.push(syn::Error::new_spanned(
+                        attr,
+                        "field-level `#[index]` does not take arguments; \
+                         for a composite index spanning multiple fields, use a \
+                         struct-level `#[index(field1, field2, ...)]` attribute on the model",
+                    ));
+                } else if field_attr.index {
                     errs.push(syn::Error::new_spanned(
                         attr,
                         "duplicate #[index] attribute",

--- a/tests/tests/ui/index_with_args_on_field.rs
+++ b/tests/tests/ui/index_with_args_on_field.rs
@@ -1,0 +1,16 @@
+// Field-level `#[index]` must not take arguments. A composite index that
+// spans multiple fields belongs on the struct, not on a single field.
+
+#[derive(toasty::Model)]
+struct Item {
+    #[key]
+    #[auto]
+    id: uuid::Uuid,
+
+    #[index(other)]
+    foo: uuid::Uuid,
+
+    other: uuid::Uuid,
+}
+
+fn main() {}

--- a/tests/tests/ui/index_with_args_on_field.stderr
+++ b/tests/tests/ui/index_with_args_on_field.stderr
@@ -1,0 +1,5 @@
+error: field-level `#[index]` does not take arguments; for a composite index spanning multiple fields, use a struct-level `#[index(field1, field2, ...)]` attribute on the model
+  --> tests/ui/index_with_args_on_field.rs:10:5
+   |
+10 |     #[index(other)]
+   |     ^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary

Add validation to reject arguments on field-level `#[index]` attributes. Field-level indexes must be simple markers without arguments; composite indexes spanning multiple fields belong on the struct via `#[index(field1, field2, ...)]`.

This change:
- Adds a compile-time error when `#[index(...)]` is used on a field with arguments
- Provides a clear error message directing users to use struct-level `#[index]` for composite indexes
- Updates related error messages in the foreign key verification logic to consistently refer to "struct-level" attributes

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Added UI test (`tests/tests/ui/index_with_args_on_field.rs`) with expected error output

## Notes for reviewers

The change validates the `#[index]` attribute during macro expansion in `field.rs` by checking that the attribute is a bare path (no arguments). The test case demonstrates the error message users will see when attempting to use arguments on a field-level index.

https://claude.ai/code/session_016YM9hdJHSdx3Bb8eGdcCAP