### PR TITLE
fix: enable belongs_to with embed-typed primary keys

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -56,6 +56,7 @@ pub mod query_in_list;
 pub mod raw_identifier_fields;
 pub mod record_not_found;
 pub mod relation_belongs_to_configured;
+pub mod relation_belongs_to_embed_key;
 pub mod relation_belongs_to_one_way;
 pub mod relation_belongs_to_self_referential;
 pub mod relation_filter_association;

--- a/crates/toasty-driver-integration-suite/src/tests/relation_belongs_to_embed_key.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_belongs_to_embed_key.rs
@@ -1,0 +1,60 @@
+use crate::prelude::*;
+
+/// Regression test for tokio-rs/toasty#897: a `BelongsTo` whose foreign key
+/// references a primary key that is an `Embed` newtype caused the derive macro
+/// to emit code that called `Field::key_constraint` with a `{Embed}Fields`
+/// wrapper instead of the underlying `Path`, leading to a compile error.
+#[driver_test(requires(sql))]
+pub async fn belongs_to_with_embed_pk(t: &mut Test) -> Result<()> {
+    #[derive(Clone, Debug, PartialEq, Eq, toasty::Embed)]
+    pub struct MeetingId(String);
+
+    #[derive(Clone, Debug, PartialEq, Eq, toasty::Embed)]
+    pub struct AgendaItemId(String);
+
+    #[derive(Debug, toasty::Model)]
+    pub struct Meeting {
+        #[key]
+        pub id: MeetingId,
+
+        #[has_many]
+        pub agenda_items: toasty::HasMany<AgendaItem>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    pub struct AgendaItem {
+        #[key]
+        pub id: AgendaItemId,
+
+        #[index]
+        pub meeting_id: MeetingId,
+
+        #[belongs_to(key = meeting_id, references = id)]
+        pub meeting: toasty::BelongsTo<Meeting>,
+    }
+
+    let mut db = t
+        .setup_db(models!(Meeting, AgendaItem, MeetingId, AgendaItemId))
+        .await;
+
+    let meeting = toasty::create!(Meeting {
+        id: MeetingId("m1".into()),
+    })
+    .exec(&mut db)
+    .await?;
+
+    let item = toasty::create!(AgendaItem {
+        id: AgendaItemId("a1".into()),
+        meeting: &meeting,
+    })
+    .exec(&mut db)
+    .await?;
+
+    assert_eq!(item.meeting_id.0, "m1");
+
+    // The accessor whose codegen used to fail to compile.
+    let loaded = item.meeting().exec(&mut db).await?;
+    assert_eq!(loaded.id.0, "m1");
+
+    Ok(())
+}

--- a/crates/toasty-macros/src/model/expand/relation.rs
+++ b/crates/toasty-macros/src/model/expand/relation.rs
@@ -260,10 +260,15 @@ impl Expand<'_> {
             let source_field_ident = &source.name.ident;
             let target = &fk_field.target;
 
+            // `fields().#target()` returns the target field's
+            // `<Field>::Path<Origin>` — `Path<Origin, T>` for primitives and a
+            // wrapping `{Embed}Fields<Origin>` for embedded types. Both
+            // convert into `Path<Origin, T>` via `Into`, which is what
+            // `key_constraint` expects.
             quote! {
                 #toasty::Field::key_constraint(
                     &self.#source_field_ident,
-                    <#ty as #toasty::Relation>::Model::fields().#target(),
+                    <#ty as #toasty::Relation>::Model::fields().#target().into(),
                 )
             }
         });

--- a/crates/toasty/src/engine/lower/insert.rs
+++ b/crates/toasty/src/engine/lower/insert.rs
@@ -119,13 +119,16 @@ impl LowerStatement<'_, '_> {
                 let fk_fields = &rel.foreign_key.fields;
 
                 // Distribute the BelongsTo value into its FK source column(s):
-                //   - composite FK: the value is a record (`Expr::Record` from
-                //     the tuple `IntoExpr` for composite-PK targets, or
-                //     `Expr::Value(Value::Record)` from a literal); one item
-                //     per FK column via `into_record_items`.
-                //   - single FK: the value is a scalar; it goes whole into the
-                //     single FK column.
-                if field_expr.is_record() {
+                //   - composite FK (`fk_fields.len() > 1`): the value is a
+                //     record (`Expr::Record` from the tuple `IntoExpr` for
+                //     composite-PK targets, or `Expr::Value(Value::Record)`
+                //     from a literal); one item per FK column via
+                //     `into_record_items`.
+                //   - single FK: the value goes whole into the single FK
+                //     column, whether it is a scalar or a record (an
+                //     `Embed`-typed PK produces an `Expr::Record` whose shape
+                //     matches the embed-typed FK source).
+                if fk_fields.len() > 1 && field_expr.is_record() {
                     let items = field_expr.take().into_record_items().unwrap();
                     let mut count = 0;
                     for (fk_field, item) in fk_fields.iter().zip(items) {
@@ -134,7 +137,7 @@ impl LowerStatement<'_, '_> {
                     }
                     assert_eq!(count, fk_fields.len());
                 } else {
-                    if !field_expr.is_value() {
+                    if !field_expr.is_value() && !field_expr.is_record() {
                         continue;
                     }
                     let [fk_field] = &fk_fields[..] else {


### PR DESCRIPTION
## Summary

Two-part fix to make `BelongsTo` work when the referenced primary key is an `Embed`:

1. **`fix(macros)`** — The `belongs_to` accessor generated `Field::key_constraint(&self.fk, T::fields().pk())`, which compiled when the referenced PK was a primitive but failed for `Embed` PKs because `fields().pk()` returns a `{Embed}Fields<Origin>` wrapper instead of a `Path<Origin, T>`. Insert an `.into()` so both shapes resolve to the `Path<Origin, Self::Inner>` that `key_constraint` expects — identity for primitives via the blanket `From<T> for T`, and the generated `Into<Path<…>>` for embed wrappers.
2. **`fix(engine)`** — After the macro change unblocks compilation, the runtime hits a regression introduced by #906: `apply_app_level_insertion_defaults` destructured *any* `Expr::Record` FK value into the FK source columns. That is correct for true composite (multi-field) FKs, but wrong for a single-field FK whose target PK is an embed — `&parent` lowers via the embed's `IntoExpr` to an `Expr::Record`, and the lone embed-typed FK column needs the record as a whole, not its inner item. Gate the destructuring on `fk_fields.len() > 1`.

Closes #897.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes — verified locally against all four drivers (SQLite 932, PostgreSQL 960, MySQL 943, DynamoDB 447, all green)

## Notes for reviewers

Regression test in `relation_belongs_to_embed_key.rs` covers the failing pattern from the issue: embed-newtype PK on both sides and the `belongs_to(key, references)` accessor end-to-end. Worth eyeballing the engine change in `lower/insert.rs` — the gate is purely on `fk_fields.len() > 1`, so composite-PK paths are untouched.