### PR TITLE
docs: rework README header with versioned docs links

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -59,9 +59,52 @@ jobs:
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code
       - name: Run release-plz
+        id: release-plz
         uses: release-plz/action@v0.5
         with:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+      # The README links to the released guide / API docs at a specific
+      # version. Source of truth is the `toasty` version pinned in
+      # `[workspace.dependencies]`, which release-plz bumps on the PR
+      # branch. Re-applied on every run because release-plz force-pushes
+      # its branch.
+      - name: Sync README version with release PR
+        if: ${{ steps.release-plz.outputs.prs != '' && steps.release-plz.outputs.prs != '[]' }}
+        env:
+          PRS: ${{ steps.release-plz.outputs.prs }}
+        run: |
+          set -euo pipefail
+          branch=$(jq -r '.[0].head_branch' <<<"$PRS")
+          if [ -z "$branch" ] || [ "$branch" = "null" ]; then
+            echo "No release branch detected; skipping README update."
+            exit 0
+          fi
+
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git fetch origin "$branch"
+          git checkout "$branch"
+
+          version=$(grep -m1 '^toasty = { version' Cargo.toml \
+            | sed -E 's/.*version = "([^"]+)".*/\1/')
+          if [ -z "$version" ]; then
+            echo "Failed to parse toasty version from Cargo.toml" >&2
+            exit 1
+          fi
+
+          sed -i -E \
+            "s|tokio-rs\\.github\\.io/toasty/[0-9]+\\.[0-9]+\\.[0-9]+/|tokio-rs.github.io/toasty/${version}/|g" \
+            README.md
+
+          if git diff --quiet README.md; then
+            echo "README already on version ${version}; nothing to update."
+            exit 0
+          fi
+
+          git add README.md
+          git commit -m "chore: point README docs links at ${version}"
+          git push origin "$branch"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <div align="center">
   <h3>The cozy, easy ORM for Rust</h3>
   <a href="https://tokio-rs.github.io/toasty/0.6.0/guide/">Guide</a> •
-  <a href="https://tokio-rs.github.io/toasty/0.6.0/api/">API Docs</a> •
+  <a href="https://docs.rs/toasty">API Docs</a> •
   <a href="https://crates.io/crates/toasty">Crates.io</a> •
   <a href="https://discord.gg/tokio">Discord</a>
 </div>

--- a/README.md
+++ b/README.md
@@ -1,9 +1,26 @@
-# Toasty
+<div align="center">
+  <h1>Toasty</h1>
+</div>
+
+<br/>
+<div align="center">
+  <h3>The cozy, easy ORM for Rust</h3>
+  <a href="https://tokio-rs.github.io/toasty/0.6.0/guide/">Guide</a> •
+  <a href="https://tokio-rs.github.io/toasty/0.6.0/api/">API Docs</a> •
+  <a href="https://crates.io/crates/toasty">Crates.io</a> •
+  <a href="https://discord.gg/tokio">Discord</a>
+</div>
+
+<br/>
+
+<div align="center">
 
 [![Crates.io][crates-badge]][crates-url]
 [![MIT licensed][mit-badge]][mit-url]
 [![Build Status][actions-badge]][actions-url]
 [![Discord chat][discord-badge]][discord-url]
+
+</div>
 
 [crates-badge]: https://img.shields.io/crates/v/toasty.svg
 [crates-url]: https://crates.io/crates/toasty
@@ -14,18 +31,9 @@
 [discord-badge]: https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=flat-square
 [discord-url]: https://discord.gg/tokio
 
-Toasty is an ORM for the Rust programming language that prioritizes ease-of-use.
-It currently supports SQL databases (SQLite, PostgreSQL, MySQL) and DynamoDB.
-Note that Toasty does not hide database capabilities. Instead, Toasty exposes
-features based on the target database.
-
-Current status: Preview — Most major features are in place and Toasty should be
-complete enough to build applications with. The API is not yet stable and
-breaking changes may still occur. Contributions are welcome.
-
-[User guide](https://tokio-rs.github.io/toasty/nightly/guide/): Explore Toasty in depth.
-
-[Nightly API docs](https://tokio-rs.github.io/toasty/nightly/api/): API reference built from the latest commit.
+Toasty supports SQL databases (SQLite, PostgreSQL, MySQL) and DynamoDB. It does
+not hide database capabilities — it exposes features based on the target
+database.
 
 ## Using Toasty
 

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -6,6 +6,11 @@ documentation, see the [Toasty Guide](../guide/).
 Start with [`CONTRIBUTING.md`](../../CONTRIBUTING.md) — it describes how
 to propose changes and land PRs.
 
+Docs built from the latest commit on `main`:
+
+- [Nightly user guide](https://tokio-rs.github.io/toasty/nightly/guide/)
+- [Nightly API docs](https://tokio-rs.github.io/toasty/nightly/api/)
+
 ## Architecture
 
 High-level documentation of how Toasty is put together.
@@ -20,7 +25,13 @@ Guide-level design documents for specific features. Use
 [`_template.md`](./design/_template.md) when starting a new one.
 
 - [Design Overview](./design/README.md)
+- [Per-Call Column Projection](./design/column-projection.md)
+- [DynamoDB Scan Support](./design/ddb-scan.md)
+- [Deferred Fields](./design/deferred-fields.md)
+- [Document and Collection Fields](./design/document-fields.md)
 - [Enums and Embedded Structs](./design/enums-and-embedded-structs.md)
+- [Optimistic Concurrency with `#[version]`](./design/field-version.md)
+- [`query!` Macro](./design/query-macro.md)
 - [Static Assertions for `create!` Required Fields](./design/static-assertions-create-macro.md)
 
 ## Roadmap


### PR DESCRIPTION
## Summary

Rework the top of the README in the drizzle style: centered title, tagline, and nav row (Guide, API Docs, Crates.io, Discord), badges below.

- Guide link points at the latest released version's docs (currently `0.6.0/guide/`) instead of nightly.
- API Docs link points at `docs.rs/toasty`, which always serves the latest release.
- The two nightly docs links move to `docs/dev/README.md` where contributors look.
- New release-plz workflow step keeps the versioned Guide URL in sync. After release-plz creates / updates the PR, it reads the new `toasty` version from `[workspace.dependencies]` on the PR branch and rewrites the URL in the README. Idempotent and re-applied each run since release-plz force-pushes its branch.
- Drive-by: the design doc TOC in `docs/dev/README.md` was missing six entries; refreshed.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format

## Notes for reviewers

The workflow change can only really be tested by the next release run. Pattern is the standard `grep | sed` on `[workspace.dependencies]`; the regex was verified locally against the current README.