### PR TITLE
fix(engine): handle composite FKs in relation-chain lowering

### DIFF
--- a/crates/toasty-driver-integration-suite/src/scenarios.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios.rs
@@ -1,3 +1,4 @@
+pub mod composite_chain_relations;
 pub mod composite_fk_has_many_belongs_to;
 pub mod composite_has_many_belongs_to;
 pub mod deferred_document;

--- a/crates/toasty-driver-integration-suite/src/scenarios/composite_chain_relations.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios/composite_chain_relations.rs
@@ -1,0 +1,72 @@
+use crate::prelude::*;
+
+scenario! {
+    /// Multi-relation chain scenario with composite keys at two of the three
+    /// hops:
+    ///
+    /// - `User` has a single-column auto PK.
+    /// - `Todo` has a single-column PK, a single-column FK back to `User`,
+    ///   and a *composite* FK `(category_id, category_revision)` pointing at
+    ///   `Category`.
+    /// - `Category` has a *composite* PK `(id, revision)`.
+    ///
+    /// This lets the chain tests exercise composite-key handling at two
+    /// distinct positions:
+    ///
+    /// - `user.todos().category()` — the second hop is a `BelongsTo` with a
+    ///   composite FK.
+    /// - `category.todos()` — the first hop is a `HasMany` whose paired
+    ///   `BelongsTo` (on `Todo`) is composite.
+    /// - `category.todos().user()` — chains the composite-pair first hop into
+    ///   a single-column second hop.
+
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+
+        name: String,
+
+        #[has_many]
+        todos: toasty::HasMany<Todo>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    #[index(category_id, category_revision)]
+    struct Todo {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+
+        #[index]
+        user_id: uuid::Uuid,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: toasty::BelongsTo<User>,
+
+        category_id: uuid::Uuid,
+        category_revision: i64,
+
+        #[belongs_to(key = [category_id, category_revision], references = [id, revision])]
+        category: toasty::BelongsTo<Category>,
+
+        title: String,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    #[key(id, revision)]
+    struct Category {
+        id: uuid::Uuid,
+        revision: i64,
+
+        name: String,
+
+        #[has_many]
+        todos: toasty::HasMany<Todo>,
+    }
+
+    async fn setup(test: &mut Test) -> toasty::Db {
+        test.setup_db(models!(User, Todo, Category)).await
+    }
+}

--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -60,6 +60,7 @@ pub mod relation_belongs_to_embed_key;
 pub mod relation_belongs_to_one_way;
 pub mod relation_belongs_to_self_referential;
 pub mod relation_chain;
+pub mod relation_chain_composite_key;
 pub mod relation_filter_association;
 pub mod relation_has_many_batch_create;
 pub mod relation_has_many_boxed_fk;

--- a/crates/toasty-driver-integration-suite/src/tests/relation_chain_composite_key.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_chain_composite_key.rs
@@ -1,0 +1,446 @@
+//! Chain relation methods on `Many` where one or more hops in the chain has
+//! a composite key. Parallels [`crate::tests::relation_chain`] which covers
+//! the all-single-key case.
+//!
+//! Two positions are interesting:
+//!
+//! - A `BelongsTo` second hop whose foreign key spans multiple columns.
+//! - A `HasMany` first hop whose paired `BelongsTo` on the target has a
+//!   composite foreign key.
+//!
+//! The shared scenario [`crate::scenarios::composite_chain_relations`]
+//! arranges `User → Todo → Category` so both positions are reachable from a
+//! single dataset: `Category` has composite PK `(id, revision)` and Todo's
+//! FK to it spans `(category_id, category_revision)`. The Todo→User FK is
+//! single-column, so `category.todos().user()` cross-checks that a composite
+//! first hop chains cleanly into a single-column second hop.
+
+use crate::prelude::*;
+use crate::scenarios::composite_chain_relations::Category;
+
+/// Insert a Category with both fields of its composite PK set. The scenario
+/// uses a non-auto composite PK so callers have to pick `id` and `revision`
+/// themselves; centralising that here keeps the tests focused on chain
+/// behavior rather than key plumbing.
+async fn make_category(db: &mut toasty::Db, name: &str, revision: i64) -> Result<Category> {
+    toasty::create!(Category {
+        id: uuid::Uuid::new_v4(),
+        revision,
+        name,
+    })
+    .exec(db)
+    .await
+}
+
+// =====================================================================
+// `user.todos().category()` — second hop is BelongsTo with composite FK
+// =====================================================================
+
+/// Happy path mirroring `relation_chain::user_todos_category` but the
+/// `Todo → Category` belongs_to spans `(category_id, category_revision)`.
+/// The result must dedupe on the composite key, not just on `id`.
+#[driver_test(scenario(crate::scenarios::composite_chain_relations))]
+pub async fn user_todos_category_composite(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user = toasty::create!(User { name: "Anchovy" })
+        .exec(&mut db)
+        .await?;
+    let other_user = toasty::create!(User { name: "Other" })
+        .exec(&mut db)
+        .await?;
+
+    let food = make_category(&mut db, "Food", 1).await?;
+    let drink = make_category(&mut db, "Drink", 1).await?;
+    let _unused = make_category(&mut db, "Unused", 1).await?;
+
+    toasty::create!(Todo::[
+        { title: "salad", user: &user, category: &food },
+        { title: "tea",   user: &user, category: &drink },
+        { title: "sushi", user: &user, category: &food },
+        { title: "wine",  user: &other_user, category: &drink },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let mut categories = user.todos().category().exec(&mut db).await?;
+    categories.sort_by_key(|c| c.name.clone());
+
+    let ids: Vec<_> = categories.iter().map(|c| (c.id, c.revision)).collect();
+    assert_unique!(ids);
+    assert_eq!(categories.len(), 2);
+    assert_eq!(
+        (categories[0].id, categories[0].revision),
+        (drink.id, drink.revision)
+    );
+    assert_eq!(
+        (categories[1].id, categories[1].revision),
+        (food.id, food.revision)
+    );
+    Ok(())
+}
+
+/// Two Categories that share `id` but differ in `revision` must both come
+/// back as distinct rows from a chain query. This protects against a
+/// regression where the IN-subquery was generated over `category_id` only,
+/// silently merging different revisions.
+#[driver_test(scenario(crate::scenarios::composite_chain_relations))]
+pub async fn user_todos_category_distinguishes_by_revision(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user = toasty::create!(User { name: "Owner" })
+        .exec(&mut db)
+        .await?;
+
+    // Same `id`, different `revision` — without composite-key handling
+    // these would collide in the FK subquery.
+    let shared_id = uuid::Uuid::new_v4();
+    let v1 = toasty::create!(Category {
+        id: shared_id,
+        revision: 1,
+        name: "v1",
+    })
+    .exec(&mut db)
+    .await?;
+    let v2 = toasty::create!(Category {
+        id: shared_id,
+        revision: 2,
+        name: "v2",
+    })
+    .exec(&mut db)
+    .await?;
+
+    toasty::create!(Todo::[
+        { title: "old", user: &user, category: &v1 },
+        { title: "new", user: &user, category: &v2 },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let mut categories = user.todos().category().exec(&mut db).await?;
+    categories.sort_by_key(|c| c.revision);
+
+    assert_eq!(categories.len(), 2);
+    assert_eq!(
+        (categories[0].id, categories[0].revision),
+        (v1.id, v1.revision)
+    );
+    assert_eq!(
+        (categories[1].id, categories[1].revision),
+        (v2.id, v2.revision)
+    );
+    Ok(())
+}
+
+/// A chain whose source produces no rows (`user` has no todos) must
+/// short-circuit to an empty result, even when there is unrelated data of
+/// the matching shape in the table.
+#[driver_test(scenario(crate::scenarios::composite_chain_relations))]
+pub async fn composite_chain_from_empty_source_is_empty(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let lonely = toasty::create!(User { name: "Lonely" })
+        .exec(&mut db)
+        .await?;
+
+    let busy = toasty::create!(User { name: "Busy" }).exec(&mut db).await?;
+    let cat = make_category(&mut db, "Solo", 1).await?;
+    toasty::create!(Todo {
+        title: "salad",
+        user: &busy,
+        category: &cat,
+    })
+    .exec(&mut db)
+    .await?;
+
+    let categories = lonely.todos().category().exec(&mut db).await?;
+    assert!(categories.is_empty());
+    Ok(())
+}
+
+/// Filter applied to the chain's terminal model narrows the chain's result.
+/// Mirrors `relation_chain::chain_then_filter` but the terminal model has a
+/// composite PK.
+#[driver_test(scenario(crate::scenarios::composite_chain_relations))]
+pub async fn composite_chain_then_filter(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user = toasty::create!(User { name: "Filty" })
+        .exec(&mut db)
+        .await?;
+    let food = make_category(&mut db, "Food", 1).await?;
+    let drink = make_category(&mut db, "Drink", 1).await?;
+
+    toasty::create!(Todo::[
+        { title: "salad", user: &user, category: &food },
+        { title: "tea",   user: &user, category: &drink },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let only_food = user
+        .todos()
+        .category()
+        .filter(Category::fields().name().eq("Food"))
+        .exec(&mut db)
+        .await?;
+    assert_eq!(only_food.len(), 1);
+    assert_eq!(
+        (only_food[0].id, only_food[0].revision),
+        (food.id, food.revision)
+    );
+    Ok(())
+}
+
+// =====================================================================
+// `category.todos()` — first hop is HasMany whose pair is composite-FK
+// =====================================================================
+
+/// Chain starting at a model with a composite PK. The first hop's pair
+/// (Todo's `belongs_to` back to Category) is composite, so the filter
+/// generated for `Todo.category_id` must include both `category_id` and
+/// `category_revision`.
+#[driver_test(scenario(crate::scenarios::composite_chain_relations))]
+pub async fn category_todos_user_composite_first_hop(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let alice = toasty::create!(User { name: "Alice" })
+        .exec(&mut db)
+        .await?;
+    let bob = toasty::create!(User { name: "Bob" }).exec(&mut db).await?;
+
+    let food = make_category(&mut db, "Food", 1).await?;
+    let other = make_category(&mut db, "Other", 1).await?;
+
+    toasty::create!(Todo::[
+        { title: "salad", user: &alice, category: &food },
+        { title: "tea",   user: &bob,   category: &food },
+        { title: "wine",  user: &alice, category: &other },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let mut users = food.todos().user().exec(&mut db).await?;
+    users.sort_by_key(|u| u.name.clone());
+
+    let ids: Vec<_> = users.iter().map(|u| u.id).collect();
+    assert_unique!(ids);
+    assert_eq!(users.len(), 2);
+    assert_eq!(users[0].name, "Alice");
+    assert_eq!(users[1].name, "Bob");
+    Ok(())
+}
+
+/// `Category(id=X, revision=1)` and `Category(id=X, revision=2)` are two
+/// distinct categories. The chain starting at one must not pick up the
+/// other's todos — the filter has to discriminate on both FK columns.
+#[driver_test(scenario(crate::scenarios::composite_chain_relations))]
+pub async fn category_todos_respects_revision(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let alice = toasty::create!(User { name: "Alice" })
+        .exec(&mut db)
+        .await?;
+    let bob = toasty::create!(User { name: "Bob" }).exec(&mut db).await?;
+
+    // Two categories sharing the same `id`, differing only in `revision`.
+    let shared_id = uuid::Uuid::new_v4();
+    let v1 = toasty::create!(Category {
+        id: shared_id,
+        revision: 1,
+        name: "v1",
+    })
+    .exec(&mut db)
+    .await?;
+    let v2 = toasty::create!(Category {
+        id: shared_id,
+        revision: 2,
+        name: "v2",
+    })
+    .exec(&mut db)
+    .await?;
+
+    toasty::create!(Todo::[
+        { title: "for-v1", user: &alice, category: &v1 },
+        { title: "for-v2", user: &bob,   category: &v2 },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let v1_users = v1.todos().user().exec(&mut db).await?;
+    assert_eq!(v1_users.len(), 1);
+    assert_eq!(v1_users[0].name, "Alice");
+
+    let v2_users = v2.todos().user().exec(&mut db).await?;
+    assert_eq!(v2_users.len(), 1);
+    assert_eq!(v2_users[0].name, "Bob");
+    Ok(())
+}
+
+/// A `category.todos()` chain that ends in `.filter(...)` narrows the
+/// terminal model the same way as in the single-key chain tests. This
+/// pairs with `composite_chain_then_filter` (which exercises the
+/// second-hop composite case) to make sure both endpoints respect filters.
+#[driver_test(scenario(crate::scenarios::composite_chain_relations))]
+pub async fn category_todos_filter(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let alice = toasty::create!(User { name: "Alice" })
+        .exec(&mut db)
+        .await?;
+    let bob = toasty::create!(User { name: "Bob" }).exec(&mut db).await?;
+
+    let food = make_category(&mut db, "Food", 1).await?;
+
+    toasty::create!(Todo::[
+        { title: "salad",   user: &alice, category: &food },
+        { title: "sushi",   user: &bob,   category: &food },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let just_salad = food
+        .todos()
+        .filter(Todo::fields().title().eq("salad"))
+        .exec(&mut db)
+        .await?;
+    assert_eq!(just_salad.len(), 1);
+    assert_eq!(just_salad[0].title, "salad");
+    Ok(())
+}
+
+/// `Category::filter(name = ...).todos().user()` — the chain's source query
+/// is filtered by a *non-FK* column (`name`). The fallback path inside
+/// `lift_belongs_to_in_subquery` (which can't lift the filter onto FK
+/// columns) must still produce a working composite-FK IN subquery rather
+/// than panicking on `todo!("composite keys")`.
+#[driver_test(scenario(crate::scenarios::composite_chain_relations))]
+pub async fn filtered_category_todos_user_composite(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let alice = toasty::create!(User { name: "Alice" })
+        .exec(&mut db)
+        .await?;
+    let bob = toasty::create!(User { name: "Bob" }).exec(&mut db).await?;
+
+    let food = make_category(&mut db, "Food", 1).await?;
+    let drink = make_category(&mut db, "Drink", 1).await?;
+
+    toasty::create!(Todo::[
+        { title: "salad", user: &alice, category: &food },
+        { title: "tea",   user: &bob,   category: &drink },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let mut users = Category::filter(Category::fields().name().eq("Food"))
+        .todos()
+        .user()
+        .exec(&mut db)
+        .await?;
+    users.sort_by_key(|u| u.name.clone());
+
+    assert_eq!(users.len(), 1);
+    assert_eq!(users[0].name, "Alice");
+    Ok(())
+}
+
+// =====================================================================
+// Both hops composite — HasMany→HasMany where parent has composite PK
+// =====================================================================
+
+/// `Author → posts → comments` with composite keys on `Author` and `Post`.
+/// The chain involves two HasMany hops, each producing an IN-subquery
+/// against a composite-FK pair. Mirrors `relation_chain::has_many_through_has_many`.
+#[driver_test]
+pub async fn composite_has_many_through_has_many(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    #[key(id, revision)]
+    struct Author {
+        id: uuid::Uuid,
+        revision: i64,
+        name: String,
+        #[has_many]
+        posts: toasty::HasMany<Post>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    #[index(author_id, author_revision)]
+    struct Post {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+        author_id: uuid::Uuid,
+        author_revision: i64,
+        #[belongs_to(key = [author_id, author_revision], references = [id, revision])]
+        author: toasty::BelongsTo<Author>,
+        title: String,
+        #[has_many]
+        comments: toasty::HasMany<Comment>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Comment {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+        #[index]
+        post_id: uuid::Uuid,
+        #[belongs_to(key = post_id, references = id)]
+        post: toasty::BelongsTo<Post>,
+        body: String,
+    }
+
+    let mut db = test.setup_db(models!(Author, Post, Comment)).await;
+
+    let alice = toasty::create!(Author {
+        id: uuid::Uuid::new_v4(),
+        revision: 1,
+        name: "Alice",
+    })
+    .exec(&mut db)
+    .await?;
+    let bob = toasty::create!(Author {
+        id: uuid::Uuid::new_v4(),
+        revision: 1,
+        name: "Bob",
+    })
+    .exec(&mut db)
+    .await?;
+
+    let p1 = toasty::create!(Post {
+        title: "p1",
+        author: &alice
+    })
+    .exec(&mut db)
+    .await?;
+    let p2 = toasty::create!(Post {
+        title: "p2",
+        author: &alice
+    })
+    .exec(&mut db)
+    .await?;
+    let _p3 = toasty::create!(Post {
+        title: "p3",
+        author: &bob
+    })
+    .exec(&mut db)
+    .await?;
+
+    toasty::create!(Comment::[
+        { body: "c1", post: &p1 },
+        { body: "c2", post: &p1 },
+        { body: "c3", post: &p2 },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let mut alice_comments = alice.posts().comments().exec(&mut db).await?;
+    alice_comments.sort_by_key(|c| c.body.clone());
+    let bodies: Vec<_> = alice_comments.into_iter().map(|c| c.body).collect();
+    assert_eq!(bodies, vec!["c1", "c2", "c3"]);
+
+    let bob_comments = bob.posts().comments().exec(&mut db).await?;
+    assert!(bob_comments.is_empty());
+    Ok(())
+}

--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -1620,12 +1620,14 @@ impl LoweringContext<'_> {
     }
 }
 
-/// Build the LHS shape of an equality whose RHS is a key value:
-/// a single field reference for a single-column key, a record of field
-/// references for a composite key. The surrounding `==` is then decomposed
-/// into pairwise comparisons by `lower_expr_binary_op`'s `Record == Record`
-/// (or `Record == Value::Record`) handler.
-fn key_field_refs(
+/// Build a scalar-or-record expression of field references for a key
+/// (primary or foreign): a single `ref_field` for a single-column key, a
+/// `Record` of `ref_field`s for a composite key. Used both for the
+/// eq-operand rewrite (where the surrounding `==` decomposes pair-wise via
+/// `lower_expr_binary_op`'s `Record == Record` handler) and for composite
+/// FK IN-subquery comparisons (where the tuple LHS pairs with a tuple
+/// projection on the RHS).
+pub(super) fn key_field_refs(
     nesting: usize,
     mut fields: impl ExactSizeIterator<Item = app::FieldId>,
 ) -> stmt::Expr {

--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -513,13 +513,10 @@ impl visit_mut::VisitMut for LowerStatement<'_, '_> {
                 if self.capability().sql {
                     self.visit_expr_in_subquery_mut(e);
 
-                    let maybe_res = self.lower_expr_binary_op(
-                        stmt::BinaryOp::Eq,
+                    self.lower_in_subquery_operands(
                         &mut e.expr,
                         e.query.returning_mut_unwrap().as_project_mut_unwrap(),
                     );
-
-                    assert!(maybe_res.is_none(), "TODO");
 
                     let returning = e.query.returning_mut_unwrap().as_project_mut_unwrap();
 
@@ -552,13 +549,10 @@ impl visit_mut::VisitMut for LowerStatement<'_, '_> {
 
                     self.track_dependency(target_id);
 
-                    let maybe_res = self.lower_expr_binary_op(
-                        stmt::BinaryOp::Eq,
+                    self.lower_in_subquery_operands(
                         &mut e.expr,
                         e.query.returning_mut_unwrap().as_project_mut_unwrap(),
                     );
-
-                    assert!(maybe_res.is_none(), "TODO");
 
                     let stmt::Expr::InSubquery(e) = expr.take() else {
                         panic!()
@@ -1137,6 +1131,26 @@ impl<'a, 'b> LowerStatement<'a, 'b> {
             stmt::Expr::and_from_vec(comparisons)
         } else {
             stmt::Expr::or_from_vec(comparisons)
+        }
+    }
+
+    /// Lower the LHS and RHS of an `IN (subquery)` in place. When both sides
+    /// are records of equal arity (as produced for composite-key FK
+    /// comparisons) the per-element lowering is applied pair-wise so
+    /// element-level transforms (NULLs, casts) still fire while the
+    /// surrounding `IN` is preserved. Otherwise a single binary-op lowering
+    /// is applied across both sides.
+    fn lower_in_subquery_operands(&mut self, lhs: &mut stmt::Expr, rhs: &mut stmt::Expr) {
+        if let (stmt::Expr::Record(lhs_rec), stmt::Expr::Record(rhs_rec)) = (&mut *lhs, &mut *rhs)
+            && lhs_rec.len() == rhs_rec.len()
+        {
+            for (l, r) in lhs_rec.fields.iter_mut().zip(rhs_rec.fields.iter_mut()) {
+                let maybe_res = self.lower_expr_binary_op(stmt::BinaryOp::Eq, l, r);
+                assert!(maybe_res.is_none(), "TODO");
+            }
+        } else {
+            let maybe_res = self.lower_expr_binary_op(stmt::BinaryOp::Eq, lhs, rhs);
+            assert!(maybe_res.is_none(), "TODO");
         }
     }
 

--- a/crates/toasty/src/engine/lower/association.rs
+++ b/crates/toasty/src/engine/lower/association.rs
@@ -170,26 +170,13 @@ impl<'a> RewriteVia<'a> {
         // <fk.source...> FROM <source>)` — a single field reference on each
         // side for single-column FKs, a record of references for composite
         // FKs (lowered to a tuple-style IN by the SQL serializer).
-        let target = fk_field_refs(rel.foreign_key.fields.iter().map(|fk| fk.target));
-        let returning = fk_field_refs(rel.foreign_key.fields.iter().map(|fk| fk.source));
+        let target = super::key_field_refs(0, rel.foreign_key.fields.iter().map(|fk| fk.target));
+        let returning = super::key_field_refs(0, rel.foreign_key.fields.iter().map(|fk| fk.source));
 
         let mut source = *association.source;
         source.body.as_select_mut_unwrap().returning = stmt::Returning::Project(returning);
 
         stmt::Expr::in_subquery(target, source).into()
-    }
-}
-
-/// Build the LHS / projection shape for an FK comparison: a single field
-/// reference for a single-column FK, a `Record` of field references for a
-/// composite FK. The latter pairs with the `Record == Record` lowering in
-/// `lower_expr_binary_op` and the `(a, b) IN (SELECT a, b FROM ...)` SQL
-/// form.
-fn fk_field_refs(mut fields: impl ExactSizeIterator<Item = app::FieldId>) -> stmt::Expr {
-    if fields.len() == 1 {
-        stmt::Expr::ref_self_field(fields.next().unwrap())
-    } else {
-        stmt::Expr::record(fields.map(stmt::Expr::ref_self_field))
     }
 }
 

--- a/crates/toasty/src/engine/lower/association.rs
+++ b/crates/toasty/src/engine/lower/association.rs
@@ -166,21 +166,30 @@ impl<'a> RewriteVia<'a> {
         association: stmt::Association,
     ) -> stmt::Filter {
         // The FK lives on the source model; the target model carries the
-        // referenced fields. Filter is: `self.<fk.target> IN (SELECT
-        // <fk.source> FROM <source>)`. Single-column FKs only for now —
-        // composite keys can be added by switching to tuple-style IN.
-        assert_eq!(
-            rel.foreign_key.fields.len(),
-            1,
-            "composite foreign keys in BelongsTo via paths not yet supported"
-        );
-        let fk = &rel.foreign_key.fields[0];
+        // referenced fields. Filter is `<fk.target...> IN (SELECT
+        // <fk.source...> FROM <source>)` — a single field reference on each
+        // side for single-column FKs, a record of references for composite
+        // FKs (lowered to a tuple-style IN by the SQL serializer).
+        let target = fk_field_refs(rel.foreign_key.fields.iter().map(|fk| fk.target));
+        let returning = fk_field_refs(rel.foreign_key.fields.iter().map(|fk| fk.source));
 
         let mut source = *association.source;
-        source.body.as_select_mut_unwrap().returning =
-            stmt::Returning::Project(stmt::Expr::ref_self_field(fk.source));
+        source.body.as_select_mut_unwrap().returning = stmt::Returning::Project(returning);
 
-        stmt::Expr::in_subquery(stmt::Expr::ref_self_field(fk.target), source).into()
+        stmt::Expr::in_subquery(target, source).into()
+    }
+}
+
+/// Build the LHS / projection shape for an FK comparison: a single field
+/// reference for a single-column FK, a `Record` of field references for a
+/// composite FK. The latter pairs with the `Record == Record` lowering in
+/// `lower_expr_binary_op` and the `(a, b) IN (SELECT a, b FROM ...)` SQL
+/// form.
+fn fk_field_refs(mut fields: impl ExactSizeIterator<Item = app::FieldId>) -> stmt::Expr {
+    if fields.len() == 1 {
+        stmt::Expr::ref_self_field(fields.next().unwrap())
+    } else {
+        stmt::Expr::record(fields.map(stmt::Expr::ref_self_field))
     }
 }
 

--- a/crates/toasty/src/engine/lower/lift_in_subquery.rs
+++ b/crates/toasty/src/engine/lower/lift_in_subquery.rs
@@ -242,10 +242,10 @@ pub(super) fn try_lift_relation_path_comparison(
 /// BelongsTo branch: try to lift the subquery's filter into direct FK
 /// comparisons.  When the filter references only FK-mapped fields, return
 /// the AND of per-FK equalities.  Otherwise, fall back to an IN subquery
-/// on the foreign-key column.
+/// on the foreign-key column(s) — a tuple-form IN for composite FKs.
 ///
 /// Returns `None` when the subquery does not target the BelongsTo's
-/// target model.  Currently only supports single-field foreign keys.
+/// target model.
 fn lift_belongs_to_in_subquery(
     cx: &ExprContext,
     belongs_to: &BelongsTo,
@@ -276,16 +276,14 @@ fn lift_belongs_to_in_subquery(
     let all_fks_matched = lift.fk_field_matches.iter().all(|m| *m);
 
     if lift.fail || !all_fks_matched {
-        let [fk_fields] = &belongs_to.foreign_key.fields[..] else {
-            todo!("composite keys")
-        };
         let mut subquery = query.clone();
 
-        subquery.body.as_select_mut_unwrap().returning =
-            stmt::Returning::Project(stmt::Expr::ref_self_field(fk_fields.target));
+        subquery.body.as_select_mut_unwrap().returning = stmt::Returning::Project(fk_field_record(
+            belongs_to.foreign_key.fields.iter().map(|fk| fk.target),
+        ));
 
         Some(stmt::Expr::in_subquery(
-            stmt::Expr::ref_self_field(fk_fields.source),
+            fk_field_record(belongs_to.foreign_key.fields.iter().map(|fk| fk.source)),
             subquery,
         ))
     } else {
@@ -301,7 +299,9 @@ fn lift_belongs_to_in_subquery(
 }
 
 /// HasOne/HasMany branch: rewrite to a foreign-key IN subquery against
-/// the related table.
+/// the related table. Single-column FKs produce a scalar IN; composite
+/// FKs produce a tuple-form IN that the SQL serializer renders as
+/// `(a, b) IN (SELECT a, b FROM ...)`.
 fn lift_has_n_in_subquery(
     target: ModelId,
     pair: &BelongsTo,
@@ -311,27 +311,39 @@ fn lift_has_n_in_subquery(
         return None;
     }
 
-    let (self_field, child_field) = match &pair.foreign_key.fields[..] {
-        [fk_field] => (fk_field.target, fk_field.source),
-        _ => todo!("composite keys"),
-    };
-
     let mut subquery = query.clone();
 
     match &mut subquery.body {
         stmt::ExprSet::Select(select) => {
-            select.returning = stmt::Returning::Project(stmt::Expr::ref_self_field(child_field));
+            select.returning = stmt::Returning::Project(fk_field_record(
+                pair.foreign_key.fields.iter().map(|fk| fk.source),
+            ));
         }
         _ => todo!(),
     }
 
     Some(
         stmt::ExprInSubquery {
-            expr: Box::new(stmt::Expr::ref_self_field(self_field)),
+            expr: Box::new(fk_field_record(
+                pair.foreign_key.fields.iter().map(|fk| fk.target),
+            )),
             query: Box::new(subquery),
         }
         .into(),
     )
+}
+
+/// Build the LHS / projection shape for an FK comparison: a single field
+/// reference for a single-column FK, a `Record` of references for a
+/// composite FK. The composite form pairs with `lower_in_subquery_operands`
+/// in the lowering walk (which decomposes element-wise) and with the
+/// `(a, b) IN (SELECT a, b FROM ...)` SQL form.
+fn fk_field_record(mut fields: impl ExactSizeIterator<Item = FieldId>) -> stmt::Expr {
+    if fields.len() == 1 {
+        stmt::Expr::ref_self_field(fields.next().unwrap())
+    } else {
+        stmt::Expr::record(fields.map(stmt::Expr::ref_self_field))
+    }
 }
 
 impl Visit for LiftBelongsTo<'_> {

--- a/crates/toasty/src/engine/lower/lift_in_subquery.rs
+++ b/crates/toasty/src/engine/lower/lift_in_subquery.rs
@@ -278,12 +278,12 @@ fn lift_belongs_to_in_subquery(
     if lift.fail || !all_fks_matched {
         let mut subquery = query.clone();
 
-        subquery.body.as_select_mut_unwrap().returning = stmt::Returning::Project(fk_field_record(
-            belongs_to.foreign_key.fields.iter().map(|fk| fk.target),
-        ));
+        subquery.body.as_select_mut_unwrap().returning = stmt::Returning::Project(
+            super::key_field_refs(0, belongs_to.foreign_key.fields.iter().map(|fk| fk.target)),
+        );
 
         Some(stmt::Expr::in_subquery(
-            fk_field_record(belongs_to.foreign_key.fields.iter().map(|fk| fk.source)),
+            super::key_field_refs(0, belongs_to.foreign_key.fields.iter().map(|fk| fk.source)),
             subquery,
         ))
     } else {
@@ -315,7 +315,8 @@ fn lift_has_n_in_subquery(
 
     match &mut subquery.body {
         stmt::ExprSet::Select(select) => {
-            select.returning = stmt::Returning::Project(fk_field_record(
+            select.returning = stmt::Returning::Project(super::key_field_refs(
+                0,
                 pair.foreign_key.fields.iter().map(|fk| fk.source),
             ));
         }
@@ -324,26 +325,14 @@ fn lift_has_n_in_subquery(
 
     Some(
         stmt::ExprInSubquery {
-            expr: Box::new(fk_field_record(
+            expr: Box::new(super::key_field_refs(
+                0,
                 pair.foreign_key.fields.iter().map(|fk| fk.target),
             )),
             query: Box::new(subquery),
         }
         .into(),
     )
-}
-
-/// Build the LHS / projection shape for an FK comparison: a single field
-/// reference for a single-column FK, a `Record` of references for a
-/// composite FK. The composite form pairs with `lower_in_subquery_operands`
-/// in the lowering walk (which decomposes element-wise) and with the
-/// `(a, b) IN (SELECT a, b FROM ...)` SQL form.
-fn fk_field_record(mut fields: impl ExactSizeIterator<Item = FieldId>) -> stmt::Expr {
-    if fields.len() == 1 {
-        stmt::Expr::ref_self_field(fields.next().unwrap())
-    } else {
-        stmt::Expr::record(fields.map(stmt::Expr::ref_self_field))
-    }
 }
 
 impl Visit for LiftBelongsTo<'_> {


### PR DESCRIPTION
## Summary

The chained-relation rewrite from #903 (`user.todos().category()`, etc.) assumed single-column FKs at every hop. Three call sites panicked when an FK spanned multiple columns:

- `rewrite_association_belongs_to_as_filter` — `assert_eq!(.., 1)`
- `lift_belongs_to_in_subquery` — `todo!("composite keys")` in the non-liftable fallback
- `lift_has_n_in_subquery` — `todo!("composite keys")`

All three now emit `(a, b) IN (SELECT a, b FROM ...)` for composite FKs (single-column paths unchanged). Surfacing that exposed a fourth issue: the `InSubquery` lowering ran both operands through `lower_expr_binary_op`, which triggered the `Record == Record` decomposition and collapsed the `IN` into an `AND`. A new `lower_in_subquery_operands` helper lowers the record operands element-wise so the `IN` wrapper survives.

New integration tests live in `relation_chain_composite_key.rs` and cover both directions of composite-FK hops, two-versions-of-same-id discrimination, chained `.filter(...)`, the non-liftable-filter fallback path, and a composite HasMany→HasMany variant.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes (961/961 on SQLite)

## Notes for reviewers

The composite-FK paths reuse the same `Record` / tuple-IN shape that #906 introduced for `rewrite_eq_operand`. The lowering-side `lower_in_subquery_operands` helper is small but worth a look — it intentionally keeps `lower_expr_binary_op`'s element-level transforms (NULL, Cast) firing while skipping the Record-vs-Record decomposition that would discard the `IN`.