### PR TITLE
feat(engine): fold simple Batch assignments in update lowering

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_crud.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_crud.rs
@@ -185,6 +185,35 @@ pub async fn has_many_insert_on_update(test: &mut Test) -> Result<()> {
     Ok(())
 }
 
+/// `stmt::apply([])` on a has-many is a no-op: the surface API's empty
+/// Apply loop adds no entry to the assignments map, so the relation
+/// field is treated as unchanged. Run alongside a separate scalar
+/// change because the engine verifier rejects updates with no
+/// assignments at all.
+#[driver_test(id(ID), scenario(crate::scenarios::has_many_belongs_to))]
+pub async fn has_many_apply_empty_is_noop(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let mut user = User::create().name("Alice").exec(&mut db).await?;
+    user.todos()
+        .create()
+        .title("existing")
+        .exec(&mut db)
+        .await?;
+
+    user.update()
+        .name("Bob")
+        .todos(toasty::stmt::apply::<toasty::stmt::List<Todo>>([]))
+        .exec(&mut db)
+        .await?;
+
+    assert_eq!(user.name, "Bob");
+    let todos: Vec<_> = user.todos().exec(&mut db).await?;
+    assert_eq!(todos.len(), 1);
+    assert_eq!(todos[0].title, "existing");
+    Ok(())
+}
+
 #[driver_test(id(ID), scenario(crate::scenarios::has_many_belongs_to))]
 pub async fn has_many_apply_multiple_inserts(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;

--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_crud.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_crud.rs
@@ -186,6 +186,32 @@ pub async fn has_many_insert_on_update(test: &mut Test) -> Result<()> {
 }
 
 #[driver_test(id(ID), scenario(crate::scenarios::has_many_belongs_to))]
+pub async fn has_many_apply_multiple_inserts(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let mut user = User::create().name("Alice").exec(&mut db).await?;
+
+    user.update()
+        .todos(toasty::stmt::apply([
+            toasty::stmt::insert(Todo::create().title("Buy groceries")),
+            toasty::stmt::insert(Todo::create().title("Walk the dog")),
+        ]))
+        .exec(&mut db)
+        .await?;
+
+    let mut titles: Vec<_> = user
+        .todos()
+        .exec(&mut db)
+        .await?
+        .into_iter()
+        .map(|t| t.title)
+        .collect();
+    titles.sort();
+    assert_eq!(titles, ["Buy groceries", "Walk the dog"]);
+    Ok(())
+}
+
+#[driver_test(id(ID), scenario(crate::scenarios::has_many_belongs_to))]
 pub async fn scoped_find_by_id(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 

--- a/crates/toasty-driver-integration-suite/src/tests/type_collection.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/type_collection.rs
@@ -238,6 +238,51 @@ pub async fn vec_string_push(t: &mut Test) -> Result<(), BoxError> {
     Ok(())
 }
 
+/// `stmt::apply([push(a), push(b)])` chains multiple pushes on a single
+/// `Vec<scalar>` field. The Apply surface API folds same-projection ops
+/// into `Assignment::Batch`; lowering folds the entries into one
+/// equivalent `Append`.
+#[driver_test(id(ID), requires(vec_scalar))]
+pub async fn vec_string_apply_pushes(t: &mut Test) -> Result<(), BoxError> {
+    #[derive(Debug, toasty::Model)]
+    #[allow(dead_code)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: ID,
+        tags: Vec<String>,
+    }
+
+    let mut db = t.setup_db(models!(Item)).await;
+
+    let mut item = toasty::create!(Item {
+        tags: vec!["a".to_string()],
+    })
+    .exec(&mut db)
+    .await?;
+
+    item.update()
+        .tags(toasty::stmt::apply([
+            toasty::stmt::push("b"),
+            toasty::stmt::push("c"),
+        ]))
+        .exec(&mut db)
+        .await?;
+
+    assert_eq!(
+        item.tags,
+        vec!["a".to_string(), "b".to_string(), "c".to_string()]
+    );
+
+    let reloaded = Item::get_by_id(&mut db, &item.id).await?;
+    assert_eq!(
+        reloaded.tags,
+        vec!["a".to_string(), "b".to_string(), "c".to_string()]
+    );
+
+    Ok(())
+}
+
 /// `stmt::push` onto a `Vec<String>` that was created empty. Covers the
 /// "initially empty" path — DynamoDB's `if_not_exists` guard and the
 /// PG / JSON-backed paths over an empty array literal.

--- a/crates/toasty-driver-integration-suite/src/tests/type_collection.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/type_collection.rs
@@ -238,6 +238,46 @@ pub async fn vec_string_push(t: &mut Test) -> Result<(), BoxError> {
     Ok(())
 }
 
+/// `stmt::apply([])` on a `Vec<scalar>` is a no-op: the surface API's
+/// empty Apply loop adds no entry to the assignments map. Run alongside
+/// a non-`Vec<scalar>` field so the engine verifier doesn't reject the
+/// otherwise-empty update.
+#[driver_test(id(ID), requires(vec_scalar))]
+pub async fn vec_string_apply_empty_is_noop(t: &mut Test) -> Result<(), BoxError> {
+    #[derive(Debug, toasty::Model)]
+    #[allow(dead_code)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: ID,
+        name: String,
+        tags: Vec<String>,
+    }
+
+    let mut db = t.setup_db(models!(Item)).await;
+
+    let mut item = toasty::create!(Item {
+        name: "n",
+        tags: vec!["a".to_string()],
+    })
+    .exec(&mut db)
+    .await?;
+
+    item.update()
+        .name("n2")
+        .tags(toasty::stmt::apply::<toasty::stmt::List<String>>([]))
+        .exec(&mut db)
+        .await?;
+
+    assert_eq!(item.name, "n2");
+    assert_eq!(item.tags, vec!["a".to_string()]);
+
+    let reloaded = Item::get_by_id(&mut db, &item.id).await?;
+    assert_eq!(reloaded.tags, vec!["a".to_string()]);
+
+    Ok(())
+}
+
 /// `stmt::apply([push(a), push(b)])` chains multiple pushes on a single
 /// `Vec<scalar>` field. The Apply surface API folds same-projection ops
 /// into `Assignment::Batch`; lowering folds the entries into one

--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -305,6 +305,32 @@ impl LowerStatement<'_, '_> {
     }
 }
 
+/// Fold a `Batch` of column-level ops into a single equivalent `Append`
+/// expression. Currently only handles the all-`Append` shape produced by
+/// `stmt::apply([stmt::push(..), ..])` / `stmt::extend`; other shapes
+/// (mixed Append/Pop/RemoveAt, …) need per-entry dispatch plus driver-side
+/// Batch composition. See #717.
+fn fold_append_batch(entries: Vec<stmt::Assignment>) -> stmt::Expr {
+    assert!(!entries.is_empty(), "Batch must contain at least one entry");
+    let mut items = Vec::new();
+    for entry in entries {
+        match entry {
+            // `stmt::push` builds `Expr::List([elem])`; the fold pass
+            // collapses literal-only lists to `Expr::Value(Value::List)`.
+            stmt::Assignment::Append(stmt::Expr::List(list)) => {
+                items.extend(list.items);
+            }
+            stmt::Assignment::Append(stmt::Expr::Value(stmt::Value::List(values))) => {
+                items.extend(values.into_iter().map(stmt::Expr::from));
+            }
+            // Other batch entry kinds need per-entry dispatch and
+            // driver-side Batch composition.
+            other => todo!("batch entry kind not yet supported on Vec<scalar>: {other:#?}"),
+        }
+    }
+    stmt::Expr::list_from_vec(items)
+}
+
 impl LowerStatement<'_, '_> {
     fn new_dependency(&mut self, stmt: impl Into<stmt::Statement>) -> hir::StmtId {
         let row_index = match self.cx {
@@ -411,9 +437,27 @@ impl visit_mut::VisitMut for LowerStatement<'_, '_> {
                         CollectionOp::RemoveAt(expr),
                     );
                 }
-                stmt::Assignment::Insert(_) | stmt::Assignment::Batch(_) => {
+                stmt::Assignment::Batch(entries) => {
+                    // A `Batch` of column-level ops on the same field; built
+                    // when the `stmt::apply` surface API folds same-projection
+                    // ops together. Each entry should dispatch through the
+                    // per-op arms above — today only the all-`Append` shape
+                    // is wired up (see `fold_append_batch`). Other shapes
+                    // need driver-side Batch composition; see #717.
+                    let mut folded = fold_append_batch(std::mem::take(entries));
+                    self.lower_collection_op(
+                        &mut lowered,
+                        mapping,
+                        projection,
+                        CollectionOp::Append(&mut folded),
+                    );
+                }
+                stmt::Assignment::Insert(_) => {
+                    // `Insert` only applies to has-many relation fields,
+                    // which `plan_stmt_update_relations` consumes before
+                    // table-level lowering runs.
                     todo!(
-                        "Insert / Batch assignments are not produced for table lowering; got {assignment:#?}"
+                        "Insert assignment is not produced for table lowering; got {assignment:#?}"
                     )
                 }
             }

--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -310,8 +310,11 @@ impl LowerStatement<'_, '_> {
 /// `stmt::apply([stmt::push(..), ..])` / `stmt::extend`; other shapes
 /// (mixed Append/Pop/RemoveAt, …) need per-entry dispatch plus driver-side
 /// Batch composition. See #717.
+///
+/// Empty input yields an empty list expression — the surface `stmt::apply`
+/// API can't actually produce an empty `Batch`, but the helper doesn't
+/// depend on that: an empty list flows through as a no-op Append.
 fn fold_append_batch(entries: Vec<stmt::Assignment>) -> stmt::Expr {
-    assert!(!entries.is_empty(), "Batch must contain at least one entry");
     let mut items = Vec::new();
     for entry in entries {
         match entry {

--- a/crates/toasty/src/engine/lower/relation.rs
+++ b/crates/toasty/src/engine/lower/relation.rs
@@ -913,8 +913,13 @@ impl RelationSource for InsertRelationSource<'_> {
 /// INSERTs are folded into one multi-row INSERT via `Insert::merge`. Other
 /// op kinds (`Remove`, `Set`, …) hit `todo!()` for now and need per-entry
 /// dispatch through `plan_mut_relation_field` plus returning-slot merging.
+///
+/// Empty input yields an empty list expression — the surface `stmt::apply`
+/// API can't actually produce an empty `Batch` (the empty Apply loop adds
+/// no entry to the assignments map), but the helper doesn't depend on
+/// that: an empty list dispatches to a no-op in
+/// `plan_mut_has_n_associate_expr`.
 fn lower_has_many_batch(entries: Vec<stmt::Assignment>) -> stmt::Expr {
-    assert!(!entries.is_empty(), "Batch must contain at least one entry");
     let mut combined: Option<stmt::Insert> = None;
     for entry in entries {
         match entry {
@@ -932,7 +937,10 @@ fn lower_has_many_batch(entries: Vec<stmt::Assignment>) -> stmt::Expr {
             other => todo!("batch entry kind not yet supported on has-many: {other:#?}"),
         }
     }
-    stmt::Expr::from(combined.unwrap())
+    match combined {
+        Some(insert) => stmt::Expr::from(insert),
+        None => stmt::Expr::list_from_vec(vec![]),
+    }
 }
 
 fn set_returning_slot(record: &mut stmt::ExprRecord, index: usize, expr: stmt::Expr) {

--- a/crates/toasty/src/engine/lower/relation.rs
+++ b/crates/toasty/src/engine/lower/relation.rs
@@ -184,8 +184,21 @@ impl LowerStatement<'_, '_> {
                         "Pop / RemoveAt assignment on relation field — these only apply to Vec<scalar>"
                     )
                 }
-                stmt::Assignment::Batch(_) => {
-                    todo!("batch assignments for relations")
+                stmt::Assignment::Batch(entries) => {
+                    // A `Batch` carries a sequence of discrete ops on the same
+                    // projection, built by the `stmt::apply` surface API. Each
+                    // entry should dispatch as its own `Mutation` — but only
+                    // the all-`Insert` shape is wired up right now (see
+                    // `lower_has_many_batch`). Extending to `Remove`, `Set`,
+                    // or mixed batches means dispatching each entry through
+                    // `plan_mut_relation_field` individually, which in turn
+                    // requires `set_returning_slot` to merge multiple
+                    // sub-statement args into a single returning slot.
+                    assert!(field.ty.is_has_many());
+                    Mutation::Associate {
+                        expr: lower_has_many_batch(entries),
+                        exclusive: false,
+                    }
                 }
             };
 
@@ -890,6 +903,36 @@ impl RelationSource for InsertRelationSource<'_> {
     fn needs_existence_check(&self) -> bool {
         false
     }
+}
+
+/// Lower a `Batch` of ops on a has-many relation into a single combined
+/// expression suitable for `Mutation::Associate`.
+///
+/// Each entry in a `Batch` should be dispatched as its own `Mutation`, but
+/// today only the all-`Insert` shape is supported: the per-entry single-row
+/// INSERTs are folded into one multi-row INSERT via `Insert::merge`. Other
+/// op kinds (`Remove`, `Set`, …) hit `todo!()` for now and need per-entry
+/// dispatch through `plan_mut_relation_field` plus returning-slot merging.
+fn lower_has_many_batch(entries: Vec<stmt::Assignment>) -> stmt::Expr {
+    assert!(!entries.is_empty(), "Batch must contain at least one entry");
+    let mut combined: Option<stmt::Insert> = None;
+    for entry in entries {
+        match entry {
+            stmt::Assignment::Insert(stmt::Expr::Stmt(expr_stmt)) => {
+                let insert = match *expr_stmt.stmt {
+                    stmt::Statement::Insert(insert) => insert,
+                    other => todo!("non-Insert sub-statement in has-many Batch: {other:#?}"),
+                };
+                match &mut combined {
+                    None => combined = Some(insert),
+                    Some(acc) => acc.merge(insert),
+                }
+            }
+            // Other batch entry kinds need per-entry Mutation dispatch.
+            other => todo!("batch entry kind not yet supported on has-many: {other:#?}"),
+        }
+    }
+    stmt::Expr::from(combined.unwrap())
 }
 
 fn set_returning_slot(record: &mut stmt::ExprRecord, index: usize, expr: stmt::Expr) {


### PR DESCRIPTION
## Summary

`stmt::apply([..])` produced `Assignment::Batch` shapes the engine had no
arms for, panicking in two places: `lower/relation.rs` for has-many
relations and `lower.rs` for column-level (`Vec<scalar>`) updates.

Wire up the two simple-fold shapes:

- **Has-many `Batch` of `Insert(stmt)`** → fold into one multi-row INSERT
  via `Insert::merge` and dispatch as one `Mutation::Associate`. One
  child statement instead of N, and `set_returning_slot`'s one-write
  assumption stays intact.
- **`Vec<scalar>` `Batch` of `Append`** → concatenate the per-entry list
  operands into one combined `Append` and dispatch as a single
  collection op. Avoids needing driver-side `Batch` composition.

Mixed batches (Insert+Remove on has-many, Append+Pop on Vec<scalar>,
etc.) still hit `todo!()` and need per-entry dispatch plus driver-side
support — see [#717] for the remaining work.

Refs [#717].

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

`assert!(field.ty.is_has_many())` in the relation `Batch` arm mirrors the
adjacent `Insert` arm — runtime tripwire, not a derivation. The typed
surface API only constructs the relevant `Batch` shapes for the right
field kinds, so the asserts shouldn't fire under normal use.

[#717]: https://github.com/tokio-rs/toasty/issues/717