### PR TITLE
feat: add non-panicking `try_get` to relation types

### DIFF
--- a/crates/toasty/src/schema/belongs_to.rs
+++ b/crates/toasty/src/schema/belongs_to.rs
@@ -39,10 +39,24 @@ impl<T: Relation> BelongsTo<T> {
     ///
     /// # Panics
     ///
-    /// Panics if the association has not been loaded.
+    /// Panics if the association has not been loaded. Use [`try_get`] to
+    /// handle the unloaded state without panicking.
+    ///
+    /// [`try_get`]: BelongsTo::try_get
     #[track_caller]
     pub fn get(&self) -> &T {
         self.value.as_ref().expect("association not loaded")
+    }
+
+    /// Returns a reference to the loaded associated record, or `None` if the
+    /// association has not been loaded.
+    ///
+    /// This is the non-panicking counterpart to [`get`](BelongsTo::get). Use
+    /// it when the caller cannot guarantee that the association was preloaded
+    /// (for example, in code paths that may receive a record loaded without
+    /// an `.include()`).
+    pub fn try_get(&self) -> Option<&T> {
+        self.value.as_deref()
     }
 
     /// Returns `true` if the association has not been loaded yet.

--- a/crates/toasty/src/schema/has_many.rs
+++ b/crates/toasty/src/schema/has_many.rs
@@ -50,13 +50,26 @@ impl<T: Relation> HasMany<T> {
     ///
     /// # Panics
     ///
-    /// Panics if the association has not been loaded.
+    /// Panics if the association has not been loaded. Use [`try_get`] to
+    /// handle the unloaded state without panicking.
+    ///
+    /// [`try_get`]: HasMany::try_get
     #[track_caller]
     pub fn get(&self) -> &[T] {
         self.values
             .as_ref()
             .expect("association not loaded")
             .as_slice()
+    }
+
+    /// Returns a slice of the loaded associated records, or `None` if the
+    /// association has not been loaded.
+    ///
+    /// This is the non-panicking counterpart to [`get`](HasMany::get). An
+    /// empty slice means the association is loaded and the record has no
+    /// related rows; `None` means the association has not been loaded.
+    pub fn try_get(&self) -> Option<&[T]> {
+        self.values.as_deref()
     }
 
     /// Returns `true` if the association has not been loaded yet.

--- a/crates/toasty/src/schema/has_one.rs
+++ b/crates/toasty/src/schema/has_one.rs
@@ -39,10 +39,24 @@ impl<T: Relation> HasOne<T> {
     ///
     /// # Panics
     ///
-    /// Panics if the association has not been loaded.
+    /// Panics if the association has not been loaded. Use [`try_get`] to
+    /// handle the unloaded state without panicking.
+    ///
+    /// [`try_get`]: HasOne::try_get
     #[track_caller]
     pub fn get(&self) -> &T {
         self.value.as_ref().expect("association not loaded")
+    }
+
+    /// Returns a reference to the loaded associated record, or `None` if the
+    /// association has not been loaded.
+    ///
+    /// This is the non-panicking counterpart to [`get`](HasOne::get). For an
+    /// optional has-one (`HasOne<Option<T>>`), the inner `Option` reports
+    /// whether the related row exists; the outer `Option` returned here
+    /// reports whether the association was loaded.
+    pub fn try_get(&self) -> Option<&T> {
+        self.value.as_deref()
     }
 
     /// Returns `true` if the association has not been loaded yet.

--- a/docs/guide/src/preloading-associations.md
+++ b/docs/guide/src/preloading-associations.md
@@ -100,6 +100,35 @@ There are two ways to access a relation, depending on whether it was preloaded:
 Calling `.get()` on an unloaded relation panics. Only use `.get()` when you know
 the relation was preloaded.
 
+### `.try_get()` when the load state is uncertain
+
+When a function receives a record from a caller it does not control, it may not
+know whether a given relation was preloaded. Use `.try_get()` to access the
+loaded value without panicking — it returns `None` if the relation has not been
+loaded:
+
+```rust,ignore
+fn post_count(user: &User) -> Option<usize> {
+    user.posts.try_get().map(<[_]>::len)
+}
+```
+
+`.try_get()` is available on all three relation types and returns the same
+reference shape as `.get()` wrapped in an `Option`:
+
+| Relation type | `.get()` returns | `.try_get()` returns |
+|---|---|---|
+| `BelongsTo<T>` | `&T` | `Option<&T>` |
+| `HasOne<T>` | `&T` | `Option<&T>` |
+| `HasMany<T>` | `&[T]` | `Option<&[T]>` |
+
+For `HasMany`, an empty slice means the association was loaded and the record
+has no related rows, while `None` means the association was not loaded.
+
+Prefer `.get()` in code paths that control the query (the call site can see the
+matching `.include()`); reserve `.try_get()` for code that accepts records from
+elsewhere and needs to fall back when the data is missing.
+
 ## Preloading BelongsTo
 
 Preload a parent record from the child side:
@@ -277,4 +306,5 @@ for user in &users {
 | `model.relation.get()` | Access preloaded HasMany data (returns `&[T]`) |
 | `model.relation.get()` | Access preloaded BelongsTo data (returns `&T`) |
 | `model.relation.get()` | Access preloaded HasOne data (returns `&T` or `&Option<T>`) |
+| `model.relation.try_get()` | Non-panicking access; returns `None` if not preloaded |
 | `model.relation.is_unloaded()` | Check if a relation was preloaded |


### PR DESCRIPTION
## Summary

`BelongsTo`, `HasOne`, and `HasMany` only exposed `get`, which panics on
an unloaded association. Add `try_get` returning `Option<&T>` (or
`Option<&[T]>` for `HasMany`) so callers that cannot guarantee the
relation was preloaded can branch on the load state instead.

The preloading-associations guide gets a short subsection covering when
to prefer each, plus a row in the summary table.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes