### PR TITLE
chore: release v0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,21 +66,21 @@ unsafe_code = "deny"
 
 [workspace.dependencies]
 # Toasty crates
-toasty = { version = "0.6.1", path = "crates/toasty" }
-toasty-cli = { version = "0.6.1", path = "crates/toasty-cli" }
-toasty-core = { version = "0.6.1", path = "crates/toasty-core" }
-toasty-macros = { version = "0.6.1", path = "crates/toasty-macros" }
-toasty-sql = { version = "0.6.1", path = "crates/toasty-sql" }
+toasty = { version = "0.7.0", path = "crates/toasty" }
+toasty-cli = { version = "0.7.0", path = "crates/toasty-cli" }
+toasty-core = { version = "0.7.0", path = "crates/toasty-core" }
+toasty-macros = { version = "0.7.0", path = "crates/toasty-macros" }
+toasty-sql = { version = "0.7.0", path = "crates/toasty-sql" }
 # Driver implementations
-toasty-driver-dynamodb = { version = "0.6.1", path = "crates/toasty-driver-dynamodb" }
-toasty-driver-mysql = { version = "0.6.1", path = "crates/toasty-driver-mysql" }
-toasty-driver-postgresql = { version = "0.6.1", path = "crates/toasty-driver-postgresql" }
-toasty-driver-sqlite = { version = "0.6.1", path = "crates/toasty-driver-sqlite" }
-toasty-driver-turso = { version = "0.6.1", path = "crates/toasty-driver-turso" }
+toasty-driver-dynamodb = { version = "0.7.0", path = "crates/toasty-driver-dynamodb" }
+toasty-driver-mysql = { version = "0.7.0", path = "crates/toasty-driver-mysql" }
+toasty-driver-postgresql = { version = "0.7.0", path = "crates/toasty-driver-postgresql" }
+toasty-driver-sqlite = { version = "0.7.0", path = "crates/toasty-driver-sqlite" }
+toasty-driver-turso = { version = "0.7.0", path = "crates/toasty-driver-turso" }
 
 # Driver integration test suite dependencies
-toasty-driver-integration-suite = { version = "0.6.1", path = "crates/toasty-driver-integration-suite" }
-toasty-driver-integration-suite-macros = { version = "0.6.1", path = "crates/toasty-driver-integration-suite-macros" }
+toasty-driver-integration-suite = { version = "0.7.0", path = "crates/toasty-driver-integration-suite" }
+toasty-driver-integration-suite-macros = { version = "0.7.0", path = "crates/toasty-driver-integration-suite-macros" }
 
 # Other crates
 assert-struct = "0.4.2"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <div align="center">
   <h3>The cozy, easy ORM for Rust</h3>
-  <a href="https://tokio-rs.github.io/toasty/0.6.1/guide/">Guide</a> •
+  <a href="https://tokio-rs.github.io/toasty/0.7.0/guide/">Guide</a> •
   <a href="https://docs.rs/toasty">API Docs</a> •
   <a href="https://crates.io/crates/toasty">Crates.io</a> •
   <a href="https://discord.gg/tokio">Discord</a>

--- a/crates/toasty-cli/CHANGELOG.md
+++ b/crates/toasty-cli/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-cli-v0.6.1...toasty-cli-v0.7.0) - 2026-05-26
+
+### Added
+
+- Expose migration core from toasty ([#944])
+- Turso driver with TransactionMode-aware concurrent writes ([#938])
+
+### Changed
+
+- [**breaking**] Require Deferred relation fields ([#954])
+- [**breaking**] Move schema diff types to `schema::diff` ([#929])
+
+[#929]: https://github.com/tokio-rs/toasty/pull/929
+[#938]: https://github.com/tokio-rs/toasty/pull/938
+[#944]: https://github.com/tokio-rs/toasty/pull/944
+[#954]: https://github.com/tokio-rs/toasty/pull/954
+
 ## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-cli-v0.6.0...toasty-cli-v0.6.1) - 2026-05-16
 
 - Internal improvements only.

--- a/crates/toasty-cli/Cargo.toml
+++ b/crates/toasty-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-cli"
-version = "0.6.1"
+version = "0.7.0"
 description = "Command-line interface for Toasty schema management"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-core/CHANGELOG.md
+++ b/crates/toasty-core/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-core-v0.6.1...toasty-core-v0.7.0) - 2026-05-26
+
+### Added
+
+- Raw SQL execution ([#965])
+- [**breaking**] Relation fields use `Deferred<T>` type instead of `#[deferred]` attribute ([#961])
+- Eager relation fields ([#958])
+- Multi-step `via` relations with `.include()` support ([#946])
+- Migration core API ([#944])
+- Turso driver ([#938])
+- SQLite TransactionMode ([#931])
+- SELECT DISTINCT queries ([#934])
+- INNER joins ([#922])
+- Multi-step has_many and has_one relations ([#890])
+
+### Fixed
+
+- SQLite auto-increment storage capped at 4 bytes ([#969])
+- [**breaking**] `.ilike()` operator restricted to PostgreSQL ([#937])
+
+### Changed
+
+- [**breaking**] Merged has relation field variants ([#964])
+- [**breaking**] Schema diff types moved to `schema::diff` ([#929])
+
+[#890]: https://github.com/tokio-rs/toasty/pull/890
+[#922]: https://github.com/tokio-rs/toasty/pull/922
+[#929]: https://github.com/tokio-rs/toasty/pull/929
+[#931]: https://github.com/tokio-rs/toasty/pull/931
+[#934]: https://github.com/tokio-rs/toasty/pull/934
+[#937]: https://github.com/tokio-rs/toasty/pull/937
+[#938]: https://github.com/tokio-rs/toasty/pull/938
+[#944]: https://github.com/tokio-rs/toasty/pull/944
+[#946]: https://github.com/tokio-rs/toasty/pull/946
+[#958]: https://github.com/tokio-rs/toasty/pull/958
+[#961]: https://github.com/tokio-rs/toasty/pull/961
+[#964]: https://github.com/tokio-rs/toasty/pull/964
+[#965]: https://github.com/tokio-rs/toasty/pull/965
+[#969]: https://github.com/tokio-rs/toasty/pull/969
+
 ## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-core-v0.6.0...toasty-core-v0.6.1) - 2026-05-16
 
 ### Added

--- a/crates/toasty-core/Cargo.toml
+++ b/crates/toasty-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-core"
-version = "0.6.1"
+version = "0.7.0"
 description = "Core types, schema representations, and driver interface for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-dynamodb/CHANGELOG.md
+++ b/crates/toasty-driver-dynamodb/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-dynamodb-v0.6.1...toasty-driver-dynamodb-v0.7.0) - 2026-05-26
+
+### Added
+
+- Raw SQL execution API ([#965])
+- *(turso)* Turso driver with TransactionMode-aware concurrent writes ([#938])
+
+### Fixed
+
+- *(dynamodb)* Omit empty ExpressionAttributeValues on IS NULL / IS NOT NULL scans ([#940])
+
+### Changed
+
+- [**breaking**] Require Deferred relation fields ([#954])
+- [**breaking**] Move schema diff types to `schema::diff` ([#929])
+
+[#929]: https://github.com/tokio-rs/toasty/pull/929
+[#938]: https://github.com/tokio-rs/toasty/pull/938
+[#940]: https://github.com/tokio-rs/toasty/pull/940
+[#954]: https://github.com/tokio-rs/toasty/pull/954
+[#965]: https://github.com/tokio-rs/toasty/pull/965
+
 ## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-driver-dynamodb-v0.6.0...toasty-driver-dynamodb-v0.6.1) - 2026-05-16
 
 - Internal improvements only.

--- a/crates/toasty-driver-dynamodb/Cargo.toml
+++ b/crates/toasty-driver-dynamodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-dynamodb"
-version = "0.6.1"
+version = "0.7.0"
 description = "Amazon DynamoDB driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-integration-suite-macros/CHANGELOG.md
+++ b/crates/toasty-driver-integration-suite-macros/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-macros-v0.6.1...toasty-driver-integration-suite-macros-v0.7.0) - 2026-05-26
+
+### Added
+
+- *(turso)* Add Turso driver with TransactionMode-aware concurrent writes ([#938])
+
+### Changed
+
+- [**breaking**] Require Deferred relation fields ([#954])
+
+[#938]: https://github.com/tokio-rs/toasty/pull/938
+[#954]: https://github.com/tokio-rs/toasty/pull/954
+
 ## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-macros-v0.6.0...toasty-driver-integration-suite-macros-v0.6.1) - 2026-05-16
 
 - Internal improvements only.

--- a/crates/toasty-driver-integration-suite-macros/Cargo.toml
+++ b/crates/toasty-driver-integration-suite-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-integration-suite-macros"
-version = "0.6.1"
+version = "0.7.0"
 description = "Proc macros for the Toasty driver integration test suite"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-integration-suite/CHANGELOG.md
+++ b/crates/toasty-driver-integration-suite/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-v0.6.1...toasty-driver-integration-suite-v0.7.0) - 2026-05-26
+
+### Added
+
+- [**breaking**] Remove singular has-many create-builder methods ([#977])
+- Add raw SQL execution API ([#965])
+- [**breaking**] Remove `#[deferred]` field attribute in favor of `Deferred<T>` ([#961])
+- Support eager relation fields ([#958])
+- Support `.include()` of multi-step `via` relations ([#946])
+- Add Turso driver with TransactionMode-aware concurrent writes ([#938])
+- Add TransactionMode for SQLite lock-acquisition control ([#931])
+- Allow `#[version]` on tuple-newtype embeds of u64 ([#930])
+- [**breaking**] Replace `#[serialize(json)]` with `toasty::Json<T>` wrapper ([#926])
+- Expose primary-key type via Model::PrimaryKey ([#921])
+- Add multi-step (via) has_many and has_one relations ([#890])
+- [**breaking**] Require Deferred relation fields ([#954])
+- [**breaking**] Move schema diff types to `schema::diff` module ([#929])
+
+### Fixed
+
+- Cap SQLite auto-increment integer storage at 4 bytes ([#969])
+- Fix ExprOr handling in expression evaluation ([#959])
+- DynamoDB: omit empty ExpressionAttributeValues on IS NULL / IS NOT NULL scans ([#940])
+- [**breaking**] Scope `.ilike()` operator to PostgreSQL and document operator pass-through ([#937])
+- Respect `pair` attribute in `#[has_one]` macro ([#927])
+
+[#890]: https://github.com/tokio-rs/toasty/pull/890
+[#921]: https://github.com/tokio-rs/toasty/pull/921
+[#926]: https://github.com/tokio-rs/toasty/pull/926
+[#927]: https://github.com/tokio-rs/toasty/pull/927
+[#929]: https://github.com/tokio-rs/toasty/pull/929
+[#930]: https://github.com/tokio-rs/toasty/pull/930
+[#931]: https://github.com/tokio-rs/toasty/pull/931
+[#937]: https://github.com/tokio-rs/toasty/pull/937
+[#938]: https://github.com/tokio-rs/toasty/pull/938
+[#940]: https://github.com/tokio-rs/toasty/pull/940
+[#946]: https://github.com/tokio-rs/toasty/pull/946
+[#954]: https://github.com/tokio-rs/toasty/pull/954
+[#958]: https://github.com/tokio-rs/toasty/pull/958
+[#959]: https://github.com/tokio-rs/toasty/pull/959
+[#961]: https://github.com/tokio-rs/toasty/pull/961
+[#965]: https://github.com/tokio-rs/toasty/pull/965
+[#969]: https://github.com/tokio-rs/toasty/pull/969
+[#977]: https://github.com/tokio-rs/toasty/pull/977
+
 ## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-v0.6.0...toasty-driver-integration-suite-v0.6.1) - 2026-05-16
 
 ### Added

--- a/crates/toasty-driver-integration-suite/Cargo.toml
+++ b/crates/toasty-driver-integration-suite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-integration-suite"
-version = "0.6.1"
+version = "0.7.0"
 description = "Integration test suite for Toasty database drivers"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-mysql/CHANGELOG.md
+++ b/crates/toasty-driver-mysql/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-mysql-v0.6.1...toasty-driver-mysql-v0.7.0) - 2026-05-26
+
+### Added
+
+- Raw SQL execution API ([#965])
+- Turso driver with TransactionMode-aware concurrent writes ([#938])
+- TransactionMode for SQLite lock-acquisition control ([#931])
+
+### Changed
+
+- [**breaking**] Deferred relation fields are now required ([#954])
+- [**breaking**] Schema diff types moved to `schema::diff` module ([#929])
+
+[#929]: https://github.com/tokio-rs/toasty/pull/929
+[#931]: https://github.com/tokio-rs/toasty/pull/931
+[#938]: https://github.com/tokio-rs/toasty/pull/938
+[#954]: https://github.com/tokio-rs/toasty/pull/954
+[#965]: https://github.com/tokio-rs/toasty/pull/965
+
 ## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-driver-mysql-v0.6.0...toasty-driver-mysql-v0.6.1) - 2026-05-16
 
 - Internal improvements only.

--- a/crates/toasty-driver-mysql/Cargo.toml
+++ b/crates/toasty-driver-mysql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-mysql"
-version = "0.6.1"
+version = "0.7.0"
 description = "MySQL driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-postgresql/CHANGELOG.md
+++ b/crates/toasty-driver-postgresql/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-postgresql-v0.6.1...toasty-driver-postgresql-v0.7.0) - 2026-05-26
+
+### Added
+
+- Raw SQL execution API ([#965])
+- Turso driver with TransactionMode-aware concurrent writes ([#938])
+- TransactionMode for SQLite lock-acquisition control ([#931])
+
+### Changed
+
+- [**breaking**] Deferred relation fields are now required ([#954])
+- [**breaking**] Schema diff types moved to `schema::diff` module ([#929])
+
+[#929]: https://github.com/tokio-rs/toasty/pull/929
+[#931]: https://github.com/tokio-rs/toasty/pull/931
+[#938]: https://github.com/tokio-rs/toasty/pull/938
+[#954]: https://github.com/tokio-rs/toasty/pull/954
+[#965]: https://github.com/tokio-rs/toasty/pull/965
+
 ## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-driver-postgresql-v0.6.0...toasty-driver-postgresql-v0.6.1) - 2026-05-16
 
 - Internal improvements only.

--- a/crates/toasty-driver-postgresql/Cargo.toml
+++ b/crates/toasty-driver-postgresql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-postgresql"
-version = "0.6.1"
+version = "0.7.0"
 description = "PostgreSQL driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-sqlite/CHANGELOG.md
+++ b/crates/toasty-driver-sqlite/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-sqlite-v0.6.1...toasty-driver-sqlite-v0.7.0) - 2026-05-26
+
+### Added
+
+- Raw SQL execution API ([#965])
+- Turso driver with TransactionMode-aware concurrent writes ([#938])
+
+### Changed
+
+- [**breaking**] Require Deferred relation fields ([#954])
+- [**breaking**] Move schema diff types to `schema::diff` ([#929])
+
+[#929]: https://github.com/tokio-rs/toasty/pull/929
+[#938]: https://github.com/tokio-rs/toasty/pull/938
+[#954]: https://github.com/tokio-rs/toasty/pull/954
+[#965]: https://github.com/tokio-rs/toasty/pull/965
+
 ## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-driver-sqlite-v0.6.0...toasty-driver-sqlite-v0.6.1) - 2026-05-16
 
 - Internal improvements only.

--- a/crates/toasty-driver-sqlite/Cargo.toml
+++ b/crates/toasty-driver-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-sqlite"
-version = "0.6.1"
+version = "0.7.0"
 description = "SQLite driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-turso/CHANGELOG.md
+++ b/crates/toasty-driver-turso/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-turso-v0.6.1...toasty-driver-turso-v0.7.0) - 2026-05-26
+
+### Added
+
+- Raw SQL execution API ([#965])
+- Turso driver with TransactionMode-aware concurrent writes ([#938])
+
+### Changed
+
+- [**breaking**] Deferred relation fields are now required ([#954])
+- [**breaking**] Terminal query method renamed from `.all()` to `.exec()` ([#471])
+- [**breaking**] Removed `Cursor` type; queries now return `Vec` directly ([#448])
+- [**breaking**] Removed automatic mapping of multiple models to a single table ([#225])
+- [**breaking**] Switched to proc macros for schema declaration ([#76])
+
+[#76]: https://github.com/tokio-rs/toasty/pull/76
+[#225]: https://github.com/tokio-rs/toasty/pull/225
+[#448]: https://github.com/tokio-rs/toasty/pull/448
+[#471]: https://github.com/tokio-rs/toasty/pull/471
+[#938]: https://github.com/tokio-rs/toasty/pull/938
+[#954]: https://github.com/tokio-rs/toasty/pull/954
+[#965]: https://github.com/tokio-rs/toasty/pull/965

--- a/crates/toasty-driver-turso/Cargo.toml
+++ b/crates/toasty-driver-turso/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-turso"
-version = "0.6.1"
+version = "0.7.0"
 description = "Turso (SQLite-compatible) driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-macros/CHANGELOG.md
+++ b/crates/toasty-macros/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-macros-v0.6.1...toasty-macros-v0.7.0) - 2026-05-26
+
+### Added
+
+- reject create() on multi-step relation scopes at compile time ([#978])
+- [**breaking**] remove singular has-many create-builder methods ([#977])
+- [**breaking**] remove the `#[deferred]` field attribute in favor of `Deferred<T>` ([#961])
+- support eager relation fields ([#958])
+- support `.include()` of multi-step `via` relations ([#946])
+- add Turso driver with TransactionMode-aware concurrent writes ([#938])
+- allow #[version] on tuple-newtype embeds of u64 ([#930])
+- [**breaking**] replace `#[serialize(json)]` with `toasty::Json<T>` wrapper ([#926])
+- expose primary-key type via Model::PrimaryKey ([#921])
+- add multi-step (via) has_many and has_one relations ([#890])
+
+### Fixed
+
+- respect `pair` attribute in `#[has_one]` macro ([#927])
+
+### Changed
+
+- [**breaking**] merge one relation field traits ([#971])
+- [**breaking**] delete Relation trait, tighten relation field shapes ([#967])
+- [**breaking**] require Deferred relation fields ([#954])
+
+[#890]: https://github.com/tokio-rs/toasty/pull/890
+[#921]: https://github.com/tokio-rs/toasty/pull/921
+[#926]: https://github.com/tokio-rs/toasty/pull/926
+[#927]: https://github.com/tokio-rs/toasty/pull/927
+[#930]: https://github.com/tokio-rs/toasty/pull/930
+[#938]: https://github.com/tokio-rs/toasty/pull/938
+[#946]: https://github.com/tokio-rs/toasty/pull/946
+[#954]: https://github.com/tokio-rs/toasty/pull/954
+[#958]: https://github.com/tokio-rs/toasty/pull/958
+[#961]: https://github.com/tokio-rs/toasty/pull/961
+[#967]: https://github.com/tokio-rs/toasty/pull/967
+[#971]: https://github.com/tokio-rs/toasty/pull/971
+[#977]: https://github.com/tokio-rs/toasty/pull/977
+[#978]: https://github.com/tokio-rs/toasty/pull/978
+
 ## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-macros-v0.6.0...toasty-macros-v0.6.1) - 2026-05-16
 
 ### Added

--- a/crates/toasty-macros/Cargo.toml
+++ b/crates/toasty-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-macros"
-version = "0.6.1"
+version = "0.7.0"
 description = "Derive macros for Toasty models and embeds"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-sql/CHANGELOG.md
+++ b/crates/toasty-sql/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-sql-v0.6.1...toasty-sql-v0.7.0) - 2026-05-26
+
+### Added
+
+- Raw SQL execution API ([#965])
+- Turso driver with TransactionMode-aware concurrent writes ([#938])
+- TransactionMode for SQLite lock-acquisition control ([#931])
+- `SELECT DISTINCT` query support ([#934])
+- INNER join variant ([#922])
+
+### Fixed
+
+- Cap SQLite auto-increment integer storage at 4 bytes ([#969])
+- [**breaking**] Scope `.ilike()` to PostgreSQL ([#937])
+
+### Changed
+
+- [**breaking**] Require Deferred relation fields ([#954])
+- [**breaking**] Move schema diff types to `schema::diff` ([#929])
+
+[#922]: https://github.com/tokio-rs/toasty/pull/922
+[#929]: https://github.com/tokio-rs/toasty/pull/929
+[#931]: https://github.com/tokio-rs/toasty/pull/931
+[#934]: https://github.com/tokio-rs/toasty/pull/934
+[#937]: https://github.com/tokio-rs/toasty/pull/937
+[#938]: https://github.com/tokio-rs/toasty/pull/938
+[#954]: https://github.com/tokio-rs/toasty/pull/954
+[#965]: https://github.com/tokio-rs/toasty/pull/965
+[#969]: https://github.com/tokio-rs/toasty/pull/969
+
 ## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-sql-v0.6.0...toasty-sql-v0.6.1) - 2026-05-16
 
 - Internal improvements only

--- a/crates/toasty-sql/Cargo.toml
+++ b/crates/toasty-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-sql"
-version = "0.6.1"
+version = "0.7.0"
 description = "SQL serialization layer for Toasty database drivers"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty/CHANGELOG.md
+++ b/crates/toasty/CHANGELOG.md
@@ -7,6 +7,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-v0.6.1...toasty-v0.7.0) - 2026-05-26
+
+### Added
+
+- Raw SQL execution API ([#965])
+- Eager relation fields ([#958])
+- Support for `.include()` of multi-step `via` relations ([#946])
+- Migration core exposed from toasty ([#944])
+- Turso driver with TransactionMode-aware concurrent writes ([#938])
+- TransactionMode for SQLite lock-acquisition control ([#931])
+- `#[version]` support on tuple-newtype embeds of u64 ([#930])
+- `SELECT DISTINCT` serialization in SQL queries ([#934])
+- Primary-key type exposed via `Model::PrimaryKey` ([#921])
+- Multi-step (via) has-many and has-one relations ([#890])
+- Non-panicking `try_get` method on relation types ([#918])
+
+### Changed
+
+- [**breaking**] `toasty::Json<T>` wrapper replaces `#[serialize(json)]` attribute ([#926])
+- [**breaking**] Migration types consolidated in toasty crate; `db::diff` API reorganized ([#928])
+- [**breaking**] Schema diff types moved to `schema::diff` module ([#929])
+- [**breaking**] `.ilike()` scoped to PostgreSQL; operator pass-through documented ([#937])
+- [**breaking**] Relation fields now require `Deferred<T>` wrapper (replacing optional `#[deferred]` attribute) ([#961], [#954])
+- [**breaking**] Merged has relation field variants ([#964])
+- [**breaking**] Deleted `Relation` trait and tightened relation field shapes ([#967])
+- [**breaking**] Merged relation field traits ([#971])
+- [**breaking**] `create()` rejected at compile time on multi-step relation scopes ([#978])
+
+### Fixed
+
+- Handle `ExprOr` expressions in eval verify logic ([#959])
+
+[#890]: https://github.com/tokio-rs/toasty/pull/890
+[#918]: https://github.com/tokio-rs/toasty/pull/918
+[#921]: https://github.com/tokio-rs/toasty/pull/921
+[#926]: https://github.com/tokio-rs/toasty/pull/926
+[#928]: https://github.com/tokio-rs/toasty/pull/928
+[#929]: https://github.com/tokio-rs/toasty/pull/929
+[#930]: https://github.com/tokio-rs/toasty/pull/930
+[#931]: https://github.com/tokio-rs/toasty/pull/931
+[#934]: https://github.com/tokio-rs/toasty/pull/934
+[#937]: https://github.com/tokio-rs/toasty/pull/937
+[#938]: https://github.com/tokio-rs/toasty/pull/938
+[#944]: https://github.com/tokio-rs/toasty/pull/944
+[#946]: https://github.com/tokio-rs/toasty/pull/946
+[#954]: https://github.com/tokio-rs/toasty/pull/954
+[#958]: https://github.com/tokio-rs/toasty/pull/958
+[#959]: https://github.com/tokio-rs/toasty/pull/959
+[#961]: https://github.com/tokio-rs/toasty/pull/961
+[#964]: https://github.com/tokio-rs/toasty/pull/964
+[#965]: https://github.com/tokio-rs/toasty/pull/965
+[#967]: https://github.com/tokio-rs/toasty/pull/967
+[#971]: https://github.com/tokio-rs/toasty/pull/971
+[#978]: https://github.com/tokio-rs/toasty/pull/978
+
 ## [0.6.1](https://github.com/tokio-rs/toasty/compare/toasty-v0.6.0...toasty-v0.6.1) - 2026-05-16
 
 ### Added

--- a/crates/toasty/Cargo.toml
+++ b/crates/toasty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty"
-version = "0.6.1"
+version = "0.7.0"
 description = "An async ORM for Rust supporting SQL and NoSQL databases"
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `toasty-core`: 0.6.1 -> 0.7.0 (⚠ API breaking changes)
* `toasty-driver-dynamodb`: 0.6.1 -> 0.7.0 (✓ API compatible changes)
* `toasty-sql`: 0.6.1 -> 0.7.0 (✓ API compatible changes)
* `toasty-driver-mysql`: 0.6.1 -> 0.7.0 (✓ API compatible changes)
* `toasty-driver-postgresql`: 0.6.1 -> 0.7.0 (✓ API compatible changes)
* `toasty-driver-sqlite`: 0.6.1 -> 0.7.0 (✓ API compatible changes)
* `toasty-driver-turso`: 0.6.1 -> 0.7.0
* `toasty-macros`: 0.6.1 -> 0.7.0
* `toasty`: 0.6.1 -> 0.7.0 (⚠ API breaking changes)
* `toasty-cli`: 0.6.1 -> 0.7.0 (⚠ API breaking changes)
* `toasty-driver-integration-suite-macros`: 0.6.1 -> 0.7.0
* `toasty-driver-integration-suite`: 0.6.1 -> 0.7.0 (⚠ API breaking changes)

### ⚠ `toasty-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Capability.sql_placeholder in /tmp/.tmpxAP4V8/toasty/crates/toasty-core/src/driver/capability.rs:33
  field Capability.max_auto_increment_integer_width in /tmp/.tmpxAP4V8/toasty/crates/toasty-core/src/driver/capability.rs:68
  field Capability.native_ilike in /tmp/.tmpxAP4V8/toasty/crates/toasty-core/src/driver/capability.rs:150
  field Capability.transaction_lock_mode in /tmp/.tmpxAP4V8/toasty/crates/toasty-core/src/driver/capability.rs:182
  field Select.distinct in /tmp/.tmpxAP4V8/toasty/crates/toasty-core/src/stmt/select.rs:40

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_missing.ron

Failed in:
  enum toasty_core::schema::db::IndicesDiffItem, previously in file /tmp/.tmpqjTIZf/toasty-core/src/schema/db/index.rs:302
  enum toasty_core::schema::db::TypesDiffItem, previously in file /tmp/.tmpqjTIZf/toasty-core/src/schema/db/ty_enum_diff.rs:13
  enum toasty_core::schema::db::TablesDiffItem, previously in file /tmp/.tmpqjTIZf/toasty-core/src/schema/db/table.rs:205
  enum toasty_core::schema::db::ColumnsDiffItem, previously in file /tmp/.tmpqjTIZf/toasty-core/src/schema/db/column.rs:195

--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field mode of variant Transaction::Start in /tmp/.tmpxAP4V8/toasty/crates/toasty-core/src/driver/operation/transaction.rs:103

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_added.ron

Failed in:
  variant Operation:RawSql in /tmp/.tmpxAP4V8/toasty/crates/toasty-core/src/driver/operation.rs:89
  variant Operation:RawSql in /tmp/.tmpxAP4V8/toasty/crates/toasty-core/src/driver/operation.rs:89
  variant JoinOp:Inner in /tmp/.tmpxAP4V8/toasty/crates/toasty-core/src/stmt/join.rs:39
  variant FieldTy:Has in /tmp/.tmpxAP4V8/toasty/crates/toasty-core/src/schema/app/field.rs:202
  variant FieldTy:Via in /tmp/.tmpxAP4V8/toasty/crates/toasty-core/src/schema/app/field.rs:204

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_missing.ron

Failed in:
  variant FieldTy::HasMany, previously in file /tmp/.tmpqjTIZf/toasty-core/src/schema/app/field.rs:203
  variant FieldTy::HasOne, previously in file /tmp/.tmpqjTIZf/toasty-core/src/schema/app/field.rs:205

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/struct_missing.ron

Failed in:
  struct toasty_core::schema::db::IndicesDiff, previously in file /tmp/.tmpqjTIZf/toasty-core/src/schema/db/index.rs:208
  struct toasty_core::schema::db::RenameHints, previously in file /tmp/.tmpqjTIZf/toasty-core/src/schema/db/diff.rs:22
  struct toasty_core::schema::app::HasMany, previously in file /tmp/.tmpqjTIZf/toasty-core/src/schema/app/relation/has_many.rs:21
  struct toasty_core::schema::db::SchemaDiff, previously in file /tmp/.tmpqjTIZf/toasty-core/src/schema/db/schema.rs:114
  struct toasty_core::schema::app::HasOne, previously in file /tmp/.tmpqjTIZf/toasty-core/src/schema/app/relation/has_one.rs:21
  struct toasty_core::schema::db::ColumnsDiff, previously in file /tmp/.tmpqjTIZf/toasty-core/src/schema/db/column.rs:130
  struct toasty_core::schema::db::TablesDiff, previously in file /tmp/.tmpqjTIZf/toasty-core/src/schema/db/table.rs:145
  struct toasty_core::schema::db::TypesDiff, previously in file /tmp/.tmpqjTIZf/toasty-core/src/schema/db/ty_enum_diff.rs:8
  struct toasty_core::schema::db::DiffContext, previously in file /tmp/.tmpqjTIZf/toasty-core/src/schema/db/diff.rs:81
```

### ⚠ `toasty` breaking changes

```text
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/struct_missing.ron

Failed in:
  struct toasty::schema::HasMany, previously in file /tmp/.tmpqjTIZf/toasty/src/schema/has_many.rs:18
  struct toasty::HasMany, previously in file /tmp/.tmpqjTIZf/toasty/src/schema/has_many.rs:18
  struct toasty::schema::BelongsTo, previously in file /tmp/.tmpqjTIZf/toasty/src/schema/belongs_to.rs:16
  struct toasty::BelongsTo, previously in file /tmp/.tmpqjTIZf/toasty/src/schema/belongs_to.rs:16
  struct toasty::schema::HasOne, previously in file /tmp/.tmpqjTIZf/toasty/src/schema/has_one.rs:16
  struct toasty::HasOne, previously in file /tmp/.tmpqjTIZf/toasty/src/schema/has_one.rs:16

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/trait_missing.ron

Failed in:
  trait toasty::schema::Relation, previously in file /tmp/.tmpqjTIZf/toasty/src/schema/relation.rs:15
  trait toasty::schema::Defer, previously in file /tmp/.tmpqjTIZf/toasty/src/schema/deferred.rs:31
```

### ⚠ `toasty-cli` breaking changes

```text
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/struct_missing.ron

Failed in:
  struct toasty_cli::HistoryFileMigration, previously in file /tmp/.tmpqjTIZf/toasty-cli/src/migration/history_file.rs:71
  struct toasty_cli::HistoryFile, previously in file /tmp/.tmpqjTIZf/toasty-cli/src/migration/history_file.rs:42
  struct toasty_cli::SnapshotFile, previously in file /tmp/.tmpqjTIZf/toasty-cli/src/migration/snapshot_file.rs:34
```

### ⚠ `toasty-driver-integration-suite` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/function_missing.ron

Failed in:
  function toasty_driver_integration_suite::tests::deferred_field::deferred_exec_loads_value::id_uuid, previously in file /tmp/.tmpqjTIZf/toasty-driver-integration-suite/src/tests/deferred_field.rs:27
  function toasty_driver_integration_suite::tests::deferred_field::deferred_optional_exec_loads_value::id_uuid, previously in file /tmp/.tmpqjTIZf/toasty-driver-integration-suite/src/tests/deferred_field.rs:51
  function toasty_driver_integration_suite::tests::type_serialize::serialize_vec_string::id_u64, previously in file /tmp/.tmpqjTIZf/toasty-driver-integration-suite/src/tests/type_serialize.rs:35
  function toasty_driver_integration_suite::tests::type_serialize::serialize_nullable::id_u64, previously in file /tmp/.tmpqjTIZf/toasty-driver-integration-suite/src/tests/type_serialize.rs:86
  function toasty_driver_integration_suite::tests::type_serialize::serialize_non_nullable_option::id_u64, previously in file /tmp/.tmpqjTIZf/toasty-driver-integration-suite/src/tests/type_serialize.rs:130
  function toasty_driver_integration_suite::tests::type_serialize::serialize_custom_struct::id_u64, previously in file /tmp/.tmpqjTIZf/toasty-driver-integration-suite/src/tests/type_serialize.rs:176
  function toasty_driver_integration_suite::tests::type_serialize::serialize_vec_string::id_uuid, previously in file /tmp/.tmpqjTIZf/toasty-driver-integration-suite/src/tests/type_serialize.rs:35
  function toasty_driver_integration_suite::tests::type_serialize::serialize_nullable::id_uuid, previously in file /tmp/.tmpqjTIZf/toasty-driver-integration-suite/src/tests/type_serialize.rs:86
  function toasty_driver_integration_suite::tests::type_serialize::serialize_non_nullable_option::id_uuid, previously in file /tmp/.tmpqjTIZf/toasty-driver-integration-suite/src/tests/type_serialize.rs:130
  function toasty_driver_integration_suite::tests::type_serialize::serialize_custom_struct::id_uuid, previously in file /tmp/.tmpqjTIZf/toasty-driver-integration-suite/src/tests/type_serialize.rs:176
  function toasty_driver_integration_suite::tests::deferred_field::deferred_exec_loads_value::id_u64, previously in file /tmp/.tmpqjTIZf/toasty-driver-integration-suite/src/tests/deferred_field.rs:27
  function toasty_driver_integration_suite::tests::deferred_field::deferred_optional_exec_loads_value::id_u64, previously in file /tmp/.tmpqjTIZf/toasty-driver-integration-suite/src/tests/deferred_field.rs:51

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/module_missing.ron

Failed in:
  mod toasty_driver_integration_suite::tests::type_serialize::serialize_nullable, previously in file /tmp/.tmpqjTIZf/toasty-driver-integration-suite/src/tests/type_serialize.rs:85
  mod toasty_driver_integration_suite::tests::type_serialize::serialize_non_nullable_option, previously in file /tmp/.tmpqjTIZf/toasty-driver-integration-suite/src/tests/type_serialize.rs:129
  mod toasty_driver_integration_suite::tests::type_serialize::serialize_custom_struct, previously in file /tmp/.tmpqjTIZf/toasty-driver-integration-suite/src/tests/type_serialize.rs:175
  mod toasty_driver_integration_suite::tests::deferred_field::deferred_exec_loads_value, previously in file /tmp/.tmpqjTIZf/toasty-driver-integration-suite/src/tests/deferred_field.rs:26
  mod toasty_driver_integration_suite::tests::deferred_field::deferred_optional_exec_loads_value, previously in file /tmp/.tmpqjTIZf/toasty-driver-integration-suite/src/tests/deferred_field.rs:50
  mod toasty_driver_integration_suite::tests::type_serialize::serialize_vec_string, previously in file /tmp/.tmpqjTIZf/toasty-driver-integration-suite/src/tests/type_serialize.rs:34
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `toasty-core`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-core-v0.6.1...toasty-core-v0.7.0) - 2026-05-26

### Added

- Raw SQL execution ([#965])
- [**breaking**] Relation fields use `Deferred<T>` type instead of `#[deferred]` attribute ([#961])
- Eager relation fields ([#958])
- Multi-step `via` relations with `.include()` support ([#946])
- Migration core API ([#944])
- Turso driver ([#938])
- SQLite TransactionMode ([#931])
- SELECT DISTINCT queries ([#934])
- INNER joins ([#922])
- Multi-step has_many and has_one relations ([#890])

### Fixed

- SQLite auto-increment storage capped at 4 bytes ([#969])
- [**breaking**] `.ilike()` operator restricted to PostgreSQL ([#937])

### Changed

- [**breaking**] Merged has relation field variants ([#964])
- [**breaking**] Schema diff types moved to `schema::diff` ([#929])

[#890]: https://github.com/tokio-rs/toasty/pull/890
[#922]: https://github.com/tokio-rs/toasty/pull/922
[#929]: https://github.com/tokio-rs/toasty/pull/929
[#931]: https://github.com/tokio-rs/toasty/pull/931
[#934]: https://github.com/tokio-rs/toasty/pull/934
[#937]: https://github.com/tokio-rs/toasty/pull/937
[#938]: https://github.com/tokio-rs/toasty/pull/938
[#944]: https://github.com/tokio-rs/toasty/pull/944
[#946]: https://github.com/tokio-rs/toasty/pull/946
[#958]: https://github.com/tokio-rs/toasty/pull/958
[#961]: https://github.com/tokio-rs/toasty/pull/961
[#964]: https://github.com/tokio-rs/toasty/pull/964
[#965]: https://github.com/tokio-rs/toasty/pull/965
[#969]: https://github.com/tokio-rs/toasty/pull/969
</blockquote>

## `toasty-driver-dynamodb`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-dynamodb-v0.6.1...toasty-driver-dynamodb-v0.7.0) - 2026-05-26

### Added

- Raw SQL execution API ([#965])
- *(turso)* Turso driver with TransactionMode-aware concurrent writes ([#938])

### Fixed

- *(dynamodb)* Omit empty ExpressionAttributeValues on IS NULL / IS NOT NULL scans ([#940])

### Changed

- [**breaking**] Require Deferred relation fields ([#954])
- [**breaking**] Move schema diff types to `schema::diff` ([#929])

[#929]: https://github.com/tokio-rs/toasty/pull/929
[#938]: https://github.com/tokio-rs/toasty/pull/938
[#940]: https://github.com/tokio-rs/toasty/pull/940
[#954]: https://github.com/tokio-rs/toasty/pull/954
[#965]: https://github.com/tokio-rs/toasty/pull/965
</blockquote>

## `toasty-sql`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-sql-v0.6.1...toasty-sql-v0.7.0) - 2026-05-26

### Added

- Raw SQL execution API ([#965])
- Turso driver with TransactionMode-aware concurrent writes ([#938])
- TransactionMode for SQLite lock-acquisition control ([#931])
- `SELECT DISTINCT` query support ([#934])
- INNER join variant ([#922])

### Fixed

- Cap SQLite auto-increment integer storage at 4 bytes ([#969])
- [**breaking**] Scope `.ilike()` to PostgreSQL ([#937])

### Changed

- [**breaking**] Require Deferred relation fields ([#954])
- [**breaking**] Move schema diff types to `schema::diff` ([#929])

[#922]: https://github.com/tokio-rs/toasty/pull/922
[#929]: https://github.com/tokio-rs/toasty/pull/929
[#931]: https://github.com/tokio-rs/toasty/pull/931
[#934]: https://github.com/tokio-rs/toasty/pull/934
[#937]: https://github.com/tokio-rs/toasty/pull/937
[#938]: https://github.com/tokio-rs/toasty/pull/938
[#954]: https://github.com/tokio-rs/toasty/pull/954
[#965]: https://github.com/tokio-rs/toasty/pull/965
[#969]: https://github.com/tokio-rs/toasty/pull/969
</blockquote>

## `toasty-driver-mysql`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-mysql-v0.6.1...toasty-driver-mysql-v0.7.0) - 2026-05-26

### Added

- Raw SQL execution API ([#965])
- Turso driver with TransactionMode-aware concurrent writes ([#938])
- TransactionMode for SQLite lock-acquisition control ([#931])

### Changed

- [**breaking**] Deferred relation fields are now required ([#954])
- [**breaking**] Schema diff types moved to `schema::diff` module ([#929])

[#929]: https://github.com/tokio-rs/toasty/pull/929
[#931]: https://github.com/tokio-rs/toasty/pull/931
[#938]: https://github.com/tokio-rs/toasty/pull/938
[#954]: https://github.com/tokio-rs/toasty/pull/954
[#965]: https://github.com/tokio-rs/toasty/pull/965
</blockquote>

## `toasty-driver-postgresql`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-postgresql-v0.6.1...toasty-driver-postgresql-v0.7.0) - 2026-05-26

### Added

- Raw SQL execution API ([#965])
- Turso driver with TransactionMode-aware concurrent writes ([#938])
- TransactionMode for SQLite lock-acquisition control ([#931])

### Changed

- [**breaking**] Deferred relation fields are now required ([#954])
- [**breaking**] Schema diff types moved to `schema::diff` module ([#929])

[#929]: https://github.com/tokio-rs/toasty/pull/929
[#931]: https://github.com/tokio-rs/toasty/pull/931
[#938]: https://github.com/tokio-rs/toasty/pull/938
[#954]: https://github.com/tokio-rs/toasty/pull/954
[#965]: https://github.com/tokio-rs/toasty/pull/965
</blockquote>

## `toasty-driver-sqlite`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-sqlite-v0.6.1...toasty-driver-sqlite-v0.7.0) - 2026-05-26

### Added

- Raw SQL execution API ([#965])
- Turso driver with TransactionMode-aware concurrent writes ([#938])

### Changed

- [**breaking**] Require Deferred relation fields ([#954])
- [**breaking**] Move schema diff types to `schema::diff` ([#929])

[#929]: https://github.com/tokio-rs/toasty/pull/929
[#938]: https://github.com/tokio-rs/toasty/pull/938
[#954]: https://github.com/tokio-rs/toasty/pull/954
[#965]: https://github.com/tokio-rs/toasty/pull/965
</blockquote>

## `toasty-driver-turso`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-turso-v0.6.1...toasty-driver-turso-v0.7.0) - 2026-05-26

### Added

- Raw SQL execution API ([#965])
- Turso driver with TransactionMode-aware concurrent writes ([#938])

### Changed

- [**breaking**] Deferred relation fields are now required ([#954])
- [**breaking**] Terminal query method renamed from `.all()` to `.exec()` ([#471])
- [**breaking**] Removed `Cursor` type; queries now return `Vec` directly ([#448])
- [**breaking**] Removed automatic mapping of multiple models to a single table ([#225])
- [**breaking**] Switched to proc macros for schema declaration ([#76])

[#76]: https://github.com/tokio-rs/toasty/pull/76
[#225]: https://github.com/tokio-rs/toasty/pull/225
[#448]: https://github.com/tokio-rs/toasty/pull/448
[#471]: https://github.com/tokio-rs/toasty/pull/471
[#938]: https://github.com/tokio-rs/toasty/pull/938
[#954]: https://github.com/tokio-rs/toasty/pull/954
[#965]: https://github.com/tokio-rs/toasty/pull/965
</blockquote>

## `toasty-macros`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-macros-v0.6.1...toasty-macros-v0.7.0) - 2026-05-26

### Added

- reject create() on multi-step relation scopes at compile time ([#978])
- [**breaking**] remove singular has-many create-builder methods ([#977])
- [**breaking**] remove the `#[deferred]` field attribute in favor of `Deferred<T>` ([#961])
- support eager relation fields ([#958])
- support `.include()` of multi-step `via` relations ([#946])
- add Turso driver with TransactionMode-aware concurrent writes ([#938])
- allow #[version] on tuple-newtype embeds of u64 ([#930])
- [**breaking**] replace `#[serialize(json)]` with `toasty::Json<T>` wrapper ([#926])
- expose primary-key type via Model::PrimaryKey ([#921])
- add multi-step (via) has_many and has_one relations ([#890])

### Fixed

- respect `pair` attribute in `#[has_one]` macro ([#927])

### Changed

- [**breaking**] merge one relation field traits ([#971])
- [**breaking**] delete Relation trait, tighten relation field shapes ([#967])
- [**breaking**] require Deferred relation fields ([#954])

[#890]: https://github.com/tokio-rs/toasty/pull/890
[#921]: https://github.com/tokio-rs/toasty/pull/921
[#926]: https://github.com/tokio-rs/toasty/pull/926
[#927]: https://github.com/tokio-rs/toasty/pull/927
[#930]: https://github.com/tokio-rs/toasty/pull/930
[#938]: https://github.com/tokio-rs/toasty/pull/938
[#946]: https://github.com/tokio-rs/toasty/pull/946
[#954]: https://github.com/tokio-rs/toasty/pull/954
[#958]: https://github.com/tokio-rs/toasty/pull/958
[#961]: https://github.com/tokio-rs/toasty/pull/961
[#967]: https://github.com/tokio-rs/toasty/pull/967
[#971]: https://github.com/tokio-rs/toasty/pull/971
[#977]: https://github.com/tokio-rs/toasty/pull/977
[#978]: https://github.com/tokio-rs/toasty/pull/978
</blockquote>

## `toasty`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-v0.6.1...toasty-v0.7.0) - 2026-05-26

### Added

- Raw SQL execution API ([#965])
- Eager relation fields ([#958])
- Support for `.include()` of multi-step `via` relations ([#946])
- Migration core exposed from toasty ([#944])
- Turso driver with TransactionMode-aware concurrent writes ([#938])
- TransactionMode for SQLite lock-acquisition control ([#931])
- `#[version]` support on tuple-newtype embeds of u64 ([#930])
- `SELECT DISTINCT` serialization in SQL queries ([#934])
- Primary-key type exposed via `Model::PrimaryKey` ([#921])
- Multi-step (via) has-many and has-one relations ([#890])
- Non-panicking `try_get` method on relation types ([#918])

### Changed

- [**breaking**] `toasty::Json<T>` wrapper replaces `#[serialize(json)]` attribute ([#926])
- [**breaking**] Migration types consolidated in toasty crate; `db::diff` API reorganized ([#928])
- [**breaking**] Schema diff types moved to `schema::diff` module ([#929])
- [**breaking**] `.ilike()` scoped to PostgreSQL; operator pass-through documented ([#937])
- [**breaking**] Relation fields now require `Deferred<T>` wrapper (replacing optional `#[deferred]` attribute) ([#961], [#954])
- [**breaking**] Merged has relation field variants ([#964])
- [**breaking**] Deleted `Relation` trait and tightened relation field shapes ([#967])
- [**breaking**] Merged relation field traits ([#971])
- [**breaking**] `create()` rejected at compile time on multi-step relation scopes ([#978])

### Fixed

- Handle `ExprOr` expressions in eval verify logic ([#959])

[#890]: https://github.com/tokio-rs/toasty/pull/890
[#918]: https://github.com/tokio-rs/toasty/pull/918
[#921]: https://github.com/tokio-rs/toasty/pull/921
[#926]: https://github.com/tokio-rs/toasty/pull/926
[#928]: https://github.com/tokio-rs/toasty/pull/928
[#929]: https://github.com/tokio-rs/toasty/pull/929
[#930]: https://github.com/tokio-rs/toasty/pull/930
[#931]: https://github.com/tokio-rs/toasty/pull/931
[#934]: https://github.com/tokio-rs/toasty/pull/934
[#937]: https://github.com/tokio-rs/toasty/pull/937
[#938]: https://github.com/tokio-rs/toasty/pull/938
[#944]: https://github.com/tokio-rs/toasty/pull/944
[#946]: https://github.com/tokio-rs/toasty/pull/946
[#954]: https://github.com/tokio-rs/toasty/pull/954
[#958]: https://github.com/tokio-rs/toasty/pull/958
[#959]: https://github.com/tokio-rs/toasty/pull/959
[#961]: https://github.com/tokio-rs/toasty/pull/961
[#964]: https://github.com/tokio-rs/toasty/pull/964
[#965]: https://github.com/tokio-rs/toasty/pull/965
[#967]: https://github.com/tokio-rs/toasty/pull/967
[#971]: https://github.com/tokio-rs/toasty/pull/971
[#978]: https://github.com/tokio-rs/toasty/pull/978
</blockquote>

## `toasty-cli`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-cli-v0.6.1...toasty-cli-v0.7.0) - 2026-05-26

### Added

- Expose migration core from toasty ([#944])
- Turso driver with TransactionMode-aware concurrent writes ([#938])

### Changed

- [**breaking**] Require Deferred relation fields ([#954])
- [**breaking**] Move schema diff types to `schema::diff` ([#929])

[#929]: https://github.com/tokio-rs/toasty/pull/929
[#938]: https://github.com/tokio-rs/toasty/pull/938
[#944]: https://github.com/tokio-rs/toasty/pull/944
[#954]: https://github.com/tokio-rs/toasty/pull/954
</blockquote>

## `toasty-driver-integration-suite-macros`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-macros-v0.6.1...toasty-driver-integration-suite-macros-v0.7.0) - 2026-05-26

### Added

- *(turso)* Add Turso driver with TransactionMode-aware concurrent writes ([#938])

### Changed

- [**breaking**] Require Deferred relation fields ([#954])

[#938]: https://github.com/tokio-rs/toasty/pull/938
[#954]: https://github.com/tokio-rs/toasty/pull/954
</blockquote>

## `toasty-driver-integration-suite`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-v0.6.1...toasty-driver-integration-suite-v0.7.0) - 2026-05-26

### Added

- [**breaking**] Remove singular has-many create-builder methods ([#977])
- Add raw SQL execution API ([#965])
- [**breaking**] Remove `#[deferred]` field attribute in favor of `Deferred<T>` ([#961])
- Support eager relation fields ([#958])
- Support `.include()` of multi-step `via` relations ([#946])
- Add Turso driver with TransactionMode-aware concurrent writes ([#938])
- Add TransactionMode for SQLite lock-acquisition control ([#931])
- Allow `#[version]` on tuple-newtype embeds of u64 ([#930])
- [**breaking**] Replace `#[serialize(json)]` with `toasty::Json<T>` wrapper ([#926])
- Expose primary-key type via Model::PrimaryKey ([#921])
- Add multi-step (via) has_many and has_one relations ([#890])
- [**breaking**] Require Deferred relation fields ([#954])
- [**breaking**] Move schema diff types to `schema::diff` module ([#929])

### Fixed

- Cap SQLite auto-increment integer storage at 4 bytes ([#969])
- Fix ExprOr handling in expression evaluation ([#959])
- DynamoDB: omit empty ExpressionAttributeValues on IS NULL / IS NOT NULL scans ([#940])
- [**breaking**] Scope `.ilike()` operator to PostgreSQL and document operator pass-through ([#937])
- Respect `pair` attribute in `#[has_one]` macro ([#927])

[#890]: https://github.com/tokio-rs/toasty/pull/890
[#921]: https://github.com/tokio-rs/toasty/pull/921
[#926]: https://github.com/tokio-rs/toasty/pull/926
[#927]: https://github.com/tokio-rs/toasty/pull/927
[#929]: https://github.com/tokio-rs/toasty/pull/929
[#930]: https://github.com/tokio-rs/toasty/pull/930
[#931]: https://github.com/tokio-rs/toasty/pull/931
[#937]: https://github.com/tokio-rs/toasty/pull/937
[#938]: https://github.com/tokio-rs/toasty/pull/938
[#940]: https://github.com/tokio-rs/toasty/pull/940
[#946]: https://github.com/tokio-rs/toasty/pull/946
[#954]: https://github.com/tokio-rs/toasty/pull/954
[#958]: https://github.com/tokio-rs/toasty/pull/958
[#959]: https://github.com/tokio-rs/toasty/pull/959
[#961]: https://github.com/tokio-rs/toasty/pull/961
[#965]: https://github.com/tokio-rs/toasty/pull/965
[#969]: https://github.com/tokio-rs/toasty/pull/969
[#977]: https://github.com/tokio-rs/toasty/pull/977
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).