### PR TITLE
feat: expose primary-key type via Model::PrimaryKey

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -12,6 +12,7 @@ pub mod crud_composite_key_in_list;
 pub mod crud_composite_key_pagination;
 pub mod crud_create_macro;
 pub mod crud_driver_ops;
+pub mod crud_model_find_by_primary_key;
 pub mod crud_model_level_key;
 pub mod crud_option_filter;
 pub mod crud_partitioned;

--- a/crates/toasty-driver-integration-suite/src/tests/crud_model_find_by_primary_key.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/crud_model_find_by_primary_key.rs
@@ -1,0 +1,95 @@
+use crate::prelude::*;
+
+use toasty::schema::Model;
+use toasty::stmt::IntoExpr;
+
+#[driver_test(id(ID))]
+pub async fn single_column_pk(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Widget {
+        #[key]
+        #[auto]
+        id: ID,
+
+        name: String,
+    }
+
+    let mut db = test.setup_db(models!(Widget)).await;
+
+    let widget = toasty::create!(Widget { name: "alpha" })
+        .exec(&mut db)
+        .await?;
+
+    let found = Widget::find_by_primary_key(widget.id.into_expr())
+        .get(&mut db)
+        .await?;
+    assert_eq!(found.name, "alpha");
+
+    Ok(())
+}
+
+#[driver_test]
+pub async fn composite_pk(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    #[key(one, two)]
+    struct Pair {
+        one: String,
+        two: String,
+    }
+
+    let mut db = test.setup_db(models!(Pair)).await;
+
+    toasty::create!(Pair::[
+        { one: "hello", two: "world" },
+        { one: "left",  two: "right" },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let found = Pair::find_by_primary_key(("hello".to_string(), "world".to_string()).into_expr())
+        .get(&mut db)
+        .await?;
+    assert_eq!(found.one, "hello");
+    assert_eq!(found.two, "world");
+
+    Ok(())
+}
+
+/// Calling `find_by_primary_key` through a generic bound on
+/// `Model<PrimaryKey = ...>` — the use case the trait method exists to enable.
+#[driver_test]
+pub async fn generic_by_primary_key(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Widget {
+        #[key]
+        id: String,
+
+        name: String,
+    }
+
+    let mut db = test.setup_db(models!(Widget)).await;
+
+    toasty::create!(Widget {
+        id: "w1",
+        name: "alpha"
+    })
+    .exec(&mut db)
+    .await?;
+
+    async fn fetch<M>(db: &mut toasty::Db, id: String) -> Result<Vec<M>>
+    where
+        M: toasty::schema::Model<PrimaryKey = String>,
+        M::Query: toasty::stmt::IntoStatement<Returning = toasty::stmt::List<M>>,
+    {
+        use toasty::stmt::IntoStatement;
+        let stmt = M::find_by_primary_key(id.into_expr()).into_statement();
+        let executor: &mut dyn toasty::Executor = db;
+        executor.exec(stmt).await
+    }
+
+    let widgets: Vec<Widget> = fetch(&mut db, "w1".to_string()).await?;
+    assert_eq!(widgets.len(), 1);
+    assert_eq!(widgets[0].name, "alpha");
+
+    Ok(())
+}

--- a/crates/toasty-macros/src/model/expand/model.rs
+++ b/crates/toasty-macros/src/model/expand/model.rs
@@ -45,6 +45,8 @@ impl Expand<'_> {
         let create_meta_fields = self.expand_create_meta_fields();
         let check_required_fn = self.expand_check_required_fn();
         let version_update_stmts = self.expand_version_update_stmts();
+        let primary_key_ty = self.expand_primary_key_ty();
+        let find_by_primary_key_body = self.expand_find_by_primary_key_body();
 
         quote! {
             impl #model_ident {
@@ -131,6 +133,7 @@ impl Expand<'_> {
                 type Update<'a> = #update_struct_ident<&'a mut Self>;
                 type UpdateQuery = #update_struct_ident;
                 type Path<__Origin> = #field_struct_ident<__Origin>;
+                type PrimaryKey = #primary_key_ty;
 
                 const CREATE_META: #toasty::CreateMeta = #toasty::CreateMeta {
                     fields: &[ #create_meta_fields ],
@@ -139,6 +142,10 @@ impl Expand<'_> {
 
                 fn new_path<__Origin>(path: #toasty::Path<__Origin, Self>) -> Self::Path<__Origin> {
                     #field_struct_ident::from_path(path)
+                }
+
+                fn find_by_primary_key(id: #toasty::stmt::Expr<Self::PrimaryKey>) -> Self::Query {
+                    #find_by_primary_key_body
                 }
             }
 
@@ -282,6 +289,68 @@ impl Expand<'_> {
                     )
                 )
             )
+        }
+    }
+
+    /// Emit the Rust type used for `Model::PrimaryKey`: the scalar type for
+    /// single-column keys, or a tuple of column types for composite keys.
+    fn expand_primary_key_ty(&self) -> TokenStream {
+        let pk_fields: Vec<_> = self
+            .model
+            .primary_key_fields()
+            .expect("expand_primary_key_ty called on model without primary key")
+            .collect();
+
+        let types: Vec<&syn::Type> = pk_fields
+            .iter()
+            .map(|field| match &field.ty {
+                FieldTy::Primitive(ty) => ty,
+                _ => panic!("primary key fields must be primitive"),
+            })
+            .collect();
+
+        if types.len() == 1 {
+            let ty = &types[0];
+            quote!(#ty)
+        } else {
+            quote!(( #( #types ),* ))
+        }
+    }
+
+    /// Emit the body of `Model::find_by_primary_key`.
+    ///
+    /// For a single-column PK, delegate to the inherent `filter_by_<pk>` method
+    /// (which takes `impl IntoExpr<T>`; `Expr<T>` satisfies that bound).
+    ///
+    /// For a composite PK, the inherent `filter_by_<pk1>_and_<pk2>` takes
+    /// positional args — we only have a single opaque `Expr<(T1, T2)>`, so we
+    /// build a record expression of the PK column paths and compare to it
+    /// instead. The simplifier decomposes `Record == Record` into per-column
+    /// equalities.
+    fn expand_find_by_primary_key_body(&self) -> TokenStream {
+        let toasty = &self.toasty;
+        let model_ident = &self.model.ident;
+        let filter = self.primary_key_filter();
+        let pk_fields: Vec<_> = self
+            .model
+            .primary_key_fields()
+            .expect("expand_find_by_primary_key_body called on model without primary key")
+            .collect();
+
+        if pk_fields.len() == 1 {
+            let filter_method_ident = &filter.filter_method_ident;
+            quote! {
+                Self::#filter_method_ident(id)
+            }
+        } else {
+            let field_idents = pk_fields.iter().map(|f| &f.name.ident);
+            quote! {
+                let pk_expr: #toasty::stmt::Expr<Self::PrimaryKey> =
+                    #toasty::IntoExpr::into_expr((
+                        #( #model_ident::fields().#field_idents() ),*
+                    ));
+                Self::filter(pk_expr.eq(id))
+            }
         }
     }
 

--- a/crates/toasty/src/schema/model.rs
+++ b/crates/toasty/src/schema/model.rs
@@ -1,6 +1,6 @@
 use super::create_meta::CreateMeta;
 use super::{Load, Register};
-use crate::stmt::{IntoExpr, IntoInsert, Path};
+use crate::stmt::{Expr, IntoExpr, IntoInsert, Path};
 
 /// Trait for root models that map to database tables and can be queried.
 ///
@@ -23,12 +23,31 @@ pub trait Model: Register + Load<Output = Self> + Sized {
     /// A typed path from `Origin` into this model.
     type Path<Origin>;
 
+    /// The model's primary key type.
+    ///
+    /// For a single-column key, this is the column's Rust type (e.g.
+    /// `Uuid`, `i64`). For a composite key, this is a tuple of the
+    /// column types in declaration order.
+    ///
+    /// Generic code can bind on this to write functions that accept any
+    /// model identified by a particular PK type — for example, a request
+    /// extractor for any `M: Model<PrimaryKey = Uuid>`.
+    type PrimaryKey;
+
     /// Metadata about the model's fields for compile-time validation of
     /// `create!` invocations.
     const CREATE_META: CreateMeta;
 
     /// Construct a model path from a [`Path`] targeting this model.
     fn new_path<Origin>(path: Path<Origin, Self>) -> Self::Path<Origin>;
+
+    /// Build a query that filters this model by its primary key.
+    ///
+    /// `id` takes any expression that evaluates to the model's
+    /// [`PrimaryKey`](Self::PrimaryKey) type — bare PK values via their
+    /// `IntoExpr` impl, subqueries that return a PK, or any other
+    /// [`Expr`] of the correct type.
+    fn find_by_primary_key(id: Expr<Self::PrimaryKey>) -> Self::Query;
 
     /// Construct a path rooted at this model.
     fn new_root_path() -> Self::Path<Self> {


### PR DESCRIPTION
## Summary

Adds a `PrimaryKey` associated type and a `find_by_primary_key(id: Expr<Self::PrimaryKey>) -> Self::Query` method to the `Model` trait, so generic code can bind on the PK type — e.g. an axum extractor for any `M: Model<PrimaryKey = Uuid>`.

Codegen emits the scalar type for single-column keys and a tuple for composite keys. The single-PK case delegates to the inherent `filter_by_<pk>`; the composite case builds a record-of-paths and compares to the input expression so the simplifier can decompose `Record == Record` into per-column equalities.

Closes #786

## Type of change

- [x] Other: implements the design discussed and accepted in #786.

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

The trait method is named `find_by_primary_key` (not `filter_by_id`) to avoid shadowing the inherent `filter_by_id` that codegen already emits for models whose PK field is named `id`.