### PR TITLE
feat(core): add INNER join variant + broaden serializer test coverage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ clap = { version = "4.6.0", features = ["derive"] }
 console = "0.16"
 deadpool = { version = "0.13", features = ["rt_tokio_1"] }
 dialoguer = "0.12"
+expect-test = "1.5"
 hashbrown = "0.17"
 heck = "0.5.0"
 indexmap = "2.13.0"

--- a/crates/toasty-core/src/stmt/join.rs
+++ b/crates/toasty-core/src/stmt/join.rs
@@ -26,8 +26,6 @@ pub struct Join {
 
 /// The type of join and its ON condition.
 ///
-/// Currently only left joins are supported.
-///
 /// # Examples
 ///
 /// ```ignore
@@ -37,6 +35,9 @@ pub struct Join {
 /// ```
 #[derive(Debug, Clone, PartialEq)]
 pub enum JoinOp {
+    /// An `INNER JOIN` with the given ON condition.
+    Inner(Expr),
+
     /// A `LEFT JOIN` with the given ON condition.
     Left(Expr),
 }

--- a/crates/toasty-core/src/stmt/visit.rs
+++ b/crates/toasty-core/src/stmt/visit.rs
@@ -1280,7 +1280,7 @@ where
 {
     v.visit_source_table_id(&node.table);
     match &node.constraint {
-        JoinOp::Left(expr) => v.visit_expr(expr),
+        JoinOp::Inner(expr) | JoinOp::Left(expr) => v.visit_expr(expr),
     }
 }
 

--- a/crates/toasty-core/src/stmt/visit_mut.rs
+++ b/crates/toasty-core/src/stmt/visit_mut.rs
@@ -1282,7 +1282,7 @@ where
 {
     v.visit_source_table_id_mut(&mut node.table);
     match &mut node.constraint {
-        JoinOp::Left(expr) => v.visit_expr_mut(expr),
+        JoinOp::Inner(expr) | JoinOp::Left(expr) => v.visit_expr_mut(expr),
     }
 }
 

--- a/crates/toasty-sql/Cargo.toml
+++ b/crates/toasty-sql/Cargo.toml
@@ -25,5 +25,8 @@ rust_decimal = ["dep:rust_decimal", "toasty-core/rust_decimal"]
 bigdecimal = ["dep:bigdecimal", "toasty-core/bigdecimal"]
 jiff = ["dep:jiff", "toasty-core/jiff"]
 
+[dev-dependencies]
+expect-test.workspace = true
+
 [lints]
 workspace = true

--- a/crates/toasty-sql/src/serializer/column.rs
+++ b/crates/toasty-sql/src/serializer/column.rs
@@ -5,6 +5,12 @@ pub(crate) struct ColumnAlias(pub(crate) usize);
 
 impl ToSql for ColumnAlias {
     fn to_sql(self, cx: &super::ExprContext<'_>, f: &mut super::Formatter<'_>) {
+        // The per-flavor format matches each engine's auto-naming convention
+        // for derived-table columns. MySQL's `VALUES ROW(...) AS t` exposes
+        // columns as `column_0`, `column_1`, ...; PG and SQLite use
+        // `column1`, `column2`, ... in equivalent contexts. The engine emits
+        // VALUES-derived tables in include lowering, and outer references
+        // (e.g. `tbl_1_0.column_0`) must match what the engine sees.
         if f.serializer.is_mysql() {
             let i = self.0;
             fmt!(cx, f, "column_" i);

--- a/crates/toasty-sql/src/serializer/statement.rs
+++ b/crates/toasty-sql/src/serializer/statement.rs
@@ -574,16 +574,16 @@ impl ToSql for &stmt::SourceTable {
 
             // Serialize the joins
             for join in &table_with_joins.joins {
-                match &join.constraint {
-                    stmt::JoinOp::Left(expr) => {
-                        let join_table_ref = &self.tables[join.table.0];
-                        let alias = TableAlias {
-                            depth: f.depth,
-                            table: join.table,
-                        };
-                        fmt!(cx, f, " LEFT JOIN " join_table_ref " AS " alias " ON " expr);
-                    }
-                }
+                let (kw, expr) = match &join.constraint {
+                    stmt::JoinOp::Inner(expr) => (" INNER JOIN ", expr),
+                    stmt::JoinOp::Left(expr) => (" LEFT JOIN ", expr),
+                };
+                let join_table_ref = &self.tables[join.table.0];
+                let alias = TableAlias {
+                    depth: f.depth,
+                    table: join.table,
+                };
+                fmt!(cx, f, kw join_table_ref " AS " alias " ON " expr);
             }
         }
     }

--- a/crates/toasty-sql/src/serializer/statement.rs
+++ b/crates/toasty-sql/src/serializer/statement.rs
@@ -822,11 +822,33 @@ impl ToSql for &stmt::UpdateTarget {
 
 impl ToSql for &stmt::Values {
     fn to_sql(self, cx: &ExprContext<'_>, f: &mut super::Formatter<'_>) {
-        // MySQL requires ROW() keyword for table value constructors when used
-        // in subqueries, but NOT in INSERT statements
+        // MySQL requires the `ROW(...)` keyword for table value constructors
+        // when used in subqueries, but NOT in INSERT statements.
+        //
+        // Rows are `Expr::Record`s, which serialize with their own `(...)`.
+        // Inside `ROW(...)` we need the fields comma-separated *without*
+        // those parens — otherwise MySQL parses `ROW((1, 'a'))` as a single
+        // row-expression operand and rejects it with "Operand should contain
+        // 1 column(s)".
         if f.serializer.is_mysql() && !f.in_insert {
-            let rows = Comma(self.rows.iter().map(|row| ("ROW(", row, ")")));
-            fmt!(cx, f, "VALUES " rows)
+            // `Expr::Record` serializes with its own `(...)`; render its
+            // fields directly inside `ROW(...)` so we don't end up with
+            // `ROW((a, b))` (which MySQL parses as a single row-typed
+            // operand and rejects). Other expression shapes are wrapped
+            // as-is — a single-scalar row `ROW(x)` is well-formed.
+            for (i, row) in self.rows.iter().enumerate() {
+                if i == 0 {
+                    fmt!(cx, f, "VALUES ");
+                } else {
+                    fmt!(cx, f, ", ");
+                }
+                match row {
+                    stmt::Expr::Record(record) => {
+                        fmt!(cx, f, "ROW(" Comma(record.fields.iter()) ")")
+                    }
+                    _ => fmt!(cx, f, "ROW(" row ")"),
+                }
+            }
         } else {
             let rows = Comma(self.rows.iter());
             fmt!(cx, f, "VALUES " rows)

--- a/crates/toasty-sql/tests/serialize_array_predicates.rs
+++ b/crates/toasty-sql/tests/serialize_array_predicates.rs
@@ -7,6 +7,7 @@
 //! serializer is tested in isolation, including operators (e.g. `>`) the
 //! engine does not currently emit but that the node generalizes to.
 
+use expect_test::expect;
 use toasty_core::{
     schema::db::Schema,
     stmt::{self, BinaryOp, Expr, ExprAllOp, ExprAnyOp},
@@ -32,11 +33,7 @@ fn any_op_eq() {
         rhs: Box::new(Expr::arg(1)),
     }
     .into();
-    let sql = render(expr);
-    assert!(
-        sql.contains("$1 = ANY($2)"),
-        "expected `$1 = ANY($2)` in: {sql}"
-    );
+    expect!["VALUES ($1 = ANY($2));"].assert_eq(&render(expr));
 }
 
 #[test]
@@ -47,11 +44,7 @@ fn all_op_ne() {
         rhs: Box::new(Expr::arg(1)),
     }
     .into();
-    let sql = render(expr);
-    assert!(
-        sql.contains("$1 <> ALL($2)"),
-        "expected `$1 <> ALL($2)` in: {sql}"
-    );
+    expect!["VALUES ($1 <> ALL($2));"].assert_eq(&render(expr));
 }
 
 #[test]
@@ -65,9 +58,5 @@ fn any_op_gt_generalizes_to_other_operators() {
         rhs: Box::new(Expr::arg(1)),
     }
     .into();
-    let sql = render(expr);
-    assert!(
-        sql.contains("$1 > ANY($2)"),
-        "expected `$1 > ANY($2)` in: {sql}"
-    );
+    expect!["VALUES ($1 > ANY($2));"].assert_eq(&render(expr));
 }

--- a/crates/toasty-sql/tests/serialize_dml.rs
+++ b/crates/toasty-sql/tests/serialize_dml.rs
@@ -1,0 +1,370 @@
+//! Verifies the serializer renders `INSERT` / `UPDATE` / `DELETE` shapes,
+//! including the `RETURNING` clause where supported, and that MySQL (which has
+//! no `RETURNING` support) panics as expected.
+//!
+//! Tests construct the AST directly so the serializer is exercised in
+//! isolation — no lowering pipeline involved.
+
+use toasty_core::{
+    schema::db::{Column, ColumnId, PrimaryKey, Schema, Table, TableId, Type as StorageType},
+    stmt::{
+        self, Assignments, Delete, Expr, ExprColumn, Filter, Insert, InsertTable, InsertTarget,
+        Returning, Source, Update, UpdateTarget, Values,
+    },
+};
+use toasty_sql::{Serializer, Statement as SqlStatement};
+
+#[derive(Clone, Copy)]
+enum Flavor {
+    Sqlite,
+    Postgresql,
+    Mysql,
+}
+
+/// Minimal `id INTEGER PRIMARY KEY, *cols` table. `cols` start at column index
+/// 1 and are all `TEXT`. Stored as `id` for the PK column to keep predicates
+/// easy to read in assertions.
+fn make_table(id: usize, name: &str, cols: &[&str]) -> Table {
+    let mut columns = vec![Column {
+        id: ColumnId {
+            table: TableId(id),
+            index: 0,
+        },
+        name: "id".to_string(),
+        ty: stmt::Type::I64,
+        storage_ty: StorageType::Integer(8),
+        nullable: false,
+        primary_key: true,
+        auto_increment: false,
+        versionable: false,
+    }];
+    for (i, name) in cols.iter().enumerate() {
+        columns.push(Column {
+            id: ColumnId {
+                table: TableId(id),
+                index: i + 1,
+            },
+            name: (*name).to_string(),
+            ty: stmt::Type::String,
+            storage_ty: StorageType::Text,
+            nullable: false,
+            primary_key: false,
+            auto_increment: false,
+            versionable: false,
+        });
+    }
+    Table {
+        id: TableId(id),
+        name: name.to_string(),
+        columns,
+        primary_key: PrimaryKey {
+            columns: vec![ColumnId {
+                table: TableId(id),
+                index: 0,
+            }],
+            index: toasty_core::schema::db::IndexId {
+                table: TableId(id),
+                index: 0,
+            },
+        },
+        indices: vec![],
+    }
+}
+
+/// Reference to column `column` of the `table`th entry in `SourceTable::tables`.
+fn col(table: usize, column: usize) -> Expr {
+    Expr::column(ExprColumn {
+        nesting: 0,
+        table,
+        column,
+    })
+}
+
+fn render(flavor: Flavor, schema: &Schema, stmt: stmt::Statement) -> String {
+    let sql_stmt = SqlStatement::from(stmt);
+    match flavor {
+        Flavor::Sqlite => Serializer::sqlite(schema).serialize(&sql_stmt),
+        Flavor::Postgresql => Serializer::postgresql(schema).serialize(&sql_stmt),
+        Flavor::Mysql => Serializer::mysql(schema).serialize(&sql_stmt),
+    }
+}
+
+fn users_schema() -> Schema {
+    Schema {
+        tables: vec![make_table(0, "users", &["name"])],
+    }
+}
+
+/// Build `INSERT INTO users (id, name) VALUES (1, 'a')`.
+fn insert_basic(returning: Option<Returning>) -> stmt::Statement {
+    let target = InsertTarget::Table(InsertTable {
+        table: TableId(0),
+        columns: vec![
+            ColumnId {
+                table: TableId(0),
+                index: 0,
+            },
+            ColumnId {
+                table: TableId(0),
+                index: 1,
+            },
+        ],
+    });
+
+    let row = Expr::record([Expr::from(1i64), Expr::from("a")]);
+    let source = stmt::Query::values(Values::new(vec![row]));
+
+    Insert {
+        target,
+        source,
+        returning,
+    }
+    .into()
+}
+
+/// Build `UPDATE users SET name = 'b' [WHERE id = 1]` with optional RETURNING.
+fn update_stmt(with_where: bool, returning: Option<Returning>) -> stmt::Statement {
+    let mut assignments = Assignments::default();
+    assignments.set(1usize, Expr::from("b"));
+
+    let filter = if with_where {
+        Filter::new(Expr::eq(col(0, 0), Expr::from(1i64)))
+    } else {
+        Filter::ALL
+    };
+
+    Update {
+        target: UpdateTarget::Table(TableId(0)),
+        assignments,
+        filter,
+        condition: stmt::Condition::default(),
+        returning,
+    }
+    .into()
+}
+
+/// Build `DELETE FROM users [WHERE id = 1]` with optional RETURNING.
+fn delete_stmt(with_where: bool, returning: Option<Returning>) -> stmt::Statement {
+    let filter = if with_where {
+        Filter::new(Expr::eq(col(0, 0), Expr::from(1i64)))
+    } else {
+        Filter::ALL
+    };
+
+    Delete {
+        from: Source::from(TableId(0)),
+        filter,
+        returning,
+        condition: stmt::Condition::default(),
+    }
+    .into()
+}
+
+/// Backtick (MySQL) or double-quote (PG/SQLite) ident quote char.
+fn q(flavor: Flavor) -> char {
+    match flavor {
+        Flavor::Mysql => '`',
+        _ => '"',
+    }
+}
+
+// -----------------------------------------------------------------------------
+// INSERT
+// -----------------------------------------------------------------------------
+
+#[test]
+fn insert_basic_values() {
+    let schema = users_schema();
+    for flavor in [Flavor::Sqlite, Flavor::Postgresql, Flavor::Mysql] {
+        let sql = render(flavor, &schema, insert_basic(None));
+        let q = q(flavor);
+        let expected = format!("INSERT INTO {q}users{q} ({q}id{q}, {q}name{q}) VALUES (1, 'a');");
+        assert_eq!(sql, expected, "flavor mismatch for {expected:?}");
+        assert!(
+            !sql.contains("RETURNING"),
+            "did not expect RETURNING in: {sql}"
+        );
+    }
+}
+
+#[test]
+fn insert_with_returning() {
+    let schema = users_schema();
+    let returning = Some(Returning::Project(Expr::record([col(0, 0)])));
+    for flavor in [Flavor::Sqlite, Flavor::Postgresql] {
+        let sql = render(flavor, &schema, insert_basic(returning.clone()));
+        assert!(
+            sql.contains("RETURNING "),
+            "expected `RETURNING ` in: {sql}"
+        );
+        // The returning projection references the `id` column.
+        let q = q(flavor);
+        let ident = format!("{q}id{q}");
+        assert!(
+            sql.contains(&ident),
+            "expected `{ident}` in returning: {sql}"
+        );
+    }
+}
+
+#[test]
+fn insert_returning_panics_on_mysql() {
+    let schema = users_schema();
+    let returning = Some(Returning::Project(Expr::record([col(0, 0)])));
+    let result =
+        std::panic::catch_unwind(|| render(Flavor::Mysql, &schema, insert_basic(returning)));
+    assert!(
+        result.is_err(),
+        "expected MySQL INSERT+RETURNING to panic, got: {:?}",
+        result.ok()
+    );
+}
+
+// -----------------------------------------------------------------------------
+// UPDATE
+// -----------------------------------------------------------------------------
+
+#[test]
+fn update_basic() {
+    let schema = users_schema();
+    for flavor in [Flavor::Sqlite, Flavor::Postgresql, Flavor::Mysql] {
+        let sql = render(flavor, &schema, update_stmt(false, None));
+        let q = q(flavor);
+        // `UPDATE "users" AS tbl_0_0 SET "name" = 'b';`
+        let expected = format!("UPDATE {q}users{q} AS tbl_0_0 SET {q}name{q} = 'b';");
+        assert_eq!(sql, expected, "flavor mismatch for {expected:?}");
+        assert!(!sql.contains(" WHERE "), "did not expect WHERE in: {sql}");
+        assert!(
+            !sql.contains("RETURNING"),
+            "did not expect RETURNING in: {sql}"
+        );
+    }
+}
+
+#[test]
+fn update_with_where() {
+    let schema = users_schema();
+    for flavor in [Flavor::Sqlite, Flavor::Postgresql, Flavor::Mysql] {
+        let sql = render(flavor, &schema, update_stmt(true, None));
+        assert!(sql.contains(" SET "), "expected ` SET ` in: {sql}");
+        assert!(sql.contains(" WHERE "), "expected ` WHERE ` in: {sql}");
+        // The Update serializer disables alias prefixing — `WHERE "id" = 1`,
+        // not `WHERE tbl_0_0."id" = 1`.
+        let q = q(flavor);
+        let needle = format!("WHERE {q}id{q} = 1");
+        assert!(sql.contains(&needle), "expected `{needle}` in: {sql}");
+    }
+}
+
+#[test]
+fn update_with_returning() {
+    let schema = users_schema();
+    let returning = Some(Returning::Project(Expr::record([col(0, 0)])));
+    for flavor in [Flavor::Sqlite, Flavor::Postgresql] {
+        let sql = render(flavor, &schema, update_stmt(true, returning.clone()));
+        assert!(
+            sql.contains(" RETURNING "),
+            "expected ` RETURNING ` in: {sql}"
+        );
+    }
+}
+
+#[test]
+fn update_returning_panics_on_mysql() {
+    let schema = users_schema();
+    let returning = Some(Returning::Project(Expr::record([col(0, 0)])));
+    let result =
+        std::panic::catch_unwind(|| render(Flavor::Mysql, &schema, update_stmt(true, returning)));
+    assert!(
+        result.is_err(),
+        "expected MySQL UPDATE+RETURNING to panic, got: {:?}",
+        result.ok()
+    );
+}
+
+// -----------------------------------------------------------------------------
+// DELETE
+// -----------------------------------------------------------------------------
+
+#[test]
+fn delete_basic() {
+    let schema = users_schema();
+    for flavor in [Flavor::Sqlite, Flavor::Postgresql, Flavor::Mysql] {
+        let sql = render(flavor, &schema, delete_stmt(false, None));
+        let q = q(flavor);
+        let expected = format!("DELETE FROM {q}users{q} AS tbl_0_0;");
+        assert_eq!(sql, expected, "flavor mismatch for {expected:?}");
+        assert!(!sql.contains(" WHERE "), "did not expect WHERE in: {sql}");
+    }
+}
+
+#[test]
+fn delete_with_where() {
+    let schema = users_schema();
+    for flavor in [Flavor::Sqlite, Flavor::Postgresql, Flavor::Mysql] {
+        let sql = render(flavor, &schema, delete_stmt(true, None));
+        assert!(
+            sql.starts_with("DELETE FROM "),
+            "expected DELETE FROM prefix in: {sql}"
+        );
+        assert!(sql.contains(" WHERE "), "expected ` WHERE ` in: {sql}");
+        // Delete enables alias prefixing — `WHERE tbl_0_0."id" = 1`.
+        let q = q(flavor);
+        let needle = format!("tbl_0_0.{q}id{q} = 1");
+        assert!(sql.contains(&needle), "expected `{needle}` in: {sql}");
+    }
+}
+
+/// MySQL has no `RETURNING` clause for any DML statement, so the serializer
+/// must reject a `DELETE ... RETURNING` on this flavor.
+#[test]
+fn delete_with_returning_panics_on_mysql() {
+    let schema = users_schema();
+    let returning = Some(Returning::Project(Expr::record([col(0, 0)])));
+    let result =
+        std::panic::catch_unwind(|| render(Flavor::Mysql, &schema, delete_stmt(true, returning)));
+    assert!(
+        result.is_err(),
+        "expected MySQL DELETE+RETURNING to panic, got: {:?}",
+        result.ok()
+    );
+}
+
+// PostgreSQL has supported `DELETE ... RETURNING` since 8.2; SQLite since
+// 3.35. The serializer currently asserts `returning.is_none()` unconditionally
+// in `impl ToSql for &stmt::Delete`, so the tests below would panic today —
+// they are `#[ignore]`'d and pin the expected behavior once the serializer is
+// taught to emit `RETURNING` for these flavors (mirroring the existing pattern
+// for INSERT/UPDATE).
+
+#[ignore = "DELETE+RETURNING is not yet implemented; serializer panics unconditionally"]
+#[test]
+fn delete_with_returning_postgresql() {
+    let schema = users_schema();
+    let returning = Some(Returning::Project(Expr::record([col(0, 0)])));
+    let sql = render(Flavor::Postgresql, &schema, delete_stmt(true, returning));
+    assert!(
+        sql.contains(" RETURNING "),
+        "expected ` RETURNING ` in: {sql}"
+    );
+    assert!(
+        sql.contains(r#"tbl_0_0."id""#),
+        "expected projected column in: {sql}"
+    );
+}
+
+#[ignore = "DELETE+RETURNING is not yet implemented; serializer panics unconditionally"]
+#[test]
+fn delete_with_returning_sqlite() {
+    let schema = users_schema();
+    let returning = Some(Returning::Project(Expr::record([col(0, 0)])));
+    let sql = render(Flavor::Sqlite, &schema, delete_stmt(true, returning));
+    assert!(
+        sql.contains(" RETURNING "),
+        "expected ` RETURNING ` in: {sql}"
+    );
+    assert!(
+        sql.contains(r#"tbl_0_0."id""#),
+        "expected projected column in: {sql}"
+    );
+}

--- a/crates/toasty-sql/tests/serialize_dml.rs
+++ b/crates/toasty-sql/tests/serialize_dml.rs
@@ -208,16 +208,11 @@ fn insert_with_returning() {
 }
 
 #[test]
+#[should_panic(expected = "MySQL does not support the RETURNING clause with INSERT")]
 fn insert_returning_panics_on_mysql() {
     let schema = users_schema();
     let returning = Some(Returning::Project(Expr::record([col(0, 0)])));
-    let result =
-        std::panic::catch_unwind(|| render(Flavor::Mysql, &schema, insert_basic(returning)));
-    assert!(
-        result.is_err(),
-        "expected MySQL INSERT+RETURNING to panic, got: {:?}",
-        result.ok()
-    );
+    render(Flavor::Mysql, &schema, insert_basic(returning));
 }
 
 // -----------------------------------------------------------------------------
@@ -270,16 +265,11 @@ fn update_with_returning() {
 }
 
 #[test]
+#[should_panic(expected = "MySQL does not support the RETURNING clause with UPDATE")]
 fn update_returning_panics_on_mysql() {
     let schema = users_schema();
     let returning = Some(Returning::Project(Expr::record([col(0, 0)])));
-    let result =
-        std::panic::catch_unwind(|| render(Flavor::Mysql, &schema, update_stmt(true, returning)));
-    assert!(
-        result.is_err(),
-        "expected MySQL UPDATE+RETURNING to panic, got: {:?}",
-        result.ok()
-    );
+    render(Flavor::Mysql, &schema, update_stmt(true, returning));
 }
 
 // -----------------------------------------------------------------------------
@@ -317,17 +307,18 @@ fn delete_with_where() {
 
 /// MySQL has no `RETURNING` clause for any DML statement, so the serializer
 /// must reject a `DELETE ... RETURNING` on this flavor.
+///
+/// The panic today comes from the unconditional `assert!(returning.is_none())`
+/// in the Delete serializer, so the message is the assert text — once the
+/// serializer learns to emit RETURNING for PG/SQLite (see #[ignore]'d tests
+/// below), the MySQL branch should become an explicit panic mirroring INSERT
+/// and UPDATE, and this `expected` substring should track it.
 #[test]
+#[should_panic(expected = "self.returning.is_none()")]
 fn delete_with_returning_panics_on_mysql() {
     let schema = users_schema();
     let returning = Some(Returning::Project(Expr::record([col(0, 0)])));
-    let result =
-        std::panic::catch_unwind(|| render(Flavor::Mysql, &schema, delete_stmt(true, returning)));
-    assert!(
-        result.is_err(),
-        "expected MySQL DELETE+RETURNING to panic, got: {:?}",
-        result.ok()
-    );
+    render(Flavor::Mysql, &schema, delete_stmt(true, returning));
 }
 
 // PostgreSQL has supported `DELETE ... RETURNING` since 8.2; SQLite since

--- a/crates/toasty-sql/tests/serialize_dml.rs
+++ b/crates/toasty-sql/tests/serialize_dml.rs
@@ -5,6 +5,7 @@
 //! Tests construct the AST directly so the serializer is exercised in
 //! isolation — no lowering pipeline involved.
 
+use expect_test::expect;
 use toasty_core::{
     schema::db::{Column, ColumnId, PrimaryKey, Schema, Table, TableId, Type as StorageType},
     stmt::{
@@ -160,14 +161,6 @@ fn delete_stmt(with_where: bool, returning: Option<Returning>) -> stmt::Statemen
     .into()
 }
 
-/// Backtick (MySQL) or double-quote (PG/SQLite) ident quote char.
-fn q(flavor: Flavor) -> char {
-    match flavor {
-        Flavor::Mysql => '`',
-        _ => '"',
-    }
-}
-
 // -----------------------------------------------------------------------------
 // INSERT
 // -----------------------------------------------------------------------------
@@ -175,36 +168,33 @@ fn q(flavor: Flavor) -> char {
 #[test]
 fn insert_basic_values() {
     let schema = users_schema();
-    for flavor in [Flavor::Sqlite, Flavor::Postgresql, Flavor::Mysql] {
-        let sql = render(flavor, &schema, insert_basic(None));
-        let q = q(flavor);
-        let expected = format!("INSERT INTO {q}users{q} ({q}id{q}, {q}name{q}) VALUES (1, 'a');");
-        assert_eq!(sql, expected, "flavor mismatch for {expected:?}");
-        assert!(
-            !sql.contains("RETURNING"),
-            "did not expect RETURNING in: {sql}"
-        );
-    }
+    expect![[r#"INSERT INTO "users" ("id", "name") VALUES (1, 'a');"#]].assert_eq(&render(
+        Flavor::Sqlite,
+        &schema,
+        insert_basic(None),
+    ));
+    expect![[r#"INSERT INTO "users" ("id", "name") VALUES (1, 'a');"#]].assert_eq(&render(
+        Flavor::Postgresql,
+        &schema,
+        insert_basic(None),
+    ));
+    expect!["INSERT INTO `users` (`id`, `name`) VALUES (1, 'a');"].assert_eq(&render(
+        Flavor::Mysql,
+        &schema,
+        insert_basic(None),
+    ));
 }
 
 #[test]
 fn insert_with_returning() {
     let schema = users_schema();
     let returning = Some(Returning::Project(Expr::record([col(0, 0)])));
-    for flavor in [Flavor::Sqlite, Flavor::Postgresql] {
-        let sql = render(flavor, &schema, insert_basic(returning.clone()));
-        assert!(
-            sql.contains("RETURNING "),
-            "expected `RETURNING ` in: {sql}"
-        );
-        // The returning projection references the `id` column.
-        let q = q(flavor);
-        let ident = format!("{q}id{q}");
-        assert!(
-            sql.contains(&ident),
-            "expected `{ident}` in returning: {sql}"
-        );
-    }
+    expect![[r#"INSERT INTO "users" ("id", "name") VALUES (1, 'a')RETURNING "id";"#]].assert_eq(
+        &render(Flavor::Sqlite, &schema, insert_basic(returning.clone())),
+    );
+    expect![[r#"INSERT INTO "users" ("id", "name") VALUES (1, 'a')RETURNING "id";"#]].assert_eq(
+        &render(Flavor::Postgresql, &schema, insert_basic(returning)),
+    );
 }
 
 #[test]
@@ -222,46 +212,59 @@ fn insert_returning_panics_on_mysql() {
 #[test]
 fn update_basic() {
     let schema = users_schema();
-    for flavor in [Flavor::Sqlite, Flavor::Postgresql, Flavor::Mysql] {
-        let sql = render(flavor, &schema, update_stmt(false, None));
-        let q = q(flavor);
-        // `UPDATE "users" AS tbl_0_0 SET "name" = 'b';`
-        let expected = format!("UPDATE {q}users{q} AS tbl_0_0 SET {q}name{q} = 'b';");
-        assert_eq!(sql, expected, "flavor mismatch for {expected:?}");
-        assert!(!sql.contains(" WHERE "), "did not expect WHERE in: {sql}");
-        assert!(
-            !sql.contains("RETURNING"),
-            "did not expect RETURNING in: {sql}"
-        );
-    }
+    expect![[r#"UPDATE "users" AS tbl_0_0 SET "name" = 'b';"#]].assert_eq(&render(
+        Flavor::Sqlite,
+        &schema,
+        update_stmt(false, None),
+    ));
+    expect![[r#"UPDATE "users" AS tbl_0_0 SET "name" = 'b';"#]].assert_eq(&render(
+        Flavor::Postgresql,
+        &schema,
+        update_stmt(false, None),
+    ));
+    expect!["UPDATE `users` AS tbl_0_0 SET `name` = 'b';"].assert_eq(&render(
+        Flavor::Mysql,
+        &schema,
+        update_stmt(false, None),
+    ));
 }
 
 #[test]
 fn update_with_where() {
     let schema = users_schema();
-    for flavor in [Flavor::Sqlite, Flavor::Postgresql, Flavor::Mysql] {
-        let sql = render(flavor, &schema, update_stmt(true, None));
-        assert!(sql.contains(" SET "), "expected ` SET ` in: {sql}");
-        assert!(sql.contains(" WHERE "), "expected ` WHERE ` in: {sql}");
-        // The Update serializer disables alias prefixing — `WHERE "id" = 1`,
-        // not `WHERE tbl_0_0."id" = 1`.
-        let q = q(flavor);
-        let needle = format!("WHERE {q}id{q} = 1");
-        assert!(sql.contains(&needle), "expected `{needle}` in: {sql}");
-    }
+    expect![[r#"UPDATE "users" AS tbl_0_0 SET "name" = 'b' WHERE "id" = 1;"#]].assert_eq(&render(
+        Flavor::Sqlite,
+        &schema,
+        update_stmt(true, None),
+    ));
+    expect![[r#"UPDATE "users" AS tbl_0_0 SET "name" = 'b' WHERE "id" = 1;"#]].assert_eq(&render(
+        Flavor::Postgresql,
+        &schema,
+        update_stmt(true, None),
+    ));
+    expect!["UPDATE `users` AS tbl_0_0 SET `name` = 'b' WHERE `id` = 1;"].assert_eq(&render(
+        Flavor::Mysql,
+        &schema,
+        update_stmt(true, None),
+    ));
 }
 
 #[test]
 fn update_with_returning() {
     let schema = users_schema();
     let returning = Some(Returning::Project(Expr::record([col(0, 0)])));
-    for flavor in [Flavor::Sqlite, Flavor::Postgresql] {
-        let sql = render(flavor, &schema, update_stmt(true, returning.clone()));
-        assert!(
-            sql.contains(" RETURNING "),
-            "expected ` RETURNING ` in: {sql}"
-        );
-    }
+    expect![[r#"UPDATE "users" AS tbl_0_0 SET "name" = 'b' WHERE "id" = 1 RETURNING "id";"#]]
+        .assert_eq(&render(
+            Flavor::Sqlite,
+            &schema,
+            update_stmt(true, returning.clone()),
+        ));
+    expect![[r#"UPDATE "users" AS tbl_0_0 SET "name" = 'b' WHERE "id" = 1 RETURNING "id";"#]]
+        .assert_eq(&render(
+            Flavor::Postgresql,
+            &schema,
+            update_stmt(true, returning),
+        ));
 }
 
 #[test]
@@ -279,30 +282,41 @@ fn update_returning_panics_on_mysql() {
 #[test]
 fn delete_basic() {
     let schema = users_schema();
-    for flavor in [Flavor::Sqlite, Flavor::Postgresql, Flavor::Mysql] {
-        let sql = render(flavor, &schema, delete_stmt(false, None));
-        let q = q(flavor);
-        let expected = format!("DELETE FROM {q}users{q} AS tbl_0_0;");
-        assert_eq!(sql, expected, "flavor mismatch for {expected:?}");
-        assert!(!sql.contains(" WHERE "), "did not expect WHERE in: {sql}");
-    }
+    expect![[r#"DELETE FROM "users" AS tbl_0_0;"#]].assert_eq(&render(
+        Flavor::Sqlite,
+        &schema,
+        delete_stmt(false, None),
+    ));
+    expect![[r#"DELETE FROM "users" AS tbl_0_0;"#]].assert_eq(&render(
+        Flavor::Postgresql,
+        &schema,
+        delete_stmt(false, None),
+    ));
+    expect!["DELETE FROM `users` AS tbl_0_0;"].assert_eq(&render(
+        Flavor::Mysql,
+        &schema,
+        delete_stmt(false, None),
+    ));
 }
 
 #[test]
 fn delete_with_where() {
     let schema = users_schema();
-    for flavor in [Flavor::Sqlite, Flavor::Postgresql, Flavor::Mysql] {
-        let sql = render(flavor, &schema, delete_stmt(true, None));
-        assert!(
-            sql.starts_with("DELETE FROM "),
-            "expected DELETE FROM prefix in: {sql}"
-        );
-        assert!(sql.contains(" WHERE "), "expected ` WHERE ` in: {sql}");
-        // Delete enables alias prefixing — `WHERE tbl_0_0."id" = 1`.
-        let q = q(flavor);
-        let needle = format!("tbl_0_0.{q}id{q} = 1");
-        assert!(sql.contains(&needle), "expected `{needle}` in: {sql}");
-    }
+    expect![[r#"DELETE FROM "users" AS tbl_0_0 WHERE tbl_0_0."id" = 1;"#]].assert_eq(&render(
+        Flavor::Sqlite,
+        &schema,
+        delete_stmt(true, None),
+    ));
+    expect![[r#"DELETE FROM "users" AS tbl_0_0 WHERE tbl_0_0."id" = 1;"#]].assert_eq(&render(
+        Flavor::Postgresql,
+        &schema,
+        delete_stmt(true, None),
+    ));
+    expect!["DELETE FROM `users` AS tbl_0_0 WHERE tbl_0_0.`id` = 1;"].assert_eq(&render(
+        Flavor::Mysql,
+        &schema,
+        delete_stmt(true, None),
+    ));
 }
 
 /// MySQL has no `RETURNING` clause for any DML statement, so the serializer
@@ -333,15 +347,13 @@ fn delete_with_returning_panics_on_mysql() {
 fn delete_with_returning_postgresql() {
     let schema = users_schema();
     let returning = Some(Returning::Project(Expr::record([col(0, 0)])));
-    let sql = render(Flavor::Postgresql, &schema, delete_stmt(true, returning));
-    assert!(
-        sql.contains(" RETURNING "),
-        "expected ` RETURNING ` in: {sql}"
-    );
-    assert!(
-        sql.contains(r#"tbl_0_0."id""#),
-        "expected projected column in: {sql}"
-    );
+    // Expected string stays empty — will be populated when the serializer
+    // learns to emit DELETE+RETURNING.
+    expect![[r#""#]].assert_eq(&render(
+        Flavor::Postgresql,
+        &schema,
+        delete_stmt(true, returning),
+    ));
 }
 
 #[ignore = "DELETE+RETURNING is not yet implemented; serializer panics unconditionally"]
@@ -349,13 +361,11 @@ fn delete_with_returning_postgresql() {
 fn delete_with_returning_sqlite() {
     let schema = users_schema();
     let returning = Some(Returning::Project(Expr::record([col(0, 0)])));
-    let sql = render(Flavor::Sqlite, &schema, delete_stmt(true, returning));
-    assert!(
-        sql.contains(" RETURNING "),
-        "expected ` RETURNING ` in: {sql}"
-    );
-    assert!(
-        sql.contains(r#"tbl_0_0."id""#),
-        "expected projected column in: {sql}"
-    );
+    // Expected string stays empty — will be populated when the serializer
+    // learns to emit DELETE+RETURNING.
+    expect![[r#""#]].assert_eq(&render(
+        Flavor::Sqlite,
+        &schema,
+        delete_stmt(true, returning),
+    ));
 }

--- a/crates/toasty-sql/tests/serialize_expressions.rs
+++ b/crates/toasty-sql/tests/serialize_expressions.rs
@@ -1,0 +1,377 @@
+//! Verifies the serializer renders the various `Expr` branches handled in
+//! `serializer/expr.rs` — binary ops, logical chains, LIKE / ILIKE,
+//! starts-with, COUNT, LAST_INSERT_ID, the array set/length operators with
+//! flavor divergence, and `Expr::Default`.
+//!
+//! Each case wraps the predicate in a minimal `VALUES` row, which serializes
+//! to `SELECT <expr>`-equivalent SQL without needing a full table schema.
+//! The serializer is exercised in isolation — no lowering pipeline involved.
+
+use std::panic;
+
+use toasty_core::{
+    schema::db::Schema,
+    stmt::{
+        self, BinaryOp, Expr, ExprAnd, ExprIntersects, ExprIsSuperset, ExprLength, ExprLike,
+        ExprOr, FuncCount,
+    },
+};
+use toasty_sql::{Serializer, Statement as SqlStatement};
+
+/// Render a top-level `Expr` by embedding it as the projection of a `VALUES`
+/// row, which serializes to `SELECT <expr>`-equivalent SQL without needing a
+/// full table schema.
+fn make_stmt(expr: Expr) -> SqlStatement {
+    let values = stmt::Values::new(vec![Expr::record([expr])]);
+    let core_stmt: stmt::Statement = stmt::Query::values(values).into();
+    SqlStatement::from(core_stmt)
+}
+
+fn render_pg(expr: Expr) -> String {
+    let stmt = make_stmt(expr);
+    let schema = Schema::default();
+    Serializer::postgresql(&schema).serialize(&stmt)
+}
+
+fn render_mysql(expr: Expr) -> String {
+    let stmt = make_stmt(expr);
+    let schema = Schema::default();
+    Serializer::mysql(&schema).serialize(&stmt)
+}
+
+fn render_sqlite(expr: Expr) -> String {
+    let stmt = make_stmt(expr);
+    let schema = Schema::default();
+    Serializer::sqlite(&schema).serialize(&stmt)
+}
+
+// ---------- BinaryOp ----------
+
+#[test]
+fn binary_op_all_comparison_operators() {
+    let cases: &[(BinaryOp, &str)] = &[
+        (BinaryOp::Eq, "$1 = $2"),
+        (BinaryOp::Ne, "$1 <> $2"),
+        (BinaryOp::Lt, "$1 < $2"),
+        (BinaryOp::Le, "$1 <= $2"),
+        (BinaryOp::Gt, "$1 > $2"),
+        (BinaryOp::Ge, "$1 >= $2"),
+    ];
+    for (op, expected) in cases {
+        let expr = Expr::binary_op(Expr::arg(0), *op, Expr::arg(1));
+        let sql = render_pg(expr);
+        assert!(
+            sql.contains(expected),
+            "expected `{expected}` for op {op:?} in: {sql}"
+        );
+    }
+}
+
+// ---------- Logical ----------
+
+#[test]
+fn and_chain_joins_operands_with_and_keyword() {
+    // `Expr::and` short-circuits on `true`, so build `ExprAnd` directly with
+    // three non-trivial operands to exercise the delimiter path.
+    let expr: Expr = ExprAnd {
+        operands: vec![
+            Expr::eq(Expr::arg(0), Expr::arg(1)),
+            Expr::eq(Expr::arg(2), Expr::arg(3)),
+            Expr::eq(Expr::arg(4), Expr::arg(5)),
+        ],
+    }
+    .into();
+    let sql = render_pg(expr);
+    assert!(
+        sql.contains("$1 = $2 AND $3 = $4 AND $5 = $6"),
+        "expected three operands joined by AND in: {sql}"
+    );
+}
+
+#[test]
+fn or_chain_joins_operands_with_or_keyword() {
+    let expr: Expr = ExprOr {
+        operands: vec![
+            Expr::eq(Expr::arg(0), Expr::arg(1)),
+            Expr::eq(Expr::arg(2), Expr::arg(3)),
+            Expr::eq(Expr::arg(4), Expr::arg(5)),
+        ],
+    }
+    .into();
+    let sql = render_pg(expr);
+    assert!(
+        sql.contains("$1 = $2 OR $3 = $4 OR $5 = $6"),
+        "expected three operands joined by OR in: {sql}"
+    );
+}
+
+// ---------- LIKE family ----------
+
+#[test]
+fn like_renders_with_like_keyword() {
+    let expr = Expr::like(Expr::arg(0), Expr::arg(1));
+    let sql = render_pg(expr);
+    assert!(sql.contains("$1 LIKE $2"), "expected ` LIKE ` in: {sql}");
+}
+
+#[test]
+fn like_with_escape_appends_escape_clause() {
+    let expr: Expr = ExprLike {
+        expr: Box::new(Expr::arg(0)),
+        pattern: Box::new(Expr::arg(1)),
+        escape: Some('\\'),
+        case_insensitive: false,
+    }
+    .into();
+    let sql = render_pg(expr);
+    assert!(
+        sql.contains("$1 LIKE $2 ESCAPE "),
+        "expected ESCAPE clause in: {sql}"
+    );
+}
+
+#[test]
+fn ilike_renders_on_postgresql() {
+    let expr = Expr::ilike(Expr::arg(0), Expr::arg(1));
+    let sql = render_pg(expr);
+    assert!(sql.contains("$1 ILIKE $2"), "expected ` ILIKE ` in: {sql}");
+}
+
+#[test]
+fn ilike_falls_back_to_like_on_mysql_and_sqlite() {
+    // The `Like` serializer only emits ILIKE on PostgreSQL; for other flavors
+    // it falls back to plain `LIKE`, treating `case_insensitive` as a no-op
+    // at the SQL layer (collations / lower() handle case folding upstream).
+    let expr_mysql = Expr::ilike(Expr::arg(0), Expr::arg(1));
+    let sql = render_mysql(expr_mysql);
+    assert!(sql.contains("LIKE"), "expected LIKE on MySQL in: {sql}");
+    assert!(
+        !sql.contains("ILIKE"),
+        "MySQL should not render ILIKE in: {sql}"
+    );
+
+    let expr_sqlite = Expr::ilike(Expr::arg(0), Expr::arg(1));
+    let sql = render_sqlite(expr_sqlite);
+    assert!(sql.contains("LIKE"), "expected LIKE on SQLite in: {sql}");
+    assert!(
+        !sql.contains("ILIKE"),
+        "SQLite should not render ILIKE in: {sql}"
+    );
+}
+
+#[test]
+fn starts_with_uses_postgresql_prefix_operator() {
+    let expr = Expr::starts_with(Expr::arg(0), Expr::arg(1));
+    let sql = render_pg(expr);
+    assert!(sql.contains("$1 ^@ $2"), "expected `^@` in: {sql}");
+}
+
+#[test]
+fn starts_with_panics_on_non_postgresql_flavors() {
+    // The lowering pass rewrites `StartsWith` to `LIKE` for MySQL/SQLite;
+    // hitting the serializer directly with `StartsWith` is `unreachable!`.
+    for render in [
+        render_mysql as fn(Expr) -> String,
+        render_sqlite as fn(Expr) -> String,
+    ] {
+        let result = panic::catch_unwind(|| {
+            let expr = Expr::starts_with(Expr::arg(0), Expr::arg(1));
+            render(expr)
+        });
+        assert!(
+            result.is_err(),
+            "expected StartsWith to panic on non-PG flavor"
+        );
+    }
+}
+
+// ---------- COUNT ----------
+
+#[test]
+fn count_star_renders_as_count_star() {
+    let sql = render_pg(Expr::count_star());
+    assert!(sql.contains("COUNT(*)"), "expected COUNT(*) in: {sql}");
+}
+
+#[test]
+fn count_star_with_filter_renders_filter_clause_on_postgresql() {
+    let expr: Expr = FuncCount {
+        arg: None,
+        filter: Some(Box::new(Expr::eq(Expr::arg(0), Expr::arg(1)))),
+    }
+    .into();
+    let sql = render_pg(expr);
+    assert!(
+        sql.contains("COUNT(*) FILTER (WHERE $1 = $2)"),
+        "expected FILTER clause in: {sql}"
+    );
+}
+
+#[test]
+fn count_star_with_filter_rewrites_to_case_on_mysql() {
+    // MySQL does not support `FILTER (WHERE …)` on aggregates; the serializer
+    // rewrites it to `COUNT(CASE WHEN … THEN 1 END)`.
+    let expr: Expr = FuncCount {
+        arg: None,
+        filter: Some(Box::new(Expr::eq(Expr::arg(0), Expr::arg(1)))),
+    }
+    .into();
+    let sql = render_mysql(expr);
+    assert!(
+        sql.contains("COUNT(CASE WHEN ? = ? THEN 1 END)"),
+        "expected CASE rewrite in: {sql}"
+    );
+}
+
+// ---------- LAST_INSERT_ID ----------
+
+#[test]
+fn last_insert_id_renders_on_mysql() {
+    let sql = render_mysql(Expr::last_insert_id());
+    assert!(
+        sql.contains("LAST_INSERT_ID()"),
+        "expected LAST_INSERT_ID() in: {sql}"
+    );
+}
+
+// ---------- IsSuperset ----------
+
+#[test]
+fn is_superset_uses_at_gt_on_postgresql() {
+    let expr: Expr = ExprIsSuperset {
+        lhs: Box::new(Expr::arg(0)),
+        rhs: Box::new(Expr::arg(1)),
+    }
+    .into();
+    let sql = render_pg(expr);
+    assert!(sql.contains("$1 @> $2"), "expected `@>` in: {sql}");
+}
+
+#[test]
+fn is_superset_uses_json_contains_on_mysql() {
+    let expr: Expr = ExprIsSuperset {
+        lhs: Box::new(Expr::arg(0)),
+        rhs: Box::new(Expr::arg(1)),
+    }
+    .into();
+    let sql = render_mysql(expr);
+    assert!(
+        sql.contains("JSON_CONTAINS("),
+        "expected JSON_CONTAINS( in: {sql}"
+    );
+}
+
+#[test]
+fn is_superset_uses_not_exists_on_sqlite() {
+    let expr: Expr = ExprIsSuperset {
+        lhs: Box::new(Expr::arg(0)),
+        rhs: Box::new(Expr::arg(1)),
+    }
+    .into();
+    let sql = render_sqlite(expr);
+    assert!(
+        sql.contains("NOT EXISTS ("),
+        "expected NOT EXISTS ( in: {sql}"
+    );
+}
+
+// ---------- Intersects (overlap) ----------
+
+#[test]
+fn intersects_uses_amp_amp_on_postgresql() {
+    let expr: Expr = ExprIntersects {
+        lhs: Box::new(Expr::arg(0)),
+        rhs: Box::new(Expr::arg(1)),
+    }
+    .into();
+    let sql = render_pg(expr);
+    assert!(sql.contains("$1 && $2"), "expected `&&` in: {sql}");
+}
+
+#[test]
+fn intersects_uses_json_overlaps_on_mysql() {
+    let expr: Expr = ExprIntersects {
+        lhs: Box::new(Expr::arg(0)),
+        rhs: Box::new(Expr::arg(1)),
+    }
+    .into();
+    let sql = render_mysql(expr);
+    assert!(
+        sql.contains("JSON_OVERLAPS("),
+        "expected JSON_OVERLAPS( in: {sql}"
+    );
+}
+
+#[test]
+fn intersects_uses_exists_on_sqlite() {
+    let expr: Expr = ExprIntersects {
+        lhs: Box::new(Expr::arg(0)),
+        rhs: Box::new(Expr::arg(1)),
+    }
+    .into();
+    let sql = render_sqlite(expr);
+    assert!(sql.contains("EXISTS ("), "expected EXISTS ( in: {sql}");
+    assert!(
+        !sql.contains("NOT EXISTS ("),
+        "Intersects should not emit NOT EXISTS on SQLite in: {sql}"
+    );
+}
+
+// ---------- Length ----------
+
+#[test]
+fn length_uses_cardinality_on_postgresql() {
+    let expr: Expr = ExprLength {
+        expr: Box::new(Expr::arg(0)),
+    }
+    .into();
+    let sql = render_pg(expr);
+    assert!(
+        sql.contains("cardinality($1)"),
+        "expected cardinality(...) in: {sql}"
+    );
+}
+
+#[test]
+fn length_uses_json_length_on_mysql() {
+    let expr: Expr = ExprLength {
+        expr: Box::new(Expr::arg(0)),
+    }
+    .into();
+    let sql = render_mysql(expr);
+    assert!(
+        sql.contains("JSON_LENGTH(?)"),
+        "expected JSON_LENGTH(...) in: {sql}"
+    );
+}
+
+#[test]
+fn length_uses_json_array_length_on_sqlite() {
+    let expr: Expr = ExprLength {
+        expr: Box::new(Expr::arg(0)),
+    }
+    .into();
+    let sql = render_sqlite(expr);
+    assert!(
+        sql.contains("json_array_length(?1)"),
+        "expected json_array_length(...) in: {sql}"
+    );
+}
+
+// ---------- Default ----------
+
+#[test]
+fn default_renders_default_on_postgresql_and_mysql_and_null_on_sqlite() {
+    let pg = render_pg(Expr::Default);
+    assert!(pg.contains("DEFAULT"), "expected DEFAULT on PG in: {pg}");
+
+    let my = render_mysql(Expr::Default);
+    assert!(my.contains("DEFAULT"), "expected DEFAULT on MySQL in: {my}");
+
+    let lite = render_sqlite(Expr::Default);
+    assert!(lite.contains("NULL"), "expected NULL on SQLite in: {lite}");
+    assert!(
+        !lite.contains("DEFAULT"),
+        "SQLite should not render DEFAULT in: {lite}"
+    );
+}

--- a/crates/toasty-sql/tests/serialize_expressions.rs
+++ b/crates/toasty-sql/tests/serialize_expressions.rs
@@ -137,25 +137,37 @@ fn ilike_renders_on_postgresql() {
     assert!(sql.contains("$1 ILIKE $2"), "expected ` ILIKE ` in: {sql}");
 }
 
-#[test]
-fn ilike_falls_back_to_like_on_mysql_and_sqlite() {
-    // The `Like` serializer only emits ILIKE on PostgreSQL; for other flavors
-    // it falls back to plain `LIKE`, treating `case_insensitive` as a no-op
-    // at the SQL layer (collations / lower() handle case folding upstream).
-    let expr_mysql = Expr::ilike(Expr::arg(0), Expr::arg(1));
-    let sql = render_mysql(expr_mysql);
-    assert!(sql.contains("LIKE"), "expected LIKE on MySQL in: {sql}");
-    assert!(
-        !sql.contains("ILIKE"),
-        "MySQL should not render ILIKE in: {sql}"
-    );
+// MySQL and SQLite do not have `ILIKE`. The serializer currently emits plain
+// `LIKE`, which happens to match case-insensitively for ASCII because of the
+// default collations on both engines — but SQLite's `LIKE` is case-sensitive
+// for non-ASCII characters, so `.ilike("café%")` silently fails to match
+// `CAFÉ`. See https://github.com/tokio-rs/toasty/issues/802.
+//
+// The tests below pin the expected behavior once the serializer is fixed —
+// likely by wrapping both sides in `LOWER(...)` (the most portable option)
+// or by adding a `COLLATE` clause. They assert the most-likely shape; if
+// the eventual fix lands a different mechanism the assertion should be
+// adjusted at that point.
 
-    let expr_sqlite = Expr::ilike(Expr::arg(0), Expr::arg(1));
-    let sql = render_sqlite(expr_sqlite);
-    assert!(sql.contains("LIKE"), "expected LIKE on SQLite in: {sql}");
+#[ignore = "ilike case-insensitivity for non-ASCII is broken on MySQL/SQLite — see #802"]
+#[test]
+fn ilike_handles_non_ascii_case_insensitivity_on_mysql() {
+    let expr = Expr::ilike(Expr::arg(0), Expr::arg(1));
+    let sql = render_mysql(expr);
     assert!(
-        !sql.contains("ILIKE"),
-        "SQLite should not render ILIKE in: {sql}"
+        sql.contains("LOWER("),
+        "expected case-folding wrapper (e.g. LOWER) in: {sql}"
+    );
+}
+
+#[ignore = "ilike case-insensitivity for non-ASCII is broken on MySQL/SQLite — see #802"]
+#[test]
+fn ilike_handles_non_ascii_case_insensitivity_on_sqlite() {
+    let expr = Expr::ilike(Expr::arg(0), Expr::arg(1));
+    let sql = render_sqlite(expr);
+    assert!(
+        sql.contains("LOWER("),
+        "expected case-folding wrapper (e.g. LOWER) in: {sql}"
     );
 }
 

--- a/crates/toasty-sql/tests/serialize_expressions.rs
+++ b/crates/toasty-sql/tests/serialize_expressions.rs
@@ -9,6 +9,7 @@
 
 use std::panic;
 
+use expect_test::expect;
 use toasty_core::{
     schema::db::Schema,
     stmt::{
@@ -49,22 +50,23 @@ fn render_sqlite(expr: Expr) -> String {
 
 #[test]
 fn binary_op_all_comparison_operators() {
-    let cases: &[(BinaryOp, &str)] = &[
-        (BinaryOp::Eq, "$1 = $2"),
-        (BinaryOp::Ne, "$1 <> $2"),
-        (BinaryOp::Lt, "$1 < $2"),
-        (BinaryOp::Le, "$1 <= $2"),
-        (BinaryOp::Gt, "$1 > $2"),
-        (BinaryOp::Ge, "$1 >= $2"),
-    ];
-    for (op, expected) in cases {
-        let expr = Expr::binary_op(Expr::arg(0), *op, Expr::arg(1));
-        let sql = render_pg(expr);
-        assert!(
-            sql.contains(expected),
-            "expected `{expected}` for op {op:?} in: {sql}"
-        );
-    }
+    let expr = Expr::binary_op(Expr::arg(0), BinaryOp::Eq, Expr::arg(1));
+    expect!["VALUES ($1 = $2);"].assert_eq(&render_pg(expr));
+
+    let expr = Expr::binary_op(Expr::arg(0), BinaryOp::Ne, Expr::arg(1));
+    expect!["VALUES ($1 <> $2);"].assert_eq(&render_pg(expr));
+
+    let expr = Expr::binary_op(Expr::arg(0), BinaryOp::Lt, Expr::arg(1));
+    expect!["VALUES ($1 < $2);"].assert_eq(&render_pg(expr));
+
+    let expr = Expr::binary_op(Expr::arg(0), BinaryOp::Le, Expr::arg(1));
+    expect!["VALUES ($1 <= $2);"].assert_eq(&render_pg(expr));
+
+    let expr = Expr::binary_op(Expr::arg(0), BinaryOp::Gt, Expr::arg(1));
+    expect!["VALUES ($1 > $2);"].assert_eq(&render_pg(expr));
+
+    let expr = Expr::binary_op(Expr::arg(0), BinaryOp::Ge, Expr::arg(1));
+    expect!["VALUES ($1 >= $2);"].assert_eq(&render_pg(expr));
 }
 
 // ---------- Logical ----------
@@ -81,11 +83,7 @@ fn and_chain_joins_operands_with_and_keyword() {
         ],
     }
     .into();
-    let sql = render_pg(expr);
-    assert!(
-        sql.contains("$1 = $2 AND $3 = $4 AND $5 = $6"),
-        "expected three operands joined by AND in: {sql}"
-    );
+    expect!["VALUES ($1 = $2 AND $3 = $4 AND $5 = $6);"].assert_eq(&render_pg(expr));
 }
 
 #[test]
@@ -98,11 +96,7 @@ fn or_chain_joins_operands_with_or_keyword() {
         ],
     }
     .into();
-    let sql = render_pg(expr);
-    assert!(
-        sql.contains("$1 = $2 OR $3 = $4 OR $5 = $6"),
-        "expected three operands joined by OR in: {sql}"
-    );
+    expect!["VALUES ($1 = $2 OR $3 = $4 OR $5 = $6);"].assert_eq(&render_pg(expr));
 }
 
 // ---------- LIKE family ----------
@@ -110,8 +104,7 @@ fn or_chain_joins_operands_with_or_keyword() {
 #[test]
 fn like_renders_with_like_keyword() {
     let expr = Expr::like(Expr::arg(0), Expr::arg(1));
-    let sql = render_pg(expr);
-    assert!(sql.contains("$1 LIKE $2"), "expected ` LIKE ` in: {sql}");
+    expect!["VALUES ($1 LIKE $2);"].assert_eq(&render_pg(expr));
 }
 
 #[test]
@@ -123,18 +116,13 @@ fn like_with_escape_appends_escape_clause() {
         case_insensitive: false,
     }
     .into();
-    let sql = render_pg(expr);
-    assert!(
-        sql.contains("$1 LIKE $2 ESCAPE "),
-        "expected ESCAPE clause in: {sql}"
-    );
+    expect![[r#"VALUES ($1 LIKE $2 ESCAPE '\');"#]].assert_eq(&render_pg(expr));
 }
 
 #[test]
 fn ilike_renders_on_postgresql() {
     let expr = Expr::ilike(Expr::arg(0), Expr::arg(1));
-    let sql = render_pg(expr);
-    assert!(sql.contains("$1 ILIKE $2"), "expected ` ILIKE ` in: {sql}");
+    expect!["VALUES ($1 ILIKE $2);"].assert_eq(&render_pg(expr));
 }
 
 // MySQL and SQLite do not have `ILIKE`. The serializer currently emits plain
@@ -153,29 +141,20 @@ fn ilike_renders_on_postgresql() {
 #[test]
 fn ilike_handles_non_ascii_case_insensitivity_on_mysql() {
     let expr = Expr::ilike(Expr::arg(0), Expr::arg(1));
-    let sql = render_mysql(expr);
-    assert!(
-        sql.contains("LOWER("),
-        "expected case-folding wrapper (e.g. LOWER) in: {sql}"
-    );
+    expect![[r#""#]].assert_eq(&render_mysql(expr));
 }
 
 #[ignore = "ilike case-insensitivity for non-ASCII is broken on MySQL/SQLite — see #802"]
 #[test]
 fn ilike_handles_non_ascii_case_insensitivity_on_sqlite() {
     let expr = Expr::ilike(Expr::arg(0), Expr::arg(1));
-    let sql = render_sqlite(expr);
-    assert!(
-        sql.contains("LOWER("),
-        "expected case-folding wrapper (e.g. LOWER) in: {sql}"
-    );
+    expect![[r#""#]].assert_eq(&render_sqlite(expr));
 }
 
 #[test]
 fn starts_with_uses_postgresql_prefix_operator() {
     let expr = Expr::starts_with(Expr::arg(0), Expr::arg(1));
-    let sql = render_pg(expr);
-    assert!(sql.contains("$1 ^@ $2"), "expected `^@` in: {sql}");
+    expect!["VALUES ($1 ^@ $2);"].assert_eq(&render_pg(expr));
 }
 
 #[test]
@@ -201,8 +180,7 @@ fn starts_with_panics_on_non_postgresql_flavors() {
 
 #[test]
 fn count_star_renders_as_count_star() {
-    let sql = render_pg(Expr::count_star());
-    assert!(sql.contains("COUNT(*)"), "expected COUNT(*) in: {sql}");
+    expect!["VALUES (COUNT(*));"].assert_eq(&render_pg(Expr::count_star()));
 }
 
 #[test]
@@ -212,11 +190,7 @@ fn count_star_with_filter_renders_filter_clause_on_postgresql() {
         filter: Some(Box::new(Expr::eq(Expr::arg(0), Expr::arg(1)))),
     }
     .into();
-    let sql = render_pg(expr);
-    assert!(
-        sql.contains("COUNT(*) FILTER (WHERE $1 = $2)"),
-        "expected FILTER clause in: {sql}"
-    );
+    expect!["VALUES (COUNT(*) FILTER (WHERE $1 = $2));"].assert_eq(&render_pg(expr));
 }
 
 #[test]
@@ -228,22 +202,14 @@ fn count_star_with_filter_rewrites_to_case_on_mysql() {
         filter: Some(Box::new(Expr::eq(Expr::arg(0), Expr::arg(1)))),
     }
     .into();
-    let sql = render_mysql(expr);
-    assert!(
-        sql.contains("COUNT(CASE WHEN ? = ? THEN 1 END)"),
-        "expected CASE rewrite in: {sql}"
-    );
+    expect!["VALUES ROW(COUNT(CASE WHEN ? = ? THEN 1 END));"].assert_eq(&render_mysql(expr));
 }
 
 // ---------- LAST_INSERT_ID ----------
 
 #[test]
 fn last_insert_id_renders_on_mysql() {
-    let sql = render_mysql(Expr::last_insert_id());
-    assert!(
-        sql.contains("LAST_INSERT_ID()"),
-        "expected LAST_INSERT_ID() in: {sql}"
-    );
+    expect!["VALUES ROW(LAST_INSERT_ID());"].assert_eq(&render_mysql(Expr::last_insert_id()));
 }
 
 // ---------- IsSuperset ----------
@@ -255,8 +221,7 @@ fn is_superset_uses_at_gt_on_postgresql() {
         rhs: Box::new(Expr::arg(1)),
     }
     .into();
-    let sql = render_pg(expr);
-    assert!(sql.contains("$1 @> $2"), "expected `@>` in: {sql}");
+    expect!["VALUES ($1 @> $2);"].assert_eq(&render_pg(expr));
 }
 
 #[test]
@@ -266,11 +231,7 @@ fn is_superset_uses_json_contains_on_mysql() {
         rhs: Box::new(Expr::arg(1)),
     }
     .into();
-    let sql = render_mysql(expr);
-    assert!(
-        sql.contains("JSON_CONTAINS("),
-        "expected JSON_CONTAINS( in: {sql}"
-    );
+    expect!["VALUES ROW(JSON_CONTAINS(?, ?));"].assert_eq(&render_mysql(expr));
 }
 
 #[test]
@@ -280,11 +241,7 @@ fn is_superset_uses_not_exists_on_sqlite() {
         rhs: Box::new(Expr::arg(1)),
     }
     .into();
-    let sql = render_sqlite(expr);
-    assert!(
-        sql.contains("NOT EXISTS ("),
-        "expected NOT EXISTS ( in: {sql}"
-    );
+    expect!["VALUES (NOT EXISTS (SELECT 1 FROM json_each(?2) AS r WHERE r.value NOT IN (SELECT l.value FROM json_each(?1) AS l)));"].assert_eq(&render_sqlite(expr));
 }
 
 // ---------- Intersects (overlap) ----------
@@ -296,8 +253,7 @@ fn intersects_uses_amp_amp_on_postgresql() {
         rhs: Box::new(Expr::arg(1)),
     }
     .into();
-    let sql = render_pg(expr);
-    assert!(sql.contains("$1 && $2"), "expected `&&` in: {sql}");
+    expect!["VALUES ($1 && $2);"].assert_eq(&render_pg(expr));
 }
 
 #[test]
@@ -307,11 +263,7 @@ fn intersects_uses_json_overlaps_on_mysql() {
         rhs: Box::new(Expr::arg(1)),
     }
     .into();
-    let sql = render_mysql(expr);
-    assert!(
-        sql.contains("JSON_OVERLAPS("),
-        "expected JSON_OVERLAPS( in: {sql}"
-    );
+    expect!["VALUES ROW(JSON_OVERLAPS(?, ?));"].assert_eq(&render_mysql(expr));
 }
 
 #[test]
@@ -321,12 +273,7 @@ fn intersects_uses_exists_on_sqlite() {
         rhs: Box::new(Expr::arg(1)),
     }
     .into();
-    let sql = render_sqlite(expr);
-    assert!(sql.contains("EXISTS ("), "expected EXISTS ( in: {sql}");
-    assert!(
-        !sql.contains("NOT EXISTS ("),
-        "Intersects should not emit NOT EXISTS on SQLite in: {sql}"
-    );
+    expect!["VALUES (EXISTS (SELECT 1 FROM json_each(?2) AS r WHERE r.value IN (SELECT l.value FROM json_each(?1) AS l)));"].assert_eq(&render_sqlite(expr));
 }
 
 // ---------- Length ----------
@@ -337,11 +284,7 @@ fn length_uses_cardinality_on_postgresql() {
         expr: Box::new(Expr::arg(0)),
     }
     .into();
-    let sql = render_pg(expr);
-    assert!(
-        sql.contains("cardinality($1)"),
-        "expected cardinality(...) in: {sql}"
-    );
+    expect!["VALUES (cardinality($1));"].assert_eq(&render_pg(expr));
 }
 
 #[test]
@@ -350,11 +293,7 @@ fn length_uses_json_length_on_mysql() {
         expr: Box::new(Expr::arg(0)),
     }
     .into();
-    let sql = render_mysql(expr);
-    assert!(
-        sql.contains("JSON_LENGTH(?)"),
-        "expected JSON_LENGTH(...) in: {sql}"
-    );
+    expect!["VALUES ROW(JSON_LENGTH(?));"].assert_eq(&render_mysql(expr));
 }
 
 #[test]
@@ -363,27 +302,14 @@ fn length_uses_json_array_length_on_sqlite() {
         expr: Box::new(Expr::arg(0)),
     }
     .into();
-    let sql = render_sqlite(expr);
-    assert!(
-        sql.contains("json_array_length(?1)"),
-        "expected json_array_length(...) in: {sql}"
-    );
+    expect!["VALUES (json_array_length(?1));"].assert_eq(&render_sqlite(expr));
 }
 
 // ---------- Default ----------
 
 #[test]
 fn default_renders_default_on_postgresql_and_mysql_and_null_on_sqlite() {
-    let pg = render_pg(Expr::Default);
-    assert!(pg.contains("DEFAULT"), "expected DEFAULT on PG in: {pg}");
-
-    let my = render_mysql(Expr::Default);
-    assert!(my.contains("DEFAULT"), "expected DEFAULT on MySQL in: {my}");
-
-    let lite = render_sqlite(Expr::Default);
-    assert!(lite.contains("NULL"), "expected NULL on SQLite in: {lite}");
-    assert!(
-        !lite.contains("DEFAULT"),
-        "SQLite should not render DEFAULT in: {lite}"
-    );
+    expect!["VALUES (DEFAULT);"].assert_eq(&render_pg(Expr::Default));
+    expect!["VALUES ROW(DEFAULT);"].assert_eq(&render_mysql(Expr::Default));
+    expect!["VALUES (NULL);"].assert_eq(&render_sqlite(Expr::Default));
 }

--- a/crates/toasty-sql/tests/serialize_joins.rs
+++ b/crates/toasty-sql/tests/serialize_joins.rs
@@ -1,0 +1,256 @@
+//! Verifies the serializer renders `JoinOp::Left` / `JoinOp::Inner` as
+//! `LEFT JOIN` / `INNER JOIN` with the expected ON clauses, and that
+//! multi-join chains (the shape produced by eager-loading a multi-step
+//! `via` relation) serialize as the expected sequence of joins.
+//!
+//! The test constructs the AST directly so the serializer is exercised in
+//! isolation — no lowering pipeline involved.
+
+use toasty_core::{
+    schema::db::{Column, ColumnId, PrimaryKey, Schema, Table, TableId, Type as StorageType},
+    stmt::{
+        self, Expr, ExprColumn, Filter, Join, JoinOp, Returning, Select, Source, SourceTable,
+        SourceTableId, TableFactor, TableRef, TableWithJoins,
+    },
+};
+use toasty_sql::{Serializer, Statement as SqlStatement};
+
+/// Minimal `id INTEGER PRIMARY KEY, *cols` table. `cols` start at column index
+/// 1 and are all `INTEGER`. Stored as `id` for the PK column to keep ON
+/// expressions easy to read in assertions.
+fn make_table(id: usize, name: &str, cols: &[&str]) -> Table {
+    let mut columns = vec![Column {
+        id: ColumnId {
+            table: TableId(id),
+            index: 0,
+        },
+        name: "id".to_string(),
+        ty: stmt::Type::I64,
+        storage_ty: StorageType::Integer(8),
+        nullable: false,
+        primary_key: true,
+        auto_increment: false,
+        versionable: false,
+    }];
+    for (i, name) in cols.iter().enumerate() {
+        columns.push(Column {
+            id: ColumnId {
+                table: TableId(id),
+                index: i + 1,
+            },
+            name: (*name).to_string(),
+            ty: stmt::Type::I64,
+            storage_ty: StorageType::Integer(8),
+            nullable: false,
+            primary_key: false,
+            auto_increment: false,
+            versionable: false,
+        });
+    }
+    Table {
+        id: TableId(id),
+        name: name.to_string(),
+        columns,
+        primary_key: PrimaryKey {
+            columns: vec![ColumnId {
+                table: TableId(id),
+                index: 0,
+            }],
+            index: toasty_core::schema::db::IndexId {
+                table: TableId(id),
+                index: 0,
+            },
+        },
+        indices: vec![],
+    }
+}
+
+/// Reference to column `column` of the `table`th entry in `SourceTable::tables`.
+fn col(table: usize, column: usize) -> Expr {
+    Expr::column(ExprColumn {
+        nesting: 0,
+        table,
+        column,
+    })
+}
+
+fn render_sqlite(schema: &Schema, stmt: stmt::Statement) -> String {
+    let sql_stmt = SqlStatement::from(stmt);
+    Serializer::sqlite(schema).serialize(&sql_stmt)
+}
+
+/// Build a `SELECT u.id FROM users u <join> posts p ON p.user_id = u.id`,
+/// parameterized by the `JoinOp`.
+fn select_with_join(constraint: JoinOp) -> stmt::Statement {
+    let source = Source::Table(SourceTable {
+        tables: vec![TableRef::Table(TableId(0)), TableRef::Table(TableId(1))],
+        from: vec![TableWithJoins {
+            relation: TableFactor::Table(SourceTableId(0)),
+            joins: vec![Join {
+                table: SourceTableId(1),
+                constraint,
+            }],
+        }],
+    });
+
+    let select = Select {
+        returning: Returning::Project(Expr::record([col(0, 0)])),
+        source,
+        filter: Filter::ALL,
+    };
+    stmt::Statement::Query(stmt::Query::builder(select).build())
+}
+
+#[test]
+fn left_join_renders_left_join_with_on_clause() {
+    let schema = Schema {
+        tables: vec![
+            make_table(0, "users", &[]),
+            make_table(1, "posts", &["user_id"]),
+        ],
+    };
+
+    let on = Expr::eq(col(1, 1), col(0, 0));
+    let sql = render_sqlite(&schema, select_with_join(JoinOp::Left(on)));
+
+    assert!(
+        sql.contains(" LEFT JOIN "),
+        "expected ` LEFT JOIN ` in: {sql}"
+    );
+    assert!(
+        !sql.contains("INNER JOIN"),
+        "did not expect INNER in: {sql}"
+    );
+    // Joined-table alias + ON predicate referencing both sides.
+    assert!(
+        sql.contains(r#""posts" AS tbl_0_1 ON tbl_0_1."user_id" = tbl_0_0."id""#),
+        "expected aliased ON clause in: {sql}"
+    );
+}
+
+#[test]
+fn inner_join_renders_inner_join_with_on_clause() {
+    let schema = Schema {
+        tables: vec![
+            make_table(0, "users", &[]),
+            make_table(1, "posts", &["user_id"]),
+        ],
+    };
+
+    let on = Expr::eq(col(1, 1), col(0, 0));
+    let sql = render_sqlite(&schema, select_with_join(JoinOp::Inner(on)));
+
+    assert!(
+        sql.contains(" INNER JOIN "),
+        "expected ` INNER JOIN ` in: {sql}"
+    );
+    assert!(!sql.contains("LEFT JOIN"), "did not expect LEFT in: {sql}");
+    assert!(
+        sql.contains(r#""posts" AS tbl_0_1 ON tbl_0_1."user_id" = tbl_0_0."id""#),
+        "expected aliased ON clause in: {sql}"
+    );
+}
+
+/// Multi-step join: `users LEFT JOIN posts ON ... LEFT JOIN comments ON ...`.
+/// This is the shape an eager-loaded multi-step `via` relation would emit.
+#[test]
+fn multi_step_left_join_chain() {
+    let schema = Schema {
+        tables: vec![
+            make_table(0, "users", &[]),
+            make_table(1, "posts", &["user_id"]),
+            make_table(2, "comments", &["post_id"]),
+        ],
+    };
+
+    let source = Source::Table(SourceTable {
+        tables: vec![
+            TableRef::Table(TableId(0)),
+            TableRef::Table(TableId(1)),
+            TableRef::Table(TableId(2)),
+        ],
+        from: vec![TableWithJoins {
+            relation: TableFactor::Table(SourceTableId(0)),
+            joins: vec![
+                Join {
+                    table: SourceTableId(1),
+                    constraint: JoinOp::Left(Expr::eq(col(1, 1), col(0, 0))),
+                },
+                Join {
+                    table: SourceTableId(2),
+                    constraint: JoinOp::Left(Expr::eq(col(2, 1), col(1, 0))),
+                },
+            ],
+        }],
+    });
+
+    let select = Select {
+        returning: Returning::Project(Expr::record([col(0, 0), col(1, 0), col(2, 0)])),
+        source,
+        filter: Filter::ALL,
+    };
+    let stmt = stmt::Statement::Query(stmt::Query::builder(select).build());
+    let sql = render_sqlite(&schema, stmt);
+
+    // Order matters: posts is joined before comments.
+    let posts = sql
+        .find(r#"LEFT JOIN "posts" AS tbl_0_1 ON tbl_0_1."user_id" = tbl_0_0."id""#)
+        .unwrap_or_else(|| panic!("expected posts join in: {sql}"));
+    let comments = sql
+        .find(r#"LEFT JOIN "comments" AS tbl_0_2 ON tbl_0_2."post_id" = tbl_0_1."id""#)
+        .unwrap_or_else(|| panic!("expected comments join in: {sql}"));
+    assert!(
+        posts < comments,
+        "expected posts join to precede comments join in: {sql}"
+    );
+}
+
+/// Mixed-kind chain: `users INNER JOIN posts ON ... LEFT JOIN comments ON ...`.
+/// Confirms the per-join keyword selection is independent.
+#[test]
+fn mixed_inner_then_left_join() {
+    let schema = Schema {
+        tables: vec![
+            make_table(0, "users", &[]),
+            make_table(1, "posts", &["user_id"]),
+            make_table(2, "comments", &["post_id"]),
+        ],
+    };
+
+    let source = Source::Table(SourceTable {
+        tables: vec![
+            TableRef::Table(TableId(0)),
+            TableRef::Table(TableId(1)),
+            TableRef::Table(TableId(2)),
+        ],
+        from: vec![TableWithJoins {
+            relation: TableFactor::Table(SourceTableId(0)),
+            joins: vec![
+                Join {
+                    table: SourceTableId(1),
+                    constraint: JoinOp::Inner(Expr::eq(col(1, 1), col(0, 0))),
+                },
+                Join {
+                    table: SourceTableId(2),
+                    constraint: JoinOp::Left(Expr::eq(col(2, 1), col(1, 0))),
+                },
+            ],
+        }],
+    });
+
+    let select = Select {
+        returning: Returning::Project(Expr::record([col(0, 0)])),
+        source,
+        filter: Filter::ALL,
+    };
+    let stmt = stmt::Statement::Query(stmt::Query::builder(select).build());
+    let sql = render_sqlite(&schema, stmt);
+
+    let inner = sql
+        .find(r#"INNER JOIN "posts" AS tbl_0_1"#)
+        .unwrap_or_else(|| panic!("expected INNER posts join in: {sql}"));
+    let left = sql
+        .find(r#"LEFT JOIN "comments" AS tbl_0_2"#)
+        .unwrap_or_else(|| panic!("expected LEFT comments join in: {sql}"));
+    assert!(inner < left, "expected INNER before LEFT in: {sql}");
+}

--- a/crates/toasty-sql/tests/serialize_joins.rs
+++ b/crates/toasty-sql/tests/serialize_joins.rs
@@ -6,6 +6,7 @@
 //! The test constructs the AST directly so the serializer is exercised in
 //! isolation — no lowering pipeline involved.
 
+use expect_test::expect;
 use toasty_core::{
     schema::db::{Column, ColumnId, PrimaryKey, Schema, Table, TableId, Type as StorageType},
     stmt::{
@@ -111,21 +112,7 @@ fn left_join_renders_left_join_with_on_clause() {
     };
 
     let on = Expr::eq(col(1, 1), col(0, 0));
-    let sql = render_sqlite(&schema, select_with_join(JoinOp::Left(on)));
-
-    assert!(
-        sql.contains(" LEFT JOIN "),
-        "expected ` LEFT JOIN ` in: {sql}"
-    );
-    assert!(
-        !sql.contains("INNER JOIN"),
-        "did not expect INNER in: {sql}"
-    );
-    // Joined-table alias + ON predicate referencing both sides.
-    assert!(
-        sql.contains(r#""posts" AS tbl_0_1 ON tbl_0_1."user_id" = tbl_0_0."id""#),
-        "expected aliased ON clause in: {sql}"
-    );
+    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 LEFT JOIN "posts" AS tbl_0_1 ON tbl_0_1."user_id" = tbl_0_0."id";"#]].assert_eq(&render_sqlite(&schema, select_with_join(JoinOp::Left(on))));
 }
 
 #[test]
@@ -138,17 +125,7 @@ fn inner_join_renders_inner_join_with_on_clause() {
     };
 
     let on = Expr::eq(col(1, 1), col(0, 0));
-    let sql = render_sqlite(&schema, select_with_join(JoinOp::Inner(on)));
-
-    assert!(
-        sql.contains(" INNER JOIN "),
-        "expected ` INNER JOIN ` in: {sql}"
-    );
-    assert!(!sql.contains("LEFT JOIN"), "did not expect LEFT in: {sql}");
-    assert!(
-        sql.contains(r#""posts" AS tbl_0_1 ON tbl_0_1."user_id" = tbl_0_0."id""#),
-        "expected aliased ON clause in: {sql}"
-    );
+    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 INNER JOIN "posts" AS tbl_0_1 ON tbl_0_1."user_id" = tbl_0_0."id";"#]].assert_eq(&render_sqlite(&schema, select_with_join(JoinOp::Inner(on))));
 }
 
 /// Multi-step join: `users LEFT JOIN posts ON ... LEFT JOIN comments ON ...`.
@@ -190,19 +167,7 @@ fn multi_step_left_join_chain() {
         filter: Filter::ALL,
     };
     let stmt = stmt::Statement::Query(stmt::Query::builder(select).build());
-    let sql = render_sqlite(&schema, stmt);
-
-    // Order matters: posts is joined before comments.
-    let posts = sql
-        .find(r#"LEFT JOIN "posts" AS tbl_0_1 ON tbl_0_1."user_id" = tbl_0_0."id""#)
-        .unwrap_or_else(|| panic!("expected posts join in: {sql}"));
-    let comments = sql
-        .find(r#"LEFT JOIN "comments" AS tbl_0_2 ON tbl_0_2."post_id" = tbl_0_1."id""#)
-        .unwrap_or_else(|| panic!("expected comments join in: {sql}"));
-    assert!(
-        posts < comments,
-        "expected posts join to precede comments join in: {sql}"
-    );
+    expect![[r#"SELECT tbl_0_0."id", tbl_0_1."id", tbl_0_2."id" FROM "users" AS tbl_0_0 LEFT JOIN "posts" AS tbl_0_1 ON tbl_0_1."user_id" = tbl_0_0."id" LEFT JOIN "comments" AS tbl_0_2 ON tbl_0_2."post_id" = tbl_0_1."id";"#]].assert_eq(&render_sqlite(&schema, stmt));
 }
 
 /// Mixed-kind chain: `users INNER JOIN posts ON ... LEFT JOIN comments ON ...`.
@@ -244,13 +209,5 @@ fn mixed_inner_then_left_join() {
         filter: Filter::ALL,
     };
     let stmt = stmt::Statement::Query(stmt::Query::builder(select).build());
-    let sql = render_sqlite(&schema, stmt);
-
-    let inner = sql
-        .find(r#"INNER JOIN "posts" AS tbl_0_1"#)
-        .unwrap_or_else(|| panic!("expected INNER posts join in: {sql}"));
-    let left = sql
-        .find(r#"LEFT JOIN "comments" AS tbl_0_2"#)
-        .unwrap_or_else(|| panic!("expected LEFT comments join in: {sql}"));
-    assert!(inner < left, "expected INNER before LEFT in: {sql}");
+    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 INNER JOIN "posts" AS tbl_0_1 ON tbl_0_1."user_id" = tbl_0_0."id" LEFT JOIN "comments" AS tbl_0_2 ON tbl_0_2."post_id" = tbl_0_1."id";"#]].assert_eq(&render_sqlite(&schema, stmt));
 }

--- a/crates/toasty-sql/tests/serialize_select.rs
+++ b/crates/toasty-sql/tests/serialize_select.rs
@@ -5,6 +5,7 @@
 //! clauses around the `SELECT` body. Each test constructs the AST directly so
 //! the serializer is exercised in isolation — no lowering pipeline involved.
 
+use expect_test::expect;
 use toasty_core::{
     schema::db::{Column, ColumnId, PrimaryKey, Schema, Table, TableId, Type as StorageType},
     stmt::{
@@ -81,16 +82,6 @@ enum Flavor {
     Mysql,
 }
 
-impl Flavor {
-    fn name(self) -> &'static str {
-        match self {
-            Flavor::Sqlite => "sqlite",
-            Flavor::Postgresql => "postgresql",
-            Flavor::Mysql => "mysql",
-        }
-    }
-}
-
 fn render(flavor: Flavor, schema: &Schema, stmt: stmt::Statement) -> String {
     let sql_stmt = SqlStatement::from(stmt);
     let serializer = match flavor {
@@ -138,51 +129,44 @@ fn make_query(
     stmt::Statement::Query(query)
 }
 
-/// Returns the identifier quote character used by `flavor` — `"` for
-/// SQLite/PostgreSQL, `` ` `` for MySQL.
-fn q(flavor: Flavor) -> char {
-    match flavor {
-        Flavor::Sqlite | Flavor::Postgresql => '"',
-        Flavor::Mysql => '`',
-    }
-}
-
 #[test]
 fn select_basic() {
     let schema = users_schema();
-    for flavor in [Flavor::Sqlite, Flavor::Postgresql, Flavor::Mysql] {
-        let stmt = make_query(Filter::ALL, None, None, vec![]);
-        let sql = render(flavor, &schema, stmt);
-        let q = q(flavor);
-        let expected = format!("SELECT tbl_0_0.{q}id{q} FROM {q}users{q} AS tbl_0_0");
-        assert!(
-            sql.contains(&expected),
-            "[{}] expected `{expected}` in: {sql}",
-            flavor.name()
-        );
-        assert!(
-            !sql.contains("WHERE"),
-            "[{}] did not expect WHERE in: {sql}",
-            flavor.name()
-        );
-    }
+    let stmt = make_query(Filter::ALL, None, None, vec![]);
+    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0;"#]].assert_eq(&render(
+        Flavor::Sqlite,
+        &schema,
+        stmt,
+    ));
+    let stmt = make_query(Filter::ALL, None, None, vec![]);
+    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0;"#]].assert_eq(&render(
+        Flavor::Postgresql,
+        &schema,
+        stmt,
+    ));
+    let stmt = make_query(Filter::ALL, None, None, vec![]);
+    expect!["SELECT tbl_0_0.`id` FROM `users` AS tbl_0_0;"].assert_eq(&render(
+        Flavor::Mysql,
+        &schema,
+        stmt,
+    ));
 }
 
 #[test]
 fn select_with_where() {
     let schema = users_schema();
-    for flavor in [Flavor::Sqlite, Flavor::Postgresql, Flavor::Mysql] {
-        let filter = Filter::from(Expr::eq(col(0, 0), Expr::from(1i64)));
-        let stmt = make_query(filter, None, None, vec![]);
-        let sql = render(flavor, &schema, stmt);
-        let q = q(flavor);
-        let expected = format!("WHERE tbl_0_0.{q}id{q} = 1");
-        assert!(
-            sql.contains(&expected),
-            "[{}] expected `{expected}` in: {sql}",
-            flavor.name()
-        );
-    }
+    let filter = Filter::from(Expr::eq(col(0, 0), Expr::from(1i64)));
+    let stmt = make_query(filter, None, None, vec![]);
+    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 WHERE tbl_0_0."id" = 1;"#]]
+        .assert_eq(&render(Flavor::Sqlite, &schema, stmt));
+    let filter = Filter::from(Expr::eq(col(0, 0), Expr::from(1i64)));
+    let stmt = make_query(filter, None, None, vec![]);
+    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 WHERE tbl_0_0."id" = 1;"#]]
+        .assert_eq(&render(Flavor::Postgresql, &schema, stmt));
+    let filter = Filter::from(Expr::eq(col(0, 0), Expr::from(1i64)));
+    let stmt = make_query(filter, None, None, vec![]);
+    expect!["SELECT tbl_0_0.`id` FROM `users` AS tbl_0_0 WHERE tbl_0_0.`id` = 1;"]
+        .assert_eq(&render(Flavor::Mysql, &schema, stmt));
 }
 
 #[test]
@@ -193,11 +177,7 @@ fn select_with_and_filter() {
         Expr::eq(col(0, 1), Expr::from("foo")),
     ));
     let stmt = make_query(filter, None, None, vec![]);
-    let sql = render(Flavor::Sqlite, &schema, stmt);
-    assert!(
-        sql.contains(r#"WHERE tbl_0_0."id" = 1 AND tbl_0_0."name" = 'foo'"#),
-        "expected AND filter in: {sql}"
-    );
+    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 WHERE tbl_0_0."id" = 1 AND tbl_0_0."name" = 'foo';"#]].assert_eq(&render(Flavor::Sqlite, &schema, stmt));
 }
 
 #[test]
@@ -208,11 +188,10 @@ fn select_with_or_filter() {
         Expr::eq(col(0, 0), Expr::from(2i64)),
     ));
     let stmt = make_query(filter, None, None, vec![]);
-    let sql = render(Flavor::Sqlite, &schema, stmt);
-    assert!(
-        sql.contains(r#"WHERE tbl_0_0."id" = 1 OR tbl_0_0."id" = 2"#),
-        "expected OR filter in: {sql}"
-    );
+    expect![[
+        r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 WHERE tbl_0_0."id" = 1 OR tbl_0_0."id" = 2;"#
+    ]]
+    .assert_eq(&render(Flavor::Sqlite, &schema, stmt));
 }
 
 #[test]
@@ -225,11 +204,8 @@ fn select_with_order_by_asc() {
         }],
     };
     let stmt = make_query(Filter::ALL, Some(order_by), None, vec![]);
-    let sql = render(Flavor::Sqlite, &schema, stmt);
-    assert!(
-        sql.contains(r#"ORDER BY tbl_0_0."id" ASC"#),
-        "expected `ORDER BY tbl_0_0.\"id\" ASC` in: {sql}"
-    );
+    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 ORDER BY tbl_0_0."id" ASC;"#]]
+        .assert_eq(&render(Flavor::Sqlite, &schema, stmt));
 }
 
 #[test]
@@ -242,11 +218,8 @@ fn select_with_order_by_desc() {
         }],
     };
     let stmt = make_query(Filter::ALL, Some(order_by), None, vec![]);
-    let sql = render(Flavor::Sqlite, &schema, stmt);
-    assert!(
-        sql.contains(r#"ORDER BY tbl_0_0."id" DESC"#),
-        "expected `ORDER BY tbl_0_0.\"id\" DESC` in: {sql}"
-    );
+    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 ORDER BY tbl_0_0."id" DESC;"#]]
+        .assert_eq(&render(Flavor::Sqlite, &schema, stmt));
 }
 
 #[test]
@@ -265,11 +238,7 @@ fn select_with_order_by_multiple_columns() {
         ],
     };
     let stmt = make_query(Filter::ALL, Some(order_by), None, vec![]);
-    let sql = render(Flavor::Sqlite, &schema, stmt);
-    assert!(
-        sql.contains(r#"ORDER BY tbl_0_0."name" ASC, tbl_0_0."id" DESC"#),
-        "expected multi-column ORDER BY in: {sql}"
-    );
+    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 ORDER BY tbl_0_0."name" ASC, tbl_0_0."id" DESC;"#]].assert_eq(&render(Flavor::Sqlite, &schema, stmt));
 }
 
 #[test]
@@ -280,9 +249,11 @@ fn select_with_limit() {
         offset: None,
     });
     let stmt = make_query(Filter::ALL, None, Some(limit), vec![]);
-    let sql = render(Flavor::Sqlite, &schema, stmt);
-    assert!(sql.contains("LIMIT 10"), "expected `LIMIT 10` in: {sql}");
-    assert!(!sql.contains("OFFSET"), "did not expect OFFSET in: {sql}");
+    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 LIMIT 10;"#]].assert_eq(&render(
+        Flavor::Sqlite,
+        &schema,
+        stmt,
+    ));
 }
 
 #[test]
@@ -293,11 +264,8 @@ fn select_with_limit_and_offset() {
         offset: Some(Expr::from(20i64)),
     });
     let stmt = make_query(Filter::ALL, None, Some(limit), vec![]);
-    let sql = render(Flavor::Sqlite, &schema, stmt);
-    assert!(
-        sql.contains("LIMIT 10 OFFSET 20"),
-        "expected `LIMIT 10 OFFSET 20` in: {sql}"
-    );
+    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 LIMIT 10 OFFSET 20;"#]]
+        .assert_eq(&render(Flavor::Sqlite, &schema, stmt));
 }
 
 #[test]
@@ -305,15 +273,24 @@ fn select_with_for_update() {
     let schema = users_schema();
     // SQLite has no row-level locks, but the serializer renders `FOR UPDATE`
     // unconditionally — verify that for all three flavors.
-    for flavor in [Flavor::Sqlite, Flavor::Postgresql, Flavor::Mysql] {
-        let stmt = make_query(Filter::ALL, None, None, vec![Lock::Update]);
-        let sql = render(flavor, &schema, stmt);
-        assert!(
-            sql.contains("FOR UPDATE"),
-            "[{}] expected `FOR UPDATE` in: {sql}",
-            flavor.name()
-        );
-    }
+    let stmt = make_query(Filter::ALL, None, None, vec![Lock::Update]);
+    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 FOR UPDATE;"#]].assert_eq(&render(
+        Flavor::Sqlite,
+        &schema,
+        stmt,
+    ));
+    let stmt = make_query(Filter::ALL, None, None, vec![Lock::Update]);
+    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 FOR UPDATE;"#]].assert_eq(&render(
+        Flavor::Postgresql,
+        &schema,
+        stmt,
+    ));
+    let stmt = make_query(Filter::ALL, None, None, vec![Lock::Update]);
+    expect!["SELECT tbl_0_0.`id` FROM `users` AS tbl_0_0 FOR UPDATE;"].assert_eq(&render(
+        Flavor::Mysql,
+        &schema,
+        stmt,
+    ));
 }
 
 #[test]
@@ -321,13 +298,22 @@ fn select_with_for_share() {
     let schema = users_schema();
     // As with `FOR UPDATE`, the serializer renders `FOR SHARE` unconditionally
     // across flavors; database compatibility is enforced at execution, not here.
-    for flavor in [Flavor::Sqlite, Flavor::Postgresql, Flavor::Mysql] {
-        let stmt = make_query(Filter::ALL, None, None, vec![Lock::Share]);
-        let sql = render(flavor, &schema, stmt);
-        assert!(
-            sql.contains("FOR SHARE"),
-            "[{}] expected `FOR SHARE` in: {sql}",
-            flavor.name()
-        );
-    }
+    let stmt = make_query(Filter::ALL, None, None, vec![Lock::Share]);
+    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 FOR SHARE;"#]].assert_eq(&render(
+        Flavor::Sqlite,
+        &schema,
+        stmt,
+    ));
+    let stmt = make_query(Filter::ALL, None, None, vec![Lock::Share]);
+    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 FOR SHARE;"#]].assert_eq(&render(
+        Flavor::Postgresql,
+        &schema,
+        stmt,
+    ));
+    let stmt = make_query(Filter::ALL, None, None, vec![Lock::Share]);
+    expect!["SELECT tbl_0_0.`id` FROM `users` AS tbl_0_0 FOR SHARE;"].assert_eq(&render(
+        Flavor::Mysql,
+        &schema,
+        stmt,
+    ));
 }

--- a/crates/toasty-sql/tests/serialize_select.rs
+++ b/crates/toasty-sql/tests/serialize_select.rs
@@ -1,0 +1,333 @@
+//! Verifies the serializer renders `SELECT` shape — WHERE, ORDER BY,
+//! LIMIT/OFFSET, and `FOR UPDATE` / `FOR SHARE` row-level locks.
+//!
+//! Joins and ANY/ALL operators have their own files; this file focuses on the
+//! clauses around the `SELECT` body. Each test constructs the AST directly so
+//! the serializer is exercised in isolation — no lowering pipeline involved.
+
+use toasty_core::{
+    schema::db::{Column, ColumnId, PrimaryKey, Schema, Table, TableId, Type as StorageType},
+    stmt::{
+        self, Direction, Expr, ExprColumn, Filter, Limit, LimitOffset, Lock, OrderBy, OrderByExpr,
+        Returning, Select, Source, SourceTable, SourceTableId, TableFactor, TableRef,
+        TableWithJoins,
+    },
+};
+use toasty_sql::{Serializer, Statement as SqlStatement};
+
+/// Minimal `id INTEGER PRIMARY KEY, *cols` table. `cols` start at column index
+/// 1 and are all `INTEGER`.
+fn make_table(id: usize, name: &str, cols: &[&str]) -> Table {
+    let mut columns = vec![Column {
+        id: ColumnId {
+            table: TableId(id),
+            index: 0,
+        },
+        name: "id".to_string(),
+        ty: stmt::Type::I64,
+        storage_ty: StorageType::Integer(8),
+        nullable: false,
+        primary_key: true,
+        auto_increment: false,
+        versionable: false,
+    }];
+    for (i, name) in cols.iter().enumerate() {
+        columns.push(Column {
+            id: ColumnId {
+                table: TableId(id),
+                index: i + 1,
+            },
+            name: (*name).to_string(),
+            ty: stmt::Type::I64,
+            storage_ty: StorageType::Integer(8),
+            nullable: false,
+            primary_key: false,
+            auto_increment: false,
+            versionable: false,
+        });
+    }
+    Table {
+        id: TableId(id),
+        name: name.to_string(),
+        columns,
+        primary_key: PrimaryKey {
+            columns: vec![ColumnId {
+                table: TableId(id),
+                index: 0,
+            }],
+            index: toasty_core::schema::db::IndexId {
+                table: TableId(id),
+                index: 0,
+            },
+        },
+        indices: vec![],
+    }
+}
+
+/// Reference to column `column` of the `table`th entry in `SourceTable::tables`.
+fn col(table: usize, column: usize) -> Expr {
+    Expr::column(ExprColumn {
+        nesting: 0,
+        table,
+        column,
+    })
+}
+
+/// SQL flavor selector for the `render` helper.
+#[derive(Clone, Copy)]
+enum Flavor {
+    Sqlite,
+    Postgresql,
+    Mysql,
+}
+
+impl Flavor {
+    fn name(self) -> &'static str {
+        match self {
+            Flavor::Sqlite => "sqlite",
+            Flavor::Postgresql => "postgresql",
+            Flavor::Mysql => "mysql",
+        }
+    }
+}
+
+fn render(flavor: Flavor, schema: &Schema, stmt: stmt::Statement) -> String {
+    let sql_stmt = SqlStatement::from(stmt);
+    let serializer = match flavor {
+        Flavor::Sqlite => Serializer::sqlite(schema),
+        Flavor::Postgresql => Serializer::postgresql(schema),
+        Flavor::Mysql => Serializer::mysql(schema),
+    };
+    serializer.serialize(&sql_stmt)
+}
+
+/// Schema with a single `users(id, name)` table.
+fn users_schema() -> Schema {
+    Schema {
+        tables: vec![make_table(0, "users", &["name"])],
+    }
+}
+
+/// Single-table `users` source.
+fn users_source() -> Source {
+    Source::Table(SourceTable {
+        tables: vec![TableRef::Table(TableId(0))],
+        from: vec![TableWithJoins {
+            relation: TableFactor::Table(SourceTableId(0)),
+            joins: vec![],
+        }],
+    })
+}
+
+/// `SELECT id FROM users` with the given filter, ordering, limit, and locks.
+fn make_query(
+    filter: Filter,
+    order_by: Option<OrderBy>,
+    limit: Option<Limit>,
+    locks: Vec<Lock>,
+) -> stmt::Statement {
+    let select = Select {
+        returning: Returning::Project(Expr::record([col(0, 0)])),
+        source: users_source(),
+        filter,
+    };
+    let mut query = stmt::Query::builder(select).build();
+    query.order_by = order_by;
+    query.limit = limit;
+    query.locks = locks;
+    stmt::Statement::Query(query)
+}
+
+/// Returns the identifier quote character used by `flavor` — `"` for
+/// SQLite/PostgreSQL, `` ` `` for MySQL.
+fn q(flavor: Flavor) -> char {
+    match flavor {
+        Flavor::Sqlite | Flavor::Postgresql => '"',
+        Flavor::Mysql => '`',
+    }
+}
+
+#[test]
+fn select_basic() {
+    let schema = users_schema();
+    for flavor in [Flavor::Sqlite, Flavor::Postgresql, Flavor::Mysql] {
+        let stmt = make_query(Filter::ALL, None, None, vec![]);
+        let sql = render(flavor, &schema, stmt);
+        let q = q(flavor);
+        let expected = format!("SELECT tbl_0_0.{q}id{q} FROM {q}users{q} AS tbl_0_0");
+        assert!(
+            sql.contains(&expected),
+            "[{}] expected `{expected}` in: {sql}",
+            flavor.name()
+        );
+        assert!(
+            !sql.contains("WHERE"),
+            "[{}] did not expect WHERE in: {sql}",
+            flavor.name()
+        );
+    }
+}
+
+#[test]
+fn select_with_where() {
+    let schema = users_schema();
+    for flavor in [Flavor::Sqlite, Flavor::Postgresql, Flavor::Mysql] {
+        let filter = Filter::from(Expr::eq(col(0, 0), Expr::from(1i64)));
+        let stmt = make_query(filter, None, None, vec![]);
+        let sql = render(flavor, &schema, stmt);
+        let q = q(flavor);
+        let expected = format!("WHERE tbl_0_0.{q}id{q} = 1");
+        assert!(
+            sql.contains(&expected),
+            "[{}] expected `{expected}` in: {sql}",
+            flavor.name()
+        );
+    }
+}
+
+#[test]
+fn select_with_and_filter() {
+    let schema = users_schema();
+    let filter = Filter::from(Expr::and(
+        Expr::eq(col(0, 0), Expr::from(1i64)),
+        Expr::eq(col(0, 1), Expr::from("foo")),
+    ));
+    let stmt = make_query(filter, None, None, vec![]);
+    let sql = render(Flavor::Sqlite, &schema, stmt);
+    assert!(
+        sql.contains(r#"WHERE tbl_0_0."id" = 1 AND tbl_0_0."name" = 'foo'"#),
+        "expected AND filter in: {sql}"
+    );
+}
+
+#[test]
+fn select_with_or_filter() {
+    let schema = users_schema();
+    let filter = Filter::from(Expr::or(
+        Expr::eq(col(0, 0), Expr::from(1i64)),
+        Expr::eq(col(0, 0), Expr::from(2i64)),
+    ));
+    let stmt = make_query(filter, None, None, vec![]);
+    let sql = render(Flavor::Sqlite, &schema, stmt);
+    assert!(
+        sql.contains(r#"WHERE tbl_0_0."id" = 1 OR tbl_0_0."id" = 2"#),
+        "expected OR filter in: {sql}"
+    );
+}
+
+#[test]
+fn select_with_order_by_asc() {
+    let schema = users_schema();
+    let order_by = OrderBy {
+        exprs: vec![OrderByExpr {
+            expr: col(0, 0),
+            order: Some(Direction::Asc),
+        }],
+    };
+    let stmt = make_query(Filter::ALL, Some(order_by), None, vec![]);
+    let sql = render(Flavor::Sqlite, &schema, stmt);
+    assert!(
+        sql.contains(r#"ORDER BY tbl_0_0."id" ASC"#),
+        "expected `ORDER BY tbl_0_0.\"id\" ASC` in: {sql}"
+    );
+}
+
+#[test]
+fn select_with_order_by_desc() {
+    let schema = users_schema();
+    let order_by = OrderBy {
+        exprs: vec![OrderByExpr {
+            expr: col(0, 0),
+            order: Some(Direction::Desc),
+        }],
+    };
+    let stmt = make_query(Filter::ALL, Some(order_by), None, vec![]);
+    let sql = render(Flavor::Sqlite, &schema, stmt);
+    assert!(
+        sql.contains(r#"ORDER BY tbl_0_0."id" DESC"#),
+        "expected `ORDER BY tbl_0_0.\"id\" DESC` in: {sql}"
+    );
+}
+
+#[test]
+fn select_with_order_by_multiple_columns() {
+    let schema = users_schema();
+    let order_by = OrderBy {
+        exprs: vec![
+            OrderByExpr {
+                expr: col(0, 1),
+                order: Some(Direction::Asc),
+            },
+            OrderByExpr {
+                expr: col(0, 0),
+                order: Some(Direction::Desc),
+            },
+        ],
+    };
+    let stmt = make_query(Filter::ALL, Some(order_by), None, vec![]);
+    let sql = render(Flavor::Sqlite, &schema, stmt);
+    assert!(
+        sql.contains(r#"ORDER BY tbl_0_0."name" ASC, tbl_0_0."id" DESC"#),
+        "expected multi-column ORDER BY in: {sql}"
+    );
+}
+
+#[test]
+fn select_with_limit() {
+    let schema = users_schema();
+    let limit = Limit::Offset(LimitOffset {
+        limit: Expr::from(10i64),
+        offset: None,
+    });
+    let stmt = make_query(Filter::ALL, None, Some(limit), vec![]);
+    let sql = render(Flavor::Sqlite, &schema, stmt);
+    assert!(sql.contains("LIMIT 10"), "expected `LIMIT 10` in: {sql}");
+    assert!(!sql.contains("OFFSET"), "did not expect OFFSET in: {sql}");
+}
+
+#[test]
+fn select_with_limit_and_offset() {
+    let schema = users_schema();
+    let limit = Limit::Offset(LimitOffset {
+        limit: Expr::from(10i64),
+        offset: Some(Expr::from(20i64)),
+    });
+    let stmt = make_query(Filter::ALL, None, Some(limit), vec![]);
+    let sql = render(Flavor::Sqlite, &schema, stmt);
+    assert!(
+        sql.contains("LIMIT 10 OFFSET 20"),
+        "expected `LIMIT 10 OFFSET 20` in: {sql}"
+    );
+}
+
+#[test]
+fn select_with_for_update() {
+    let schema = users_schema();
+    // SQLite has no row-level locks, but the serializer renders `FOR UPDATE`
+    // unconditionally — verify that for all three flavors.
+    for flavor in [Flavor::Sqlite, Flavor::Postgresql, Flavor::Mysql] {
+        let stmt = make_query(Filter::ALL, None, None, vec![Lock::Update]);
+        let sql = render(flavor, &schema, stmt);
+        assert!(
+            sql.contains("FOR UPDATE"),
+            "[{}] expected `FOR UPDATE` in: {sql}",
+            flavor.name()
+        );
+    }
+}
+
+#[test]
+fn select_with_for_share() {
+    let schema = users_schema();
+    // As with `FOR UPDATE`, the serializer renders `FOR SHARE` unconditionally
+    // across flavors; database compatibility is enforced at execution, not here.
+    for flavor in [Flavor::Sqlite, Flavor::Postgresql, Flavor::Mysql] {
+        let stmt = make_query(Filter::ALL, None, None, vec![Lock::Share]);
+        let sql = render(flavor, &schema, stmt);
+        assert!(
+            sql.contains("FOR SHARE"),
+            "[{}] expected `FOR SHARE` in: {sql}",
+            flavor.name()
+        );
+    }
+}

--- a/crates/toasty-sql/tests/serialize_subqueries.rs
+++ b/crates/toasty-sql/tests/serialize_subqueries.rs
@@ -157,7 +157,9 @@ fn values_multiple_rows_postgresql() {
 #[test]
 fn values_uses_row_wrapper_on_mysql_outside_insert() {
     // Outside of INSERT, MySQL's table value constructor requires each row to
-    // be wrapped in `ROW(...)`.
+    // be wrapped in `ROW(...)`. The fields go directly inside `ROW(...)`,
+    // not wrapped in an extra layer of parens — `ROW((1, 'a'))` is rejected
+    // by MySQL as a single row-typed operand.
     let schema = Schema::default();
     let values = Values::new(vec![
         Expr::record([Expr::from(1i64), Expr::from("a")]),
@@ -166,15 +168,13 @@ fn values_uses_row_wrapper_on_mysql_outside_insert() {
     let stmt: stmt::Statement = stmt::Query::values(values).into();
     let sql = render_mysql(&schema, stmt);
 
-    // Each row is a `Record`, which serializes with parens — so MySQL emits
-    // `ROW((...))` (the `ROW(` wrapper around the record's own `(...)`).
     assert!(
-        sql.contains("ROW(("),
-        "expected `ROW((...))` wrappers in MySQL: {sql}"
+        sql.contains("ROW(1, 'a'), ROW(2, 'b')"),
+        "expected canonical `ROW(...)` wrappers in MySQL: {sql}"
     );
     assert!(
-        sql.matches("ROW(").count() == 2,
-        "expected one `ROW(` per row in MySQL: {sql}"
+        !sql.contains("ROW(("),
+        "did not expect `ROW((...))` double-paren in MySQL: {sql}"
     );
 }
 

--- a/crates/toasty-sql/tests/serialize_subqueries.rs
+++ b/crates/toasty-sql/tests/serialize_subqueries.rs
@@ -1,0 +1,462 @@
+//! Verifies the serializer renders subquery-bearing shapes:
+//!
+//! * `VALUES` queries (bare and as `INSERT` sources, including MySQL's
+//!   `ROW(...)` wrapper rule)
+//! * `WITH` / CTE definitions and `cte_<depth>_<index>` references
+//! * `TableDerived` (a subquery used as a `FROM` factor)
+//! * `EXISTS` / `NOT EXISTS` predicates
+//! * `IN (subquery)` predicates
+//!
+//! Each test constructs the AST directly so the serializer is exercised in
+//! isolation — no lowering pipeline involved.
+
+use toasty_core::{
+    schema::db::{Column, ColumnId, PrimaryKey, Schema, Table, TableId, Type as StorageType},
+    stmt::{
+        self, Cte, Expr, ExprColumn, Filter, Insert, InsertTable, InsertTarget, Returning, Select,
+        Source, SourceTable, SourceTableId, TableDerived, TableFactor, TableRef, TableWithJoins,
+        Values, With,
+    },
+};
+use toasty_sql::{Serializer, Statement as SqlStatement};
+
+/// Minimal `id INTEGER PRIMARY KEY, *cols` table. `cols` start at column index
+/// 1 and are all `INTEGER`. Mirrors the helper in `serialize_joins.rs`.
+fn make_table(id: usize, name: &str, cols: &[&str]) -> Table {
+    let mut columns = vec![Column {
+        id: ColumnId {
+            table: TableId(id),
+            index: 0,
+        },
+        name: "id".to_string(),
+        ty: stmt::Type::I64,
+        storage_ty: StorageType::Integer(8),
+        nullable: false,
+        primary_key: true,
+        auto_increment: false,
+        versionable: false,
+    }];
+    for (i, name) in cols.iter().enumerate() {
+        columns.push(Column {
+            id: ColumnId {
+                table: TableId(id),
+                index: i + 1,
+            },
+            name: (*name).to_string(),
+            ty: stmt::Type::I64,
+            storage_ty: StorageType::Integer(8),
+            nullable: false,
+            primary_key: false,
+            auto_increment: false,
+            versionable: false,
+        });
+    }
+    Table {
+        id: TableId(id),
+        name: name.to_string(),
+        columns,
+        primary_key: PrimaryKey {
+            columns: vec![ColumnId {
+                table: TableId(id),
+                index: 0,
+            }],
+            index: toasty_core::schema::db::IndexId {
+                table: TableId(id),
+                index: 0,
+            },
+        },
+        indices: vec![],
+    }
+}
+
+/// Reference to column `column` of the `table`th entry in `SourceTable::tables`.
+fn col(table: usize, column: usize) -> Expr {
+    Expr::column(ExprColumn {
+        nesting: 0,
+        table,
+        column,
+    })
+}
+
+fn render_sqlite(schema: &Schema, stmt: stmt::Statement) -> String {
+    Serializer::sqlite(schema).serialize(&SqlStatement::from(stmt))
+}
+
+fn render_postgresql(schema: &Schema, stmt: stmt::Statement) -> String {
+    Serializer::postgresql(schema).serialize(&SqlStatement::from(stmt))
+}
+
+fn render_mysql(schema: &Schema, stmt: stmt::Statement) -> String {
+    Serializer::mysql(schema).serialize(&SqlStatement::from(stmt))
+}
+
+fn users_schema() -> Schema {
+    Schema {
+        tables: vec![make_table(0, "users", &[])],
+    }
+}
+
+/// `SELECT id FROM users` (column 0 of the only table in the source).
+fn select_id_from_users() -> stmt::Query {
+    let source = Source::Table(SourceTable {
+        tables: vec![TableRef::Table(TableId(0))],
+        from: vec![TableWithJoins {
+            relation: TableFactor::Table(SourceTableId(0)),
+            joins: vec![],
+        }],
+    });
+    let select = Select {
+        returning: Returning::Project(Expr::record([col(0, 0)])),
+        source,
+        filter: Filter::ALL,
+    };
+    stmt::Query::builder(select).build()
+}
+
+// -----------------------------------------------------------------------------
+// VALUES
+// -----------------------------------------------------------------------------
+
+#[test]
+fn values_single_row_postgresql() {
+    let schema = Schema::default();
+    let values = Values::new(vec![Expr::record([Expr::from(1i64), Expr::from("a")])]);
+    let stmt: stmt::Statement = stmt::Query::values(values).into();
+    let sql = render_postgresql(&schema, stmt);
+
+    assert!(
+        sql.contains("VALUES (1, 'a')"),
+        "expected `VALUES (1, 'a')` in: {sql}"
+    );
+    assert!(
+        !sql.contains("ROW("),
+        "did not expect ROW(...) wrapper in PG: {sql}"
+    );
+}
+
+#[test]
+fn values_multiple_rows_postgresql() {
+    let schema = Schema::default();
+    let values = Values::new(vec![
+        Expr::record([Expr::from(1i64), Expr::from("a")]),
+        Expr::record([Expr::from(2i64), Expr::from("b")]),
+    ]);
+    let stmt: stmt::Statement = stmt::Query::values(values).into();
+    let sql = render_postgresql(&schema, stmt);
+
+    assert!(
+        sql.contains("VALUES (1, 'a'), (2, 'b')"),
+        "expected comma-separated bare rows in: {sql}"
+    );
+    assert!(
+        !sql.contains("ROW("),
+        "did not expect ROW(...) wrapper in PG: {sql}"
+    );
+}
+
+#[test]
+fn values_uses_row_wrapper_on_mysql_outside_insert() {
+    // Outside of INSERT, MySQL's table value constructor requires each row to
+    // be wrapped in `ROW(...)`.
+    let schema = Schema::default();
+    let values = Values::new(vec![
+        Expr::record([Expr::from(1i64), Expr::from("a")]),
+        Expr::record([Expr::from(2i64), Expr::from("b")]),
+    ]);
+    let stmt: stmt::Statement = stmt::Query::values(values).into();
+    let sql = render_mysql(&schema, stmt);
+
+    // Each row is a `Record`, which serializes with parens — so MySQL emits
+    // `ROW((...))` (the `ROW(` wrapper around the record's own `(...)`).
+    assert!(
+        sql.contains("ROW(("),
+        "expected `ROW((...))` wrappers in MySQL: {sql}"
+    );
+    assert!(
+        sql.matches("ROW(").count() == 2,
+        "expected one `ROW(` per row in MySQL: {sql}"
+    );
+}
+
+#[test]
+fn values_inside_insert_no_row_wrapper_on_mysql() {
+    // Inside INSERT, MySQL omits the `ROW(...)` wrapper.
+    let schema = users_schema();
+    let target = InsertTarget::Table(InsertTable {
+        table: TableId(0),
+        columns: vec![ColumnId {
+            table: TableId(0),
+            index: 0,
+        }],
+    });
+    let values = Values::new(vec![
+        Expr::record([Expr::from(1i64)]),
+        Expr::record([Expr::from(2i64)]),
+    ]);
+    let stmt: stmt::Statement = Insert {
+        target,
+        source: stmt::Query::values(values),
+        returning: None,
+    }
+    .into();
+    let sql = render_mysql(&schema, stmt);
+
+    assert!(
+        sql.contains("VALUES (1), (2)"),
+        "expected comma-separated bare rows in INSERT: {sql}"
+    );
+    assert!(
+        !sql.contains("ROW("),
+        "did not expect ROW(...) wrapper inside INSERT on MySQL: {sql}"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// WITH / CTE
+// -----------------------------------------------------------------------------
+
+#[test]
+fn select_with_single_cte() {
+    let schema = users_schema();
+
+    let cte_query = select_id_from_users();
+
+    // Outer query selects from the CTE: `SELECT col_0 FROM cte_0_0`. The CTE
+    // is at index 0 in the outer query's `with` clause; the inner reference
+    // has nesting=0 because, at serialize time, the CTE binding lives at the
+    // outer query's depth which equals the body's depth.
+    let outer_source = Source::Table(SourceTable {
+        tables: vec![TableRef::Cte {
+            nesting: 0,
+            index: 0,
+        }],
+        from: vec![TableWithJoins {
+            relation: TableFactor::Table(SourceTableId(0)),
+            joins: vec![],
+        }],
+    });
+    let outer_select = Select {
+        // Reference column 0 of the CTE: the serializer resolves this as a
+        // `ColumnAlias` (`col_0`) because the underlying table_ref is a CTE.
+        returning: Returning::Project(Expr::record([col(0, 0)])),
+        source: outer_source,
+        filter: Filter::ALL,
+    };
+    let stmt = stmt::Statement::Query(
+        stmt::Query::builder(outer_select)
+            .with(With {
+                ctes: vec![Cte { query: cte_query }],
+            })
+            .build(),
+    );
+
+    let sql = render_sqlite(&schema, stmt);
+
+    // Top-level query renders at depth 0, so the CTE binding is `cte_0_0`
+    // and the outer FROM aliases it as `tbl_0_0`. The inner subquery is at
+    // depth 1.
+    assert!(
+        sql.contains("WITH cte_0_0 as ("),
+        "expected `WITH cte_0_0 as (` in: {sql}"
+    );
+    assert!(
+        sql.contains("FROM cte_0_0 AS tbl_0_0"),
+        "expected outer FROM to alias the CTE in: {sql}"
+    );
+    // The outer projection of `column 0` of a CTE renders as `ColumnAlias`
+    // (`column1`, 1-based), not the underlying schema column name.
+    assert!(
+        sql.contains("tbl_0_0.column1"),
+        "expected outer projection to use ColumnAlias in: {sql}"
+    );
+}
+
+#[test]
+fn select_with_multiple_ctes() {
+    let schema = users_schema();
+
+    let outer_source = Source::Table(SourceTable {
+        tables: vec![TableRef::Cte {
+            nesting: 0,
+            index: 0,
+        }],
+        from: vec![TableWithJoins {
+            relation: TableFactor::Table(SourceTableId(0)),
+            joins: vec![],
+        }],
+    });
+    let outer_select = Select {
+        returning: Returning::Project(Expr::record([col(0, 0)])),
+        source: outer_source,
+        filter: Filter::ALL,
+    };
+    let stmt = stmt::Statement::Query(
+        stmt::Query::builder(outer_select)
+            .with(With {
+                ctes: vec![
+                    Cte {
+                        query: select_id_from_users(),
+                    },
+                    Cte {
+                        query: select_id_from_users(),
+                    },
+                ],
+            })
+            .build(),
+    );
+
+    let sql = render_sqlite(&schema, stmt);
+
+    // Both CTEs appear, comma-separated, with `_0` and `_1` indices.
+    let first = sql
+        .find("cte_0_0 as (")
+        .unwrap_or_else(|| panic!("expected first CTE in: {sql}"));
+    let second = sql
+        .find("cte_0_1 as (")
+        .unwrap_or_else(|| panic!("expected second CTE in: {sql}"));
+    assert!(first < second, "expected CTE order in: {sql}");
+    // The two CTE bindings are separated by `, ` (rendered by the `Comma`
+    // delimiter wrapping the enumerated CTE list).
+    assert!(
+        sql.contains("), cte_0_1 as ("),
+        "expected comma-separated CTEs in: {sql}"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Derived table in FROM
+// -----------------------------------------------------------------------------
+
+#[test]
+fn select_from_derived_subquery() {
+    let schema = users_schema();
+
+    let inner = select_id_from_users();
+
+    let outer_source = Source::Table(SourceTable {
+        tables: vec![TableRef::Derived(TableDerived {
+            subquery: Box::new(inner),
+        })],
+        from: vec![TableWithJoins {
+            relation: TableFactor::Table(SourceTableId(0)),
+            joins: vec![],
+        }],
+    });
+    let outer_select = Select {
+        returning: Returning::Project(Expr::record([col(0, 0)])),
+        source: outer_source,
+        filter: Filter::ALL,
+    };
+    let stmt = stmt::Statement::Query(stmt::Query::builder(outer_select).build());
+
+    let sql = render_sqlite(&schema, stmt);
+
+    // Top-level query is depth 0; the derived subquery renders at depth 1.
+    // The outer column reference uses `ColumnAlias` (`column1`, 1-based)
+    // because the underlying table is a derived subquery, not a schema
+    // table.
+    assert!(
+        sql.contains(r#"FROM (SELECT tbl_1_0."id" FROM "users" AS tbl_1_0) AS tbl_0_0"#),
+        "expected derived `FROM (...) AS tbl_0_0` in: {sql}"
+    );
+    assert!(
+        sql.contains("tbl_0_0.column1"),
+        "expected outer projection to use ColumnAlias in: {sql}"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// EXISTS / NOT EXISTS
+// -----------------------------------------------------------------------------
+
+fn select_users_with_filter(filter: Expr) -> stmt::Statement {
+    let source = Source::Table(SourceTable {
+        tables: vec![TableRef::Table(TableId(0))],
+        from: vec![TableWithJoins {
+            relation: TableFactor::Table(SourceTableId(0)),
+            joins: vec![],
+        }],
+    });
+    let select = Select {
+        returning: Returning::Project(Expr::record([col(0, 0)])),
+        source,
+        filter: Filter::new(filter),
+    };
+    stmt::Statement::Query(stmt::Query::builder(select).build())
+}
+
+#[test]
+fn expr_exists_subquery() {
+    let schema = users_schema();
+    let exists = Expr::exists(select_id_from_users());
+
+    for (label, sql) in [
+        (
+            "postgresql",
+            render_postgresql(&schema, select_users_with_filter(exists.clone())),
+        ),
+        (
+            "sqlite",
+            render_sqlite(&schema, select_users_with_filter(exists)),
+        ),
+    ] {
+        assert!(
+            sql.contains("WHERE EXISTS ("),
+            "[{label}] expected `WHERE EXISTS (` in: {sql}"
+        );
+        assert!(
+            !sql.contains("NOT EXISTS"),
+            "[{label}] did not expect NOT EXISTS in: {sql}"
+        );
+    }
+}
+
+#[test]
+fn expr_not_exists_subquery() {
+    let schema = users_schema();
+    // `Expr::not_exists` wraps `Exists` in `Not`, which the serializer renders
+    // as `NOT (EXISTS (...))`.
+    let not_exists = Expr::not_exists(select_id_from_users());
+
+    for (label, sql) in [
+        (
+            "postgresql",
+            render_postgresql(&schema, select_users_with_filter(not_exists.clone())),
+        ),
+        (
+            "sqlite",
+            render_sqlite(&schema, select_users_with_filter(not_exists)),
+        ),
+    ] {
+        assert!(
+            sql.contains("NOT (EXISTS ("),
+            "[{label}] expected `NOT (EXISTS (` in: {sql}"
+        );
+    }
+}
+
+// -----------------------------------------------------------------------------
+// IN (subquery)
+// -----------------------------------------------------------------------------
+
+#[test]
+fn expr_in_subquery() {
+    let schema = users_schema();
+    let in_sub = Expr::in_subquery(col(0, 0), select_id_from_users());
+
+    for (label, sql) in [
+        (
+            "postgresql",
+            render_postgresql(&schema, select_users_with_filter(in_sub.clone())),
+        ),
+        (
+            "sqlite",
+            render_sqlite(&schema, select_users_with_filter(in_sub)),
+        ),
+    ] {
+        assert!(
+            sql.contains(r#"WHERE tbl_0_0."id" IN (SELECT "#),
+            "[{label}] expected `id IN (SELECT ...)` predicate in: {sql}"
+        );
+    }
+}

--- a/crates/toasty-sql/tests/serialize_subqueries.rs
+++ b/crates/toasty-sql/tests/serialize_subqueries.rs
@@ -10,6 +10,7 @@
 //! Each test constructs the AST directly so the serializer is exercised in
 //! isolation — no lowering pipeline involved.
 
+use expect_test::expect;
 use toasty_core::{
     schema::db::{Column, ColumnId, PrimaryKey, Schema, Table, TableId, Type as StorageType},
     stmt::{
@@ -122,16 +123,8 @@ fn values_single_row_postgresql() {
     let schema = Schema::default();
     let values = Values::new(vec![Expr::record([Expr::from(1i64), Expr::from("a")])]);
     let stmt: stmt::Statement = stmt::Query::values(values).into();
-    let sql = render_postgresql(&schema, stmt);
 
-    assert!(
-        sql.contains("VALUES (1, 'a')"),
-        "expected `VALUES (1, 'a')` in: {sql}"
-    );
-    assert!(
-        !sql.contains("ROW("),
-        "did not expect ROW(...) wrapper in PG: {sql}"
-    );
+    expect!["VALUES (1, 'a');"].assert_eq(&render_postgresql(&schema, stmt));
 }
 
 #[test]
@@ -142,16 +135,8 @@ fn values_multiple_rows_postgresql() {
         Expr::record([Expr::from(2i64), Expr::from("b")]),
     ]);
     let stmt: stmt::Statement = stmt::Query::values(values).into();
-    let sql = render_postgresql(&schema, stmt);
 
-    assert!(
-        sql.contains("VALUES (1, 'a'), (2, 'b')"),
-        "expected comma-separated bare rows in: {sql}"
-    );
-    assert!(
-        !sql.contains("ROW("),
-        "did not expect ROW(...) wrapper in PG: {sql}"
-    );
+    expect!["VALUES (1, 'a'), (2, 'b');"].assert_eq(&render_postgresql(&schema, stmt));
 }
 
 #[test]
@@ -166,16 +151,8 @@ fn values_uses_row_wrapper_on_mysql_outside_insert() {
         Expr::record([Expr::from(2i64), Expr::from("b")]),
     ]);
     let stmt: stmt::Statement = stmt::Query::values(values).into();
-    let sql = render_mysql(&schema, stmt);
 
-    assert!(
-        sql.contains("ROW(1, 'a'), ROW(2, 'b')"),
-        "expected canonical `ROW(...)` wrappers in MySQL: {sql}"
-    );
-    assert!(
-        !sql.contains("ROW(("),
-        "did not expect `ROW((...))` double-paren in MySQL: {sql}"
-    );
+    expect!["VALUES ROW(1, 'a'), ROW(2, 'b');"].assert_eq(&render_mysql(&schema, stmt));
 }
 
 #[test]
@@ -199,16 +176,8 @@ fn values_inside_insert_no_row_wrapper_on_mysql() {
         returning: None,
     }
     .into();
-    let sql = render_mysql(&schema, stmt);
 
-    assert!(
-        sql.contains("VALUES (1), (2)"),
-        "expected comma-separated bare rows in INSERT: {sql}"
-    );
-    assert!(
-        !sql.contains("ROW("),
-        "did not expect ROW(...) wrapper inside INSERT on MySQL: {sql}"
-    );
+    expect!["INSERT INTO `users` (`id`) VALUES (1), (2);"].assert_eq(&render_mysql(&schema, stmt));
 }
 
 // -----------------------------------------------------------------------------
@@ -250,25 +219,7 @@ fn select_with_single_cte() {
             .build(),
     );
 
-    let sql = render_sqlite(&schema, stmt);
-
-    // Top-level query renders at depth 0, so the CTE binding is `cte_0_0`
-    // and the outer FROM aliases it as `tbl_0_0`. The inner subquery is at
-    // depth 1.
-    assert!(
-        sql.contains("WITH cte_0_0 as ("),
-        "expected `WITH cte_0_0 as (` in: {sql}"
-    );
-    assert!(
-        sql.contains("FROM cte_0_0 AS tbl_0_0"),
-        "expected outer FROM to alias the CTE in: {sql}"
-    );
-    // The outer projection of `column 0` of a CTE renders as `ColumnAlias`
-    // (`column1`, 1-based), not the underlying schema column name.
-    assert!(
-        sql.contains("tbl_0_0.column1"),
-        "expected outer projection to use ColumnAlias in: {sql}"
-    );
+    expect![[r#"WITH cte_0_0 as (SELECT tbl_1_0."id" FROM "users" AS tbl_1_0) SELECT tbl_0_0.column1 FROM cte_0_0 AS tbl_0_0;"#]].assert_eq(&render_sqlite(&schema, stmt));
 }
 
 #[test]
@@ -305,22 +256,7 @@ fn select_with_multiple_ctes() {
             .build(),
     );
 
-    let sql = render_sqlite(&schema, stmt);
-
-    // Both CTEs appear, comma-separated, with `_0` and `_1` indices.
-    let first = sql
-        .find("cte_0_0 as (")
-        .unwrap_or_else(|| panic!("expected first CTE in: {sql}"));
-    let second = sql
-        .find("cte_0_1 as (")
-        .unwrap_or_else(|| panic!("expected second CTE in: {sql}"));
-    assert!(first < second, "expected CTE order in: {sql}");
-    // The two CTE bindings are separated by `, ` (rendered by the `Comma`
-    // delimiter wrapping the enumerated CTE list).
-    assert!(
-        sql.contains("), cte_0_1 as ("),
-        "expected comma-separated CTEs in: {sql}"
-    );
+    expect![[r#"WITH cte_0_0 as (SELECT tbl_1_0."id" FROM "users" AS tbl_1_0), cte_0_1 as (SELECT tbl_1_0."id" FROM "users" AS tbl_1_0) SELECT tbl_0_0.column1 FROM cte_0_0 AS tbl_0_0;"#]].assert_eq(&render_sqlite(&schema, stmt));
 }
 
 // -----------------------------------------------------------------------------
@@ -349,20 +285,10 @@ fn select_from_derived_subquery() {
     };
     let stmt = stmt::Statement::Query(stmt::Query::builder(outer_select).build());
 
-    let sql = render_sqlite(&schema, stmt);
-
-    // Top-level query is depth 0; the derived subquery renders at depth 1.
-    // The outer column reference uses `ColumnAlias` (`column1`, 1-based)
-    // because the underlying table is a derived subquery, not a schema
-    // table.
-    assert!(
-        sql.contains(r#"FROM (SELECT tbl_1_0."id" FROM "users" AS tbl_1_0) AS tbl_0_0"#),
-        "expected derived `FROM (...) AS tbl_0_0` in: {sql}"
-    );
-    assert!(
-        sql.contains("tbl_0_0.column1"),
-        "expected outer projection to use ColumnAlias in: {sql}"
-    );
+    expect![[
+        r#"SELECT tbl_0_0.column1 FROM (SELECT tbl_1_0."id" FROM "users" AS tbl_1_0) AS tbl_0_0;"#
+    ]]
+    .assert_eq(&render_sqlite(&schema, stmt));
 }
 
 // -----------------------------------------------------------------------------
@@ -390,25 +316,11 @@ fn expr_exists_subquery() {
     let schema = users_schema();
     let exists = Expr::exists(select_id_from_users());
 
-    for (label, sql) in [
-        (
-            "postgresql",
-            render_postgresql(&schema, select_users_with_filter(exists.clone())),
-        ),
-        (
-            "sqlite",
-            render_sqlite(&schema, select_users_with_filter(exists)),
-        ),
-    ] {
-        assert!(
-            sql.contains("WHERE EXISTS ("),
-            "[{label}] expected `WHERE EXISTS (` in: {sql}"
-        );
-        assert!(
-            !sql.contains("NOT EXISTS"),
-            "[{label}] did not expect NOT EXISTS in: {sql}"
-        );
-    }
+    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 WHERE EXISTS (SELECT tbl_1_0."id" FROM "users" AS tbl_1_0);"#]].assert_eq(&render_postgresql(
+        &schema,
+        select_users_with_filter(exists.clone()),
+    ));
+    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 WHERE EXISTS (SELECT tbl_1_0."id" FROM "users" AS tbl_1_0);"#]].assert_eq(&render_sqlite(&schema, select_users_with_filter(exists)));
 }
 
 #[test]
@@ -418,21 +330,14 @@ fn expr_not_exists_subquery() {
     // as `NOT (EXISTS (...))`.
     let not_exists = Expr::not_exists(select_id_from_users());
 
-    for (label, sql) in [
-        (
-            "postgresql",
-            render_postgresql(&schema, select_users_with_filter(not_exists.clone())),
-        ),
-        (
-            "sqlite",
-            render_sqlite(&schema, select_users_with_filter(not_exists)),
-        ),
-    ] {
-        assert!(
-            sql.contains("NOT (EXISTS ("),
-            "[{label}] expected `NOT (EXISTS (` in: {sql}"
-        );
-    }
+    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 WHERE NOT (EXISTS (SELECT tbl_1_0."id" FROM "users" AS tbl_1_0));"#]].assert_eq(&render_postgresql(
+        &schema,
+        select_users_with_filter(not_exists.clone()),
+    ));
+    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 WHERE NOT (EXISTS (SELECT tbl_1_0."id" FROM "users" AS tbl_1_0));"#]].assert_eq(&render_sqlite(
+        &schema,
+        select_users_with_filter(not_exists),
+    ));
 }
 
 // -----------------------------------------------------------------------------
@@ -444,19 +349,9 @@ fn expr_in_subquery() {
     let schema = users_schema();
     let in_sub = Expr::in_subquery(col(0, 0), select_id_from_users());
 
-    for (label, sql) in [
-        (
-            "postgresql",
-            render_postgresql(&schema, select_users_with_filter(in_sub.clone())),
-        ),
-        (
-            "sqlite",
-            render_sqlite(&schema, select_users_with_filter(in_sub)),
-        ),
-    ] {
-        assert!(
-            sql.contains(r#"WHERE tbl_0_0."id" IN (SELECT "#),
-            "[{label}] expected `id IN (SELECT ...)` predicate in: {sql}"
-        );
-    }
+    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 WHERE tbl_0_0."id" IN (SELECT tbl_0_0."id" FROM "users" AS tbl_0_0);"#]].assert_eq(&render_postgresql(
+        &schema,
+        select_users_with_filter(in_sub.clone()),
+    ));
+    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 WHERE tbl_0_0."id" IN (SELECT tbl_0_0."id" FROM "users" AS tbl_0_0);"#]].assert_eq(&render_sqlite(&schema, select_users_with_filter(in_sub)));
 }

--- a/crates/toasty-sql/tests/serialize_types.rs
+++ b/crates/toasty-sql/tests/serialize_types.rs
@@ -3,11 +3,9 @@
 //!
 //! Each non-`todo!()` `(Type variant × flavor)` combination is exercised
 //! through a `CREATE TABLE` migration so the rendered column type surfaces in
-//! the generated DDL. `todo!()` combinations are asserted via
-//! `std::panic::catch_unwind` so the test suite documents which combinations
-//! intentionally panic today.
-
-use std::panic;
+//! the generated DDL. `todo!()` combinations are pinned with
+//! `#[should_panic(expected = "...")]` so the test suite documents which
+//! combinations intentionally panic today and tracks the exact panic message.
 
 use toasty_core::{
     driver::Capability,
@@ -104,12 +102,6 @@ fn render_type(flavor: &str, storage_ty: Type) -> Vec<String> {
     let diff = SchemaDiff::from(&from, &to, &hints);
     let stmts = MigrationStatement::from_diff(&diff, capability_for(flavor));
     serialize_migration(&stmts, flavor)
-}
-
-/// Try to render a storage type; return `Err` if rendering panics (e.g. the
-/// serializer hits a `todo!()` arm).
-fn try_render_type(flavor: &'static str, storage_ty: Type) -> std::thread::Result<Vec<String>> {
-    panic::catch_unwind(move || render_type(flavor, storage_ty))
 }
 
 /// Convenience: assert that the `CREATE TABLE` for column `col` contains the
@@ -368,15 +360,15 @@ fn uuid_postgresql() {
 }
 
 #[test]
+#[should_panic(expected = "Unsupported type UUID")]
 fn uuid_mysql_panics() {
-    let result = try_render_type("mysql", Type::Uuid);
-    assert!(result.is_err(), "expected MySQL UUID rendering to panic");
+    render_type("mysql", Type::Uuid);
 }
 
 #[test]
+#[should_panic(expected = "Unsupported type UUID")]
 fn uuid_sqlite_panics() {
-    let result = try_render_type("sqlite", Type::Uuid);
-    assert!(result.is_err(), "expected SQLite UUID rendering to panic");
+    render_type("sqlite", Type::Uuid);
 }
 
 // ---------------------------------------------------------------------------
@@ -402,30 +394,21 @@ fn numeric_with_precision_mysql() {
 }
 
 #[test]
+#[should_panic(expected = "MySQL does not support arbitrary-precision NUMERIC")]
 fn numeric_unconstrained_mysql_panics() {
-    let result = try_render_type("mysql", Type::Numeric(None));
-    assert!(
-        result.is_err(),
-        "expected MySQL unconstrained NUMERIC rendering to panic"
-    );
+    render_type("mysql", Type::Numeric(None));
 }
 
 #[test]
+#[should_panic(expected = "SQLite does not support NUMERIC type")]
 fn numeric_unconstrained_sqlite_panics() {
-    let result = try_render_type("sqlite", Type::Numeric(None));
-    assert!(
-        result.is_err(),
-        "expected SQLite NUMERIC rendering to panic"
-    );
+    render_type("sqlite", Type::Numeric(None));
 }
 
 #[test]
+#[should_panic(expected = "SQLite does not support NUMERIC type")]
 fn numeric_with_precision_sqlite_panics() {
-    let result = try_render_type("sqlite", Type::Numeric(Some((10, 2))));
-    assert!(
-        result.is_err(),
-        "expected SQLite NUMERIC(p, s) rendering to panic"
-    );
+    render_type("sqlite", Type::Numeric(Some((10, 2))));
 }
 
 // ---------------------------------------------------------------------------
@@ -439,21 +422,15 @@ fn binary_mysql() {
 }
 
 #[test]
+#[should_panic(expected = "Unsupported fixed size binary type")]
 fn binary_postgresql_panics() {
-    let result = try_render_type("postgresql", Type::Binary(16));
-    assert!(
-        result.is_err(),
-        "expected PostgreSQL BINARY(n) rendering to panic"
-    );
+    render_type("postgresql", Type::Binary(16));
 }
 
 #[test]
+#[should_panic(expected = "Unsupported fixed size binary type")]
 fn binary_sqlite_panics() {
-    let result = try_render_type("sqlite", Type::Binary(16));
-    assert!(
-        result.is_err(),
-        "expected SQLite BINARY(n) rendering to panic"
-    );
+    render_type("sqlite", Type::Binary(16));
 }
 
 // ---------------------------------------------------------------------------
@@ -495,12 +472,9 @@ fn timestamp_mysql_timestamp() {
 }
 
 #[test]
+#[should_panic(expected = "SQLite does not support Timestamp")]
 fn timestamp_sqlite_panics() {
-    let result = try_render_type("sqlite", Type::Timestamp(6));
-    assert!(
-        result.is_err(),
-        "expected SQLite Timestamp rendering to panic"
-    );
+    render_type("sqlite", Type::Timestamp(6));
 }
 
 // ---------------------------------------------------------------------------
@@ -520,9 +494,9 @@ fn date_mysql() {
 }
 
 #[test]
+#[should_panic(expected = "SQLite does not support Date")]
 fn date_sqlite_panics() {
-    let result = try_render_type("sqlite", Type::Date);
-    assert!(result.is_err(), "expected SQLite Date rendering to panic");
+    render_type("sqlite", Type::Date);
 }
 
 // ---------------------------------------------------------------------------
@@ -542,9 +516,9 @@ fn time_mysql() {
 }
 
 #[test]
+#[should_panic(expected = "SQLite does not support Time")]
 fn time_sqlite_panics() {
-    let result = try_render_type("sqlite", Type::Time(3));
-    assert!(result.is_err(), "expected SQLite Time rendering to panic");
+    render_type("sqlite", Type::Time(3));
 }
 
 // ---------------------------------------------------------------------------
@@ -564,12 +538,9 @@ fn datetime_mysql_datetime() {
 }
 
 #[test]
+#[should_panic(expected = "SQLite does not support DateTime")]
 fn datetime_sqlite_panics() {
-    let result = try_render_type("sqlite", Type::DateTime(6));
-    assert!(
-        result.is_err(),
-        "expected SQLite DateTime rendering to panic"
-    );
+    render_type("sqlite", Type::DateTime(6));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/toasty-sql/tests/serialize_types.rs
+++ b/crates/toasty-sql/tests/serialize_types.rs
@@ -1,0 +1,652 @@
+//! Exhaustive coverage of `db::Type` → SQL type rendering in
+//! `toasty-sql/src/serializer/ty.rs`, across PostgreSQL, MySQL, and SQLite.
+//!
+//! Each non-`todo!()` `(Type variant × flavor)` combination is exercised
+//! through a `CREATE TABLE` migration so the rendered column type surfaces in
+//! the generated DDL. `todo!()` combinations are asserted via
+//! `std::panic::catch_unwind` so the test suite documents which combinations
+//! intentionally panic today.
+
+use std::panic;
+
+use toasty_core::{
+    driver::Capability,
+    schema::db::{
+        Column, ColumnId, EnumVariant, PrimaryKey, RenameHints, Schema, SchemaDiff, Table, TableId,
+        Type, TypeEnum,
+    },
+    stmt as core_stmt,
+};
+use toasty_sql::{Serializer, migration::MigrationStatement};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_column(table_id: usize, index: usize, name: &str, storage_ty: Type) -> Column {
+    Column {
+        id: ColumnId {
+            table: TableId(table_id),
+            index,
+        },
+        name: name.to_string(),
+        ty: core_stmt::Type::String,
+        storage_ty,
+        nullable: false,
+        primary_key: index == 0,
+        auto_increment: false,
+        versionable: false,
+    }
+}
+
+fn make_table(id: usize, name: &str, columns: Vec<Column>) -> Table {
+    let pk_columns: Vec<ColumnId> = columns
+        .iter()
+        .filter(|c| c.primary_key)
+        .map(|c| c.id)
+        .collect();
+
+    Table {
+        id: TableId(id),
+        name: name.to_string(),
+        columns,
+        primary_key: PrimaryKey {
+            columns: pk_columns,
+            index: toasty_core::schema::db::IndexId {
+                table: TableId(id),
+                index: 0,
+            },
+        },
+        indices: vec![],
+    }
+}
+
+fn serialize_migration(stmts: &[MigrationStatement<'_>], flavor: &str) -> Vec<String> {
+    stmts
+        .iter()
+        .map(|ms| {
+            let serializer = match flavor {
+                "sqlite" => Serializer::sqlite(ms.schema()),
+                "postgresql" => Serializer::postgresql(ms.schema()),
+                "mysql" => Serializer::mysql(ms.schema()),
+                _ => panic!("unknown flavor: {flavor}"),
+            };
+            serializer.serialize(ms.statement())
+        })
+        .collect()
+}
+
+fn capability_for(flavor: &str) -> &'static Capability {
+    match flavor {
+        "sqlite" => &Capability::SQLITE,
+        "postgresql" => &Capability::POSTGRESQL,
+        "mysql" => &Capability::MYSQL,
+        _ => panic!("unknown flavor: {flavor}"),
+    }
+}
+
+/// Build a one-column `CREATE TABLE` migration for the given storage type and
+/// flavor, then return the rendered DDL strings.
+fn render_type(flavor: &str, storage_ty: Type) -> Vec<String> {
+    let from = Schema::default();
+    let to = Schema {
+        tables: vec![make_table(
+            0,
+            "t",
+            vec![
+                make_column(0, 0, "id", Type::Integer(8)),
+                make_column(0, 1, "col", storage_ty),
+            ],
+        )],
+    };
+
+    let hints = RenameHints::new();
+    let diff = SchemaDiff::from(&from, &to, &hints);
+    let stmts = MigrationStatement::from_diff(&diff, capability_for(flavor));
+    serialize_migration(&stmts, flavor)
+}
+
+/// Try to render a storage type; return `Err` if rendering panics (e.g. the
+/// serializer hits a `todo!()` arm).
+fn try_render_type(flavor: &'static str, storage_ty: Type) -> std::thread::Result<Vec<String>> {
+    panic::catch_unwind(move || render_type(flavor, storage_ty))
+}
+
+/// Convenience: assert that the `CREATE TABLE` for column `col` contains the
+/// expected substring (the rendered storage type).
+fn assert_col_type(sql: &[String], expected: &str) {
+    assert!(
+        sql.iter().any(|s| s.contains(expected)),
+        "expected column type {expected:?} in: {sql:?}"
+    );
+}
+
+fn make_enum_type(name: Option<&str>, variants: &[&str]) -> TypeEnum {
+    TypeEnum {
+        name: name.map(|s| s.to_string()),
+        variants: variants
+            .iter()
+            .map(|v| EnumVariant {
+                name: v.to_string(),
+            })
+            .collect(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Boolean
+// ---------------------------------------------------------------------------
+
+#[test]
+fn boolean_postgresql() {
+    let sql = render_type("postgresql", Type::Boolean);
+    assert_col_type(&sql, "\"col\" BOOLEAN");
+}
+
+#[test]
+fn boolean_mysql() {
+    let sql = render_type("mysql", Type::Boolean);
+    assert_col_type(&sql, "`col` BOOLEAN");
+}
+
+#[test]
+fn boolean_sqlite() {
+    let sql = render_type("sqlite", Type::Boolean);
+    assert_col_type(&sql, "\"col\" BOOLEAN");
+}
+
+// ---------------------------------------------------------------------------
+// Integer (signed)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn integer_2_postgresql_smallint() {
+    let sql = render_type("postgresql", Type::Integer(2));
+    assert_col_type(&sql, "\"col\" SMALLINT");
+}
+
+#[test]
+fn integer_2_mysql_smallint() {
+    let sql = render_type("mysql", Type::Integer(2));
+    assert_col_type(&sql, "`col` SMALLINT");
+}
+
+#[test]
+fn integer_2_sqlite_smallint() {
+    let sql = render_type("sqlite", Type::Integer(2));
+    assert_col_type(&sql, "\"col\" SMALLINT");
+}
+
+#[test]
+fn integer_4_postgresql_integer() {
+    let sql = render_type("postgresql", Type::Integer(4));
+    assert_col_type(&sql, "\"col\" INTEGER");
+}
+
+#[test]
+fn integer_4_mysql_integer() {
+    let sql = render_type("mysql", Type::Integer(4));
+    assert_col_type(&sql, "`col` INTEGER");
+}
+
+#[test]
+fn integer_4_sqlite_integer() {
+    let sql = render_type("sqlite", Type::Integer(4));
+    assert_col_type(&sql, "\"col\" INTEGER");
+}
+
+#[test]
+fn integer_8_postgresql_bigint() {
+    let sql = render_type("postgresql", Type::Integer(8));
+    assert_col_type(&sql, "\"col\" BIGINT");
+}
+
+#[test]
+fn integer_8_mysql_bigint() {
+    let sql = render_type("mysql", Type::Integer(8));
+    assert_col_type(&sql, "`col` BIGINT");
+}
+
+#[test]
+fn integer_8_sqlite_bigint() {
+    let sql = render_type("sqlite", Type::Integer(8));
+    assert_col_type(&sql, "\"col\" BIGINT");
+}
+
+// ---------------------------------------------------------------------------
+// UnsignedInteger
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unsigned_integer_1_mysql_tinyint_unsigned() {
+    let sql = render_type("mysql", Type::UnsignedInteger(1));
+    assert_col_type(&sql, "`col` TINYINT UNSIGNED");
+}
+
+#[test]
+fn unsigned_integer_2_mysql_smallint_unsigned() {
+    let sql = render_type("mysql", Type::UnsignedInteger(2));
+    assert_col_type(&sql, "`col` SMALLINT UNSIGNED");
+}
+
+#[test]
+fn unsigned_integer_4_mysql_int_unsigned() {
+    let sql = render_type("mysql", Type::UnsignedInteger(4));
+    assert_col_type(&sql, "`col` INT UNSIGNED");
+}
+
+#[test]
+fn unsigned_integer_8_mysql_bigint_unsigned() {
+    let sql = render_type("mysql", Type::UnsignedInteger(8));
+    assert_col_type(&sql, "`col` BIGINT UNSIGNED");
+}
+
+#[test]
+fn unsigned_integer_1_postgresql_promotes_to_smallint() {
+    let sql = render_type("postgresql", Type::UnsignedInteger(1));
+    assert_col_type(&sql, "\"col\" SMALLINT");
+}
+
+#[test]
+fn unsigned_integer_2_postgresql_promotes_to_integer() {
+    let sql = render_type("postgresql", Type::UnsignedInteger(2));
+    assert_col_type(&sql, "\"col\" INTEGER");
+}
+
+#[test]
+fn unsigned_integer_4_postgresql_promotes_to_bigint() {
+    let sql = render_type("postgresql", Type::UnsignedInteger(4));
+    assert_col_type(&sql, "\"col\" BIGINT");
+}
+
+#[test]
+fn unsigned_integer_8_postgresql_promotes_to_bigint() {
+    let sql = render_type("postgresql", Type::UnsignedInteger(8));
+    assert_col_type(&sql, "\"col\" BIGINT");
+}
+
+#[test]
+fn unsigned_integer_4_sqlite_integer() {
+    let sql = render_type("sqlite", Type::UnsignedInteger(4));
+    assert_col_type(&sql, "\"col\" INTEGER");
+}
+
+#[test]
+fn unsigned_integer_8_sqlite_integer() {
+    let sql = render_type("sqlite", Type::UnsignedInteger(8));
+    assert_col_type(&sql, "\"col\" INTEGER");
+}
+
+// ---------------------------------------------------------------------------
+// Float
+// ---------------------------------------------------------------------------
+
+#[test]
+fn float_4_postgresql_real() {
+    let sql = render_type("postgresql", Type::Float(4));
+    assert_col_type(&sql, "\"col\" REAL");
+}
+
+#[test]
+fn float_8_postgresql_double_precision() {
+    let sql = render_type("postgresql", Type::Float(8));
+    assert_col_type(&sql, "\"col\" DOUBLE PRECISION");
+}
+
+#[test]
+fn float_4_mysql_float() {
+    let sql = render_type("mysql", Type::Float(4));
+    assert_col_type(&sql, "`col` FLOAT");
+}
+
+#[test]
+fn float_8_mysql_double() {
+    let sql = render_type("mysql", Type::Float(8));
+    assert_col_type(&sql, "`col` DOUBLE");
+}
+
+#[test]
+fn float_4_sqlite_real() {
+    let sql = render_type("sqlite", Type::Float(4));
+    assert_col_type(&sql, "\"col\" REAL");
+}
+
+#[test]
+fn float_8_sqlite_real() {
+    let sql = render_type("sqlite", Type::Float(8));
+    assert_col_type(&sql, "\"col\" REAL");
+}
+
+// ---------------------------------------------------------------------------
+// Text & VarChar
+// ---------------------------------------------------------------------------
+
+#[test]
+fn text_postgresql() {
+    let sql = render_type("postgresql", Type::Text);
+    assert_col_type(&sql, "\"col\" TEXT");
+}
+
+#[test]
+fn text_mysql() {
+    let sql = render_type("mysql", Type::Text);
+    assert_col_type(&sql, "`col` TEXT");
+}
+
+#[test]
+fn text_sqlite() {
+    let sql = render_type("sqlite", Type::Text);
+    assert_col_type(&sql, "\"col\" TEXT");
+}
+
+#[test]
+fn varchar_postgresql() {
+    let sql = render_type("postgresql", Type::VarChar(255));
+    assert_col_type(&sql, "\"col\" VARCHAR(255)");
+}
+
+#[test]
+fn varchar_mysql() {
+    let sql = render_type("mysql", Type::VarChar(255));
+    assert_col_type(&sql, "`col` VARCHAR(255)");
+}
+
+#[test]
+fn varchar_sqlite() {
+    let sql = render_type("sqlite", Type::VarChar(255));
+    assert_col_type(&sql, "\"col\" VARCHAR(255)");
+}
+
+// ---------------------------------------------------------------------------
+// Uuid (PG only; MySQL / SQLite hit `todo!()`)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn uuid_postgresql() {
+    let sql = render_type("postgresql", Type::Uuid);
+    assert_col_type(&sql, "\"col\" UUID");
+}
+
+#[test]
+fn uuid_mysql_panics() {
+    let result = try_render_type("mysql", Type::Uuid);
+    assert!(result.is_err(), "expected MySQL UUID rendering to panic");
+}
+
+#[test]
+fn uuid_sqlite_panics() {
+    let result = try_render_type("sqlite", Type::Uuid);
+    assert!(result.is_err(), "expected SQLite UUID rendering to panic");
+}
+
+// ---------------------------------------------------------------------------
+// Numeric
+// ---------------------------------------------------------------------------
+
+#[test]
+fn numeric_unconstrained_postgresql() {
+    let sql = render_type("postgresql", Type::Numeric(None));
+    assert_col_type(&sql, "\"col\" NUMERIC");
+}
+
+#[test]
+fn numeric_with_precision_postgresql() {
+    let sql = render_type("postgresql", Type::Numeric(Some((10, 2))));
+    assert_col_type(&sql, "\"col\" NUMERIC(10, 2)");
+}
+
+#[test]
+fn numeric_with_precision_mysql() {
+    let sql = render_type("mysql", Type::Numeric(Some((10, 2))));
+    assert_col_type(&sql, "`col` DECIMAL(10, 2)");
+}
+
+#[test]
+fn numeric_unconstrained_mysql_panics() {
+    let result = try_render_type("mysql", Type::Numeric(None));
+    assert!(
+        result.is_err(),
+        "expected MySQL unconstrained NUMERIC rendering to panic"
+    );
+}
+
+#[test]
+fn numeric_unconstrained_sqlite_panics() {
+    let result = try_render_type("sqlite", Type::Numeric(None));
+    assert!(
+        result.is_err(),
+        "expected SQLite NUMERIC rendering to panic"
+    );
+}
+
+#[test]
+fn numeric_with_precision_sqlite_panics() {
+    let result = try_render_type("sqlite", Type::Numeric(Some((10, 2))));
+    assert!(
+        result.is_err(),
+        "expected SQLite NUMERIC(p, s) rendering to panic"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Binary (MySQL only)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn binary_mysql() {
+    let sql = render_type("mysql", Type::Binary(16));
+    assert_col_type(&sql, "`col` BINARY(16)");
+}
+
+#[test]
+fn binary_postgresql_panics() {
+    let result = try_render_type("postgresql", Type::Binary(16));
+    assert!(
+        result.is_err(),
+        "expected PostgreSQL BINARY(n) rendering to panic"
+    );
+}
+
+#[test]
+fn binary_sqlite_panics() {
+    let result = try_render_type("sqlite", Type::Binary(16));
+    assert!(
+        result.is_err(),
+        "expected SQLite BINARY(n) rendering to panic"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Blob
+// ---------------------------------------------------------------------------
+
+#[test]
+fn blob_postgresql_bytea() {
+    let sql = render_type("postgresql", Type::Blob);
+    assert_col_type(&sql, "\"col\" BYTEA");
+}
+
+#[test]
+fn blob_mysql_blob() {
+    let sql = render_type("mysql", Type::Blob);
+    assert_col_type(&sql, "`col` BLOB");
+}
+
+#[test]
+fn blob_sqlite_blob() {
+    let sql = render_type("sqlite", Type::Blob);
+    assert_col_type(&sql, "\"col\" BLOB");
+}
+
+// ---------------------------------------------------------------------------
+// Timestamp
+// ---------------------------------------------------------------------------
+
+#[test]
+fn timestamp_postgresql_timestamptz() {
+    let sql = render_type("postgresql", Type::Timestamp(6));
+    assert_col_type(&sql, "\"col\" TIMESTAMPTZ(6)");
+}
+
+#[test]
+fn timestamp_mysql_timestamp() {
+    let sql = render_type("mysql", Type::Timestamp(6));
+    assert_col_type(&sql, "`col` TIMESTAMP(6)");
+}
+
+#[test]
+fn timestamp_sqlite_panics() {
+    let result = try_render_type("sqlite", Type::Timestamp(6));
+    assert!(
+        result.is_err(),
+        "expected SQLite Timestamp rendering to panic"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Date
+// ---------------------------------------------------------------------------
+
+#[test]
+fn date_postgresql() {
+    let sql = render_type("postgresql", Type::Date);
+    assert_col_type(&sql, "\"col\" DATE");
+}
+
+#[test]
+fn date_mysql() {
+    let sql = render_type("mysql", Type::Date);
+    assert_col_type(&sql, "`col` DATE");
+}
+
+#[test]
+fn date_sqlite_panics() {
+    let result = try_render_type("sqlite", Type::Date);
+    assert!(result.is_err(), "expected SQLite Date rendering to panic");
+}
+
+// ---------------------------------------------------------------------------
+// Time
+// ---------------------------------------------------------------------------
+
+#[test]
+fn time_postgresql() {
+    let sql = render_type("postgresql", Type::Time(3));
+    assert_col_type(&sql, "\"col\" TIME(3)");
+}
+
+#[test]
+fn time_mysql() {
+    let sql = render_type("mysql", Type::Time(3));
+    assert_col_type(&sql, "`col` TIME(3)");
+}
+
+#[test]
+fn time_sqlite_panics() {
+    let result = try_render_type("sqlite", Type::Time(3));
+    assert!(result.is_err(), "expected SQLite Time rendering to panic");
+}
+
+// ---------------------------------------------------------------------------
+// DateTime
+// ---------------------------------------------------------------------------
+
+#[test]
+fn datetime_postgresql_timestamp() {
+    let sql = render_type("postgresql", Type::DateTime(6));
+    assert_col_type(&sql, "\"col\" TIMESTAMP(6)");
+}
+
+#[test]
+fn datetime_mysql_datetime() {
+    let sql = render_type("mysql", Type::DateTime(6));
+    assert_col_type(&sql, "`col` DATETIME(6)");
+}
+
+#[test]
+fn datetime_sqlite_panics() {
+    let result = try_render_type("sqlite", Type::DateTime(6));
+    assert!(
+        result.is_err(),
+        "expected SQLite DateTime rendering to panic"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Enum
+// ---------------------------------------------------------------------------
+
+#[test]
+fn enum_postgresql_named_type() {
+    let status = make_enum_type(Some("status"), &["pending", "active", "done"]);
+    let sql = render_type("postgresql", Type::Enum(status));
+    // Postgres references the named enum type; the actual `CREATE TYPE` is a
+    // separate statement. The column DDL just names the type.
+    assert_col_type(&sql, "\"col\" status NOT NULL");
+}
+
+#[test]
+fn enum_mysql_inline() {
+    let status = make_enum_type(None, &["pending", "active", "done"]);
+    let sql = render_type("mysql", Type::Enum(status));
+    assert_col_type(&sql, "`col` ENUM('pending', 'active', 'done')");
+}
+
+#[test]
+fn enum_sqlite_text_with_check() {
+    let status = make_enum_type(None, &["pending", "active", "done"]);
+    let sql = render_type("sqlite", Type::Enum(status));
+    // SQLite renders TEXT and adds a CHECK constraint in the column def.
+    assert_col_type(&sql, "\"col\" TEXT");
+    assert_col_type(&sql, "CHECK (\"col\" IN ('pending', 'active', 'done'))");
+}
+
+// ---------------------------------------------------------------------------
+// List
+// ---------------------------------------------------------------------------
+
+#[test]
+fn list_postgresql_array_suffix() {
+    let sql = render_type("postgresql", Type::List(Box::new(Type::Integer(8))));
+    assert_col_type(&sql, "\"col\" BIGINT[]");
+}
+
+#[test]
+fn list_postgresql_text_array() {
+    let sql = render_type("postgresql", Type::List(Box::new(Type::Text)));
+    assert_col_type(&sql, "\"col\" TEXT[]");
+}
+
+#[test]
+fn list_mysql_json() {
+    let sql = render_type("mysql", Type::List(Box::new(Type::Integer(8))));
+    assert_col_type(&sql, "`col` JSON");
+}
+
+#[test]
+fn list_sqlite_text() {
+    let sql = render_type("sqlite", Type::List(Box::new(Type::Integer(8))));
+    assert_col_type(&sql, "\"col\" TEXT");
+}
+
+// ---------------------------------------------------------------------------
+// Custom (pass-through)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn custom_pass_through_postgresql() {
+    let sql = render_type("postgresql", Type::Custom("CITEXT".to_string()));
+    assert_col_type(&sql, "\"col\" CITEXT");
+}
+
+#[test]
+fn custom_pass_through_mysql() {
+    let sql = render_type("mysql", Type::Custom("MEDIUMTEXT".to_string()));
+    assert_col_type(&sql, "`col` MEDIUMTEXT");
+}
+
+#[test]
+fn custom_pass_through_sqlite() {
+    let sql = render_type("sqlite", Type::Custom("ANY".to_string()));
+    assert_col_type(&sql, "\"col\" ANY");
+}

--- a/crates/toasty-sql/tests/serialize_types.rs
+++ b/crates/toasty-sql/tests/serialize_types.rs
@@ -7,6 +7,7 @@
 //! `#[should_panic(expected = "...")]` so the test suite documents which
 //! combinations intentionally panic today and tracks the exact panic message.
 
+use expect_test::expect;
 use toasty_core::{
     driver::Capability,
     schema::db::{
@@ -104,15 +105,6 @@ fn render_type(flavor: &str, storage_ty: Type) -> Vec<String> {
     serialize_migration(&stmts, flavor)
 }
 
-/// Convenience: assert that the `CREATE TABLE` for column `col` contains the
-/// expected substring (the rendered storage type).
-fn assert_col_type(sql: &[String], expected: &str) {
-    assert!(
-        sql.iter().any(|s| s.contains(expected)),
-        "expected column type {expected:?} in: {sql:?}"
-    );
-}
-
 fn make_enum_type(name: Option<&str>, variants: &[&str]) -> TypeEnum {
     TypeEnum {
         name: name.map(|s| s.to_string()),
@@ -131,20 +123,35 @@ fn make_enum_type(name: Option<&str>, variants: &[&str]) -> TypeEnum {
 
 #[test]
 fn boolean_postgresql() {
-    let sql = render_type("postgresql", Type::Boolean);
-    assert_col_type(&sql, "\"col\" BOOLEAN");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" BOOLEAN NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("postgresql", Type::Boolean).join("\n"));
 }
 
 #[test]
 fn boolean_mysql() {
-    let sql = render_type("mysql", Type::Boolean);
-    assert_col_type(&sql, "`col` BOOLEAN");
+    expect![[r#"
+        CREATE TABLE `t` (
+            `id` BIGINT NOT NULL,
+            `col` BOOLEAN NOT NULL,
+            PRIMARY KEY (`id`)
+        );"#]]
+    .assert_eq(&render_type("mysql", Type::Boolean).join("\n"));
 }
 
 #[test]
 fn boolean_sqlite() {
-    let sql = render_type("sqlite", Type::Boolean);
-    assert_col_type(&sql, "\"col\" BOOLEAN");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" BOOLEAN NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("sqlite", Type::Boolean).join("\n"));
 }
 
 // ---------------------------------------------------------------------------
@@ -153,56 +160,101 @@ fn boolean_sqlite() {
 
 #[test]
 fn integer_2_postgresql_smallint() {
-    let sql = render_type("postgresql", Type::Integer(2));
-    assert_col_type(&sql, "\"col\" SMALLINT");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" SMALLINT NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("postgresql", Type::Integer(2)).join("\n"));
 }
 
 #[test]
 fn integer_2_mysql_smallint() {
-    let sql = render_type("mysql", Type::Integer(2));
-    assert_col_type(&sql, "`col` SMALLINT");
+    expect![[r#"
+        CREATE TABLE `t` (
+            `id` BIGINT NOT NULL,
+            `col` SMALLINT NOT NULL,
+            PRIMARY KEY (`id`)
+        );"#]]
+    .assert_eq(&render_type("mysql", Type::Integer(2)).join("\n"));
 }
 
 #[test]
 fn integer_2_sqlite_smallint() {
-    let sql = render_type("sqlite", Type::Integer(2));
-    assert_col_type(&sql, "\"col\" SMALLINT");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" SMALLINT NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("sqlite", Type::Integer(2)).join("\n"));
 }
 
 #[test]
 fn integer_4_postgresql_integer() {
-    let sql = render_type("postgresql", Type::Integer(4));
-    assert_col_type(&sql, "\"col\" INTEGER");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" INTEGER NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("postgresql", Type::Integer(4)).join("\n"));
 }
 
 #[test]
 fn integer_4_mysql_integer() {
-    let sql = render_type("mysql", Type::Integer(4));
-    assert_col_type(&sql, "`col` INTEGER");
+    expect![[r#"
+        CREATE TABLE `t` (
+            `id` BIGINT NOT NULL,
+            `col` INTEGER NOT NULL,
+            PRIMARY KEY (`id`)
+        );"#]]
+    .assert_eq(&render_type("mysql", Type::Integer(4)).join("\n"));
 }
 
 #[test]
 fn integer_4_sqlite_integer() {
-    let sql = render_type("sqlite", Type::Integer(4));
-    assert_col_type(&sql, "\"col\" INTEGER");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" INTEGER NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("sqlite", Type::Integer(4)).join("\n"));
 }
 
 #[test]
 fn integer_8_postgresql_bigint() {
-    let sql = render_type("postgresql", Type::Integer(8));
-    assert_col_type(&sql, "\"col\" BIGINT");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" BIGINT NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("postgresql", Type::Integer(8)).join("\n"));
 }
 
 #[test]
 fn integer_8_mysql_bigint() {
-    let sql = render_type("mysql", Type::Integer(8));
-    assert_col_type(&sql, "`col` BIGINT");
+    expect![[r#"
+        CREATE TABLE `t` (
+            `id` BIGINT NOT NULL,
+            `col` BIGINT NOT NULL,
+            PRIMARY KEY (`id`)
+        );"#]]
+    .assert_eq(&render_type("mysql", Type::Integer(8)).join("\n"));
 }
 
 #[test]
 fn integer_8_sqlite_bigint() {
-    let sql = render_type("sqlite", Type::Integer(8));
-    assert_col_type(&sql, "\"col\" BIGINT");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" BIGINT NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("sqlite", Type::Integer(8)).join("\n"));
 }
 
 // ---------------------------------------------------------------------------
@@ -211,62 +263,112 @@ fn integer_8_sqlite_bigint() {
 
 #[test]
 fn unsigned_integer_1_mysql_tinyint_unsigned() {
-    let sql = render_type("mysql", Type::UnsignedInteger(1));
-    assert_col_type(&sql, "`col` TINYINT UNSIGNED");
+    expect![[r#"
+        CREATE TABLE `t` (
+            `id` BIGINT NOT NULL,
+            `col` TINYINT UNSIGNED NOT NULL,
+            PRIMARY KEY (`id`)
+        );"#]]
+    .assert_eq(&render_type("mysql", Type::UnsignedInteger(1)).join("\n"));
 }
 
 #[test]
 fn unsigned_integer_2_mysql_smallint_unsigned() {
-    let sql = render_type("mysql", Type::UnsignedInteger(2));
-    assert_col_type(&sql, "`col` SMALLINT UNSIGNED");
+    expect![[r#"
+        CREATE TABLE `t` (
+            `id` BIGINT NOT NULL,
+            `col` SMALLINT UNSIGNED NOT NULL,
+            PRIMARY KEY (`id`)
+        );"#]]
+    .assert_eq(&render_type("mysql", Type::UnsignedInteger(2)).join("\n"));
 }
 
 #[test]
 fn unsigned_integer_4_mysql_int_unsigned() {
-    let sql = render_type("mysql", Type::UnsignedInteger(4));
-    assert_col_type(&sql, "`col` INT UNSIGNED");
+    expect![[r#"
+        CREATE TABLE `t` (
+            `id` BIGINT NOT NULL,
+            `col` INT UNSIGNED NOT NULL,
+            PRIMARY KEY (`id`)
+        );"#]]
+    .assert_eq(&render_type("mysql", Type::UnsignedInteger(4)).join("\n"));
 }
 
 #[test]
 fn unsigned_integer_8_mysql_bigint_unsigned() {
-    let sql = render_type("mysql", Type::UnsignedInteger(8));
-    assert_col_type(&sql, "`col` BIGINT UNSIGNED");
+    expect![[r#"
+        CREATE TABLE `t` (
+            `id` BIGINT NOT NULL,
+            `col` BIGINT UNSIGNED NOT NULL,
+            PRIMARY KEY (`id`)
+        );"#]]
+    .assert_eq(&render_type("mysql", Type::UnsignedInteger(8)).join("\n"));
 }
 
 #[test]
 fn unsigned_integer_1_postgresql_promotes_to_smallint() {
-    let sql = render_type("postgresql", Type::UnsignedInteger(1));
-    assert_col_type(&sql, "\"col\" SMALLINT");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" SMALLINT NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("postgresql", Type::UnsignedInteger(1)).join("\n"));
 }
 
 #[test]
 fn unsigned_integer_2_postgresql_promotes_to_integer() {
-    let sql = render_type("postgresql", Type::UnsignedInteger(2));
-    assert_col_type(&sql, "\"col\" INTEGER");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" INTEGER NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("postgresql", Type::UnsignedInteger(2)).join("\n"));
 }
 
 #[test]
 fn unsigned_integer_4_postgresql_promotes_to_bigint() {
-    let sql = render_type("postgresql", Type::UnsignedInteger(4));
-    assert_col_type(&sql, "\"col\" BIGINT");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" BIGINT NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("postgresql", Type::UnsignedInteger(4)).join("\n"));
 }
 
 #[test]
 fn unsigned_integer_8_postgresql_promotes_to_bigint() {
-    let sql = render_type("postgresql", Type::UnsignedInteger(8));
-    assert_col_type(&sql, "\"col\" BIGINT");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" BIGINT NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("postgresql", Type::UnsignedInteger(8)).join("\n"));
 }
 
 #[test]
 fn unsigned_integer_4_sqlite_integer() {
-    let sql = render_type("sqlite", Type::UnsignedInteger(4));
-    assert_col_type(&sql, "\"col\" INTEGER");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" INTEGER NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("sqlite", Type::UnsignedInteger(4)).join("\n"));
 }
 
 #[test]
 fn unsigned_integer_8_sqlite_integer() {
-    let sql = render_type("sqlite", Type::UnsignedInteger(8));
-    assert_col_type(&sql, "\"col\" INTEGER");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" INTEGER NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("sqlite", Type::UnsignedInteger(8)).join("\n"));
 }
 
 // ---------------------------------------------------------------------------
@@ -275,38 +377,68 @@ fn unsigned_integer_8_sqlite_integer() {
 
 #[test]
 fn float_4_postgresql_real() {
-    let sql = render_type("postgresql", Type::Float(4));
-    assert_col_type(&sql, "\"col\" REAL");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" REAL NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("postgresql", Type::Float(4)).join("\n"));
 }
 
 #[test]
 fn float_8_postgresql_double_precision() {
-    let sql = render_type("postgresql", Type::Float(8));
-    assert_col_type(&sql, "\"col\" DOUBLE PRECISION");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" DOUBLE PRECISION NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("postgresql", Type::Float(8)).join("\n"));
 }
 
 #[test]
 fn float_4_mysql_float() {
-    let sql = render_type("mysql", Type::Float(4));
-    assert_col_type(&sql, "`col` FLOAT");
+    expect![[r#"
+        CREATE TABLE `t` (
+            `id` BIGINT NOT NULL,
+            `col` FLOAT NOT NULL,
+            PRIMARY KEY (`id`)
+        );"#]]
+    .assert_eq(&render_type("mysql", Type::Float(4)).join("\n"));
 }
 
 #[test]
 fn float_8_mysql_double() {
-    let sql = render_type("mysql", Type::Float(8));
-    assert_col_type(&sql, "`col` DOUBLE");
+    expect![[r#"
+        CREATE TABLE `t` (
+            `id` BIGINT NOT NULL,
+            `col` DOUBLE NOT NULL,
+            PRIMARY KEY (`id`)
+        );"#]]
+    .assert_eq(&render_type("mysql", Type::Float(8)).join("\n"));
 }
 
 #[test]
 fn float_4_sqlite_real() {
-    let sql = render_type("sqlite", Type::Float(4));
-    assert_col_type(&sql, "\"col\" REAL");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" REAL NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("sqlite", Type::Float(4)).join("\n"));
 }
 
 #[test]
 fn float_8_sqlite_real() {
-    let sql = render_type("sqlite", Type::Float(8));
-    assert_col_type(&sql, "\"col\" REAL");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" REAL NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("sqlite", Type::Float(8)).join("\n"));
 }
 
 // ---------------------------------------------------------------------------
@@ -315,38 +447,68 @@ fn float_8_sqlite_real() {
 
 #[test]
 fn text_postgresql() {
-    let sql = render_type("postgresql", Type::Text);
-    assert_col_type(&sql, "\"col\" TEXT");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" TEXT NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("postgresql", Type::Text).join("\n"));
 }
 
 #[test]
 fn text_mysql() {
-    let sql = render_type("mysql", Type::Text);
-    assert_col_type(&sql, "`col` TEXT");
+    expect![[r#"
+        CREATE TABLE `t` (
+            `id` BIGINT NOT NULL,
+            `col` TEXT NOT NULL,
+            PRIMARY KEY (`id`)
+        );"#]]
+    .assert_eq(&render_type("mysql", Type::Text).join("\n"));
 }
 
 #[test]
 fn text_sqlite() {
-    let sql = render_type("sqlite", Type::Text);
-    assert_col_type(&sql, "\"col\" TEXT");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" TEXT NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("sqlite", Type::Text).join("\n"));
 }
 
 #[test]
 fn varchar_postgresql() {
-    let sql = render_type("postgresql", Type::VarChar(255));
-    assert_col_type(&sql, "\"col\" VARCHAR(255)");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" VARCHAR(255) NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("postgresql", Type::VarChar(255)).join("\n"));
 }
 
 #[test]
 fn varchar_mysql() {
-    let sql = render_type("mysql", Type::VarChar(255));
-    assert_col_type(&sql, "`col` VARCHAR(255)");
+    expect![[r#"
+        CREATE TABLE `t` (
+            `id` BIGINT NOT NULL,
+            `col` VARCHAR(255) NOT NULL,
+            PRIMARY KEY (`id`)
+        );"#]]
+    .assert_eq(&render_type("mysql", Type::VarChar(255)).join("\n"));
 }
 
 #[test]
 fn varchar_sqlite() {
-    let sql = render_type("sqlite", Type::VarChar(255));
-    assert_col_type(&sql, "\"col\" VARCHAR(255)");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" VARCHAR(255) NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("sqlite", Type::VarChar(255)).join("\n"));
 }
 
 // ---------------------------------------------------------------------------
@@ -355,8 +517,13 @@ fn varchar_sqlite() {
 
 #[test]
 fn uuid_postgresql() {
-    let sql = render_type("postgresql", Type::Uuid);
-    assert_col_type(&sql, "\"col\" UUID");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" UUID NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("postgresql", Type::Uuid).join("\n"));
 }
 
 #[test]
@@ -377,20 +544,35 @@ fn uuid_sqlite_panics() {
 
 #[test]
 fn numeric_unconstrained_postgresql() {
-    let sql = render_type("postgresql", Type::Numeric(None));
-    assert_col_type(&sql, "\"col\" NUMERIC");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" NUMERIC NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("postgresql", Type::Numeric(None)).join("\n"));
 }
 
 #[test]
 fn numeric_with_precision_postgresql() {
-    let sql = render_type("postgresql", Type::Numeric(Some((10, 2))));
-    assert_col_type(&sql, "\"col\" NUMERIC(10, 2)");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" NUMERIC(10, 2) NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("postgresql", Type::Numeric(Some((10, 2)))).join("\n"));
 }
 
 #[test]
 fn numeric_with_precision_mysql() {
-    let sql = render_type("mysql", Type::Numeric(Some((10, 2))));
-    assert_col_type(&sql, "`col` DECIMAL(10, 2)");
+    expect![[r#"
+        CREATE TABLE `t` (
+            `id` BIGINT NOT NULL,
+            `col` DECIMAL(10, 2) NOT NULL,
+            PRIMARY KEY (`id`)
+        );"#]]
+    .assert_eq(&render_type("mysql", Type::Numeric(Some((10, 2)))).join("\n"));
 }
 
 #[test]
@@ -417,8 +599,13 @@ fn numeric_with_precision_sqlite_panics() {
 
 #[test]
 fn binary_mysql() {
-    let sql = render_type("mysql", Type::Binary(16));
-    assert_col_type(&sql, "`col` BINARY(16)");
+    expect![[r#"
+        CREATE TABLE `t` (
+            `id` BIGINT NOT NULL,
+            `col` BINARY(16) NOT NULL,
+            PRIMARY KEY (`id`)
+        );"#]]
+    .assert_eq(&render_type("mysql", Type::Binary(16)).join("\n"));
 }
 
 #[test]
@@ -439,20 +626,35 @@ fn binary_sqlite_panics() {
 
 #[test]
 fn blob_postgresql_bytea() {
-    let sql = render_type("postgresql", Type::Blob);
-    assert_col_type(&sql, "\"col\" BYTEA");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" BYTEA NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("postgresql", Type::Blob).join("\n"));
 }
 
 #[test]
 fn blob_mysql_blob() {
-    let sql = render_type("mysql", Type::Blob);
-    assert_col_type(&sql, "`col` BLOB");
+    expect![[r#"
+        CREATE TABLE `t` (
+            `id` BIGINT NOT NULL,
+            `col` BLOB NOT NULL,
+            PRIMARY KEY (`id`)
+        );"#]]
+    .assert_eq(&render_type("mysql", Type::Blob).join("\n"));
 }
 
 #[test]
 fn blob_sqlite_blob() {
-    let sql = render_type("sqlite", Type::Blob);
-    assert_col_type(&sql, "\"col\" BLOB");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" BLOB NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("sqlite", Type::Blob).join("\n"));
 }
 
 // ---------------------------------------------------------------------------
@@ -461,14 +663,24 @@ fn blob_sqlite_blob() {
 
 #[test]
 fn timestamp_postgresql_timestamptz() {
-    let sql = render_type("postgresql", Type::Timestamp(6));
-    assert_col_type(&sql, "\"col\" TIMESTAMPTZ(6)");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" TIMESTAMPTZ(6) NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("postgresql", Type::Timestamp(6)).join("\n"));
 }
 
 #[test]
 fn timestamp_mysql_timestamp() {
-    let sql = render_type("mysql", Type::Timestamp(6));
-    assert_col_type(&sql, "`col` TIMESTAMP(6)");
+    expect![[r#"
+        CREATE TABLE `t` (
+            `id` BIGINT NOT NULL,
+            `col` TIMESTAMP(6) NOT NULL,
+            PRIMARY KEY (`id`)
+        );"#]]
+    .assert_eq(&render_type("mysql", Type::Timestamp(6)).join("\n"));
 }
 
 #[test]
@@ -483,14 +695,24 @@ fn timestamp_sqlite_panics() {
 
 #[test]
 fn date_postgresql() {
-    let sql = render_type("postgresql", Type::Date);
-    assert_col_type(&sql, "\"col\" DATE");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" DATE NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("postgresql", Type::Date).join("\n"));
 }
 
 #[test]
 fn date_mysql() {
-    let sql = render_type("mysql", Type::Date);
-    assert_col_type(&sql, "`col` DATE");
+    expect![[r#"
+        CREATE TABLE `t` (
+            `id` BIGINT NOT NULL,
+            `col` DATE NOT NULL,
+            PRIMARY KEY (`id`)
+        );"#]]
+    .assert_eq(&render_type("mysql", Type::Date).join("\n"));
 }
 
 #[test]
@@ -505,14 +727,24 @@ fn date_sqlite_panics() {
 
 #[test]
 fn time_postgresql() {
-    let sql = render_type("postgresql", Type::Time(3));
-    assert_col_type(&sql, "\"col\" TIME(3)");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" TIME(3) NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("postgresql", Type::Time(3)).join("\n"));
 }
 
 #[test]
 fn time_mysql() {
-    let sql = render_type("mysql", Type::Time(3));
-    assert_col_type(&sql, "`col` TIME(3)");
+    expect![[r#"
+        CREATE TABLE `t` (
+            `id` BIGINT NOT NULL,
+            `col` TIME(3) NOT NULL,
+            PRIMARY KEY (`id`)
+        );"#]]
+    .assert_eq(&render_type("mysql", Type::Time(3)).join("\n"));
 }
 
 #[test]
@@ -527,14 +759,24 @@ fn time_sqlite_panics() {
 
 #[test]
 fn datetime_postgresql_timestamp() {
-    let sql = render_type("postgresql", Type::DateTime(6));
-    assert_col_type(&sql, "\"col\" TIMESTAMP(6)");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" TIMESTAMP(6) NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("postgresql", Type::DateTime(6)).join("\n"));
 }
 
 #[test]
 fn datetime_mysql_datetime() {
-    let sql = render_type("mysql", Type::DateTime(6));
-    assert_col_type(&sql, "`col` DATETIME(6)");
+    expect![[r#"
+        CREATE TABLE `t` (
+            `id` BIGINT NOT NULL,
+            `col` DATETIME(6) NOT NULL,
+            PRIMARY KEY (`id`)
+        );"#]]
+    .assert_eq(&render_type("mysql", Type::DateTime(6)).join("\n"));
 }
 
 #[test]
@@ -550,26 +792,38 @@ fn datetime_sqlite_panics() {
 #[test]
 fn enum_postgresql_named_type() {
     let status = make_enum_type(Some("status"), &["pending", "active", "done"]);
-    let sql = render_type("postgresql", Type::Enum(status));
-    // Postgres references the named enum type; the actual `CREATE TYPE` is a
-    // separate statement. The column DDL just names the type.
-    assert_col_type(&sql, "\"col\" status NOT NULL");
+    expect![[r#"
+        CREATE TYPE "status" AS ENUM ('pending', 'active', 'done');
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" status NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("postgresql", Type::Enum(status)).join("\n"));
 }
 
 #[test]
 fn enum_mysql_inline() {
     let status = make_enum_type(None, &["pending", "active", "done"]);
-    let sql = render_type("mysql", Type::Enum(status));
-    assert_col_type(&sql, "`col` ENUM('pending', 'active', 'done')");
+    expect![[r#"
+        CREATE TABLE `t` (
+            `id` BIGINT NOT NULL,
+            `col` ENUM('pending', 'active', 'done') NOT NULL,
+            PRIMARY KEY (`id`)
+        );"#]]
+    .assert_eq(&render_type("mysql", Type::Enum(status)).join("\n"));
 }
 
 #[test]
 fn enum_sqlite_text_with_check() {
     let status = make_enum_type(None, &["pending", "active", "done"]);
-    let sql = render_type("sqlite", Type::Enum(status));
-    // SQLite renders TEXT and adds a CHECK constraint in the column def.
-    assert_col_type(&sql, "\"col\" TEXT");
-    assert_col_type(&sql, "CHECK (\"col\" IN ('pending', 'active', 'done'))");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" TEXT NOT NULL CHECK ("col" IN ('pending', 'active', 'done')),
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("sqlite", Type::Enum(status)).join("\n"));
 }
 
 // ---------------------------------------------------------------------------
@@ -578,26 +832,46 @@ fn enum_sqlite_text_with_check() {
 
 #[test]
 fn list_postgresql_array_suffix() {
-    let sql = render_type("postgresql", Type::List(Box::new(Type::Integer(8))));
-    assert_col_type(&sql, "\"col\" BIGINT[]");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" BIGINT[] NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("postgresql", Type::List(Box::new(Type::Integer(8)))).join("\n"));
 }
 
 #[test]
 fn list_postgresql_text_array() {
-    let sql = render_type("postgresql", Type::List(Box::new(Type::Text)));
-    assert_col_type(&sql, "\"col\" TEXT[]");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" TEXT[] NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("postgresql", Type::List(Box::new(Type::Text))).join("\n"));
 }
 
 #[test]
 fn list_mysql_json() {
-    let sql = render_type("mysql", Type::List(Box::new(Type::Integer(8))));
-    assert_col_type(&sql, "`col` JSON");
+    expect![[r#"
+        CREATE TABLE `t` (
+            `id` BIGINT NOT NULL,
+            `col` JSON NOT NULL,
+            PRIMARY KEY (`id`)
+        );"#]]
+    .assert_eq(&render_type("mysql", Type::List(Box::new(Type::Integer(8)))).join("\n"));
 }
 
 #[test]
 fn list_sqlite_text() {
-    let sql = render_type("sqlite", Type::List(Box::new(Type::Integer(8))));
-    assert_col_type(&sql, "\"col\" TEXT");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" TEXT NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("sqlite", Type::List(Box::new(Type::Integer(8)))).join("\n"));
 }
 
 // ---------------------------------------------------------------------------
@@ -606,18 +880,33 @@ fn list_sqlite_text() {
 
 #[test]
 fn custom_pass_through_postgresql() {
-    let sql = render_type("postgresql", Type::Custom("CITEXT".to_string()));
-    assert_col_type(&sql, "\"col\" CITEXT");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" CITEXT NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("postgresql", Type::Custom("CITEXT".to_string())).join("\n"));
 }
 
 #[test]
 fn custom_pass_through_mysql() {
-    let sql = render_type("mysql", Type::Custom("MEDIUMTEXT".to_string()));
-    assert_col_type(&sql, "`col` MEDIUMTEXT");
+    expect![[r#"
+        CREATE TABLE `t` (
+            `id` BIGINT NOT NULL,
+            `col` MEDIUMTEXT NOT NULL,
+            PRIMARY KEY (`id`)
+        );"#]]
+    .assert_eq(&render_type("mysql", Type::Custom("MEDIUMTEXT".to_string())).join("\n"));
 }
 
 #[test]
 fn custom_pass_through_sqlite() {
-    let sql = render_type("sqlite", Type::Custom("ANY".to_string()));
-    assert_col_type(&sql, "\"col\" ANY");
+    expect![[r#"
+        CREATE TABLE "t" (
+            "id" BIGINT NOT NULL,
+            "col" ANY NOT NULL,
+            PRIMARY KEY ("id")
+        );"#]]
+    .assert_eq(&render_type("sqlite", Type::Custom("ANY".to_string())).join("\n"));
 }

--- a/crates/toasty-sql/tests/serialize_update_assignments.rs
+++ b/crates/toasty-sql/tests/serialize_update_assignments.rs
@@ -1,0 +1,368 @@
+//! Verifies the flavor-divergent serialization of `Assignments` in `UPDATE`
+//! statements: `Set`, `Append`, `Remove`, `Pop`, and `RemoveAt`.
+//!
+//! Plain `Set` renders the same shape across all flavors (with backend ident
+//! quoting). The collection operators (`Append`, `Remove`, `Pop`, `RemoveAt`)
+//! target a `Vec<scalar>` column and render flavor-specific shapes. Currently
+//! only PostgreSQL has implementations of `Remove` / `Pop` / `RemoveAt`; MySQL
+//! and SQLite panic in the serializer because the lowering is supposed to
+//! reject those backends earlier. The tests below capture that explicitly.
+//!
+//! Tests construct the AST directly so the serializer is exercised in
+//! isolation — no lowering pipeline involved.
+
+use toasty_core::{
+    schema::db::{Column, ColumnId, PrimaryKey, Schema, Table, TableId, Type as StorageType},
+    stmt::{self, Assignments, Expr, Filter, Update, UpdateTarget},
+};
+use toasty_sql::{Serializer, Statement as SqlStatement};
+
+#[derive(Clone, Copy)]
+enum Flavor {
+    Sqlite,
+    Postgresql,
+    Mysql,
+}
+
+/// Build a `users` table with `id INTEGER PRIMARY KEY` plus the supplied
+/// extra columns. Each extra column is either a scalar `TEXT` column or a
+/// `Vec<scalar>` column (rendered as a `List(I64)` so the column has a list
+/// type the collection operators can target).
+fn make_table(id: usize, name: &str, cols: &[(&str, bool)]) -> Table {
+    // (name, is_list)
+    let mut columns = vec![Column {
+        id: ColumnId {
+            table: TableId(id),
+            index: 0,
+        },
+        name: "id".to_string(),
+        ty: stmt::Type::I64,
+        storage_ty: StorageType::Integer(8),
+        nullable: false,
+        primary_key: true,
+        auto_increment: false,
+        versionable: false,
+    }];
+    for (i, (col_name, is_list)) in cols.iter().enumerate() {
+        let (ty, storage_ty) = if *is_list {
+            (
+                stmt::Type::List(Box::new(stmt::Type::I64)),
+                StorageType::List(Box::new(StorageType::Integer(8))),
+            )
+        } else {
+            (stmt::Type::String, StorageType::Text)
+        };
+        columns.push(Column {
+            id: ColumnId {
+                table: TableId(id),
+                index: i + 1,
+            },
+            name: (*col_name).to_string(),
+            ty,
+            storage_ty,
+            nullable: false,
+            primary_key: false,
+            auto_increment: false,
+            versionable: false,
+        });
+    }
+    Table {
+        id: TableId(id),
+        name: name.to_string(),
+        columns,
+        primary_key: PrimaryKey {
+            columns: vec![ColumnId {
+                table: TableId(id),
+                index: 0,
+            }],
+            index: toasty_core::schema::db::IndexId {
+                table: TableId(id),
+                index: 0,
+            },
+        },
+        indices: vec![],
+    }
+}
+
+fn render(flavor: Flavor, schema: &Schema, stmt: stmt::Statement) -> String {
+    let sql_stmt = SqlStatement::from(stmt);
+    match flavor {
+        Flavor::Sqlite => Serializer::sqlite(schema).serialize(&sql_stmt),
+        Flavor::Postgresql => Serializer::postgresql(schema).serialize(&sql_stmt),
+        Flavor::Mysql => Serializer::mysql(schema).serialize(&sql_stmt),
+    }
+}
+
+/// Schema with a `users` table holding `id`, scalar `name`, and list `tags`.
+fn users_schema() -> Schema {
+    Schema {
+        tables: vec![make_table(0, "users", &[("name", false), ("tags", true)])],
+    }
+}
+
+/// Build `UPDATE users SET <single assignment>` with no `WHERE`, no
+/// `RETURNING`, and no `Condition`.
+fn update_with(assignments: Assignments) -> stmt::Statement {
+    Update {
+        target: UpdateTarget::Table(TableId(0)),
+        assignments,
+        filter: Filter::ALL,
+        condition: stmt::Condition::default(),
+        returning: None,
+    }
+    .into()
+}
+
+// -----------------------------------------------------------------------------
+// Set (plain assignment) — same shape across flavors, modulo ident quoting.
+// -----------------------------------------------------------------------------
+
+#[test]
+fn set_assignment_postgresql() {
+    let schema = users_schema();
+    let mut assignments = Assignments::default();
+    assignments.set(1usize, Expr::from("x"));
+
+    let sql = render(Flavor::Postgresql, &schema, update_with(assignments));
+    assert!(
+        sql.contains(r#"SET "name" = 'x'"#),
+        "expected `SET \"name\" = 'x'` in: {sql}"
+    );
+}
+
+#[test]
+fn set_assignment_mysql() {
+    let schema = users_schema();
+    let mut assignments = Assignments::default();
+    assignments.set(1usize, Expr::from("x"));
+
+    let sql = render(Flavor::Mysql, &schema, update_with(assignments));
+    assert!(
+        sql.contains("SET `name` = 'x'"),
+        "expected ``SET `name` = 'x'`` in: {sql}"
+    );
+}
+
+#[test]
+fn set_assignment_sqlite() {
+    let schema = users_schema();
+    let mut assignments = Assignments::default();
+    assignments.set(1usize, Expr::from("x"));
+
+    let sql = render(Flavor::Sqlite, &schema, update_with(assignments));
+    assert!(
+        sql.contains(r#"SET "name" = 'x'"#),
+        "expected `SET \"name\" = 'x'` in: {sql}"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Append — flavor-divergent: PG `||`, MySQL `JSON_MERGE_PRESERVE`, SQLite
+// `json_each` subquery.
+// -----------------------------------------------------------------------------
+
+#[test]
+fn append_assignment_postgresql() {
+    let schema = users_schema();
+    let mut assignments = Assignments::default();
+    assignments.append(2usize, Expr::list([Expr::from(7i64)]));
+
+    let sql = render(Flavor::Postgresql, &schema, update_with(assignments));
+    // PostgreSQL uses `text[] || text[]` array concatenation.
+    assert!(
+        sql.contains(r#""tags" = "tags" || "#),
+        "expected `\"tags\" = \"tags\" || ...` in: {sql}"
+    );
+}
+
+#[test]
+fn append_assignment_mysql() {
+    let schema = users_schema();
+    let mut assignments = Assignments::default();
+    assignments.append(2usize, Expr::list([Expr::from(7i64)]));
+
+    let sql = render(Flavor::Mysql, &schema, update_with(assignments));
+    // MySQL uses JSON_MERGE_PRESERVE for JSON-array append semantics.
+    assert!(
+        sql.contains("JSON_MERGE_PRESERVE(`tags`, "),
+        "expected `JSON_MERGE_PRESERVE(`tags`, ...)` in: {sql}"
+    );
+}
+
+#[test]
+fn append_assignment_sqlite() {
+    let schema = users_schema();
+    let mut assignments = Assignments::default();
+    assignments.append(2usize, Expr::list([Expr::from(7i64)]));
+
+    let sql = render(Flavor::Sqlite, &schema, update_with(assignments));
+    // SQLite uses a `json_group_array` / `json_each` UNION ALL subquery.
+    assert!(
+        sql.contains("SELECT json_group_array(value) FROM"),
+        "expected SQLite json_group_array subquery in: {sql}"
+    );
+    assert!(
+        sql.contains(r#"json_each("tags")"#),
+        "expected `json_each(\"tags\")` in: {sql}"
+    );
+    assert!(
+        sql.contains("UNION ALL SELECT value FROM json_each("),
+        "expected UNION ALL json_each(rhs) in: {sql}"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Remove — PG `array_remove`; MySQL / SQLite panic in the serializer.
+// -----------------------------------------------------------------------------
+
+#[test]
+fn remove_assignment_postgresql() {
+    let schema = users_schema();
+    let mut assignments = Assignments::default();
+    assignments.remove(2usize, Expr::from(7i64));
+
+    let sql = render(Flavor::Postgresql, &schema, update_with(assignments));
+    assert!(
+        sql.contains(r#"array_remove("tags", "#),
+        "expected `array_remove(\"tags\", ...)` in: {sql}"
+    );
+}
+
+#[test]
+fn remove_assignment_mysql_panics() {
+    // The MySQL branch of `serialize_remove` is a `panic!` — the lowering
+    // is supposed to reject `vec_remove` on this backend before reaching
+    // the serializer.
+    let schema = users_schema();
+    let mut assignments = Assignments::default();
+    assignments.remove(2usize, Expr::from(7i64));
+
+    let result =
+        std::panic::catch_unwind(|| render(Flavor::Mysql, &schema, update_with(assignments)));
+    assert!(
+        result.is_err(),
+        "expected MySQL `Remove` serialization to panic, got: {:?}",
+        result.ok()
+    );
+}
+
+#[test]
+fn remove_assignment_sqlite_panics() {
+    let schema = users_schema();
+    let mut assignments = Assignments::default();
+    assignments.remove(2usize, Expr::from(7i64));
+
+    let result =
+        std::panic::catch_unwind(|| render(Flavor::Sqlite, &schema, update_with(assignments)));
+    assert!(
+        result.is_err(),
+        "expected SQLite `Remove` serialization to panic, got: {:?}",
+        result.ok()
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Pop — PG 1-based array slice; MySQL / SQLite panic.
+// -----------------------------------------------------------------------------
+
+#[test]
+fn pop_assignment_postgresql() {
+    let schema = users_schema();
+    let mut assignments = Assignments::default();
+    assignments.pop(2usize);
+
+    let sql = render(Flavor::Postgresql, &schema, update_with(assignments));
+    // PG: `col[1:cardinality(col) - 1]` — drops the last element via slicing.
+    assert!(
+        sql.contains(r#""tags" = "tags"[1:cardinality("tags") - 1]"#),
+        "expected PG array slice `\"tags\"[1:cardinality(\"tags\") - 1]` in: {sql}"
+    );
+}
+
+#[test]
+fn pop_assignment_mysql_panics() {
+    let schema = users_schema();
+    let mut assignments = Assignments::default();
+    assignments.pop(2usize);
+
+    let result =
+        std::panic::catch_unwind(|| render(Flavor::Mysql, &schema, update_with(assignments)));
+    assert!(
+        result.is_err(),
+        "expected MySQL `Pop` serialization to panic, got: {:?}",
+        result.ok()
+    );
+}
+
+#[test]
+fn pop_assignment_sqlite_panics() {
+    let schema = users_schema();
+    let mut assignments = Assignments::default();
+    assignments.pop(2usize);
+
+    let result =
+        std::panic::catch_unwind(|| render(Flavor::Sqlite, &schema, update_with(assignments)));
+    assert!(
+        result.is_err(),
+        "expected SQLite `Pop` serialization to panic, got: {:?}",
+        result.ok()
+    );
+}
+
+// -----------------------------------------------------------------------------
+// RemoveAt — PG prefix + suffix concat via array slices; MySQL / SQLite panic.
+// -----------------------------------------------------------------------------
+
+#[test]
+fn remove_at_assignment_postgresql() {
+    let schema = users_schema();
+    let mut assignments = Assignments::default();
+    assignments.remove_at(2usize, Expr::from(3i64));
+
+    let sql = render(Flavor::Postgresql, &schema, update_with(assignments));
+    // `col[1:idx] || col[idx + 2:cardinality(col)]` — keep prefix, drop the
+    // element at user-facing index `idx`, append suffix. PG arrays are
+    // 1-based, so element at user index `i` lives at PG position `i + 1`.
+    assert!(
+        sql.contains(r#""tags"[1:3]"#),
+        "expected prefix slice `\"tags\"[1:3]` in: {sql}"
+    );
+    assert!(
+        sql.contains(r#""tags"[3 + 2:cardinality("tags")]"#),
+        "expected suffix slice `\"tags\"[3 + 2:cardinality(\"tags\")]` in: {sql}"
+    );
+    assert!(
+        sql.contains(r#""tags"[1:3] || "tags"[3 + 2:cardinality("tags")]"#),
+        "expected concat of prefix and suffix slices in: {sql}"
+    );
+}
+
+#[test]
+fn remove_at_assignment_mysql_panics() {
+    let schema = users_schema();
+    let mut assignments = Assignments::default();
+    assignments.remove_at(2usize, Expr::from(3i64));
+
+    let result =
+        std::panic::catch_unwind(|| render(Flavor::Mysql, &schema, update_with(assignments)));
+    assert!(
+        result.is_err(),
+        "expected MySQL `RemoveAt` serialization to panic, got: {:?}",
+        result.ok()
+    );
+}
+
+#[test]
+fn remove_at_assignment_sqlite_panics() {
+    let schema = users_schema();
+    let mut assignments = Assignments::default();
+    assignments.remove_at(2usize, Expr::from(3i64));
+
+    let result =
+        std::panic::catch_unwind(|| render(Flavor::Sqlite, &schema, update_with(assignments)));
+    assert!(
+        result.is_err(),
+        "expected SQLite `RemoveAt` serialization to panic, got: {:?}",
+        result.ok()
+    );
+}

--- a/crates/toasty-sql/tests/serialize_update_assignments.rs
+++ b/crates/toasty-sql/tests/serialize_update_assignments.rs
@@ -228,37 +228,26 @@ fn remove_assignment_postgresql() {
     );
 }
 
+// The MySQL/SQLite branches of `serialize_remove` are `panic!` — the
+// lowering is supposed to reject `vec_remove` on these backends before
+// reaching the serializer.
+
 #[test]
+#[should_panic(expected = "stmt::remove on a Vec<scalar> field is not yet implemented")]
 fn remove_assignment_mysql_panics() {
-    // The MySQL branch of `serialize_remove` is a `panic!` — the lowering
-    // is supposed to reject `vec_remove` on this backend before reaching
-    // the serializer.
     let schema = users_schema();
     let mut assignments = Assignments::default();
     assignments.remove(2usize, Expr::from(7i64));
-
-    let result =
-        std::panic::catch_unwind(|| render(Flavor::Mysql, &schema, update_with(assignments)));
-    assert!(
-        result.is_err(),
-        "expected MySQL `Remove` serialization to panic, got: {:?}",
-        result.ok()
-    );
+    render(Flavor::Mysql, &schema, update_with(assignments));
 }
 
 #[test]
+#[should_panic(expected = "stmt::remove on a Vec<scalar> field is not yet implemented")]
 fn remove_assignment_sqlite_panics() {
     let schema = users_schema();
     let mut assignments = Assignments::default();
     assignments.remove(2usize, Expr::from(7i64));
-
-    let result =
-        std::panic::catch_unwind(|| render(Flavor::Sqlite, &schema, update_with(assignments)));
-    assert!(
-        result.is_err(),
-        "expected SQLite `Remove` serialization to panic, got: {:?}",
-        result.ok()
-    );
+    render(Flavor::Sqlite, &schema, update_with(assignments));
 }
 
 // -----------------------------------------------------------------------------
@@ -280,33 +269,21 @@ fn pop_assignment_postgresql() {
 }
 
 #[test]
+#[should_panic(expected = "stmt::pop on a Vec<scalar> field is not yet implemented")]
 fn pop_assignment_mysql_panics() {
     let schema = users_schema();
     let mut assignments = Assignments::default();
     assignments.pop(2usize);
-
-    let result =
-        std::panic::catch_unwind(|| render(Flavor::Mysql, &schema, update_with(assignments)));
-    assert!(
-        result.is_err(),
-        "expected MySQL `Pop` serialization to panic, got: {:?}",
-        result.ok()
-    );
+    render(Flavor::Mysql, &schema, update_with(assignments));
 }
 
 #[test]
+#[should_panic(expected = "stmt::pop on a Vec<scalar> field is not yet implemented")]
 fn pop_assignment_sqlite_panics() {
     let schema = users_schema();
     let mut assignments = Assignments::default();
     assignments.pop(2usize);
-
-    let result =
-        std::panic::catch_unwind(|| render(Flavor::Sqlite, &schema, update_with(assignments)));
-    assert!(
-        result.is_err(),
-        "expected SQLite `Pop` serialization to panic, got: {:?}",
-        result.ok()
-    );
+    render(Flavor::Sqlite, &schema, update_with(assignments));
 }
 
 // -----------------------------------------------------------------------------
@@ -338,31 +315,19 @@ fn remove_at_assignment_postgresql() {
 }
 
 #[test]
+#[should_panic(expected = "stmt::remove_at on a Vec<scalar> field is not yet implemented")]
 fn remove_at_assignment_mysql_panics() {
     let schema = users_schema();
     let mut assignments = Assignments::default();
     assignments.remove_at(2usize, Expr::from(3i64));
-
-    let result =
-        std::panic::catch_unwind(|| render(Flavor::Mysql, &schema, update_with(assignments)));
-    assert!(
-        result.is_err(),
-        "expected MySQL `RemoveAt` serialization to panic, got: {:?}",
-        result.ok()
-    );
+    render(Flavor::Mysql, &schema, update_with(assignments));
 }
 
 #[test]
+#[should_panic(expected = "stmt::remove_at on a Vec<scalar> field is not yet implemented")]
 fn remove_at_assignment_sqlite_panics() {
     let schema = users_schema();
     let mut assignments = Assignments::default();
     assignments.remove_at(2usize, Expr::from(3i64));
-
-    let result =
-        std::panic::catch_unwind(|| render(Flavor::Sqlite, &schema, update_with(assignments)));
-    assert!(
-        result.is_err(),
-        "expected SQLite `RemoveAt` serialization to panic, got: {:?}",
-        result.ok()
-    );
+    render(Flavor::Sqlite, &schema, update_with(assignments));
 }

--- a/crates/toasty-sql/tests/serialize_update_assignments.rs
+++ b/crates/toasty-sql/tests/serialize_update_assignments.rs
@@ -11,6 +11,7 @@
 //! Tests construct the AST directly so the serializer is exercised in
 //! isolation — no lowering pipeline involved.
 
+use expect_test::expect;
 use toasty_core::{
     schema::db::{Column, ColumnId, PrimaryKey, Schema, Table, TableId, Type as StorageType},
     stmt::{self, Assignments, Expr, Filter, Update, UpdateTarget},
@@ -123,11 +124,11 @@ fn set_assignment_postgresql() {
     let mut assignments = Assignments::default();
     assignments.set(1usize, Expr::from("x"));
 
-    let sql = render(Flavor::Postgresql, &schema, update_with(assignments));
-    assert!(
-        sql.contains(r#"SET "name" = 'x'"#),
-        "expected `SET \"name\" = 'x'` in: {sql}"
-    );
+    expect![[r#"UPDATE "users" AS tbl_0_0 SET "name" = 'x';"#]].assert_eq(&render(
+        Flavor::Postgresql,
+        &schema,
+        update_with(assignments),
+    ));
 }
 
 #[test]
@@ -136,11 +137,11 @@ fn set_assignment_mysql() {
     let mut assignments = Assignments::default();
     assignments.set(1usize, Expr::from("x"));
 
-    let sql = render(Flavor::Mysql, &schema, update_with(assignments));
-    assert!(
-        sql.contains("SET `name` = 'x'"),
-        "expected ``SET `name` = 'x'`` in: {sql}"
-    );
+    expect!["UPDATE `users` AS tbl_0_0 SET `name` = 'x';"].assert_eq(&render(
+        Flavor::Mysql,
+        &schema,
+        update_with(assignments),
+    ));
 }
 
 #[test]
@@ -149,11 +150,11 @@ fn set_assignment_sqlite() {
     let mut assignments = Assignments::default();
     assignments.set(1usize, Expr::from("x"));
 
-    let sql = render(Flavor::Sqlite, &schema, update_with(assignments));
-    assert!(
-        sql.contains(r#"SET "name" = 'x'"#),
-        "expected `SET \"name\" = 'x'` in: {sql}"
-    );
+    expect![[r#"UPDATE "users" AS tbl_0_0 SET "name" = 'x';"#]].assert_eq(&render(
+        Flavor::Sqlite,
+        &schema,
+        update_with(assignments),
+    ));
 }
 
 // -----------------------------------------------------------------------------
@@ -167,12 +168,11 @@ fn append_assignment_postgresql() {
     let mut assignments = Assignments::default();
     assignments.append(2usize, Expr::list([Expr::from(7i64)]));
 
-    let sql = render(Flavor::Postgresql, &schema, update_with(assignments));
-    // PostgreSQL uses `text[] || text[]` array concatenation.
-    assert!(
-        sql.contains(r#""tags" = "tags" || "#),
-        "expected `\"tags\" = \"tags\" || ...` in: {sql}"
-    );
+    expect![[r#"UPDATE "users" AS tbl_0_0 SET "tags" = "tags" || (7);"#]].assert_eq(&render(
+        Flavor::Postgresql,
+        &schema,
+        update_with(assignments),
+    ));
 }
 
 #[test]
@@ -181,12 +181,8 @@ fn append_assignment_mysql() {
     let mut assignments = Assignments::default();
     assignments.append(2usize, Expr::list([Expr::from(7i64)]));
 
-    let sql = render(Flavor::Mysql, &schema, update_with(assignments));
-    // MySQL uses JSON_MERGE_PRESERVE for JSON-array append semantics.
-    assert!(
-        sql.contains("JSON_MERGE_PRESERVE(`tags`, "),
-        "expected `JSON_MERGE_PRESERVE(`tags`, ...)` in: {sql}"
-    );
+    expect!["UPDATE `users` AS tbl_0_0 SET `tags` = JSON_MERGE_PRESERVE(`tags`, (7));"]
+        .assert_eq(&render(Flavor::Mysql, &schema, update_with(assignments)));
 }
 
 #[test]
@@ -195,20 +191,7 @@ fn append_assignment_sqlite() {
     let mut assignments = Assignments::default();
     assignments.append(2usize, Expr::list([Expr::from(7i64)]));
 
-    let sql = render(Flavor::Sqlite, &schema, update_with(assignments));
-    // SQLite uses a `json_group_array` / `json_each` UNION ALL subquery.
-    assert!(
-        sql.contains("SELECT json_group_array(value) FROM"),
-        "expected SQLite json_group_array subquery in: {sql}"
-    );
-    assert!(
-        sql.contains(r#"json_each("tags")"#),
-        "expected `json_each(\"tags\")` in: {sql}"
-    );
-    assert!(
-        sql.contains("UNION ALL SELECT value FROM json_each("),
-        "expected UNION ALL json_each(rhs) in: {sql}"
-    );
+    expect![[r#"UPDATE "users" AS tbl_0_0 SET "tags" = (SELECT json_group_array(value) FROM (SELECT value FROM json_each("tags") UNION ALL SELECT value FROM json_each((7))));"#]].assert_eq(&render(Flavor::Sqlite, &schema, update_with(assignments)));
 }
 
 // -----------------------------------------------------------------------------
@@ -221,10 +204,8 @@ fn remove_assignment_postgresql() {
     let mut assignments = Assignments::default();
     assignments.remove(2usize, Expr::from(7i64));
 
-    let sql = render(Flavor::Postgresql, &schema, update_with(assignments));
-    assert!(
-        sql.contains(r#"array_remove("tags", "#),
-        "expected `array_remove(\"tags\", ...)` in: {sql}"
+    expect![[r#"UPDATE "users" AS tbl_0_0 SET "tags" = array_remove("tags", 7);"#]].assert_eq(
+        &render(Flavor::Postgresql, &schema, update_with(assignments)),
     );
 }
 
@@ -260,12 +241,12 @@ fn pop_assignment_postgresql() {
     let mut assignments = Assignments::default();
     assignments.pop(2usize);
 
-    let sql = render(Flavor::Postgresql, &schema, update_with(assignments));
-    // PG: `col[1:cardinality(col) - 1]` — drops the last element via slicing.
-    assert!(
-        sql.contains(r#""tags" = "tags"[1:cardinality("tags") - 1]"#),
-        "expected PG array slice `\"tags\"[1:cardinality(\"tags\") - 1]` in: {sql}"
-    );
+    expect![[r#"UPDATE "users" AS tbl_0_0 SET "tags" = "tags"[1:cardinality("tags") - 1];"#]]
+        .assert_eq(&render(
+            Flavor::Postgresql,
+            &schema,
+            update_with(assignments),
+        ));
 }
 
 #[test]
@@ -296,22 +277,11 @@ fn remove_at_assignment_postgresql() {
     let mut assignments = Assignments::default();
     assignments.remove_at(2usize, Expr::from(3i64));
 
-    let sql = render(Flavor::Postgresql, &schema, update_with(assignments));
-    // `col[1:idx] || col[idx + 2:cardinality(col)]` — keep prefix, drop the
-    // element at user-facing index `idx`, append suffix. PG arrays are
-    // 1-based, so element at user index `i` lives at PG position `i + 1`.
-    assert!(
-        sql.contains(r#""tags"[1:3]"#),
-        "expected prefix slice `\"tags\"[1:3]` in: {sql}"
-    );
-    assert!(
-        sql.contains(r#""tags"[3 + 2:cardinality("tags")]"#),
-        "expected suffix slice `\"tags\"[3 + 2:cardinality(\"tags\")]` in: {sql}"
-    );
-    assert!(
-        sql.contains(r#""tags"[1:3] || "tags"[3 + 2:cardinality("tags")]"#),
-        "expected concat of prefix and suffix slices in: {sql}"
-    );
+    expect![[r#"UPDATE "users" AS tbl_0_0 SET "tags" = "tags"[1:3] || "tags"[3 + 2:cardinality("tags")];"#]].assert_eq(&render(
+        Flavor::Postgresql,
+        &schema,
+        update_with(assignments),
+    ));
 }
 
 #[test]

--- a/crates/toasty-sql/tests/serialize_values_idents.rs
+++ b/crates/toasty-sql/tests/serialize_values_idents.rs
@@ -8,6 +8,7 @@
 //! identifiers actually get emitted. Each test constructs the AST directly so
 //! the serializer is exercised in isolation — no lowering pipeline involved.
 
+use expect_test::expect;
 use toasty_core::{
     schema::db::{Column, ColumnId, PrimaryKey, Schema, Table, TableId, Type as StorageType},
     stmt::{
@@ -119,47 +120,40 @@ fn users_schema() -> Schema {
 
 #[test]
 fn value_null() {
-    let sql = render_values_pg(Expr::Value(stmt::Value::Null));
-    assert!(sql.contains("NULL"), "expected `NULL` in: {sql}");
+    expect!["VALUES (NULL);"].assert_eq(&render_values_pg(Expr::Value(stmt::Value::Null)));
 }
 
 #[test]
 fn value_bool_true_and_false() {
-    let t = render_values_pg(Expr::Value(stmt::Value::Bool(true)));
-    assert!(t.contains("TRUE"), "expected `TRUE` in: {t}");
-
-    let f = render_values_pg(Expr::Value(stmt::Value::Bool(false)));
-    assert!(f.contains("FALSE"), "expected `FALSE` in: {f}");
+    expect!["VALUES (TRUE);"].assert_eq(&render_values_pg(Expr::Value(stmt::Value::Bool(true))));
+    expect!["VALUES (FALSE);"].assert_eq(&render_values_pg(Expr::Value(stmt::Value::Bool(false))));
 }
 
 #[test]
 fn value_i64() {
-    let sql = render_values_pg(Expr::Value(stmt::Value::I64(42)));
-    assert!(sql.contains("42"), "expected `42` in: {sql}");
+    expect!["VALUES (42);"].assert_eq(&render_values_pg(Expr::Value(stmt::Value::I64(42))));
 }
 
 #[test]
 fn value_string_simple() {
-    let sql = render_values_pg(Expr::Value(stmt::Value::String("hello".into())));
-    assert!(sql.contains("'hello'"), "expected `'hello'` in: {sql}");
+    expect!["VALUES ('hello');"].assert_eq(&render_values_pg(Expr::Value(stmt::Value::String(
+        "hello".into(),
+    ))));
 }
 
 #[test]
 fn value_string_with_single_quote() {
     // Embedded single quotes are SQL-escaped by doubling them: `O'Brien`
     // serializes as `'O''Brien'`.
-    let sql = render_values_pg(Expr::Value(stmt::Value::String("O'Brien".into())));
-    assert!(
-        sql.contains("'O''Brien'"),
-        "expected escaped `'O''Brien'` in: {sql}"
-    );
+    expect!["VALUES ('O''Brien');"].assert_eq(&render_values_pg(Expr::Value(stmt::Value::String(
+        "O'Brien".into(),
+    ))));
 }
 
 #[test]
 fn value_list() {
     let list = stmt::Value::List(vec![stmt::Value::I64(1), stmt::Value::I64(2)]);
-    let sql = render_values_pg(Expr::Value(list));
-    assert!(sql.contains("(1, 2)"), "expected `(1, 2)` in: {sql}");
+    expect!["VALUES ((1, 2));"].assert_eq(&render_values_pg(Expr::Value(list)));
 }
 
 #[test]
@@ -170,8 +164,7 @@ fn value_record() {
         stmt::Value::I64(1),
         stmt::Value::I64(2),
     ]));
-    let sql = render_values_pg(Expr::Value(record));
-    assert!(sql.contains("(1, 2)"), "expected `(1, 2)` in: {sql}");
+    expect!["VALUES ((1, 2));"].assert_eq(&render_values_pg(Expr::Value(record)));
 }
 
 // -----------------------------------------------------------------------------
@@ -184,8 +177,7 @@ fn ident_quoting_postgresql_double_quote() {
     let stmt = select_id_from_users();
     let sql = Serializer::postgresql(&schema).serialize(&SqlStatement::from(stmt));
 
-    assert!(sql.contains(r#""users""#), "expected `\"users\"` in: {sql}");
-    assert!(sql.contains(r#""id""#), "expected `\"id\"` in: {sql}");
+    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0;"#]].assert_eq(&sql);
 }
 
 #[test]
@@ -194,8 +186,7 @@ fn ident_quoting_sqlite_double_quote() {
     let stmt = select_id_from_users();
     let sql = Serializer::sqlite(&schema).serialize(&SqlStatement::from(stmt));
 
-    assert!(sql.contains(r#""users""#), "expected `\"users\"` in: {sql}");
-    assert!(sql.contains(r#""id""#), "expected `\"id\"` in: {sql}");
+    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0;"#]].assert_eq(&sql);
 }
 
 #[test]
@@ -204,15 +195,7 @@ fn ident_quoting_mysql_backtick() {
     let stmt = select_id_from_users();
     let sql = Serializer::mysql(&schema).serialize(&SqlStatement::from(stmt));
 
-    assert!(
-        sql.contains("`users`"),
-        "expected backticked `users` in: {sql}"
-    );
-    assert!(sql.contains("`id`"), "expected backticked `id` in: {sql}");
-    assert!(
-        !sql.contains(r#""users""#),
-        "did not expect double quotes in MySQL: {sql}"
-    );
+    expect!["SELECT tbl_0_0.`id` FROM `users` AS tbl_0_0;"].assert_eq(&sql);
 }
 
 // -----------------------------------------------------------------------------
@@ -232,10 +215,7 @@ fn name_renders_qualified_period_separated() {
     let stmt: SqlStatement = drop.into();
     let sql = Serializer::postgresql(&schema).serialize(&stmt);
 
-    assert!(
-        sql.contains(r#""public"."users""#),
-        "expected `\"public\".\"users\"` in: {sql}"
-    );
+    expect![[r#"DROP TABLE "public"."users";"#]].assert_eq(&sql);
 }
 
 // -----------------------------------------------------------------------------
@@ -298,22 +278,13 @@ fn column_alias_format_per_flavor() {
     let sql_stmt = SqlStatement::from(stmt);
 
     let pg = Serializer::postgresql(&schema).serialize(&sql_stmt);
-    assert!(
-        pg.contains("column1"),
-        "expected 1-based `column1` in PG: {pg}"
-    );
+    expect![[r#"WITH cte_0_0 as (SELECT tbl_1_0."id" FROM "users" AS tbl_1_0) SELECT tbl_0_0.column1 FROM cte_0_0 AS tbl_0_0;"#]].assert_eq(&pg);
 
     let sqlite = Serializer::sqlite(&schema).serialize(&sql_stmt);
-    assert!(
-        sqlite.contains("column1"),
-        "expected 1-based `column1` in SQLite: {sqlite}"
-    );
+    expect![[r#"WITH cte_0_0 as (SELECT tbl_1_0."id" FROM "users" AS tbl_1_0) SELECT tbl_0_0.column1 FROM cte_0_0 AS tbl_0_0;"#]].assert_eq(&sqlite);
 
     let mysql = Serializer::mysql(&schema).serialize(&sql_stmt);
-    assert!(
-        mysql.contains("column_0"),
-        "expected 0-based `column_0` in MySQL (matches `VALUES ROW(...) AS t` auto-naming): {mysql}"
-    );
+    expect!["WITH cte_0_0 as (SELECT tbl_1_0.`id` FROM `users` AS tbl_1_0) SELECT tbl_0_0.column_0 FROM cte_0_0 AS tbl_0_0;"].assert_eq(&mysql);
 }
 
 // -----------------------------------------------------------------------------
@@ -329,8 +300,7 @@ fn placeholder_postgresql_dollar_n() {
     let core_stmt: stmt::Statement = stmt::Query::values(values).into();
     let sql = Serializer::postgresql(&Schema::default()).serialize(&SqlStatement::from(core_stmt));
 
-    assert!(sql.contains("$1"), "expected `$1` in PG: {sql}");
-    assert!(sql.contains("$2"), "expected `$2` in PG: {sql}");
+    expect!["VALUES ($1, $2);"].assert_eq(&sql);
 }
 
 #[test]
@@ -342,17 +312,7 @@ fn placeholder_mysql_question_mark() {
     let core_stmt: stmt::Statement = stmt::Query::values(values).into();
     let sql = Serializer::mysql(&Schema::default()).serialize(&SqlStatement::from(core_stmt));
 
-    assert!(sql.contains("?"), "expected `?` in MySQL: {sql}");
-    assert!(
-        !sql.contains("$1") && !sql.contains("?1"),
-        "MySQL placeholder should not be indexed: {sql}"
-    );
-    // Two args -> two `?`.
-    assert_eq!(
-        sql.matches('?').count(),
-        2,
-        "expected two `?` placeholders in MySQL: {sql}"
-    );
+    expect!["VALUES ROW(?, ?);"].assert_eq(&sql);
 }
 
 #[test]
@@ -362,8 +322,7 @@ fn placeholder_sqlite_question_n() {
     let core_stmt: stmt::Statement = stmt::Query::values(values).into();
     let sql = Serializer::sqlite(&Schema::default()).serialize(&SqlStatement::from(core_stmt));
 
-    assert!(sql.contains("?1"), "expected `?1` in SQLite: {sql}");
-    assert!(sql.contains("?2"), "expected `?2` in SQLite: {sql}");
+    expect!["VALUES (?1, ?2);"].assert_eq(&sql);
 }
 
 #[test]
@@ -377,12 +336,11 @@ fn placeholder_mysql_arg_order_reordering() {
     let record = Expr::record([Expr::arg(1), Expr::arg(0)]);
     let values = stmt::Values::new(vec![record]);
     let core_stmt: stmt::Statement = stmt::Query::values(values).into();
-    let (_sql, arg_order) = Serializer::mysql(&Schema::default())
+    let (sql, arg_order) = Serializer::mysql(&Schema::default())
         .serialize_with_arg_order(&SqlStatement::from(core_stmt));
 
-    assert_eq!(
-        arg_order,
-        vec![1, 0],
-        "expected arg_order [1, 0] tracking SQL occurrence: got {arg_order:?}"
-    );
+    expect![[r#"
+        VALUES ROW(?, ?);
+        [1, 0]"#]]
+    .assert_eq(&format!("{}\n{:?}", sql, arg_order));
 }

--- a/crates/toasty-sql/tests/serialize_values_idents.rs
+++ b/crates/toasty-sql/tests/serialize_values_idents.rs
@@ -1,0 +1,387 @@
+//! Verifies the low-level serialization helpers — `Value`, `Ident`, `Name`,
+//! `ColumnAlias`, and `Placeholder` — render correctly, including their
+//! per-flavor differences.
+//!
+//! Most cases wrap the value or expression in a bare `VALUES (...)` row so the
+//! helper's output appears directly in the SQL. Identifier-quoting cases use a
+//! minimal `SELECT col FROM users` against a real schema so column and table
+//! identifiers actually get emitted. Each test constructs the AST directly so
+//! the serializer is exercised in isolation — no lowering pipeline involved.
+
+use toasty_core::{
+    schema::db::{Column, ColumnId, PrimaryKey, Schema, Table, TableId, Type as StorageType},
+    stmt::{
+        self, Cte, Expr, ExprColumn, Filter, Returning, Select, Source, SourceTable, SourceTableId,
+        TableFactor, TableRef, TableWithJoins, With,
+    },
+};
+use toasty_sql::{Serializer, Statement as SqlStatement};
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+/// Minimal `id INTEGER PRIMARY KEY, *cols` table. Mirrors the helper in
+/// `serialize_joins.rs`.
+fn make_table(id: usize, name: &str, cols: &[&str]) -> Table {
+    let mut columns = vec![Column {
+        id: ColumnId {
+            table: TableId(id),
+            index: 0,
+        },
+        name: "id".to_string(),
+        ty: stmt::Type::I64,
+        storage_ty: StorageType::Integer(8),
+        nullable: false,
+        primary_key: true,
+        auto_increment: false,
+        versionable: false,
+    }];
+    for (i, name) in cols.iter().enumerate() {
+        columns.push(Column {
+            id: ColumnId {
+                table: TableId(id),
+                index: i + 1,
+            },
+            name: (*name).to_string(),
+            ty: stmt::Type::I64,
+            storage_ty: StorageType::Integer(8),
+            nullable: false,
+            primary_key: false,
+            auto_increment: false,
+            versionable: false,
+        });
+    }
+    Table {
+        id: TableId(id),
+        name: name.to_string(),
+        columns,
+        primary_key: PrimaryKey {
+            columns: vec![ColumnId {
+                table: TableId(id),
+                index: 0,
+            }],
+            index: toasty_core::schema::db::IndexId {
+                table: TableId(id),
+                index: 0,
+            },
+        },
+        indices: vec![],
+    }
+}
+
+/// Reference to column `column` of the `table`th entry in `SourceTable::tables`.
+fn col(table: usize, column: usize) -> Expr {
+    Expr::column(ExprColumn {
+        nesting: 0,
+        table,
+        column,
+    })
+}
+
+/// Render `expr` as the projection of a bare `VALUES` row. The result is
+/// `VALUES (<expr>);` — useful for getting a value or expression rendered
+/// in isolation, without a containing SELECT.
+fn render_values_pg(expr: Expr) -> String {
+    let values = stmt::Values::new(vec![Expr::record([expr])]);
+    let core_stmt: stmt::Statement = stmt::Query::values(values).into();
+    let stmt = SqlStatement::from(core_stmt);
+    let schema = Schema::default();
+    Serializer::postgresql(&schema).serialize(&stmt)
+}
+
+/// `SELECT id FROM users` against a schema with a single `users(id)` table.
+fn select_id_from_users() -> stmt::Statement {
+    let source = Source::Table(SourceTable {
+        tables: vec![TableRef::Table(TableId(0))],
+        from: vec![TableWithJoins {
+            relation: TableFactor::Table(SourceTableId(0)),
+            joins: vec![],
+        }],
+    });
+    let select = Select {
+        returning: Returning::Project(Expr::record([col(0, 0)])),
+        source,
+        filter: Filter::ALL,
+    };
+    stmt::Statement::Query(stmt::Query::builder(select).build())
+}
+
+fn users_schema() -> Schema {
+    Schema {
+        tables: vec![make_table(0, "users", &[])],
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Value literals (`serializer/value.rs`)
+// -----------------------------------------------------------------------------
+
+#[test]
+fn value_null() {
+    let sql = render_values_pg(Expr::Value(stmt::Value::Null));
+    assert!(sql.contains("NULL"), "expected `NULL` in: {sql}");
+}
+
+#[test]
+fn value_bool_true_and_false() {
+    let t = render_values_pg(Expr::Value(stmt::Value::Bool(true)));
+    assert!(t.contains("TRUE"), "expected `TRUE` in: {t}");
+
+    let f = render_values_pg(Expr::Value(stmt::Value::Bool(false)));
+    assert!(f.contains("FALSE"), "expected `FALSE` in: {f}");
+}
+
+#[test]
+fn value_i64() {
+    let sql = render_values_pg(Expr::Value(stmt::Value::I64(42)));
+    assert!(sql.contains("42"), "expected `42` in: {sql}");
+}
+
+#[test]
+fn value_string_simple() {
+    let sql = render_values_pg(Expr::Value(stmt::Value::String("hello".into())));
+    assert!(sql.contains("'hello'"), "expected `'hello'` in: {sql}");
+}
+
+#[test]
+fn value_string_with_single_quote() {
+    // Embedded single quotes are SQL-escaped by doubling them: `O'Brien`
+    // serializes as `'O''Brien'`.
+    let sql = render_values_pg(Expr::Value(stmt::Value::String("O'Brien".into())));
+    assert!(
+        sql.contains("'O''Brien'"),
+        "expected escaped `'O''Brien'` in: {sql}"
+    );
+}
+
+#[test]
+fn value_list() {
+    let list = stmt::Value::List(vec![stmt::Value::I64(1), stmt::Value::I64(2)]);
+    let sql = render_values_pg(Expr::Value(list));
+    assert!(sql.contains("(1, 2)"), "expected `(1, 2)` in: {sql}");
+}
+
+#[test]
+fn value_record() {
+    // `stmt::Value::Record` renders with `(...)` and comma-separated fields,
+    // matching the `Record` arm in `serializer/value.rs`.
+    let record = stmt::Value::Record(stmt::ValueRecord::from_vec(vec![
+        stmt::Value::I64(1),
+        stmt::Value::I64(2),
+    ]));
+    let sql = render_values_pg(Expr::Value(record));
+    assert!(sql.contains("(1, 2)"), "expected `(1, 2)` in: {sql}");
+}
+
+// -----------------------------------------------------------------------------
+// Ident quoting (`serializer/ident.rs`)
+// -----------------------------------------------------------------------------
+
+#[test]
+fn ident_quoting_postgresql_double_quote() {
+    let schema = users_schema();
+    let stmt = select_id_from_users();
+    let sql = Serializer::postgresql(&schema).serialize(&SqlStatement::from(stmt));
+
+    assert!(sql.contains(r#""users""#), "expected `\"users\"` in: {sql}");
+    assert!(sql.contains(r#""id""#), "expected `\"id\"` in: {sql}");
+}
+
+#[test]
+fn ident_quoting_sqlite_double_quote() {
+    let schema = users_schema();
+    let stmt = select_id_from_users();
+    let sql = Serializer::sqlite(&schema).serialize(&SqlStatement::from(stmt));
+
+    assert!(sql.contains(r#""users""#), "expected `\"users\"` in: {sql}");
+    assert!(sql.contains(r#""id""#), "expected `\"id\"` in: {sql}");
+}
+
+#[test]
+fn ident_quoting_mysql_backtick() {
+    let schema = users_schema();
+    let stmt = select_id_from_users();
+    let sql = Serializer::mysql(&schema).serialize(&SqlStatement::from(stmt));
+
+    assert!(
+        sql.contains("`users`"),
+        "expected backticked `users` in: {sql}"
+    );
+    assert!(sql.contains("`id`"), "expected backticked `id` in: {sql}");
+    assert!(
+        !sql.contains(r#""users""#),
+        "did not expect double quotes in MySQL: {sql}"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Name qualified (`serializer/name.rs`)
+// -----------------------------------------------------------------------------
+
+#[test]
+fn name_renders_qualified_period_separated() {
+    // A multi-part `Name` should render as period-separated quoted segments.
+    // `DropTable` is the simplest statement that surfaces `Name` directly in
+    // its output.
+    let schema = Schema::default();
+    let drop = toasty_sql::stmt::DropTable {
+        name: toasty_sql::stmt::Name(vec!["public".into(), "users".into()]),
+        if_exists: false,
+    };
+    let stmt: SqlStatement = drop.into();
+    let sql = Serializer::postgresql(&schema).serialize(&stmt);
+
+    assert!(
+        sql.contains(r#""public"."users""#),
+        "expected `\"public\".\"users\"` in: {sql}"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// ColumnAlias (`serializer/column.rs`)
+// -----------------------------------------------------------------------------
+
+/// `ColumnAlias` is emitted when projecting a column from a CTE or derived
+/// subquery — the underlying schema column name isn't visible at that scope,
+/// so the serializer uses a positional alias.
+///
+/// PostgreSQL / SQLite use 1-based `column<n+1>` (e.g. `column1`); MySQL uses
+/// 0-based `column_<n>` (e.g. `column_0`). The format is set by
+/// `serializer/column.rs::ColumnAlias::to_sql`.
+fn select_from_cte() -> stmt::Statement {
+    let cte_query = {
+        let source = Source::Table(SourceTable {
+            tables: vec![TableRef::Table(TableId(0))],
+            from: vec![TableWithJoins {
+                relation: TableFactor::Table(SourceTableId(0)),
+                joins: vec![],
+            }],
+        });
+        let select = Select {
+            returning: Returning::Project(Expr::record([col(0, 0)])),
+            source,
+            filter: Filter::ALL,
+        };
+        stmt::Query::builder(select).build()
+    };
+
+    let outer_source = Source::Table(SourceTable {
+        tables: vec![TableRef::Cte {
+            nesting: 0,
+            index: 0,
+        }],
+        from: vec![TableWithJoins {
+            relation: TableFactor::Table(SourceTableId(0)),
+            joins: vec![],
+        }],
+    });
+    let outer_select = Select {
+        returning: Returning::Project(Expr::record([col(0, 0)])),
+        source: outer_source,
+        filter: Filter::ALL,
+    };
+    stmt::Statement::Query(
+        stmt::Query::builder(outer_select)
+            .with(With {
+                ctes: vec![Cte { query: cte_query }],
+            })
+            .build(),
+    )
+}
+
+#[test]
+fn column_alias_format_per_flavor() {
+    let schema = users_schema();
+    let stmt = select_from_cte();
+    let sql_stmt = SqlStatement::from(stmt);
+
+    let pg = Serializer::postgresql(&schema).serialize(&sql_stmt);
+    assert!(
+        pg.contains("column1"),
+        "expected 1-based `column1` in PG: {pg}"
+    );
+
+    let sqlite = Serializer::sqlite(&schema).serialize(&sql_stmt);
+    assert!(
+        sqlite.contains("column1"),
+        "expected 1-based `column1` in SQLite: {sqlite}"
+    );
+
+    let mysql = Serializer::mysql(&schema).serialize(&sql_stmt);
+    assert!(
+        mysql.contains("column_0"),
+        "expected 0-based `column_0` in MySQL: {mysql}"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Placeholder (`serializer/params.rs`)
+// -----------------------------------------------------------------------------
+
+#[test]
+fn placeholder_postgresql_dollar_n() {
+    // `Expr::arg(0)` becomes `Placeholder(1)` (positions are 0-based; PG's
+    // placeholder is 1-based).
+    let record = Expr::record([Expr::arg(0), Expr::arg(1)]);
+    let values = stmt::Values::new(vec![record]);
+    let core_stmt: stmt::Statement = stmt::Query::values(values).into();
+    let sql = Serializer::postgresql(&Schema::default()).serialize(&SqlStatement::from(core_stmt));
+
+    assert!(sql.contains("$1"), "expected `$1` in PG: {sql}");
+    assert!(sql.contains("$2"), "expected `$2` in PG: {sql}");
+}
+
+#[test]
+fn placeholder_mysql_question_mark() {
+    // MySQL uses bare `?` with no index. Order is preserved via the
+    // `arg_positions` reordering channel returned by `serialize_with_arg_order`.
+    let record = Expr::record([Expr::arg(0), Expr::arg(1)]);
+    let values = stmt::Values::new(vec![record]);
+    let core_stmt: stmt::Statement = stmt::Query::values(values).into();
+    let sql = Serializer::mysql(&Schema::default()).serialize(&SqlStatement::from(core_stmt));
+
+    assert!(sql.contains("?"), "expected `?` in MySQL: {sql}");
+    assert!(
+        !sql.contains("$1") && !sql.contains("?1"),
+        "MySQL placeholder should not be indexed: {sql}"
+    );
+    // Two args -> two `?`.
+    assert_eq!(
+        sql.matches('?').count(),
+        2,
+        "expected two `?` placeholders in MySQL: {sql}"
+    );
+}
+
+#[test]
+fn placeholder_sqlite_question_n() {
+    let record = Expr::record([Expr::arg(0), Expr::arg(1)]);
+    let values = stmt::Values::new(vec![record]);
+    let core_stmt: stmt::Statement = stmt::Query::values(values).into();
+    let sql = Serializer::sqlite(&Schema::default()).serialize(&SqlStatement::from(core_stmt));
+
+    assert!(sql.contains("?1"), "expected `?1` in SQLite: {sql}");
+    assert!(sql.contains("?2"), "expected `?2` in SQLite: {sql}");
+}
+
+#[test]
+fn placeholder_mysql_arg_order_reordering() {
+    // `arg_positions` records the 0-based `Expr::Arg.position` of each `?`
+    // placeholder in occurrence order. The caller (the MySQL driver) uses this
+    // to reorder its params vec to match the SQL's placeholder order.
+    //
+    // Construct a record with `Expr::arg(1)` first and `Expr::arg(0)` second
+    // to confirm the order tracks SQL occurrence, not numeric position.
+    let record = Expr::record([Expr::arg(1), Expr::arg(0)]);
+    let values = stmt::Values::new(vec![record]);
+    let core_stmt: stmt::Statement = stmt::Query::values(values).into();
+    let (_sql, arg_order) = Serializer::mysql(&Schema::default())
+        .serialize_with_arg_order(&SqlStatement::from(core_stmt));
+
+    assert_eq!(
+        arg_order,
+        vec![1, 0],
+        "expected arg_order [1, 0] tracking SQL occurrence: got {arg_order:?}"
+    );
+}

--- a/crates/toasty-sql/tests/serialize_values_idents.rs
+++ b/crates/toasty-sql/tests/serialize_values_idents.rs
@@ -246,9 +246,10 @@ fn name_renders_qualified_period_separated() {
 /// subquery — the underlying schema column name isn't visible at that scope,
 /// so the serializer uses a positional alias.
 ///
-/// PostgreSQL / SQLite use 1-based `column<n+1>` (e.g. `column1`); MySQL uses
-/// 0-based `column_<n>` (e.g. `column_0`). The format is set by
-/// `serializer/column.rs::ColumnAlias::to_sql`.
+/// The per-flavor format matches each engine's auto-naming convention for
+/// derived-table columns. MySQL's `VALUES ROW(...) AS t` exposes columns as
+/// `column_0`, `column_1`, ...; PG and SQLite use `column1`, `column2`, ...
+/// in equivalent contexts. See `serializer/column.rs` for the rationale.
 fn select_from_cte() -> stmt::Statement {
     let cte_query = {
         let source = Source::Table(SourceTable {
@@ -311,7 +312,7 @@ fn column_alias_format_per_flavor() {
     let mysql = Serializer::mysql(&schema).serialize(&sql_stmt);
     assert!(
         mysql.contains("column_0"),
-        "expected 0-based `column_0` in MySQL: {mysql}"
+        "expected 0-based `column_0` in MySQL (matches `VALUES ROW(...) AS t` auto-naming): {mysql}"
     );
 }
 


### PR DESCRIPTION
## Summary

Two related changes, both serializer-layer:

**1. `JoinOp::Inner(Expr)`** — alongside the existing `JoinOp::Left(Expr)`. Multi-step `via` relations want to eager-load through joins, which needs `INNER` in addition to `LEFT` — this lands the stmt-layer support so a follow-up planner change can emit the join shape.

- `toasty-core`: new `Inner` variant; visitors merge arms so the ON expression is traversed for both kinds.
- `toasty-sql`: serializer emits `INNER JOIN` / `LEFT JOIN` via a keyword lookup, dedup'd with the alias/ON formatting.

**2. Comprehensive serializer test coverage.** toasty-sql previously had only `serialize_array_predicates.rs` (3 tests) and the migration DDL suite. Added 8 focused, serializer-isolated test files (156 new test cases):

| File | Coverage |
|------|----------|
| `serialize_joins.rs` | JoinOp (Left + Inner), multi-join chains |
| `serialize_select.rs` | SELECT: WHERE / AND / OR / ORDER BY / LIMIT / OFFSET / FOR UPDATE / FOR SHARE |
| `serialize_dml.rs` | INSERT / UPDATE / DELETE + RETURNING + MySQL panic paths |
| `serialize_subqueries.rs` | VALUES (incl. MySQL ROW wrapping), WITH / CTE, derived tables, EXISTS / IN subquery |
| `serialize_expressions.rs` | BinaryOp, AND/OR, LIKE / ILIKE / STARTS_WITH, COUNT (+FILTER), LAST_INSERT_ID, IS_SUPERSET / overlap / length per flavor, Default |
| `serialize_values_idents.rs` | Value literals (incl. quote escape), Ident quoting, qualified Name, ColumnAlias, Placeholder, MySQL arg-order reordering |
| `serialize_update_assignments.rs` | Set / Append / Remove / Pop / RemoveAt × 3 flavors |
| `serialize_types.rs` | Every non-`todo!()` `(db::Type variant × flavor)` combination |

Each file constructs the `stmt` AST directly so the serializer is tested without the engine pipeline.

### Bug found while writing tests

The `&stmt::Delete` serializer does `assert!(self.returning.is_none())` unconditionally, but PostgreSQL (since 8.2) and SQLite (since 3.35) both support `DELETE … RETURNING`. The MySQL panic path is codified; `#[ignore]`'d tests pin the expected PG/SQLite shape — they should pass once the serializer is updated to mirror the Insert/Update pattern.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] \`cargo fmt\` and \`cargo clippy\` are clean
- [x] \`cargo test\` passes

## Notes for reviewers

- The JoinOp commit is a prerequisite for an upcoming planner change that compiles `.include()` of multi-step `via` relations into a single join query — no engine code emits `Inner` yet.
- The test commit is purely additive (plus the corrected DELETE-RETURNING expectations). 2 tests are `#[ignore]`'d pending the DELETE+RETURNING serializer fix.