### PR TITLE
docs: add DynamoDB driver notes and Claude testing skill

### DIFF
--- a/.claude/skills/dynamodb-tests/SKILL.md
+++ b/.claude/skills/dynamodb-tests/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: dynamodb-tests
+description: Always use this skill when running tests against dynamodb (DDB)
+---
+
+# Run toasty-driver-integration-suite against DDB and Sqlite use
+To run against DDB only use: `cargo  test --features dynamodb  -- --test-threads=1`
+
+# Run test suite against DDB only
+Use this when troubleshooting and testing issues specific to DDB: `cargo  test --features dynamodb  --no-default-features -- --test-threads=1`
+
+## Run a specific failing test against DDB
+
+Use this when you need to troubleshoot a specific failing test method: `cargo  test --features dynamodb  --no-default-features <test method name> -- --test-threads=1`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,3 +102,4 @@ To add a new integration test, add a file to `crates/toasty-driver-integration-s
 - `docs/dev/architecture/README.md` — architectural overview
 - `docs/dev/architecture/query-engine.md` — detailed query engine documentation
 - `docs/dev/architecture/type-system.md` — type system design
+- `docs/dev/dynamodb-notes.md` — DynamoDB-specific API notes (features that post-date training data)

--- a/docs/dev/dynamodb-notes.md
+++ b/docs/dev/dynamodb-notes.md
@@ -1,0 +1,27 @@
+# DynamoDB Driver Notes
+
+DynamoDB has features that post-date the model's training data. Fetch current AWS
+documentation before implementing or designing DynamoDB driver features rather than
+relying on prior knowledge.
+
+## Multi-attribute GSI keys
+
+GSIs now support composite keys built from multiple attributes. A partition key can be
+composed of up to 4 attributes and a sort key up to 4 attributes, for up to 8 attributes
+per key schema total. Previously a GSI key was a single attribute (partition key) or two
+attributes (partition key + sort key).
+
+DynamoDB hashes the partition key attributes together for distribution and maintains
+hierarchical sort order across the sort key attributes. This eliminates the need to
+concatenate attributes into synthetic keys like `"TOURNAMENT#WINTER2024#REGION#NA-EAST"`.
+
+**Querying:** All partition key attributes must be specified using equality conditions.
+Sort key attributes can be queried left-to-right in declaration order — you can query
+the first attribute alone, the first two together, etc., but cannot skip attributes.
+Inequality conditions (`>`, `<`, `BETWEEN`, `begins_with`) must appear last.
+
+**Key attribute types:** Each attribute in a multi-attribute key can be `String`,
+`Number`, or `Binary`. `Number` sorts numerically; `String` sorts lexicographically
+(zero-pad if natural numeric order matters).
+
+Reference: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GSI.html#GSI.MultiAttributeKeys


### PR DESCRIPTION
## Summary

Adds developer-facing notes and Claude Code tooling for working on the DynamoDB driver:

- `docs/dev/dynamodb-notes.md` documents DynamoDB features that post-date the model's training data (notably multi-attribute GSI keys), with a pointer to current AWS docs so design/implementation doesn't rely on stale recall.
- `.claude/skills/dynamodb-tests/SKILL.md` records the exact commands for running the integration suite against DynamoDB (combined with SQLite, DynamoDB-only, and single-test variants).
- `CLAUDE.md` links the new notes from the "Further Reading" section.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

(Docs/tooling-only — no code changes.)

## Notes for reviewers

The skill file is Claude-specific tooling that lives alongside the existing `.claude/` content. The DynamoDB notes are intended to grow over time as additional DDB features that aren't well-covered by training data come up.