### PR TITLE
feat!: replace `#[serialize(json)]` with `toasty::Json<T>` wrapper

### DIFF
--- a/crates/toasty-driver-integration-suite/src/scenarios.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios.rs
@@ -2,6 +2,7 @@ pub mod composite_chain_relations;
 pub mod composite_fk_has_many_belongs_to;
 pub mod composite_has_many_belongs_to;
 pub mod deferred_document;
+pub mod deferred_json_document;
 pub mod deferred_optional_document;
 pub mod has_many_belongs_to;
 pub mod has_many_multi_relation;

--- a/crates/toasty-driver-integration-suite/src/scenarios/deferred_json_document.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios/deferred_json_document.rs
@@ -1,0 +1,28 @@
+use crate::prelude::*;
+use serde::{Deserialize, Serialize};
+
+scenario! {
+    #![id(ID)]
+
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct Payload {
+        name: String,
+        version: u32,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Repository {
+        #[key]
+        #[auto]
+        id: ID,
+
+        name: String,
+
+        #[deferred]
+        payload: toasty::Deferred<toasty::Json<Payload>>,
+    }
+
+    async fn setup(test: &mut Test) -> toasty::Db {
+        test.setup_db(models!(Repository)).await
+    }
+}

--- a/crates/toasty-driver-integration-suite/src/tests/deferred_field.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/deferred_field.rs
@@ -345,3 +345,166 @@ pub async fn deferred_update_refreshes_loaded_value(t: &mut Test) -> Result<()> 
 
     Ok(())
 }
+
+// ---------- `Deferred<Json<T>>` on a single field ----------
+//
+// The column is stored as JSON, the in-memory field is `Deferred<Json<T>>`,
+// and `T` only implements `serde::{Serialize, Deserialize}` — never
+// Toasty's `Load` directly. Each behavior is exercised in isolation
+// against the shared scenario.
+
+#[driver_test(
+    id(ID),
+    requires(sql),
+    scenario(crate::scenarios::deferred_json_document)
+)]
+pub async fn deferred_json_create_returns_loaded(t: &mut Test) -> Result<()> {
+    let mut db = setup(t).await;
+
+    let initial = Payload {
+        name: "users".to_string(),
+        version: 1,
+    };
+
+    let created = toasty::create!(Repository {
+        name: "main".to_string(),
+        payload: toasty::Json(initial.clone()),
+    })
+    .exec(&mut db)
+    .await?;
+
+    // INSERT...RETURNING echoes the value the caller supplied, so the field
+    // comes back already loaded — even though normal SELECTs would skip it.
+    assert!(!created.payload.is_unloaded());
+    assert_eq!(&initial, &created.payload.get().0);
+
+    Ok(())
+}
+
+#[driver_test(
+    id(ID),
+    requires(sql),
+    scenario(crate::scenarios::deferred_json_document)
+)]
+pub async fn deferred_json_default_load_leaves_unloaded(t: &mut Test) -> Result<()> {
+    let mut db = setup(t).await;
+
+    let created = toasty::create!(Repository {
+        name: "main".to_string(),
+        payload: toasty::Json(Payload {
+            name: "users".to_string(),
+            version: 1,
+        }),
+    })
+    .exec(&mut db)
+    .await?;
+
+    let read = Repository::filter_by_id(created.id).get(&mut db).await?;
+    assert!(read.payload.is_unloaded());
+
+    Ok(())
+}
+
+#[driver_test(
+    id(ID),
+    requires(sql),
+    scenario(crate::scenarios::deferred_json_document)
+)]
+pub async fn deferred_json_exec_lazy_loads_value(t: &mut Test) -> Result<()> {
+    let mut db = setup(t).await;
+
+    let initial = Payload {
+        name: "users".to_string(),
+        version: 1,
+    };
+
+    let created = toasty::create!(Repository {
+        name: "main".to_string(),
+        payload: toasty::Json(initial.clone()),
+    })
+    .exec(&mut db)
+    .await?;
+
+    let read = Repository::filter_by_id(created.id).get(&mut db).await?;
+    // The per-field accessor returns a Statement<Json<Payload>>; .exec()
+    // hands back the JSON-deserialized value through Json<T>'s Load impl.
+    let payload: toasty::Json<Payload> = read.payload().exec(&mut db).await?;
+    assert_eq!(initial, payload.0);
+
+    // The in-memory record is not mutated by `.exec()`.
+    assert!(read.payload.is_unloaded());
+
+    Ok(())
+}
+
+#[driver_test(
+    id(ID),
+    requires(sql),
+    scenario(crate::scenarios::deferred_json_document)
+)]
+pub async fn deferred_json_include_eager_loads_value(t: &mut Test) -> Result<()> {
+    let mut db = setup(t).await;
+
+    let initial = Payload {
+        name: "users".to_string(),
+        version: 1,
+    };
+
+    let created = toasty::create!(Repository {
+        name: "main".to_string(),
+        payload: toasty::Json(initial.clone()),
+    })
+    .exec(&mut db)
+    .await?;
+
+    // `.include()` projects the JSON column into the SELECT; the model
+    // loader peels the deferred envelope, JSON-decodes the inner String,
+    // and wraps the resulting `Json<Payload>` back in a loaded `Deferred`.
+    let read = Repository::filter_by_id(created.id)
+        .include(Repository::fields().payload())
+        .get(&mut db)
+        .await?;
+    assert!(!read.payload.is_unloaded());
+    assert_eq!(&initial, &read.payload.get().0);
+
+    Ok(())
+}
+
+#[driver_test(
+    id(ID),
+    requires(sql),
+    scenario(crate::scenarios::deferred_json_document)
+)]
+pub async fn deferred_json_update_refreshes_loaded_value(t: &mut Test) -> Result<()> {
+    let mut db = setup(t).await;
+
+    let initial = Payload {
+        name: "users".to_string(),
+        version: 1,
+    };
+    let next = Payload {
+        name: "users".to_string(),
+        version: 2,
+    };
+
+    let created = toasty::create!(Repository {
+        name: "main".to_string(),
+        payload: toasty::Json(initial),
+    })
+    .exec(&mut db)
+    .await?;
+
+    let mut doc = Repository::filter_by_id(created.id).get(&mut db).await?;
+    assert!(doc.payload.is_unloaded());
+
+    // The update echoes the assigned value back through the reload path,
+    // which JSON-decodes and re-wraps in `Deferred`.
+    doc.update()
+        .payload(toasty::Json(next.clone()))
+        .exec(&mut db)
+        .await?;
+    assert!(!doc.payload.is_unloaded());
+    assert_eq!(&next, &doc.payload.get().0);
+
+    Ok(())
+}

--- a/crates/toasty-driver-integration-suite/src/tests/deferred_field.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/deferred_field.rs
@@ -368,7 +368,7 @@ pub async fn deferred_json_create_returns_loaded(t: &mut Test) -> Result<()> {
 
     let created = toasty::create!(Repository {
         name: "main".to_string(),
-        payload: toasty::Json(initial.clone()),
+        payload: initial.clone(),
     })
     .exec(&mut db)
     .await?;
@@ -391,10 +391,10 @@ pub async fn deferred_json_default_load_leaves_unloaded(t: &mut Test) -> Result<
 
     let created = toasty::create!(Repository {
         name: "main".to_string(),
-        payload: toasty::Json(Payload {
+        payload: Payload {
             name: "users".to_string(),
             version: 1,
-        }),
+        },
     })
     .exec(&mut db)
     .await?;
@@ -420,7 +420,7 @@ pub async fn deferred_json_exec_lazy_loads_value(t: &mut Test) -> Result<()> {
 
     let created = toasty::create!(Repository {
         name: "main".to_string(),
-        payload: toasty::Json(initial.clone()),
+        payload: initial.clone(),
     })
     .exec(&mut db)
     .await?;
@@ -452,7 +452,7 @@ pub async fn deferred_json_include_eager_loads_value(t: &mut Test) -> Result<()>
 
     let created = toasty::create!(Repository {
         name: "main".to_string(),
-        payload: toasty::Json(initial.clone()),
+        payload: initial.clone(),
     })
     .exec(&mut db)
     .await?;
@@ -489,7 +489,7 @@ pub async fn deferred_json_update_refreshes_loaded_value(t: &mut Test) -> Result
 
     let created = toasty::create!(Repository {
         name: "main".to_string(),
-        payload: toasty::Json(initial),
+        payload: initial,
     })
     .exec(&mut db)
     .await?;
@@ -499,10 +499,7 @@ pub async fn deferred_json_update_refreshes_loaded_value(t: &mut Test) -> Result
 
     // The update echoes the assigned value back through the reload path,
     // which JSON-decodes and re-wraps in `Deferred`.
-    doc.update()
-        .payload(toasty::Json(next.clone()))
-        .exec(&mut db)
-        .await?;
+    doc.update().payload(next.clone()).exec(&mut db).await?;
     assert!(!doc.payload.is_unloaded());
     assert_eq!(&next, &doc.payload.get().0);
 

--- a/crates/toasty-driver-integration-suite/src/tests/type_serialize.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/type_serialize.rs
@@ -44,14 +44,13 @@ pub async fn json_vec_string(t: &mut Test) -> Result<(), BoxError> {
 
     let mut db = t.setup_db(models!(Item)).await;
 
-    // Insert — driver receives JSON string
+    // Insert — driver receives JSON string. The bare `Vec<String>` is
+    // accepted via the `IntoExpr<Json<T>> for T` blanket on `Json<T>`,
+    // so callers don't need to spell `Json(value)` at setter sites.
     t.log().clear();
     let tags = vec!["rust".to_string(), "toasty".to_string()];
     let expected_json = serde_json::to_string(&tags).unwrap();
-    let mut record = Item::create()
-        .tags(Json(tags.clone()))
-        .exec(&mut db)
-        .await?;
+    let mut record = Item::create().tags(tags.clone()).exec(&mut db).await?;
 
     let (op, _) = t.log().pop();
     let val_pos = if driver_test_cfg!(id_u64) { 0 } else { 1 };
@@ -62,15 +61,11 @@ pub async fn json_vec_string(t: &mut Test) -> Result<(), BoxError> {
         Json(tags.clone())
     );
 
-    // Update — driver receives JSON string
+    // Update — same blanket lets the update builder take the bare value.
     t.log().clear();
     let new_tags = vec!["b".to_string(), "c".to_string()];
     let expected_json = serde_json::to_string(&new_tags).unwrap();
-    record
-        .update()
-        .tags(Json(new_tags.clone()))
-        .exec(&mut db)
-        .await?;
+    record.update().tags(new_tags.clone()).exec(&mut db).await?;
 
     let (op, resp) = t.log().pop();
     if t.capability().sql {
@@ -108,14 +103,13 @@ pub async fn json_option_outside_sql_null(t: &mut Test) -> Result<(), BoxError> 
 
     let mut db = t.setup_db(models!(Item)).await;
 
-    // Some — driver receives JSON string
+    // Some — driver receives JSON string. The `Option<Json<T>>` field
+    // also accepts a bare `Json(value)` via the `IntoExpr<Option<T>> for T`
+    // blanket, so the `Some(...)` wrapping is optional.
     t.log().clear();
     let map = HashMap::from([("key".to_string(), "value".to_string())]);
     let expected_json = serde_json::to_string(&map).unwrap();
-    let record = Item::create()
-        .data(Some(Json(map.clone())))
-        .exec(&mut db)
-        .await?;
+    let record = Item::create().data(Json(map.clone())).exec(&mut db).await?;
 
     let (op, _) = t.log().pop();
     let val_pos = if driver_test_cfg!(id_u64) { 0 } else { 1 };
@@ -157,9 +151,11 @@ pub async fn json_option_inside_json_null(t: &mut Test) -> Result<(), BoxError> 
 
     let mut db = t.setup_db(models!(Item)).await;
 
-    // None → JSON text "null", not SQL NULL
+    // None → JSON text "null", not SQL NULL.
+    // `Option<String>` decodes through the `IntoExpr<Json<T>> for T`
+    // blanket — `T` here is `Option<String>`, which is `Serialize`.
     t.log().clear();
-    let empty_record = Item::create().extra(Json(None)).exec(&mut db).await?;
+    let empty_record = Item::create().extra(None).exec(&mut db).await?;
 
     let (op, _) = t.log().pop();
     let val_pos = if driver_test_cfg!(id_u64) { 0 } else { 1 };
@@ -174,7 +170,7 @@ pub async fn json_option_inside_json_null(t: &mut Test) -> Result<(), BoxError> 
     t.log().clear();
     let expected_json = serde_json::to_string(&Some("hello")).unwrap();
     let record = Item::create()
-        .extra(Json(Some("hello".to_string())))
+        .extra(Some("hello".to_string()))
         .exec(&mut db)
         .await?;
 
@@ -214,10 +210,7 @@ pub async fn json_custom_struct(t: &mut Test) -> Result<(), BoxError> {
         labels: vec!["alpha".to_string(), "beta".to_string()],
     };
     let expected_json = serde_json::to_string(&meta).unwrap();
-    let record = Item::create()
-        .meta(Json(meta.clone()))
-        .exec(&mut db)
-        .await?;
+    let record = Item::create().meta(meta.clone()).exec(&mut db).await?;
 
     let (op, _) = t.log().pop();
     let val_pos = if driver_test_cfg!(id_u64) { 0 } else { 1 };

--- a/crates/toasty-driver-integration-suite/src/tests/type_serialize.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/type_serialize.rs
@@ -2,6 +2,7 @@ use crate::prelude::*;
 
 use hashbrown::HashMap;
 use serde::{Deserialize, Serialize};
+use toasty::Json;
 use toasty_core::{
     driver::{Operation, Rows},
     stmt::{Assignment, Expr, ExprSet, Statement, Value},
@@ -32,14 +33,13 @@ fn assert_insert_serialized(t: &Test, op: &Operation, pos: usize, expected: &str
 }
 
 #[driver_test(id(ID))]
-pub async fn serialize_vec_string(t: &mut Test) -> Result<(), BoxError> {
+pub async fn json_vec_string(t: &mut Test) -> Result<(), BoxError> {
     #[derive(Debug, toasty::Model)]
     struct Item {
         #[key]
         #[auto]
         id: ID,
-        #[serialize(json)]
-        tags: Vec<String>,
+        tags: Json<Vec<String>>,
     }
 
     let mut db = t.setup_db(models!(Item)).await;
@@ -48,19 +48,29 @@ pub async fn serialize_vec_string(t: &mut Test) -> Result<(), BoxError> {
     t.log().clear();
     let tags = vec!["rust".to_string(), "toasty".to_string()];
     let expected_json = serde_json::to_string(&tags).unwrap();
-    let mut record = Item::create().tags(tags.clone()).exec(&mut db).await?;
+    let mut record = Item::create()
+        .tags(Json(tags.clone()))
+        .exec(&mut db)
+        .await?;
 
     let (op, _) = t.log().pop();
     let val_pos = if driver_test_cfg!(id_u64) { 0 } else { 1 };
     assert_insert_serialized(t, &op, val_pos, &expected_json);
 
-    assert_eq!(Item::get_by_id(&mut db, &record.id).await?.tags, tags);
+    assert_eq!(
+        Item::get_by_id(&mut db, &record.id).await?.tags,
+        Json(tags.clone())
+    );
 
     // Update — driver receives JSON string
     t.log().clear();
     let new_tags = vec!["b".to_string(), "c".to_string()];
     let expected_json = serde_json::to_string(&new_tags).unwrap();
-    record.update().tags(new_tags.clone()).exec(&mut db).await?;
+    record
+        .update()
+        .tags(Json(new_tags.clone()))
+        .exec(&mut db)
+        .await?;
 
     let (op, resp) = t.log().pop();
     if t.capability().sql {
@@ -77,20 +87,23 @@ pub async fn serialize_vec_string(t: &mut Test) -> Result<(), BoxError> {
     }
     assert_struct!(resp, { values: Rows::Count(1) });
 
-    assert_eq!(Item::get_by_id(&mut db, &record.id).await?.tags, new_tags);
+    assert_eq!(
+        Item::get_by_id(&mut db, &record.id).await?.tags,
+        Json(new_tags)
+    );
 
     Ok(())
 }
 
 #[driver_test(id(ID))]
-pub async fn serialize_nullable(t: &mut Test) -> Result<(), BoxError> {
+pub async fn json_option_outside_sql_null(t: &mut Test) -> Result<(), BoxError> {
+    // `Option<Json<T>>` — None maps to SQL `NULL`, Some(v) to a JSON string.
     #[derive(Debug, toasty::Model)]
     struct Item {
         #[key]
         #[auto]
         id: ID,
-        #[serialize(json, nullable)]
-        data: Option<HashMap<String, String>>,
+        data: Option<Json<HashMap<String, String>>>,
     }
 
     let mut db = t.setup_db(models!(Item)).await;
@@ -99,16 +112,21 @@ pub async fn serialize_nullable(t: &mut Test) -> Result<(), BoxError> {
     t.log().clear();
     let map = HashMap::from([("key".to_string(), "value".to_string())]);
     let expected_json = serde_json::to_string(&map).unwrap();
-    let record = Item::create().data(Some(map.clone())).exec(&mut db).await?;
+    let record = Item::create()
+        .data(Some(Json(map.clone())))
+        .exec(&mut db)
+        .await?;
 
     let (op, _) = t.log().pop();
     let val_pos = if driver_test_cfg!(id_u64) { 0 } else { 1 };
     assert_insert_serialized(t, &op, val_pos, &expected_json);
 
-    assert_eq!(Item::get_by_id(&mut db, &record.id).await?.data, Some(map));
+    assert_eq!(
+        Item::get_by_id(&mut db, &record.id).await?.data,
+        Some(Json(map))
+    );
 
-    // None — driver receives SQL NULL. NULL stays inline (extractable scalars
-    // only), so the row structure matches for both paths.
+    // None — driver receives SQL NULL.
     t.log().clear();
     let empty_record = Item::create().data(None).exec(&mut db).await?;
 
@@ -127,21 +145,21 @@ pub async fn serialize_nullable(t: &mut Test) -> Result<(), BoxError> {
 }
 
 #[driver_test(id(ID))]
-pub async fn serialize_non_nullable_option(t: &mut Test) -> Result<(), BoxError> {
+pub async fn json_option_inside_json_null(t: &mut Test) -> Result<(), BoxError> {
+    // `Json<Option<T>>` — None maps to the JSON literal `"null"`, not SQL `NULL`.
     #[derive(Debug, toasty::Model)]
     struct Item {
         #[key]
         #[auto]
         id: ID,
-        #[serialize(json)]
-        extra: Option<String>,
+        extra: Json<Option<String>>,
     }
 
     let mut db = t.setup_db(models!(Item)).await;
 
     // None → JSON text "null", not SQL NULL
     t.log().clear();
-    let empty_record = Item::create().extra(None).exec(&mut db).await?;
+    let empty_record = Item::create().extra(Json(None)).exec(&mut db).await?;
 
     let (op, _) = t.log().pop();
     let val_pos = if driver_test_cfg!(id_u64) { 0 } else { 1 };
@@ -149,14 +167,14 @@ pub async fn serialize_non_nullable_option(t: &mut Test) -> Result<(), BoxError>
 
     assert_eq!(
         Item::get_by_id(&mut db, &empty_record.id).await?.extra,
-        None
+        Json(None)
     );
 
     // Some → JSON string with quotes
     t.log().clear();
     let expected_json = serde_json::to_string(&Some("hello")).unwrap();
     let record = Item::create()
-        .extra(Some("hello".to_string()))
+        .extra(Json(Some("hello".to_string())))
         .exec(&mut db)
         .await?;
 
@@ -166,14 +184,14 @@ pub async fn serialize_non_nullable_option(t: &mut Test) -> Result<(), BoxError>
 
     assert_eq!(
         Item::get_by_id(&mut db, &record.id).await?.extra,
-        Some("hello".to_string())
+        Json(Some("hello".to_string()))
     );
 
     Ok(())
 }
 
 #[driver_test(id(ID))]
-pub async fn serialize_custom_struct(t: &mut Test) -> Result<(), BoxError> {
+pub async fn json_custom_struct(t: &mut Test) -> Result<(), BoxError> {
     #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
     struct Metadata {
         version: u32,
@@ -185,8 +203,7 @@ pub async fn serialize_custom_struct(t: &mut Test) -> Result<(), BoxError> {
         #[key]
         #[auto]
         id: ID,
-        #[serialize(json)]
-        meta: Metadata,
+        meta: Json<Metadata>,
     }
 
     let mut db = t.setup_db(models!(Item)).await;
@@ -197,13 +214,16 @@ pub async fn serialize_custom_struct(t: &mut Test) -> Result<(), BoxError> {
         labels: vec!["alpha".to_string(), "beta".to_string()],
     };
     let expected_json = serde_json::to_string(&meta).unwrap();
-    let record = Item::create().meta(meta.clone()).exec(&mut db).await?;
+    let record = Item::create()
+        .meta(Json(meta.clone()))
+        .exec(&mut db)
+        .await?;
 
     let (op, _) = t.log().pop();
     let val_pos = if driver_test_cfg!(id_u64) { 0 } else { 1 };
     assert_insert_serialized(t, &op, val_pos, &expected_json);
 
-    assert_eq!(Item::get_by_id(&mut db, &record.id).await?.meta, meta);
+    assert_eq!(Item::get_by_id(&mut db, &record.id).await?.meta, Json(meta));
 
     Ok(())
 }

--- a/crates/toasty-macros/src/lib.rs
+++ b/crates/toasty-macros/src/lib.rs
@@ -298,11 +298,11 @@ use proc_macro::TokenStream;
 ///
 /// Cannot be used on relation fields.
 ///
-/// ## `#[serialize(json)]` — serialize complex types as JSON
+/// ## JSON-encoded fields via [`Json<T>`](toasty::stmt::Json)
 ///
-/// Stores the field as a JSON string in the database. Requires the `serde`
-/// feature and that the field type implements `serde::Serialize` and
-/// `serde::Deserialize`.
+/// Wrap a serde-typed value in [`toasty::Json<T>`](toasty::stmt::Json) to
+/// store it as a JSON string in the database. Requires the `serde` feature
+/// and that `T` implements `serde::Serialize` and `serde::Deserialize`.
 ///
 /// ```
 /// # use toasty::Model;
@@ -311,13 +311,12 @@ use proc_macro::TokenStream;
 /// #     #[key]
 /// #     #[auto]
 /// #     id: i64,
-/// #[serialize(json)]
-/// tags: Vec<String>,
+/// tags: toasty::Json<Vec<String>>,
 /// # }
 /// ```
 ///
-/// For `Option<T>` fields, add `nullable` so that `None` maps to SQL
-/// `NULL` rather than the JSON string `"null"`:
+/// For nullable JSON columns, wrap `Json<T>` in `Option` — `None` maps to
+/// SQL `NULL`:
 ///
 /// ```
 /// # use toasty::Model;
@@ -327,12 +326,12 @@ use proc_macro::TokenStream;
 /// #     #[key]
 /// #     #[auto]
 /// #     id: i64,
-/// #[serialize(json, nullable)]
-/// metadata: Option<HashMap<String, String>>,
+/// metadata: Option<toasty::Json<HashMap<String, String>>>,
 /// # }
 /// ```
 ///
-/// Cannot be used on relation fields.
+/// To instead store `None` as the JSON literal `"null"` (no SQL `NULL`),
+/// wrap the other way: `Json<Option<T>>`.
 ///
 /// # Relation attributes
 ///
@@ -526,8 +525,8 @@ use proc_macro::TokenStream;
 ///   attributes, but not both.
 /// - `#[auto]` cannot be combined with `#[default]` or `#[update]` on the
 ///   same field.
-/// - `#[column]`, `#[default]`, `#[update]`, and `#[serialize]` cannot be
-///   used on relation fields (`BelongsTo`, `HasMany`, `HasOne`).
+/// - `#[column]`, `#[default]`, and `#[update]` cannot be used on relation
+///   fields (`BelongsTo`, `HasMany`, `HasOne`).
 /// - A field can have at most one relation attribute.
 /// - `Self` can be used as a type in relation fields for self-referential
 ///   models.
@@ -564,8 +563,7 @@ use proc_macro::TokenStream;
 ///
 ///     title: String,
 ///
-///     #[serialize(json)]
-///     tags: Vec<String>,
+///     tags: toasty::Json<Vec<String>>,
 ///
 ///     #[index]
 ///     user_id: i64,
@@ -578,7 +576,7 @@ use proc_macro::TokenStream;
     Model,
     attributes(
         key, auto, default, update, column, index, unique, table, has_many, has_one, belongs_to,
-        serialize, version, deferred
+        version, deferred
     )
 )]
 pub fn derive_model(input: TokenStream) -> TokenStream {
@@ -861,7 +859,7 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
 /// - Enum variants may be unit variants or have named fields. Tuple
 ///   variants are not supported.
 /// - Embedded types cannot have primary keys, relations, `#[auto]`,
-///   `#[default]`, `#[update]`, or `#[serialize]` attributes.
+///   `#[default]`, or `#[update]` attributes.
 ///
 /// # Full example
 ///

--- a/crates/toasty-macros/src/model/expand/create.rs
+++ b/crates/toasty-macros/src/model/expand/create.rs
@@ -184,36 +184,6 @@ impl Expand<'_> {
                             }
                         }
                     }
-                    FieldTy::Primitive(ty) if field.attrs.serialize.is_some() => {
-                        let serialize_attr = field.attrs.serialize.as_ref().unwrap();
-                        if serialize_attr.nullable {
-                            // For nullable serialized fields, extract the inner type from Option<T>
-                            // Accept Option<InnerType>, serialize Some(v) as JSON, None as NULL
-                            quote! {
-                                #vis fn #name(mut self, #name: #ty) -> Self {
-                                    match &#name {
-                                        Some(v) => {
-                                            let json = #toasty::serde_json::to_string(v).expect("failed to serialize");
-                                            self.stmt.set(#index_tokenized, <String as #toasty::IntoExpr<String>>::into_expr(json));
-                                        }
-                                        None => {
-                                            self.stmt.set(#index_tokenized, #toasty::stmt::Expr::<String>::from_untyped(#toasty::core::stmt::Expr::Value(#toasty::core::stmt::Value::Null)));
-                                        }
-                                    }
-                                    self
-                                }
-                            }
-                        } else {
-                            // Non-nullable serialized field: accept T directly, serialize to JSON
-                            quote! {
-                                #vis fn #name(mut self, #name: #ty) -> Self {
-                                    let json = #toasty::serde_json::to_string(&#name).expect("failed to serialize");
-                                    self.stmt.set(#index_tokenized, <String as #toasty::IntoExpr<String>>::into_expr(json));
-                                    self
-                                }
-                            }
-                        }
-                    }
                     FieldTy::Primitive(ty) if field.attrs.deferred => {
                         let inner = quote!(<#ty as #toasty::Defer>::Inner);
                         quote! {

--- a/crates/toasty-macros/src/model/expand/fields.rs
+++ b/crates/toasty-macros/src/model/expand/fields.rs
@@ -64,10 +64,6 @@ impl Expand<'_> {
                 let field_offset = util::int(offset);
 
                 match &field.ty {
-                    Primitive(_) if field.attrs.serialize.is_some() => {
-                        // Serialized fields are stored as opaque JSON; no field accessor
-                        TokenStream::new()
-                    }
                     Primitive(ty) if field.attrs.deferred => {
                         let inner: syn::Type =
                             syn::parse_quote!(<#ty as #toasty::Defer>::Inner);
@@ -169,7 +165,6 @@ impl Expand<'_> {
                 let field_offset = util::int(offset);
 
                 match &field.ty {
-                    Primitive(_) if field.attrs.serialize.is_some() => TokenStream::new(),
                     Primitive(ty) if field.attrs.deferred => {
                         let inner: syn::Type = syn::parse_quote!(<#ty as #toasty::Defer>::Inner);
                         self.expand_list_primitive_field_method(field_ident, &inner, &field_offset)

--- a/crates/toasty-macros/src/model/expand/model.rs
+++ b/crates/toasty-macros/src/model/expand/model.rs
@@ -477,7 +477,6 @@ impl Expand<'_> {
         let field_loads = self.model.fields.iter().enumerate().map(|(index, field)| {
             let field_ident = &field.name.ident;
             let index_tokenized = util::int(index);
-            let field_name_str = field.name.as_str();
 
             let field_name = if fields_named {
                 quote!(#field_ident:)
@@ -486,32 +485,6 @@ impl Expand<'_> {
             };
 
             match &field.ty {
-                FieldTy::Primitive(_ty) if field.attrs.serialize.is_some() => {
-                    let serialize_attr = field.attrs.serialize.as_ref().unwrap();
-
-                    let json_deserialize = quote! {
-                        let json_str = <String as #toasty::Load>::load(value)?;
-                        #toasty::serde_json::from_str(&json_str)
-                            .map_err(|e| #toasty::Error::from_args(
-                                format_args!("failed to deserialize field '{}': {}", #field_name_str, e)
-                            ))?
-                    };
-
-                    let field_value = if serialize_attr.nullable {
-                        quote! {
-                            if value.is_null() { None } else { Some({ #json_deserialize }) }
-                        }
-                    } else {
-                        json_deserialize
-                    };
-
-                    quote! {
-                        #field_name {
-                            let value = record[#index_tokenized].take();
-                            #field_value
-                        },
-                    }
-                }
                 FieldTy::Primitive(ty) => {
                     quote!(#field_name <#ty as #toasty::Load>::load(record[#index_tokenized].take())?,)
                 }
@@ -563,53 +536,33 @@ impl Expand<'_> {
     pub(super) fn expand_embedded_reload_body(&self, fields_named: bool) -> TokenStream {
         let toasty = &self.toasty;
 
-        let reload_arms: Vec<_> = self.model.fields.iter().enumerate().map(|(index, field)| {
-            let i = util::int(index);
-            let field_name_str = field.name.as_str();
+        let reload_arms: Vec<_> = self
+            .model
+            .fields
+            .iter()
+            .enumerate()
+            .map(|(index, field)| {
+                let i = util::int(index);
 
-            // For newtypes, access via tuple index (target.0); otherwise by name
-            let field_access = if fields_named {
-                let field_ident = &field.name.ident;
-                quote!(target.#field_ident)
-            } else {
-                let idx = syn::Index::from(index);
-                quote!(target.#idx)
-            };
+                // For newtypes, access via tuple index (target.0); otherwise by name
+                let field_access = if fields_named {
+                    let field_ident = &field.name.ident;
+                    quote!(target.#field_ident)
+                } else {
+                    let idx = syn::Index::from(index);
+                    quote!(target.#idx)
+                };
 
-            match &field.ty {
-                FieldTy::Primitive(_ty) if field.attrs.serialize.is_some() => {
-                    let serialize_attr = field.attrs.serialize.as_ref().unwrap();
-
-                    let json_deserialize = quote! {
-                        let json_str = <String as #toasty::Load>::load(value)?;
-                        #toasty::serde_json::from_str(&json_str)
-                            .map_err(|e| #toasty::Error::from_args(
-                                format_args!("failed to deserialize field '{}': {}", #field_name_str, e)
-                            ))?
-                    };
-
-                    let assign = if serialize_attr.nullable {
-                        quote! {
-                            if value.is_null() { None } else { Some({ #json_deserialize }) }
-                        }
-                    } else {
-                        quote! { { #json_deserialize } }
-                    };
-
-                    quote! {
-                        #i => {
-                            #field_access = #assign;
-                        }
+                match &field.ty {
+                    FieldTy::Primitive(ty) => {
+                        quote!(#i => <#ty as #toasty::Load>::reload(&mut #field_access, value)?,)
+                    }
+                    _ => {
+                        quote!(#i => #field_access.unload(),)
                     }
                 }
-                FieldTy::Primitive(ty) => {
-                    quote!(#i => <#ty as #toasty::Load>::reload(&mut #field_access, value)?,)
-                }
-                _ => {
-                    quote!(#i => #field_access.unload(),)
-                }
-            }
-        }).collect();
+            })
+            .collect();
 
         quote! {
             match value {
@@ -642,7 +595,7 @@ impl Expand<'_> {
     /// Collect the fields that participate in `CREATE_META`.
     ///
     /// Returns `(field_ident_name_str, field_rust_type)` pairs for primitive
-    /// fields that are not auto, default, update, serialize, or FK source.
+    /// fields that are not auto, default, update, or FK source.
     fn create_meta_field_entries(&self) -> Vec<(String, &syn::Type)> {
         let fk_sources: HashSet<usize> = self
             .model
@@ -667,7 +620,6 @@ impl Expand<'_> {
                 if field.attrs.auto.is_some()
                     || field.attrs.default_expr.is_some()
                     || field.attrs.update_expr.is_some()
-                    || field.attrs.serialize.is_some()
                     || field.attrs.versionable
                 {
                     return None;

--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -1,8 +1,5 @@
 use super::{Expand, util};
-use crate::model::schema::SerializeAttr;
-use crate::model::schema::{
-    AutoStrategy, Column, FieldTy, ModelKind, Name, SerializeFormat, UuidVersion,
-};
+use crate::model::schema::{AutoStrategy, Column, FieldTy, ModelKind, Name, UuidVersion};
 
 use proc_macro2::TokenStream;
 use quote::{quote, quote_spanned};
@@ -121,29 +118,8 @@ impl Expand<'_> {
                         _ => quote!(None),
                     };
 
-                    match &field.attrs.serialize {
-                        Some(SerializeAttr { format, nullable: serialize_nullable }) => {
-                            let serialize_format = match format {
-                                SerializeFormat::Json => {
-                                    quote!(Some(#toasty::core::schema::app::SerializeFormat::Json))
-                                }
-                            };
-                            let nullable_lit = *serialize_nullable;
-
-                            nullable = quote!(#nullable_lit);
-                            field_ty = quote!(#toasty::core::schema::app::FieldTy::Primitive(
-                                #toasty::core::schema::app::FieldPrimitive {
-                                    ty: #toasty::core::stmt::Type::String,
-                                    storage_ty: #storage_ty,
-                                    serialize: #serialize_format,
-                                }
-                            ));
-                        }
-                        None => {
-                            nullable = quote!(<#ty as #toasty::Field>::NULLABLE);
-                            field_ty = quote!(<#ty as #toasty::Field>::field_ty(#storage_ty));
-                        }
-                    }
+                    nullable = quote!(<#ty as #toasty::Field>::NULLABLE);
+                    field_ty = quote!(<#ty as #toasty::Field>::field_ty(#storage_ty));
                 }
                 FieldTy::BelongsTo(rel) => {
                     let ty = &rel.ty;
@@ -352,12 +328,6 @@ impl Expand<'_> {
         let toasty = &self.toasty;
 
         let checks = self.model.fields.iter().filter_map(|field| {
-            // `#[serialize]` stores the field as a JSON string regardless of
-            // the underlying Rust type — skip the storage compat check.
-            if field.attrs.serialize.is_some() {
-                return None;
-            }
-
             let FieldTy::Primitive(ty) = &field.ty else {
                 return None;
             };
@@ -432,36 +402,31 @@ impl Expand<'_> {
         self.model
             .fields
             .iter()
-            .filter_map(|field| match &field.ty {
+            .map(|field| match &field.ty {
                 FieldTy::Primitive(ty) => {
-                    // Fields with #[serialize] store arbitrary types as JSON
-                    // strings — they don't implement Field.
-                    if field.attrs.serialize.is_some() {
-                        return None;
-                    }
                     // Primitives use Field::register which delegates to inner
                     // type if it's an embedded type (via the Field impl).
-                    Some(quote! {
+                    quote! {
                         <#ty as #toasty::Field>::register(model_set);
-                    })
+                    }
                 }
                 FieldTy::BelongsTo(rel) => {
                     let ty = &rel.ty;
-                    Some(quote! {
+                    quote! {
                         <<#ty as #toasty::Relation>::Model as #toasty::Register>::register(model_set);
-                    })
+                    }
                 }
                 FieldTy::HasMany(rel) => {
                     let ty = &rel.ty;
-                    Some(quote! {
+                    quote! {
                         <<#ty as #toasty::Relation>::Model as #toasty::Register>::register(model_set);
-                    })
+                    }
                 }
                 FieldTy::HasOne(rel) => {
                     let ty = &rel.ty;
-                    Some(quote! {
+                    quote! {
                         <<#ty as #toasty::Relation>::Model as #toasty::Register>::register(model_set);
-                    })
+                    }
                 }
             })
             .collect()

--- a/crates/toasty-macros/src/model/expand/update.rs
+++ b/crates/toasty-macros/src/model/expand/update.rs
@@ -97,45 +97,6 @@ impl Expand<'_> {
                     }
                 }
             }
-            FieldTy::Primitive(ty) if field.attrs.serialize.is_some() => {
-                let serialize_attr = field.attrs.serialize.as_ref().unwrap();
-                if serialize_attr.nullable {
-                    quote! {
-                        #vis fn #field_ident(mut self, #field_ident: #ty) -> Self {
-                            self.#set_field_ident(#field_ident);
-                            self
-                        }
-
-                        #vis fn #set_field_ident(&mut self, #field_ident: #ty) -> &mut Self {
-                            let projection = #projection;
-                            match &#field_ident {
-                                Some(v) => {
-                                    let json = #toasty::serde_json::to_string(v).expect("failed to serialize");
-                                    self.assignments.set(projection, <String as #toasty::IntoExpr<String>>::into_expr(json));
-                                }
-                                None => {
-                                    self.assignments.set(projection, #toasty::stmt::Expr::<String>::from_untyped(#toasty::core::stmt::Expr::Value(#toasty::core::stmt::Value::Null)));
-                                }
-                            }
-                            self
-                        }
-                    }
-                } else {
-                    quote! {
-                        #vis fn #field_ident(mut self, #field_ident: #ty) -> Self {
-                            self.#set_field_ident(#field_ident);
-                            self
-                        }
-
-                        #vis fn #set_field_ident(&mut self, #field_ident: #ty) -> &mut Self {
-                            let projection = #projection;
-                            let json = #toasty::serde_json::to_string(&#field_ident).expect("failed to serialize");
-                            self.assignments.set(projection, <String as #toasty::IntoExpr<String>>::into_expr(json));
-                            self
-                        }
-                    }
-                }
-            }
             FieldTy::Primitive(ty) if field.attrs.deferred => {
                 let inner = quote!(<#ty as #toasty::Defer>::Inner);
                 quote! {
@@ -367,34 +328,8 @@ impl Expand<'_> {
         self.model.fields.iter().enumerate().map(|(offset, field)| {
             let i = util::int(offset);
             let field_ident = &field.name.ident;
-            let field_name_str = field.name.as_str();
 
             match &field.ty {
-                FieldTy::Primitive(_ty) if field.attrs.serialize.is_some() => {
-                    let serialize_attr = field.attrs.serialize.as_ref().unwrap();
-
-                    let json_deserialize = quote! {
-                        let json_str = <String as #toasty::Load>::load(value)?;
-                        #toasty::serde_json::from_str(&json_str)
-                            .map_err(|e| #toasty::Error::from_args(
-                                format_args!("failed to deserialize field '{}': {}", #field_name_str, e)
-                            ))?
-                    };
-
-                    let assign = if serialize_attr.nullable {
-                        quote! {
-                            if value.is_null() { None } else { Some({ #json_deserialize }) }
-                        }
-                    } else {
-                        quote! { { #json_deserialize } }
-                    };
-
-                    quote! {
-                        #i => {
-                            target.#field_ident = #assign;
-                        }
-                    }
-                }
                 FieldTy::Primitive(ty) => {
                     quote!(#i => <#ty as #toasty::Load>::reload(&mut target.#field_ident, value)?,)
                 }

--- a/crates/toasty-macros/src/model/schema.rs
+++ b/crates/toasty-macros/src/model/schema.rs
@@ -8,7 +8,7 @@ mod error;
 pub(crate) use error::ErrorSet;
 
 mod field;
-pub(crate) use field::{Field, FieldTy, SerializeAttr, SerializeFormat};
+pub(crate) use field::{Field, FieldTy};
 
 mod fk;
 pub(crate) use fk::ForeignKeyField;

--- a/crates/toasty-macros/src/model/schema/field.rs
+++ b/crates/toasty-macros/src/model/schema/field.rs
@@ -4,19 +4,6 @@ use super::{BelongsTo, Column, ErrorSet, HasMany, HasOne, Name};
 
 use syn::spanned::Spanned;
 
-/// Codegen-level representation of a serialization format.
-#[derive(Debug, Clone)]
-pub(crate) enum SerializeFormat {
-    Json,
-}
-
-/// Parsed `#[serialize(...)]` attribute data.
-#[derive(Debug, Clone)]
-pub(crate) struct SerializeAttr {
-    pub(crate) format: SerializeFormat,
-    pub(crate) nullable: bool,
-}
-
 #[derive(Debug)]
 pub(crate) struct Field {
     /// Index of field in the containing model
@@ -62,9 +49,6 @@ pub(crate) struct FieldAttr {
     /// Expression to apply on create and update: `#[update(<expr>)]`
     pub(crate) update_expr: Option<syn::Expr>,
 
-    /// Serialization info for the field: `#[serialize(json)]` or `#[serialize(json, nullable)]`
-    pub(crate) serialize: Option<SerializeAttr>,
-
     /// True if the field tracks an OCC version counter
     pub(crate) versionable: bool,
 
@@ -99,7 +83,6 @@ impl FieldAttr {
             column: None,
             default_expr: None,
             update_expr: None,
-            serialize: None,
             versionable: false,
             deferred: false,
         };
@@ -200,54 +183,17 @@ impl FieldAttr {
                     field_attr.deferred = true;
                 }
             } else if attr.path().is_ident("serialize") {
-                if field_attr.serialize.is_some() {
-                    errs.push(syn::Error::new_spanned(
-                        attr,
-                        "duplicate #[serialize] attribute",
-                    ));
-                } else {
-                    match attr.parse_args_with(
-                        syn::punctuated::Punctuated::<syn::Ident, syn::Token![,]>::parse_terminated,
-                    ) {
-                        Ok(args) => {
-                            let mut format = None;
-                            let mut nullable = false;
-
-                            for arg in &args {
-                                if arg == "json" {
-                                    if format.is_some() {
-                                        errs.push(syn::Error::new_spanned(
-                                            arg,
-                                            "duplicate format specifier",
-                                        ));
-                                    } else {
-                                        format = Some(SerializeFormat::Json);
-                                    }
-                                } else if arg == "nullable" {
-                                    nullable = true;
-                                } else {
-                                    errs.push(syn::Error::new_spanned(
-                                        arg,
-                                        "unsupported serialize argument; expected `json` or `nullable`",
-                                    ));
-                                }
-                            }
-
-                            match format {
-                                Some(format) => {
-                                    field_attr.serialize = Some(SerializeAttr { format, nullable });
-                                }
-                                None => {
-                                    errs.push(syn::Error::new_spanned(
-                                        attr,
-                                        "missing serialization format; expected `json`",
-                                    ));
-                                }
-                            }
-                        }
-                        Err(e) => errs.push(e),
-                    }
-                }
+                // The `#[serialize(json)]` attribute has been replaced by the
+                // `toasty::Json<T>` field wrapper. The wrapper handles the
+                // same encoding through trait dispatch, composes cleanly with
+                // `Option<T>` and `Deferred<T>`, and works in expressions
+                // (e.g. `.eq(Json("hello"))`).
+                errs.push(syn::Error::new_spanned(
+                    attr,
+                    "the `#[serialize(json)]` attribute has been removed; \
+                     wrap the field type in `toasty::Json<T>` instead \
+                     (e.g. `tags: toasty::Json<Vec<String>>`)",
+                ));
             }
         }
 
@@ -362,13 +308,6 @@ impl Field {
             errs.push(syn::Error::new_spanned(
                 field,
                 "#[update] cannot be used on relation fields",
-            ));
-        }
-
-        if ty.is_some() && attrs.serialize.is_some() {
-            errs.push(syn::Error::new_spanned(
-                field,
-                "#[serialize] cannot be used on relation fields",
             ));
         }
 

--- a/crates/toasty/src/lib.rs
+++ b/crates/toasty/src/lib.rs
@@ -122,6 +122,8 @@ pub use schema::{BelongsTo, Deferred, HasMany, HasOne};
 
 /// Typed statement, expression, and query builder types.
 pub mod stmt;
+#[cfg(feature = "serde")]
+pub use stmt::Json;
 pub use stmt::Statement;
 
 pub use toasty_macros::{Embed, Model, create, query};

--- a/crates/toasty/src/schema/field.rs
+++ b/crates/toasty/src/schema/field.rs
@@ -284,6 +284,16 @@ impl<T: Field> Field for Option<T> {
     ) -> Self::Update<'a> {
     }
 
+    /// Delegate the field-type description to `T` so wrappers carrying
+    /// schema-relevant metadata (e.g. `Json<U>::serialize = Some(Json)`)
+    /// propagate through `Option<_>` instead of getting flattened to the
+    /// default `serialize: None`.
+    fn field_ty(
+        storage_ty: Option<toasty_core::schema::db::Type>,
+    ) -> toasty_core::schema::app::FieldTy {
+        T::field_ty(storage_ty)
+    }
+
     fn key_constraint<Origin>(&self, target: stmt::Path<Origin, Self::Inner>) -> Expr<bool> {
         match self {
             Some(value) => T::key_constraint(value, target),

--- a/crates/toasty/src/stmt.rs
+++ b/crates/toasty/src/stmt.rs
@@ -30,6 +30,11 @@ pub use into_insert::IntoInsert;
 mod into_statement;
 pub use into_statement::IntoStatement;
 
+#[cfg(feature = "serde")]
+mod json;
+#[cfg(feature = "serde")]
+pub use json::Json;
+
 mod list;
 pub use list::List;
 

--- a/crates/toasty/src/stmt/json.rs
+++ b/crates/toasty/src/stmt/json.rs
@@ -1,0 +1,215 @@
+use super::{Expr, IntoExpr, List, Path, Value};
+use crate::schema::{Field, Load};
+use toasty_core::schema::app::{FieldPrimitive, FieldTy, SerializeFormat};
+use toasty_core::{schema::db, stmt};
+
+use std::fmt;
+
+/// A field wrapper that stores `T` as a JSON-encoded string in the database.
+///
+/// Use `Json<T>` as a model field type when the column has no native database
+/// representation for `T` — for example, a serde-derived struct, a `HashMap`,
+/// or any other type that round-trips through
+/// [`serde::Serialize`](serde::Serialize) and
+/// [`serde::Deserialize`](serde::Deserialize). The value is JSON-encoded on
+/// insert and update, and decoded on read.
+///
+/// The column is stored as `TEXT` (or the backend equivalent). Use a
+/// `#[column(type = "jsonb")]` annotation (or similar) on the field if a
+/// driver-native JSON column type is preferred.
+///
+/// # Two nullable variants
+///
+/// `Json<T>` composes with `Option` in two distinct, both-useful ways:
+///
+/// | Field type           | `None` is stored as      |
+/// |----------------------|--------------------------|
+/// | `Option<Json<T>>`    | SQL `NULL`               |
+/// | `Json<Option<T>>`    | JSON literal `"null"`    |
+///
+/// # Composition with `Deferred`
+///
+/// `Json<T>` is the only wrapper allowed inside [`Deferred`](crate::Deferred)
+/// for a serde-typed field, since a `#[deferred]` column needs both lazy
+/// loading and a serializer the macro can drive through trait dispatch:
+///
+/// ```ignore
+/// #[derive(Debug, toasty::Model)]
+/// struct Repository {
+///     #[key] #[auto]
+///     id: uuid::Uuid,
+///     #[deferred]
+///     schema: toasty::Deferred<toasty::Json<MySchema>>,
+/// }
+/// ```
+///
+/// # Examples
+///
+/// ```ignore
+/// use serde::{Serialize, Deserialize};
+///
+/// #[derive(Debug, Clone, Serialize, Deserialize)]
+/// struct Tags(Vec<String>);
+///
+/// #[derive(Debug, toasty::Model)]
+/// struct Item {
+///     #[key] #[auto]
+///     id: i64,
+///     tags: toasty::Json<Tags>,
+/// }
+/// ```
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Json<T>(pub T);
+
+impl<T> Json<T> {
+    /// Construct a new `Json<T>` wrapping `value`.
+    pub const fn new(value: T) -> Self {
+        Json(value)
+    }
+
+    /// Consume the wrapper and return the inner value.
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<T> From<T> for Json<T> {
+    fn from(value: T) -> Self {
+        Json(value)
+    }
+}
+
+impl<T> std::ops::Deref for Json<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> std::ops::DerefMut for Json<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
+impl<T> AsRef<T> for Json<T> {
+    fn as_ref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> AsMut<T> for Json<T> {
+    fn as_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
+impl<T> Load for Json<T>
+where
+    T: for<'de> serde_core::Deserialize<'de>,
+{
+    type Output = Self;
+
+    fn ty() -> stmt::Type {
+        stmt::Type::String
+    }
+
+    fn load(value: stmt::Value) -> crate::Result<Self> {
+        // A `NULL` cell decodes as the JSON literal `null` so
+        // `Json<Option<T>>` sees `None` here without a per-call branch.
+        let json = match value {
+            stmt::Value::Null => std::borrow::Cow::Borrowed("null"),
+            v => std::borrow::Cow::Owned(<String as Load>::load(v)?),
+        };
+        serde_json::from_str(&json).map(Json).map_err(|e| {
+            toasty_core::Error::from_args(format_args!("failed to deserialize JSON field: {e}"))
+        })
+    }
+
+    fn reload(target: &mut Self, value: stmt::Value) -> crate::Result<()> {
+        *target = Self::load(value)?;
+        Ok(())
+    }
+}
+
+impl<T> Field for Json<T>
+where
+    T: serde_core::Serialize + for<'de> serde_core::Deserialize<'de>,
+{
+    type ExprTarget = Self;
+    type Path<Origin> = Path<Origin, Self>;
+    type ListPath<Origin> = Path<Origin, List<Self>>;
+    type Update<'a> = ();
+    type Inner = Self;
+
+    fn new_path<Origin>(path: Path<Origin, Self>) -> Self::Path<Origin> {
+        path
+    }
+
+    fn new_list_path<Origin>(path: Path<Origin, List<Self>>) -> Self::ListPath<Origin> {
+        path
+    }
+
+    fn new_update<'a>(
+        _assignments: &'a mut toasty_core::stmt::Assignments,
+        _projection: toasty_core::stmt::Projection,
+    ) -> Self::Update<'a> {
+    }
+
+    /// Tag the schema entry as a JSON-serialized String column.
+    ///
+    /// The macro never inspects the wrapper at the AST level; the
+    /// `serialize: Some(Json)` metadata flows through trait dispatch
+    /// alongside the storage type, so external schema consumers can still
+    /// see that the column is JSON-typed even though the encoding itself is
+    /// invisible to the macro.
+    fn field_ty(storage_ty: Option<db::Type>) -> FieldTy {
+        FieldTy::Primitive(FieldPrimitive {
+            ty: stmt::Type::String,
+            storage_ty,
+            serialize: Some(SerializeFormat::Json),
+        })
+    }
+
+    fn key_constraint<Origin>(&self, _target: Path<Origin, Self::Inner>) -> Expr<bool> {
+        // JSON columns are not valid foreign-key targets — the comparison
+        // would happen at the serialized-string level, which is rarely what
+        // the user wants. The trait method exists for every `Field`; we
+        // satisfy it with a panic rather than admitting nonsense semantics.
+        unreachable!("Json<T> fields cannot be used as foreign-key targets")
+    }
+}
+
+impl<T> IntoExpr<Json<T>> for Json<T>
+where
+    T: serde_core::Serialize,
+{
+    fn into_expr(self) -> Expr<Json<T>> {
+        let json = serde_json::to_string(&self.0).expect("failed to serialize");
+        Expr::<String>::from_value(Value::from(json)).cast()
+    }
+
+    fn by_ref(&self) -> Expr<Json<T>> {
+        let json = serde_json::to_string(&self.0).expect("failed to serialize");
+        Expr::<String>::from_value(Value::from(json)).cast()
+    }
+}
+
+// `IntoExpr<Json<T>>` for `&Json<T>` comes from the blanket
+// `impl<T: IntoExpr<T>> IntoExpr<T> for &T` in `stmt::into_expr`.
+
+impl<T> super::assignment::Assign<Json<T>> for Json<T>
+where
+    T: serde_core::Serialize,
+{
+    fn into_assignment(self) -> super::assignment::Assignment<Json<T>> {
+        super::set(<Self as IntoExpr<Json<T>>>::into_expr(self))
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for Json<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}

--- a/crates/toasty/src/stmt/json.rs
+++ b/crates/toasty/src/stmt/json.rs
@@ -132,12 +132,13 @@ where
     }
 
     fn load(value: stmt::Value) -> crate::Result<Self> {
-        // A `NULL` cell decodes as the JSON literal `null` so
-        // `Json<Option<T>>` sees `None` here without a per-call branch.
-        let json = match value {
-            stmt::Value::Null => std::borrow::Cow::Borrowed("null"),
-            v => std::borrow::Cow::Owned(<String as Load>::load(v)?),
-        };
+        // SQL `NULL` never reaches here: a nullable JSON column is typed
+        // `Option<Json<T>>`, and `Option<T>: Load` intercepts `Value::Null`
+        // before delegating to the inner type. `Json<Option<T>>` stores the
+        // JSON literal `"null"` as a non-null string, so its `None` case
+        // comes through as `Value::String("null")` and `serde_json` decodes
+        // it. A bare `Value::Null` at this point is a driver bug.
+        let json = <String as Load>::load(value)?;
         serde_json::from_str(&json).map(Json).map_err(|e| {
             toasty_core::Error::from_args(format_args!("failed to deserialize JSON field: {e}"))
         })

--- a/crates/toasty/src/stmt/json.rs
+++ b/crates/toasty/src/stmt/json.rs
@@ -27,6 +27,22 @@ use std::fmt;
 /// | `Option<Json<T>>`    | SQL `NULL`               |
 /// | `Json<Option<T>>`    | JSON literal `"null"`    |
 ///
+/// # Setter ergonomics
+///
+/// The crate provides an `IntoExpr<Json<T>>` impl for any
+/// `T: serde::Serialize`, so create / update setters and the `create!`
+/// macro accept the bare inner value without an explicit `Json(...)`
+/// wrapper. Both forms produce the same expression:
+///
+/// ```ignore
+/// // for a `payload: Json<Payload>` (or `Deferred<Json<Payload>>`) field
+/// Repository::create().payload(my_payload.clone()).exec(&mut db).await?;
+/// Repository::create().payload(Json(my_payload.clone())).exec(&mut db).await?;
+/// ```
+///
+/// The `Json(...)` form is still useful when type inference needs a
+/// nudge (e.g., comparison expressions like `.eq(Json("hello"))`).
+///
 /// # Composition with `Deferred`
 ///
 /// `Json<T>` is the only wrapper allowed inside [`Deferred`](crate::Deferred)
@@ -199,7 +215,49 @@ where
 // `IntoExpr<Json<T>>` for `&Json<T>` comes from the blanket
 // `impl<T: IntoExpr<T>> IntoExpr<T> for &T` in `stmt::into_expr`.
 
+/// Accept a bare `T` wherever the API expects `IntoExpr<Json<T>>`, so
+/// callers don't have to spell `Json(value)` at setter sites:
+///
+/// ```ignore
+/// // both forms work for a `payload: Json<Payload>` field
+/// Repository::create().payload(Json(payload.clone())).exec(&mut db).await?;
+/// Repository::create().payload(payload.clone()).exec(&mut db).await?;
+/// ```
+///
+/// The blanket only fires when `T: serde::Serialize`; it doesn't overlap
+/// the explicit `IntoExpr<Json<T>> for Json<T>` impl because `Json<U>`
+/// itself is not `Serialize` (no derive on the wrapper).
+impl<T> IntoExpr<Json<T>> for T
+where
+    T: serde_core::Serialize,
+{
+    fn into_expr(self) -> Expr<Json<T>> {
+        let json = serde_json::to_string(&self).expect("failed to serialize");
+        Expr::<String>::from_value(Value::from(json)).cast()
+    }
+
+    fn by_ref(&self) -> Expr<Json<T>> {
+        let json = serde_json::to_string(self).expect("failed to serialize");
+        Expr::<String>::from_value(Value::from(json)).cast()
+    }
+}
+
 impl<T> super::assignment::Assign<Json<T>> for Json<T>
+where
+    T: serde_core::Serialize,
+{
+    fn into_assignment(self) -> super::assignment::Assignment<Json<T>> {
+        super::set(<Self as IntoExpr<Json<T>>>::into_expr(self))
+    }
+}
+
+/// Mirrors the `IntoExpr<Json<T>> for T` blanket on the assignment side so
+/// update builders accept a bare value too:
+///
+/// ```ignore
+/// repo.update().payload(payload.clone()).exec(&mut db).await?;
+/// ```
+impl<T> super::assignment::Assign<Json<T>> for T
 where
     T: serde_core::Serialize,
 {

--- a/crates/toasty/src/stmt/json.rs
+++ b/crates/toasty/src/stmt/json.rs
@@ -77,18 +77,6 @@ use std::fmt;
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Json<T>(pub T);
 
-impl<T> Json<T> {
-    /// Construct a new `Json<T>` wrapping `value`.
-    pub const fn new(value: T) -> Self {
-        Json(value)
-    }
-
-    /// Consume the wrapper and return the inner value.
-    pub fn into_inner(self) -> T {
-        self.0
-    }
-}
-
 impl<T> From<T> for Json<T> {
     fn from(value: T) -> Self {
         Json(value)

--- a/docs/guide/src/field-options.md
+++ b/docs/guide/src/field-options.md
@@ -417,10 +417,12 @@ that support `varchar`.
 let post = toasty::create!(Post {
     title: "Hello",
     tags: vec!["rust".to_string(), "toasty".to_string()],
-    meta: toasty::Json(Metadata {
+    // The bare value is accepted via the `IntoExpr<Json<T>> for T`
+    // blanket — wrapping with `toasty::Json(...)` is optional.
+    meta: Metadata {
         version: 1,
         labels: vec!["alpha".to_string()],
-    }),
+    },
 })
 .exec(&mut db)
 .await?;

--- a/docs/guide/src/field-options.md
+++ b/docs/guide/src/field-options.md
@@ -348,14 +348,16 @@ struct Event {
 
 ## JSON serialization
 
-Use `#[serialize(json)]` to store an arbitrary serde-serializable Rust
-value as a JSON string in the database. The field type must implement
-`serde::Serialize` and `serde::Deserialize`.
+Wrap a field type in [`toasty::Json<T>`][json-doc] to store it as a JSON
+string in the database. The inner `T` must implement `serde::Serialize`
+and `serde::Deserialize`.
 
-Reach for `#[serialize(json)]` when the field is a serde-typed value
-that Toasty doesn't natively support — for example, a third-party type
-or a struct you don't want to declare as `#[derive(toasty::Embed)]`.
-For `Vec<scalar>` fields, prefer the native form (`tags: Vec<String>`,
+[json-doc]: https://docs.rs/toasty/latest/toasty/stmt/struct.Json.html
+
+Reach for `Json<T>` when the field is a serde-typed value that Toasty
+doesn't natively support — for example, a third-party type or a struct
+you don't want to declare as `#[derive(toasty::Embed)]`. For
+`Vec<scalar>` fields, prefer the native form (`tags: Vec<String>`,
 documented in [Defining Models](./defining-models.md)) which is
 queryable and supports collection mutations via `stmt::push`,
 `stmt::extend`, `stmt::pop`, `stmt::remove`, `stmt::remove_at`, and
@@ -379,13 +381,12 @@ struct Post {
 
     title: String,
 
-    // Native `Vec<scalar>` storage — no attribute needed.
+    // Native `Vec<scalar>` storage — no wrapper needed.
     tags: Vec<String>,
 
-    // Arbitrary serde type — `#[serialize(json)]` stores it as one
-    // opaque JSON column. Toasty cannot query into it.
-    #[serialize(json)]
-    meta: Metadata,
+    // Arbitrary serde type — `Json<T>` stores it as one opaque JSON
+    // column. Toasty cannot query into it.
+    meta: toasty::Json<Metadata>,
 }
 ```
 
@@ -410,36 +411,33 @@ that support `varchar`.
 #     id: u64,
 #     title: String,
 #     tags: Vec<String>,
-#     #[serialize(json)]
-#     meta: Metadata,
+#     meta: toasty::Json<Metadata>,
 # }
 # async fn __example(mut db: toasty::Db) -> toasty::Result<()> {
 let post = toasty::create!(Post {
     title: "Hello",
     tags: vec!["rust".to_string(), "toasty".to_string()],
-    meta: Metadata {
+    meta: toasty::Json(Metadata {
         version: 1,
         labels: vec!["alpha".to_string()],
-    },
+    }),
 })
 .exec(&mut db)
 .await?;
 
 assert_eq!(post.tags, vec!["rust", "toasty"]);
-assert_eq!(post.meta.version, 1);
+assert_eq!(post.meta.0.version, 1);
 # Ok(())
 # }
 ```
 
 ### Nullable JSON fields
 
-By default, `#[serialize(json)]` creates a `NOT NULL` column. An `Option<T>`
-field with `#[serialize(json)]` serializes `None` as the JSON text `"null"` —
-the column still stores a non-null string.
+`Json<T>` composes with `Option` in two distinct, both-useful ways
+depending on whether `None` should land in a SQL `NULL` cell or be
+encoded inside the JSON itself:
 
-To allow SQL `NULL` in the column, add the `nullable` modifier:
-
-```rust
+```rust,ignore
 # use toasty::Model;
 # use std::collections::HashMap;
 # #[derive(Debug, toasty::Model)]
@@ -448,18 +446,18 @@ To allow SQL `NULL` in the column, add the `nullable` modifier:
 #     #[auto]
 #     id: u64,
 #     title: String,
-#[serialize(json, nullable)]
-metadata: Option<HashMap<String, String>>,
+// `None` maps to SQL `NULL`; `Some(v)` to a JSON string.
+metadata: Option<toasty::Json<HashMap<String, String>>>,
+
+// `None` maps to the JSON literal `"null"` (still a non-null string);
+// `Some(v)` to a JSON string.
+labels: toasty::Json<Option<Vec<String>>>,
 # }
 ```
 
-With `nullable`:
-- `None` maps to SQL `NULL` in the database
-- `Some(value)` maps to the JSON string representation
-
-Without `nullable`:
-- `None` maps to the JSON text `"null"` (a non-null string)
-- `Some(value)` maps to the JSON string representation
+`Option<Json<T>>` is the common case — pick it when the database should
+see a `NULL` for missing values. Use `Json<Option<T>>` when callers
+expect the column to always contain valid JSON.
 
 ## Scalar arrays
 
@@ -478,8 +476,11 @@ querying, and updates — see [`Vec<scalar>` Fields](./vec-scalar-fields.md).
 | `#[update(expr)]` | Automatic value | Create and update |
 | `#[auto]` on `created_at` | Shorthand for `#[default(jiff::Timestamp::now())]` | Create only |
 | `#[auto]` on `updated_at` | Shorthand for `#[update(jiff::Timestamp::now())]` | Create and update |
-| `#[serialize(json)]` | Store as JSON text | Create and update |
-| `#[serialize(json, nullable)]` | Store as JSON text with SQL NULL support | Create and update |
+
+JSON storage is handled by the [`toasty::Json<T>`][json-doc] field
+wrapper — see [JSON serialization](#json-serialization) above. Use
+`Option<Json<T>>` to allow SQL `NULL`, or `Json<Option<T>>` to embed
+the JSON literal `"null"` instead.
 
 See [Concurrency Control](./concurrency-control.md) for the `#[version]`
 attribute.

--- a/docs/guide/src/field-options.md
+++ b/docs/guide/src/field-options.md
@@ -428,7 +428,7 @@ let post = toasty::create!(Post {
 .await?;
 
 assert_eq!(post.tags, vec!["rust", "toasty"]);
-assert_eq!(post.meta.0.version, 1);
+assert_eq!(post.meta.version, 1);
 # Ok(())
 # }
 ```


### PR DESCRIPTION
The attribute-driven JSON path branched on `field.attrs.serialize` at
five sites (create / update / model load / model reload / field
accessor), and composing it with `#[deferred]` produced uncompilable
code because the serialize branch always won. The wrapper type drives
the same encoding through trait dispatch, composing cleanly with
`Option<T>` and `Deferred<T>` without per-attribute codegen.

- Add `toasty::Json<T>` (re-exported from `toasty::stmt`) — feature-
  gated on `serde`, implements `Load`, `Field`, `IntoExpr<Json<T>>`,
  and `Assign<Json<T>>`. The Field impl tags the schema entry with
  `SerializeFormat::Json` so the existing app-schema metadata is
  preserved through trait dispatch.
- Delegate `Option<T>::field_ty` to `T::field_ty` so the JSON tag
  propagates through `Option<Json<T>>`.
- Map `Json<T>`'s `load` of `Value::Null` to the JSON literal `null`,
  letting `Json<Option<T>>` decode SQL `NULL` as `None`.
- Strip every `field.attrs.serialize` branch from the macro codegen.
  Field paths/lists fall through to the standard primitive path, so
  `Item::fields().tags()` becomes a real `Path<_, Json<T>>` instead of
  being suppressed.
- Reject `#[serialize(...)]` in the attribute parser with a migration
  message pointing at `Json<T>`. The attribute is no longer in the
  derive's `attributes(...)` list.

Tests: rewrite `tests/type_serialize.rs` against `Json<T>`, covering
both nullable orderings (`Option<Json<T>>` → SQL `NULL`,
`Json<Option<T>>` → JSON `"null"`). Add a `deferred_json_document`
scenario plus five `deferred_field` tests exercising the
`Deferred<Json<T>>` composition (create-returns-loaded,
default-leaves-unloaded, exec-lazy-loads, include-eager-loads,
update-refreshes).

Closes #920

BREAKING CHANGE: `#[serialize(json)]` and `#[serialize(json,
nullable)]` are removed. Migrate by wrapping the field type in
`toasty::Json<T>`:
  `#[serialize(json)] tags: Vec<String>`
    → `tags: toasty::Json<Vec<String>>`
  `#[serialize(json, nullable)] data: Option<HashMap<_, _>>`
    → `data: Option<toasty::Json<HashMap<_, _>>>`
Call sites that supplied a bare value to setters now pass
`Json(value)`; field accessors return `&Json<T>` rather than `&T`.