### PR TITLE
fix: respect `pair` attribute in `#[has_one]` macro

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/relation_belongs_to_configured.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_belongs_to_configured.rs
@@ -48,3 +48,48 @@ pub async fn different_field_name(test: &mut Test) -> Result<()> {
     assert_eq!(user.id, user_reloaded.id);
     Ok(())
 }
+
+// Regression test for https://github.com/tokio-rs/toasty/issues/924:
+// `#[has_one(pair = <field>)]` was accepted but ignored, so the generated
+// back-reference check still looked for a `BelongsTo` field named after the
+// parent model instead of the configured pair.
+#[driver_test(id(ID))]
+pub async fn has_one_different_field_name(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Parent {
+        #[key]
+        #[auto]
+        id: ID,
+
+        #[has_one(pair = owner)]
+        other: toasty::HasOne<Child>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Child {
+        #[key]
+        #[auto]
+        id: ID,
+
+        #[belongs_to(key = owner_id, references = id)]
+        owner: toasty::BelongsTo<Parent>,
+
+        #[unique]
+        owner_id: ID,
+    }
+
+    let mut db = test.setup_db(models!(Parent, Child)).await;
+
+    let parent = Parent::create()
+        .other(Child::create())
+        .exec(&mut db)
+        .await?;
+
+    let child = parent.other().exec(&mut db).await?;
+    assert_eq!(child.owner_id, parent.id);
+
+    let parent_reloaded = child.owner().exec(&mut db).await?;
+    assert_eq!(parent.id, parent_reloaded.id);
+
+    Ok(())
+}

--- a/crates/toasty-macros/src/model/expand/relation.rs
+++ b/crates/toasty-macros/src/model/expand/relation.rs
@@ -415,7 +415,10 @@ impl Expand<'_> {
         let pair_check = if rel.via.is_some() {
             quote! {}
         } else {
-            let pair_ident = syn::Ident::new(&self.model.name.ident.to_string(), rel.span);
+            let pair_ident = rel.pair.clone().unwrap_or(syn::Ident::new(
+                &self.model.name.ident.to_string(),
+                rel.span,
+            ));
             self.expand_pair_belongs_to_check(
                 &pair_ident,
                 field_ident,


### PR DESCRIPTION
## Summary

Fixes a bug where the `pair` attribute in `#[has_one(...)]` was accepted but ignored during code generation. The generated back-reference check would always look for a `BelongsTo` field named after the parent model, rather than using the configured pair field name.

This resolves https://github.com/tokio-rs/toasty/issues/924.

## Changes

**toasty-macros/src/model/expand/relation.rs:**
- Modified the pair field name resolution to use `rel.pair` (the configured pair attribute) when available, falling back to the parent model name only if no pair is explicitly configured.

**crates/toasty-driver-integration-suite/src/tests/relation_belongs_to_configured.rs:**
- Added regression test `has_one_different_field_name` that verifies `#[has_one(pair = owner)]` correctly generates back-reference checks using the `owner` field instead of the default parent model name.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Added regression test covering the fix

## Notes for reviewers

The fix is minimal and surgical: it simply uses the already-parsed `rel.pair` field when generating the pair check, rather than always defaulting to the parent model name. The regression test demonstrates the bug and verifies the fix works correctly for both directions of the relation.

https://claude.ai/code/session_01UX9c1aiL3U41RMeDKqtVSu