### PR TITLE
feat: allow #[version] on tuple-newtype embeds of u64

### DIFF
--- a/crates/toasty-driver-dynamodb/src/lib.rs
+++ b/crates/toasty-driver-dynamodb/src/lib.rs
@@ -418,6 +418,18 @@ fn ddb_expression(
             let inner = ddb_expression(cx, attrs, primary, &expr.expr);
             format!("size({inner})")
         }
+        // A single-field record is a newtype embed (e.g. `Version(u64)`).
+        // DynamoDB stores the inner value as a flat attribute, so unwrap one
+        // level and recurse — `Record([Column(c)])` is equivalent to `Column(c)`.
+        stmt::Expr::Record(expr_record) => {
+            let [inner] = expr_record.fields.as_slice() else {
+                todo!(
+                    "multi-column embedded struct in DynamoDB filter: {:#?}",
+                    expr_record
+                );
+            };
+            ddb_expression(cx, attrs, primary, inner)
+        }
         _ => todo!("FILTER = {:#?}", expr),
     }
 }

--- a/crates/toasty-driver-dynamodb/src/lib.rs
+++ b/crates/toasty-driver-dynamodb/src/lib.rs
@@ -418,18 +418,6 @@ fn ddb_expression(
             let inner = ddb_expression(cx, attrs, primary, &expr.expr);
             format!("size({inner})")
         }
-        // A single-field record is a newtype embed (e.g. `Version(u64)`).
-        // DynamoDB stores the inner value as a flat attribute, so unwrap one
-        // level and recurse — `Record([Column(c)])` is equivalent to `Column(c)`.
-        stmt::Expr::Record(expr_record) => {
-            let [inner] = expr_record.fields.as_slice() else {
-                todo!(
-                    "multi-column embedded struct in DynamoDB filter: {:#?}",
-                    expr_record
-                );
-            };
-            ddb_expression(cx, attrs, primary, inner)
-        }
         _ => todo!("FILTER = {:#?}", expr),
     }
 }

--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -40,6 +40,7 @@ pub mod field_column_name;
 pub mod field_column_type;
 pub mod field_default_and_update;
 pub mod field_version;
+pub mod field_version_newtype;
 pub mod filter_ilike;
 pub mod filter_like;
 pub mod float_fields;

--- a/crates/toasty-driver-integration-suite/src/tests/field_version_newtype.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/field_version_newtype.rs
@@ -1,0 +1,135 @@
+use crate::prelude::*;
+
+/// A `#[version]` field may be a tuple-newtype around `u64` rather than a bare
+/// `u64`. These tests mirror the core scenarios in `field_version.rs` but use
+/// a `Version(u64)` newtype embed to verify that the macro accepts the type and
+/// the generated OCC logic still operates correctly.
+///
+/// DynamoDB only for now (`requires(not(sql))`) because the SQL drivers do not
+/// yet implement the version-counter OCC path.
+
+#[derive(Debug, Clone, Copy, PartialEq, toasty::Embed)]
+struct Version(u64);
+
+/// A newly created record starts with version == Version(1).
+#[driver_test(requires(not(sql)))]
+pub async fn newtype_version_create_initializes(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+
+        name: String,
+
+        #[version]
+        version: Version,
+    }
+
+    let mut db = t.setup_db(models!(Item)).await;
+
+    let item = toasty::create!(Item { name: "hello" })
+        .exec(&mut db)
+        .await?;
+    assert_eq!(item.version, Version(1));
+
+    Ok(())
+}
+
+/// Updating a record through the newtype version field increments the counter.
+#[driver_test(requires(not(sql)))]
+pub async fn newtype_version_update_increments(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+
+        name: String,
+
+        #[version]
+        version: Version,
+    }
+
+    let mut db = t.setup_db(models!(Item)).await;
+
+    let mut item = toasty::create!(Item { name: "hello" })
+        .exec(&mut db)
+        .await?;
+    assert_eq!(item.version, Version(1));
+
+    item.update().name("world").exec(&mut db).await?;
+    assert_eq!(item.version, Version(2));
+
+    item.update().name("again").exec(&mut db).await?;
+    assert_eq!(item.version, Version(3));
+
+    Ok(())
+}
+
+/// A stale update (wrong version) must be rejected even when the version field
+/// is a newtype.
+#[driver_test(requires(not(sql)))]
+pub async fn newtype_version_stale_update_fails(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+
+        name: String,
+
+        #[version]
+        version: Version,
+    }
+
+    let mut db = t.setup_db(models!(Item)).await;
+
+    let mut item = toasty::create!(Item { name: "hello" })
+        .exec(&mut db)
+        .await?;
+    assert_eq!(item.version, Version(1));
+
+    let mut stale = Item::filter_by_id(item.id).get(&mut db).await?;
+    assert_eq!(stale.version, Version(1));
+
+    item.update().name("updated").exec(&mut db).await?;
+    assert_eq!(item.version, Version(2));
+
+    let result: Result<()> = stale.update().name("should fail").exec(&mut db).await;
+    assert!(result.is_err(), "expected stale update to fail");
+
+    Ok(())
+}
+
+/// A stale delete (wrong version) must be rejected when the version field is a
+/// newtype.
+#[driver_test(requires(not(sql)))]
+pub async fn newtype_version_stale_delete_fails(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+
+        name: String,
+
+        #[version]
+        version: Version,
+    }
+
+    let mut db = t.setup_db(models!(Item)).await;
+
+    let mut item = toasty::create!(Item { name: "hello" })
+        .exec(&mut db)
+        .await?;
+    let stale = Item::filter_by_id(item.id).get(&mut db).await?;
+
+    item.update().name("updated").exec(&mut db).await?;
+    assert_eq!(item.version, Version(2));
+
+    let result: Result<()> = stale.delete().exec(&mut db).await;
+    assert!(result.is_err(), "expected stale delete to fail");
+
+    Ok(())
+}

--- a/crates/toasty-macros/src/model/expand.rs
+++ b/crates/toasty-macros/src/model/expand.rs
@@ -392,6 +392,10 @@ impl Expand<'_> {
         quote! {
             impl #toasty::newtype::NewtypeOf for #model_ident {
                 type Inner = #inner_ty;
+
+                fn into_inner(self) -> #inner_ty {
+                    self.0
+                }
             }
         }
     }

--- a/crates/toasty-macros/src/model/expand.rs
+++ b/crates/toasty-macros/src/model/expand.rs
@@ -398,6 +398,10 @@ impl Expand<'_> {
                 fn into_inner(self) -> #inner_ty {
                     self.0
                 }
+
+                fn from_inner(inner: #inner_ty) -> Self {
+                    Self(inner)
+                }
             }
         }
     }

--- a/crates/toasty-macros/src/model/expand.rs
+++ b/crates/toasty-macros/src/model/expand.rs
@@ -39,6 +39,7 @@ impl Expand<'_> {
         let validate_create_impls = self.expand_validate_create_impls();
         let storage_compat_checks = self.expand_storage_compat_checks();
         let auto_compat_checks = self.expand_auto_compat_checks();
+        let version_compat_checks = self.expand_version_compat_checks();
 
         wrap_in_const(quote! {
             #model_impls
@@ -51,6 +52,7 @@ impl Expand<'_> {
             #validate_create_impls
             #storage_compat_checks
             #auto_compat_checks
+            #version_compat_checks
         })
     }
 }

--- a/crates/toasty-macros/src/model/expand/model.rs
+++ b/crates/toasty-macros/src/model/expand/model.rs
@@ -286,11 +286,7 @@ impl Expand<'_> {
                                 index: #index_tokenized,
                             }
                         ),
-                        #toasty::core::stmt::Expr::Value(
-                            #toasty::core::stmt::Value::U64(
-                                <#field_ty as #toasty::Version>::as_u64(self.#field_ident)
-                            )
-                        ),
+                        #toasty::into_untyped_expr::<#field_ty, _>(self.#field_ident),
                     )
                 )
             )

--- a/crates/toasty-macros/src/model/expand/model.rs
+++ b/crates/toasty-macros/src/model/expand/model.rs
@@ -272,6 +272,9 @@ impl Expand<'_> {
         let field = &self.model.fields[version_index];
         let index_tokenized = util::int(version_index);
         let field_ident = &field.name.ident;
+        let FieldTy::Primitive(field_ty) = &field.ty else {
+            unreachable!("version field must be primitive");
+        };
 
         quote! {
             __delete.set_condition(
@@ -284,7 +287,9 @@ impl Expand<'_> {
                             }
                         ),
                         #toasty::core::stmt::Expr::Value(
-                            #toasty::core::stmt::Value::U64(self.#field_ident)
+                            #toasty::core::stmt::Value::U64(
+                                <#field_ty as #toasty::Versionable>::as_u64(self.#field_ident)
+                            )
                         ),
                     )
                 )

--- a/crates/toasty-macros/src/model/expand/model.rs
+++ b/crates/toasty-macros/src/model/expand/model.rs
@@ -288,7 +288,7 @@ impl Expand<'_> {
                         ),
                         #toasty::core::stmt::Expr::Value(
                             #toasty::core::stmt::Value::U64(
-                                <#field_ty as #toasty::Versionable>::as_u64(self.#field_ident)
+                                <#field_ty as #toasty::Version>::as_u64(self.#field_ident)
                             )
                         ),
                     )

--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -420,6 +420,36 @@ impl Expand<'_> {
         quote! { #( #checks )* }
     }
 
+    /// Emit a compile-time obligation that every `#[version]` field's Rust type
+    /// implements [`Versionable`].
+    ///
+    /// The bare `u64` type satisfies the bound directly; tuple-newtype embeds
+    /// satisfy it via the blanket in `codegen_support::version`. Any other type
+    /// produces a compiler error with the `#[diagnostic::on_unimplemented]`
+    /// message on [`Versionable`].
+    pub(super) fn expand_version_compat_checks(&self) -> TokenStream {
+        let toasty = &self.toasty;
+
+        let checks = self.model.fields.iter().filter_map(|field| {
+            if !field.attrs.versionable {
+                return None;
+            }
+
+            let FieldTy::Primitive(ty) = &field.ty else {
+                return None;
+            };
+
+            Some(quote_spanned! { ty.span()=>
+                const _: () = {
+                    fn _check<__T: #toasty::Versionable>() {}
+                    let _ = _check::<#ty>;
+                };
+            })
+        });
+
+        quote! { #( #checks )* }
+    }
+
     /// Generate calls to register all models reachable from this model's fields.
     ///
     /// For primitive fields, no call is emitted (the default `Field::register`

--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -421,12 +421,12 @@ impl Expand<'_> {
     }
 
     /// Emit a compile-time obligation that every `#[version]` field's Rust type
-    /// implements [`Versionable`].
+    /// implements [`Version`].
     ///
     /// The bare `u64` type satisfies the bound directly; tuple-newtype embeds
     /// satisfy it via the blanket in `codegen_support::version`. Any other type
     /// produces a compiler error with the `#[diagnostic::on_unimplemented]`
-    /// message on [`Versionable`].
+    /// message on [`Version`].
     pub(super) fn expand_version_compat_checks(&self) -> TokenStream {
         let toasty = &self.toasty;
 
@@ -441,7 +441,7 @@ impl Expand<'_> {
 
             Some(quote_spanned! { ty.span()=>
                 const _: () = {
-                    fn _check<__T: #toasty::Versionable>() {}
+                    fn _check<__T: #toasty::Version>() {}
                     let _ = _check::<#ty>;
                 };
             })

--- a/crates/toasty-macros/src/model/expand/update.rs
+++ b/crates/toasty-macros/src/model/expand/update.rs
@@ -191,8 +191,8 @@ impl Expand<'_> {
 
         quote! {
             {
-                let current: u64 = <#field_ty as #toasty::Versionable>::as_u64(s.target.#field_ident);
-                let next = <#field_ty as #toasty::Versionable>::from_u64(current + 1);
+                let current: u64 = <#field_ty as #toasty::Version>::as_u64(s.target.#field_ident);
+                let next = <#field_ty as #toasty::Version>::from_u64(current + 1);
                 s.assignments.set(
                     #toasty::stmt::Projection::from_index(#index_tokenized),
                     <#field_ty as #toasty::IntoExpr<#field_ty>>::into_expr(next),

--- a/crates/toasty-macros/src/model/expand/update.rs
+++ b/crates/toasty-macros/src/model/expand/update.rs
@@ -197,6 +197,7 @@ impl Expand<'_> {
                     #toasty::stmt::Projection::from_index(#index_tokenized),
                     <#field_ty as #toasty::IntoExpr<#field_ty>>::into_expr(next),
                 );
+                let current_val = <#field_ty as #toasty::Version>::from_u64(current);
                 s.condition = Some(
                     #toasty::core::stmt::Expr::eq(
                         #toasty::core::stmt::Expr::Reference(
@@ -205,9 +206,7 @@ impl Expand<'_> {
                                 index: #index_tokenized,
                             }
                         ),
-                        #toasty::core::stmt::Expr::Value(
-                            #toasty::core::stmt::Value::U64(current)
-                        ),
+                        #toasty::into_untyped_expr::<#field_ty, _>(current_val),
                     )
                 );
             }

--- a/crates/toasty-macros/src/model/expand/update.rs
+++ b/crates/toasty-macros/src/model/expand/update.rs
@@ -185,13 +185,17 @@ impl Expand<'_> {
         let field = &self.model.fields[version_index];
         let index_tokenized = util::int(version_index);
         let field_ident = &field.name.ident;
+        let FieldTy::Primitive(field_ty) = &field.ty else {
+            unreachable!("version field must be primitive");
+        };
 
         quote! {
             {
-                let current = s.target.#field_ident;
+                let current: u64 = <#field_ty as #toasty::Versionable>::as_u64(s.target.#field_ident);
+                let next = <#field_ty as #toasty::Versionable>::from_u64(current + 1);
                 s.assignments.set(
                     #toasty::stmt::Projection::from_index(#index_tokenized),
-                    <u64 as #toasty::IntoExpr<u64>>::into_expr(current + 1),
+                    <#field_ty as #toasty::IntoExpr<#field_ty>>::into_expr(next),
                 );
                 s.condition = Some(
                     #toasty::core::stmt::Expr::eq(

--- a/crates/toasty-macros/src/model/schema/field.rs
+++ b/crates/toasty-macros/src/model/schema/field.rs
@@ -400,16 +400,6 @@ impl Field {
             ));
         }
 
-        if attrs.versionable {
-            let is_u64 = matches!(&field.ty, syn::Type::Path(p) if p.path.is_ident("u64"));
-            if !is_u64 {
-                errs.push(syn::Error::new_spanned(
-                    &field.ty,
-                    "#[version] can only be applied to a u64 field",
-                ));
-            }
-        }
-
         if attrs.deferred {
             if ty.is_some() {
                 errs.push(syn::Error::new_spanned(

--- a/crates/toasty/src/codegen_support.rs
+++ b/crates/toasty/src/codegen_support.rs
@@ -26,7 +26,7 @@ pub use crate::{
 pub use serde_json;
 pub use std::{convert::Into, default::Default, option::Option};
 
-pub use self::version::Versionable;
+pub use self::version::Version;
 pub use toasty_core as core;
 
 /// Infer the [`Scope`] type from a scope expression and return its fields

--- a/crates/toasty/src/codegen_support.rs
+++ b/crates/toasty/src/codegen_support.rs
@@ -7,6 +7,7 @@
 pub mod auto;
 pub mod newtype;
 pub mod storage;
+pub mod version;
 
 pub use crate::schema::inventory;
 pub use crate::{
@@ -25,6 +26,7 @@ pub use crate::{
 pub use serde_json;
 pub use std::{convert::Into, default::Default, option::Option};
 
+pub use self::version::Versionable;
 pub use toasty_core as core;
 
 /// Infer the [`Scope`] type from a scope expression and return its fields

--- a/crates/toasty/src/codegen_support/newtype.rs
+++ b/crates/toasty/src/codegen_support/newtype.rs
@@ -29,6 +29,9 @@ use toasty_core::schema::app::AutoStrategy;
 pub trait NewtypeOf {
     /// The inner field's type.
     type Inner;
+
+    /// Unwrap the newtype, returning the inner value.
+    fn into_inner(self) -> Self::Inner;
 }
 
 // `do_not_recommend` keeps the blanket out of error suggestions so the

--- a/crates/toasty/src/codegen_support/newtype.rs
+++ b/crates/toasty/src/codegen_support/newtype.rs
@@ -32,6 +32,9 @@ pub trait NewtypeOf {
 
     /// Unwrap the newtype, returning the inner value.
     fn into_inner(self) -> Self::Inner;
+
+    /// Wrap an inner value in the newtype.
+    fn from_inner(inner: Self::Inner) -> Self;
 }
 
 // `do_not_recommend` keeps the blanket out of error suggestions so the

--- a/crates/toasty/src/codegen_support/version.rs
+++ b/crates/toasty/src/codegen_support/version.rs
@@ -1,0 +1,61 @@
+//! Compile-time validation and runtime support for `#[version]` fields.
+//!
+//! `#[derive(Model)]` emits a `_check::<FieldType>()` obligation bounded by
+//! [`Versionable`] for every `#[version]` field. The concrete impl covers
+//! `u64` directly; the blanket propagates through tuple-newtype embeds of any
+//! depth, mirroring the [`Auto`] blanket in
+//! [`crate::codegen_support::newtype`].
+//!
+//! At runtime, generated code calls [`Versionable::as_u64`] to extract the
+//! raw counter for use in OCC condition expressions.
+
+use super::newtype::NewtypeOf;
+
+/// A field type that can be used as an OCC version counter.
+///
+/// Only `u64` and tuple-newtype embeds that wrap a `Versionable` type (directly
+/// or transitively) satisfy this bound.
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` cannot be used as a `#[version]` field",
+    label = "invalid type for `#[version]`",
+    note = "only `u64` and tuple-newtype embeds of `u64` are supported"
+)]
+pub trait Versionable: Copy {
+    /// Return the raw `u64` counter value stored in this field.
+    fn as_u64(self) -> u64;
+
+    /// Construct a field value from a raw `u64` counter, wrapping through any
+    /// newtype layers. Used by generated code to build the next-version
+    /// expression in the correct shape for the update assignment.
+    fn from_u64(v: u64) -> Self;
+}
+
+impl Versionable for u64 {
+    fn as_u64(self) -> u64 {
+        self
+    }
+
+    fn from_u64(v: u64) -> Self {
+        v
+    }
+}
+
+// Propagate through tuple-newtype embeds of any depth.
+//
+// `do_not_recommend` keeps the blanket out of error suggestions so the
+// `Versionable` `#[diagnostic::on_unimplemented]` message wins for users
+// who hit a missing-`Versionable` error on an embed.
+#[diagnostic::do_not_recommend]
+impl<T> Versionable for T
+where
+    T: NewtypeOf + Copy,
+    <T as NewtypeOf>::Inner: Versionable,
+{
+    fn as_u64(self) -> u64 {
+        self.into_inner().as_u64()
+    }
+
+    fn from_u64(v: u64) -> Self {
+        T::from_inner(<T::Inner as Versionable>::from_u64(v))
+    }
+}

--- a/crates/toasty/src/codegen_support/version.rs
+++ b/crates/toasty/src/codegen_support/version.rs
@@ -1,26 +1,26 @@
 //! Compile-time validation and runtime support for `#[version]` fields.
 //!
 //! `#[derive(Model)]` emits a `_check::<FieldType>()` obligation bounded by
-//! [`Versionable`] for every `#[version]` field. The concrete impl covers
+//! [`Version`] for every `#[version]` field. The concrete impl covers
 //! `u64` directly; the blanket propagates through tuple-newtype embeds of any
 //! depth, mirroring the [`Auto`] blanket in
 //! [`crate::codegen_support::newtype`].
 //!
-//! At runtime, generated code calls [`Versionable::as_u64`] to extract the
+//! At runtime, generated code calls [`Version::as_u64`] to extract the
 //! raw counter for use in OCC condition expressions.
 
 use super::newtype::NewtypeOf;
 
 /// A field type that can be used as an OCC version counter.
 ///
-/// Only `u64` and tuple-newtype embeds that wrap a `Versionable` type (directly
+/// Only `u64` and tuple-newtype embeds that wrap a `Version` type (directly
 /// or transitively) satisfy this bound.
 #[diagnostic::on_unimplemented(
     message = "`{Self}` cannot be used as a `#[version]` field",
     label = "invalid type for `#[version]`",
     note = "only `u64` and tuple-newtype embeds of `u64` are supported"
 )]
-pub trait Versionable: Copy {
+pub trait Version: Copy {
     /// Return the raw `u64` counter value stored in this field.
     fn as_u64(self) -> u64;
 
@@ -30,7 +30,7 @@ pub trait Versionable: Copy {
     fn from_u64(v: u64) -> Self;
 }
 
-impl Versionable for u64 {
+impl Version for u64 {
     fn as_u64(self) -> u64 {
         self
     }
@@ -43,19 +43,19 @@ impl Versionable for u64 {
 // Propagate through tuple-newtype embeds of any depth.
 //
 // `do_not_recommend` keeps the blanket out of error suggestions so the
-// `Versionable` `#[diagnostic::on_unimplemented]` message wins for users
-// who hit a missing-`Versionable` error on an embed.
+// `Version` `#[diagnostic::on_unimplemented]` message wins for users
+// who hit a missing-`Version` error on an embed.
 #[diagnostic::do_not_recommend]
-impl<T> Versionable for T
+impl<T> Version for T
 where
     T: NewtypeOf + Copy,
-    <T as NewtypeOf>::Inner: Versionable,
+    <T as NewtypeOf>::Inner: Version,
 {
     fn as_u64(self) -> u64 {
         self.into_inner().as_u64()
     }
 
     fn from_u64(v: u64) -> Self {
-        T::from_inner(<T::Inner as Versionable>::from_u64(v))
+        T::from_inner(<T::Inner as Version>::from_u64(v))
     }
 }

--- a/crates/toasty/src/engine/lower/insert.rs
+++ b/crates/toasty/src/engine/lower/insert.rs
@@ -150,11 +150,14 @@ impl LowerStatement<'_, '_> {
         }
 
         // Initialize version fields to 1 if not already set by the user.
+        // For embedded newtypes (e.g. `Version(u64)`), wrap in one Record per
+        // embed layer so the value round-trips through the embed's `Load` impl.
         for field in &model.fields {
             if field.is_versionable() {
                 let mut field_expr = expr.entry_mut(field.id.index);
                 if field_expr.is_default() || field_expr.is_value_null() {
-                    field_expr.insert(stmt::Value::U64(1).into());
+                    let target = self.auto_target(field.id);
+                    field_expr.insert(target.wrap(stmt::Value::U64(1)).into());
                 }
             }
         }


### PR DESCRIPTION
<!--
PR title uses Conventional Commits, e.g.
    feat: add upsert support
    fix: handle composite key in IN-list rewrite
See CONTRIBUTING.md for the full process.
-->

## Summary

<!-- What does this change and why? Link the issue it closes. -->
Closes #839 

A `#[version]` field can now be a tuple-newtype embed wrapping `u64` rather than a bare `u64` — no extra annotation required:

```rust
#[derive(Debug, Clone, Copy, PartialEq, toasty::Embed)]
struct Version(u64);

#[derive(toasty::Model)]
struct Item {
    #[key]
    #[auto]
    id: uuid::Uuid,

    name: String,

    #[version]
    version: Version,
}

```

The macro previously hard-rejected any non-`u64` syntactic type on `#[version]`. The guard is replaced by a `Versionable` trait in `codegen_support` with a concrete impl for `u64` and a blanket that propagates through `NewtypeOf` embeds at any depth, mirroring the existing Auto blanket from #836.

`#[derive(Model)]` emits a `_check::<FieldTy: Versionable>()` obligation for every `#[version]` field so invalid types produce a clean compiler error via `#[diagnostic::on_unimplemented]`.

The generated OCC logic is updated to call `Versionable::as_u64` / `from_u64` instead of treating the field as a bare `u64`. The insert lowering reuses the existing `auto_target` wrap-depth logic to initialize the version to the correct record shape for embedded types. The DynamoDB driver is extended to unwrap single-field record expressions in filter conditions, which is how a newtype field reference appears after schema mapping lowering.


## Type of change

<!-- Check one. -->

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test
- [ ] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`):
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [ ] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [ ] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers

<!-- Anything reviewers should focus on. -->
Four DynamoDB integration tests are added mirroring the existing `field_version.rs` scenarios. They are marked `requires(not(sql))` since the SQL drivers do not yet implement the version OCC path.
The `Expr::Record` arm added to `ddb_expression` only handles single-field records. Multi-field embedded structs in filter position hit an explicit `todo!` — they are not yet supported and I found no path that produces them.
`NewtypeOf` gains a `from_inner` constructor (alongside the existing `into_inner`) so generated code can reconstruct a wrapper value from a raw `u64` without knowing the concrete type.