### PR TITLE
feat: item collection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     # Examples
     "examples/composite-key",
     "examples/hello-toasty",
+    "examples/item-collection",
     "examples/todo-with-cli",
     "examples/user-has-one-profile",
 
@@ -43,6 +44,7 @@ default-members = [
     "crates/toasty-driver-integration-suite-macros",
     "examples/composite-key",
     "examples/hello-toasty",
+    "examples/item-collection",
     "examples/todo-with-cli",
     "examples/user-has-one-profile",
     "tests",

--- a/crates/toasty-core/src/schema/app/model.rs
+++ b/crates/toasty-core/src/schema/app/model.rs
@@ -160,6 +160,10 @@ pub struct ModelRoot {
     /// model name.
     pub table_name: Option<String>,
 
+    /// If set, this model shares a DynamoDB table with the named parent model
+    /// (item collection / single-table design).
+    pub item_collection: Option<ModelId>,
+
     /// Secondary indices defined on this model.
     pub indices: Vec<Index>,
 

--- a/crates/toasty-core/src/schema/app/schema.rs
+++ b/crates/toasty-core/src/schema/app/schema.rs
@@ -227,6 +227,7 @@ impl Builder {
         self.link_relations()?;
         self.resolve_via_targets()?;
         self.verify_no_eager_load_cycles()?;
+        self.validate_item_collections()?;
 
         Ok(())
     }
@@ -327,6 +328,57 @@ impl Builder {
         }
 
         Ok(current)
+    }
+
+    fn validate_item_collections(&self) -> Result<()> {
+        for model in self.models.values() {
+            let root = match model {
+                Model::Root(r) => r,
+                _ => continue,
+            };
+
+            let Some(_parent_id) = root.item_collection else {
+                continue;
+            };
+
+            // The primary key index is always the first index in `indices`.
+            let pk_index = &root.indices[root.primary_key.index.index];
+
+            // Must have at least one Local-scoped field (compound key).
+            if pk_index.local_fields().is_empty() {
+                return Err(crate::Error::invalid_schema(format!(
+                    "model `{}` has `#[item_collection]` but no local (sort-key) component in its \
+                     primary key; add `#[key(partition = <fk_field>, local = <own_field>)]`",
+                    root.name.upper_camel_case(),
+                )));
+            }
+
+            // Collect the FieldIds of all FK source fields from BelongsTo relations.
+            let fk_sources: std::collections::HashSet<FieldId> = root
+                .fields
+                .iter()
+                .filter_map(|f| f.ty.as_belongs_to())
+                .flat_map(|bt| bt.foreign_key.fields.iter().map(|fkf| fkf.source))
+                .collect();
+
+            // Every partition-scoped PK field must be a FK source.
+            for partition_field in pk_index.partition_fields() {
+                if !fk_sources.contains(&partition_field.field) {
+                    let field_name = root.fields[partition_field.field.index]
+                        .name
+                        .app_unwrap()
+                        .to_string();
+                    return Err(crate::Error::invalid_schema(format!(
+                        "model `{}` has `#[item_collection]` but the partition key field `{}` is \
+                         not sourced from a `BelongsTo` relation; the partition key must reuse the \
+                         parent model's primary key via a foreign key field",
+                        root.name.upper_camel_case(),
+                        field_name,
+                    )));
+                }
+            }
+        }
+        Ok(())
     }
 
     fn verify_no_eager_load_cycles(&self) -> crate::Result<()> {

--- a/crates/toasty-core/src/schema/builder.rs
+++ b/crates/toasty-core/src/schema/builder.rs
@@ -127,28 +127,39 @@ impl Builder {
         // Find all models that specified a table name, ensure a table is
         // created for that model, and link the model with the table.
         // Skip embedded models as they don't have their own tables.
+        // Skip item-collection children — they share the parent's table,
+        // which gets resolved in the fixup pass below.
         for model in app.models() {
-            // Skip embedded models - they are flattened into parent tables
             let app::Model::Root(model) = model else {
                 continue;
             };
 
-            let table = builder.build_table_stub_for_model(model);
+            // Item-collection children share the parent's table; assign a
+            // placeholder now and fix it up after all root tables exist.
+            let table = if model.item_collection.is_some() {
+                TableId::placeholder()
+            } else {
+                builder.build_table_stub_for_model(model)
+            };
 
-            // Create a mapping shell for the model (fields will be built during mapping phase)
             builder.mapping.models.insert(
                 model.id,
                 mapping::Model {
                     id: model.id,
                     table,
                     columns: vec![],
-                    fields: vec![], // Will be populated during mapping phase
+                    fields: vec![],
                     model_to_table: stmt::ExprRecord::default(),
                     table_to_model: TableToModel::default(),
                     default_returning: stmt::Expr::null(),
+                    item_collection: mapping::ItemCollection::default(),
                 },
             );
         }
+
+        // Fix up item-collection children: point them at the root model's table
+        // and populate the FK→PK field mapping used during column building.
+        builder.fixup_item_collection_mappings(&app)?;
 
         builder.build_tables_from_models(&app, db)?;
 
@@ -174,6 +185,62 @@ impl Default for Builder {
 }
 
 impl BuildSchema<'_> {
+    /// Resolve table IDs and FK→PK field mappings for item-collection children.
+    ///
+    /// Walks the ancestry chain of each child until it reaches a root (a model
+    /// with no `item_collection` pointer), then assigns that root's table to
+    /// every model in the chain.
+    fn fixup_item_collection_mappings(&mut self, app: &app::Schema) -> Result<()> {
+        // Collect child model IDs first to avoid borrow issues.
+        let children: Vec<_> = app
+            .models()
+            .filter_map(|m| {
+                let r = m.as_root()?;
+                r.item_collection.map(|_| r.id)
+            })
+            .collect();
+
+        for child_id in children {
+            // Walk up to root.
+            let table = self.resolve_item_collection_table(app, child_id);
+            self.mapping.model_mut(child_id).table = table;
+
+            // Build FK-source → parent-PK field mapping.
+            let child_root = app.model(child_id).as_root_unwrap();
+            let field_mapping: indexmap::IndexMap<_, _> = child_root
+                .fields
+                .iter()
+                .filter_map(|f| f.ty.as_belongs_to())
+                .flat_map(|bt| {
+                    bt.foreign_key
+                        .fields
+                        .iter()
+                        .map(|fkf| (fkf.source, fkf.target))
+                })
+                .filter(|(src, _)| child_root.fields[src.index].primary_key)
+                .collect();
+
+            self.mapping
+                .model_mut(child_id)
+                .item_collection
+                .field_mapping = field_mapping;
+        }
+
+        Ok(())
+    }
+
+    fn resolve_item_collection_table(
+        &self,
+        app: &app::Schema,
+        model_id: app::ModelId,
+    ) -> crate::schema::TableId {
+        let root = app.model(model_id).as_root_unwrap();
+        match root.item_collection {
+            None => self.mapping.model(model_id).table,
+            Some(parent_id) => self.resolve_item_collection_table(app, parent_id),
+        }
+    }
+
     fn build_model_constraints(&self, model: &mut app::Model) -> Result<()> {
         let model_name = model.name().to_string();
 

--- a/crates/toasty-core/src/schema/builder/table.rs
+++ b/crates/toasty-core/src/schema/builder/table.rs
@@ -332,8 +332,8 @@ impl BuildTableFromModels<'_> {
                 }
                 app::FieldTy::Embedded(_)
                 | app::FieldTy::BelongsTo(_)
-                | app::FieldTy::HasMany(_)
-                | app::FieldTy::HasOne(_) => {}
+                | app::FieldTy::Has(_)
+                | app::FieldTy::Via(_) => {}
             }
         }
 
@@ -1500,7 +1500,9 @@ impl<'a, 'b> MapField<'a, 'b> {
     /// `field.nullable || self.force_nullable`, and auto-increment from
     /// `field.is_auto_increment()`.
     fn create_column(&mut self, field: &app::Field, primitive: &app::FieldPrimitive) -> ColumnId {
-        let nullable = field.nullable || self.force_nullable;
+        let nullable = field.nullable
+            || self.force_nullable
+            || (self.build.force_non_pk_nullable && !field.primary_key);
         let is_auto_increment = (field.is_auto_increment() || self.inherited_auto_increment)
             && self.build.db.auto_increment;
 
@@ -1524,10 +1526,6 @@ impl<'a, 'b> MapField<'a, 'b> {
             table: self.build.table.id,
             index: self.build.table.columns.len(),
         };
-
-        let nullable = field.nullable
-            || self.in_enum_variant
-            || (self.build.force_non_pk_nullable && !field.primary_key);
 
         self.build.table.columns.push(db::Column {
             id,

--- a/crates/toasty-core/src/schema/builder/table.rs
+++ b/crates/toasty-core/src/schema/builder/table.rs
@@ -467,7 +467,10 @@ impl BuildTableFromModels<'_> {
             name: col_name,
             ty: storage_ty.bridge_type(&primitive.ty),
             storage_ty,
-            nullable: true, // child fields always nullable
+            // Mark all non-pk fields as nullable.
+            // definitionally if a row exists, it has a pk
+            // additionally, this is required to pass index verification later.
+            nullable: !field.primary_key,
             primary_key: false,
             auto_increment: false,
             versionable: false,

--- a/crates/toasty-core/src/schema/builder/table.rs
+++ b/crates/toasty-core/src/schema/builder/table.rs
@@ -3,8 +3,8 @@ use crate::{
     Error, Result, driver,
     schema::{
         Name,
-        app::{self, Model, ModelId, ModelRoot},
-        db::{self, ColumnId, IndexId, Table, TableId},
+        app::{self, FieldId, Model, ModelId, ModelRoot},
+        db::{self, ColumnId, IndexId, IndexScope, Table, TableId},
         mapping::{self, Mapping, TableToModel},
     },
     stmt,
@@ -52,6 +52,13 @@ struct BuildMapping<'a> {
     lowering_columns: Vec<ColumnId>,
     model_to_table: Vec<stmt::Expr>,
     table_to_model: Vec<stmt::Expr>,
+    /// Pre-assigned column IDs keyed by field index. Used by item-collection
+    /// child models to reuse parent columns for FK-source fields.
+    column_overrides: indexmap::IndexMap<usize, ColumnId>,
+    /// When true, non-PK primitive fields are created nullable regardless of
+    /// the field's own nullability setting. Used for root models that have
+    /// item-collection children (child rows don't carry the root's non-PK values).
+    force_non_pk_nullable: bool,
 }
 
 /// Per-level state for the recursive `map_field*` methods.
@@ -130,27 +137,34 @@ impl BuildSchema<'_> {
         app: &app::Schema,
         db: &driver::Capability,
     ) -> Result<()> {
-        for table in &mut self.tables {
-            let models = app
+        for table_idx in 0..self.tables.len() {
+            let table_id = self.tables[table_idx].id;
+
+            let all_models: Vec<_> = app
                 .models()
                 .filter(|model| model.is_root())
-                .filter(|model| self.mapping.model(model.id()).table == table.id)
-                .collect::<Vec<_>>();
+                .filter(|model| self.mapping.model(model.id()).table == table_id)
+                .collect();
+
+            let (roots, children): (Vec<_>, Vec<_>) = all_models
+                .iter()
+                .partition(|m| m.as_root_unwrap().item_collection.is_none());
 
             assert!(
-                models.len() == 1,
-                "TODO: handle mapping many models to one table"
+                roots.len() == 1,
+                "each table must have exactly one root model"
             );
+            let root = roots[0];
 
             BuildTableFromModels {
                 app,
                 db,
-                table,
+                table: &mut self.tables[table_idx],
                 mapping: &mut self.mapping,
-                prefix_table_names: models.len() > 1,
+                prefix_table_names: false,
                 name_prefix: self.builder.table_name_prefix.clone(),
             }
-            .build(models[0])?;
+            .build(root, &children)?;
         }
 
         Ok(())
@@ -178,13 +192,295 @@ impl BuildSchema<'_> {
 }
 
 impl BuildTableFromModels<'_> {
-    fn build(&mut self, model: &Model) -> Result<()> {
-        self.map_model_fields(model)?;
+    fn build(&mut self, model: &Model, children: &[&Model]) -> Result<()> {
+        // Build columns and indices for the root model.
+        // When there are children, non-PK fields of the root become nullable
+        // (child rows don't carry root-specific non-PK values).
+        self.map_model_fields_with_nullability(model, !children.is_empty())?;
+
+        // Add a `__model` discriminator column when there are item-collection children.
+        let model_column = if !children.is_empty() {
+            let col = self.add_model_discriminator_column(model, children);
+            Some(col)
+        } else {
+            None
+        };
+
+        // Map each child model onto the same table.
+        for child in children {
+            self.map_item_collection_child(child, model)?;
+        }
+
         self.update_index_names();
+
+        // Wire up model_column in the mapping for root + children.
+        if let Some(col_id) = model_column {
+            self.add_model_column_to_mapping(model.id(), col_id);
+            for child in children {
+                self.add_model_column_to_mapping(child.id(), col_id);
+            }
+        }
+
         Ok(())
     }
 
-    fn map_model_fields(&mut self, model: &Model) -> Result<()> {
+    /// Adds a `__model` VARCHAR discriminator column and appends it to the
+    /// primary-key index as a Local-scoped (sort-key component) column.
+    ///
+    /// Returns the new column's `ColumnId`.
+    fn add_model_discriminator_column(&mut self, root: &Model, children: &[&Model]) -> ColumnId {
+        let max_len = std::iter::once(root.name().upper_camel_case().len())
+            .chain(children.iter().map(|m| m.name().upper_camel_case().len()))
+            .max()
+            .unwrap_or(1);
+
+        let col_id = ColumnId {
+            table: self.table.id,
+            index: self.table.columns.len(),
+        };
+
+        let storage_ty = db::Type::VarChar(max_len as u64);
+        self.table.columns.push(db::Column {
+            id: col_id,
+            name: "__model".to_string(),
+            ty: storage_ty.bridge_type(&stmt::Type::String),
+            storage_ty,
+            nullable: false,
+            primary_key: false,
+            auto_increment: false,
+            versionable: false,
+        });
+
+        // Append to PK table record and index.
+        self.table.primary_key.columns.push(col_id);
+
+        let pk_index = self
+            .table
+            .indices
+            .iter_mut()
+            .find(|i| i.primary_key)
+            .expect("primary key index must exist");
+        pk_index.columns.push(db::IndexColumn {
+            column: col_id,
+            op: db::IndexOp::Eq,
+            scope: IndexScope::Local,
+        });
+
+        col_id
+    }
+
+    /// Wires the model_column discriminator into the mapping for a single model.
+    ///
+    /// Appends the column to the model's `columns` list and adds a literal
+    /// `Value::String(model_name)` to `model_to_table` so inserts/updates emit
+    /// the correct discriminator value automatically.
+    fn add_model_column_to_mapping(&mut self, model_id: impl Into<app::ModelId>, col_id: ColumnId) {
+        let model_id = model_id.into();
+        let model_name = self
+            .app
+            .model(model_id)
+            .name()
+            .upper_camel_case()
+            .to_string();
+        let m = self.mapping.model_mut(model_id);
+        m.item_collection.model_column = Some(col_id);
+        m.columns.push(col_id);
+        m.model_to_table
+            .push(stmt::Value::String(model_name).into());
+    }
+
+    /// Builds columns + mapping for an item-collection child model.
+    ///
+    /// Fields that correspond to FK sources (which share a column with the
+    /// parent's PK) are wired to the existing parent column rather than
+    /// creating new ones.
+    fn map_item_collection_child(&mut self, child: &Model, _root: &Model) -> Result<()> {
+        let child_root = child.as_root_unwrap();
+
+        // Collect the set of FK-source field IDs that reuse a parent column.
+        let fk_sources: std::collections::HashSet<FieldId> = self
+            .mapping
+            .model(child.id())
+            .item_collection
+            .field_mapping
+            .keys()
+            .copied()
+            .collect();
+
+        // --- Column pass ---
+        // For each primitive field: if it's a FK source that maps to the
+        // parent PK column, reuse that column; otherwise create a new column.
+        let mut child_field_mappings: Vec<Option<ColumnId>> = vec![None; child_root.fields.len()];
+
+        for field in &child_root.fields {
+            match &field.ty {
+                app::FieldTy::Primitive(prim) => {
+                    if fk_sources.contains(&field.id) {
+                        // Reuse the parent column.
+                        let parent_field_id =
+                            self.mapping.model(child.id()).item_collection.field_mapping[&field.id];
+                        let parent_col = self.mapping.model(parent_field_id.model).fields
+                            [parent_field_id.index]
+                            .as_primitive()
+                            .expect("parent PK field must map to a primitive column")
+                            .column;
+                        child_field_mappings[field.id.index] = Some(parent_col);
+                    } else {
+                        let col_id = self.create_child_column(child_root, field, prim);
+                        child_field_mappings[field.id.index] = Some(col_id);
+                    }
+                }
+                app::FieldTy::Embedded(_)
+                | app::FieldTy::BelongsTo(_)
+                | app::FieldTy::HasMany(_)
+                | app::FieldTy::HasOne(_) => {}
+            }
+        }
+
+        // --- Build mapping via BuildMapping ---
+        // We need to supply the column IDs we determined above so BuildMapping
+        // can build model_to_table / table_to_model.  We do this by temporarily
+        // running BuildMapping with overridden columns.
+        BuildMapping {
+            app: self.app,
+            db: self.db,
+            table: self.table,
+            mapping: self.mapping.model_mut(child),
+            schema_prefix: None,
+            name_prefix: self.name_prefix.clone(),
+            next_bit: 0,
+            lowering_columns: vec![],
+            model_to_table: vec![],
+            table_to_model: vec![],
+            column_overrides: child_field_mappings
+                .into_iter()
+                .enumerate()
+                .filter_map(|(i, col)| col.map(|c| (i, c)))
+                .collect(),
+            force_non_pk_nullable: false,
+        }
+        .build_mapping(child_root)?;
+
+        // --- Build the PK index contributions ---
+        // Local (sort-key) columns from this child are added to the shared PK index.
+        // Partition columns (reused from parent) are already in the index.
+        let pk_index_for_child: Vec<db::IndexColumn> = child_root
+            .primary_key
+            .fields
+            .iter()
+            .filter(|fid| !fk_sources.contains(fid))
+            .map(|fid| {
+                let col = self.mapping.model(child.id()).fields[fid.index]
+                    .as_primitive()
+                    .expect("child PK field must be primitive")
+                    .column;
+                db::IndexColumn {
+                    column: col,
+                    op: db::IndexOp::Eq,
+                    scope: IndexScope::Local,
+                }
+            })
+            .collect();
+
+        if !pk_index_for_child.is_empty() {
+            // These columns also belong to the shared table PK list.
+            for ic in &pk_index_for_child {
+                self.table.primary_key.columns.push(ic.column);
+            }
+
+            let pk_db_index = self
+                .table
+                .indices
+                .iter_mut()
+                .find(|i| i.primary_key)
+                .expect("primary key index must exist");
+            for ic in pk_index_for_child {
+                pk_db_index.columns.push(ic);
+            }
+        }
+
+        // --- Secondary indices for the child ---
+        let child_field_mappings_for_indices: Vec<mapping::Field> =
+            self.mapping.model(child.id()).fields.clone();
+        let mut extra_indices = Vec::new();
+        self.collect_indices(
+            &child_root.fields,
+            &child_field_mappings_for_indices,
+            &child_root.indices,
+            &mut extra_indices,
+        )?;
+        // Filter out the primary key index — it's already handled above.
+        for idx in extra_indices {
+            if !idx.primary_key {
+                self.table.indices.push(db::Index {
+                    id: IndexId {
+                        table: self.table.id,
+                        index: self.table.indices.len(),
+                    },
+                    ..idx
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Creates a new column for a child model's own (non-shared) primitive field.
+    ///
+    /// The column is prefixed with the child model's snake-case name to avoid
+    /// conflicts with the root model's columns (both may have an `id` field).
+    /// Child columns are always nullable because a row in the shared table may
+    /// belong to a different model and thus not carry this field's value.
+    fn create_child_column(
+        &mut self,
+        child_model: &ModelRoot,
+        field: &app::Field,
+        primitive: &app::FieldPrimitive,
+    ) -> ColumnId {
+        let mut storage_ty = db::Type::from_app(
+            &primitive.ty,
+            primitive.storage_ty.as_ref(),
+            &self.db.storage_types,
+        )
+        .expect("unsupported storage type");
+
+        if let db::Type::Enum(ref mut type_enum) = storage_ty
+            && let (Some(prefix), Some(name)) = (&self.name_prefix, &mut type_enum.name)
+        {
+            *name = format!("{prefix}{name}");
+        }
+
+        let base_name = field
+            .name
+            .storage_name()
+            .unwrap_or_else(|| field.name.app_unwrap())
+            .to_string();
+        let col_name = format!("{}__{base_name}", child_model.name.snake_case());
+
+        let col_id = ColumnId {
+            table: self.table.id,
+            index: self.table.columns.len(),
+        };
+
+        self.table.columns.push(db::Column {
+            id: col_id,
+            name: col_name,
+            ty: storage_ty.bridge_type(&primitive.ty),
+            storage_ty,
+            nullable: true, // child fields always nullable
+            primary_key: false,
+            auto_increment: false,
+            versionable: false,
+        });
+
+        col_id
+    }
+
+    fn map_model_fields_with_nullability(
+        &mut self,
+        model: &Model,
+        force_nk_nullable: bool,
+    ) -> Result<()> {
         let root = model.as_root_unwrap();
         let schema_prefix = if self.prefix_table_names {
             Some(model.name().snake_case())
@@ -203,6 +499,8 @@ impl BuildTableFromModels<'_> {
             lowering_columns: vec![],
             model_to_table: vec![],
             table_to_model: vec![],
+            column_overrides: indexmap::IndexMap::new(),
+            force_non_pk_nullable: force_nk_nullable,
         }
         .build_mapping(root)?;
 
@@ -888,7 +1186,13 @@ impl<'a, 'b> MapField<'a, 'b> {
         field: &app::Field,
         primitive: &app::FieldPrimitive,
     ) -> mapping::Field {
-        let column_id = self.create_column(field, primitive);
+        // Check if there's a pre-assigned column override (e.g., FK-source field
+        // reusing a parent's column in an item-collection child model).
+        let column_id = if let Some(&col) = self.build.column_overrides.get(&field_index) {
+            col
+        } else {
+            self.create_column(field, primitive)
+        };
         let expr = self.field_expr(field, field_index);
         let lowering_index = self.build.push_lowering(column_id, &primitive.ty, expr);
         let bit = self.build.next_bit();
@@ -1217,6 +1521,10 @@ impl<'a, 'b> MapField<'a, 'b> {
             table: self.build.table.id,
             index: self.build.table.columns.len(),
         };
+
+        let nullable = field.nullable
+            || self.in_enum_variant
+            || (self.build.force_non_pk_nullable && !field.primary_key);
 
         self.build.table.columns.push(db::Column {
             id,

--- a/crates/toasty-core/src/schema/mapping.rs
+++ b/crates/toasty-core/src/schema/mapping.rs
@@ -26,6 +26,9 @@
 mod field;
 pub use field::{EnumVariant, Field, FieldEnum, FieldPrimitive, FieldRelation, FieldStruct};
 
+mod item_collection;
+pub use item_collection::ItemCollection;
+
 mod model;
 pub use model::{Model, TableToModel};
 

--- a/crates/toasty-core/src/schema/mapping/item_collection.rs
+++ b/crates/toasty-core/src/schema/mapping/item_collection.rs
@@ -1,0 +1,21 @@
+use crate::schema::{app::FieldId, db::ColumnId};
+
+/// Item-collection metadata stored in a model's mapping.
+///
+/// For root models (those without `#[item_collection]`) all fields are `None`/
+/// empty and the struct is effectively a no-op.  For child models the fields
+/// are populated during the db-schema build phase.
+#[derive(Debug, Clone, Default)]
+pub struct ItemCollection {
+    /// Maps this model's FK source fields to the parent model's PK fields.
+    ///
+    /// Populated during the db-schema build so child columns that reuse a
+    /// parent's PK column can be looked up without rescanning the schema.
+    pub field_mapping: indexmap::IndexMap<FieldId, FieldId>,
+
+    /// The `__model` discriminator column shared by all models in the table.
+    ///
+    /// `None` for models that are not part of any item-collection group.
+    /// `Some(column_id)` for both the root model and every child model.
+    pub model_column: Option<ColumnId>,
+}

--- a/crates/toasty-core/src/schema/mapping/model.rs
+++ b/crates/toasty-core/src/schema/mapping/model.rs
@@ -1,4 +1,4 @@
-use super::Field;
+use super::{Field, ItemCollection};
 use crate::{
     schema::{
         app::ModelId,
@@ -74,6 +74,11 @@ pub struct Model {
     /// forms in for fields named by `.include()` (or for every deferred
     /// field when an `INSERT ... RETURNING` is being lowered).
     pub default_returning: stmt::Expr,
+
+    /// Item-collection metadata for this model.
+    ///
+    /// Empty/default for models that are not part of an item-collection group.
+    pub item_collection: ItemCollection,
 }
 
 /// Expression template for converting table rows into model records.

--- a/crates/toasty-core/src/schema/verify.rs
+++ b/crates/toasty-core/src/schema/verify.rs
@@ -181,14 +181,20 @@ impl Verify<'_> {
     fn verify_table_indices_and_nullable(&self) {
         for table in &self.schema.db.tables {
             for index in &table.indices {
+                // Skip the primary key index: item-collection tables have a
+                // compound PK that includes nullable child-specific columns.
+                if index.primary_key {
+                    continue;
+                }
+
                 let nullable = index
                     .columns
                     .iter()
                     .any(|index_column| table.column(index_column.column).nullable);
 
                 if nullable {
-                    // If there are nullable columns, then (for now) the index
-                    // should only have one column
+                    // For secondary indices, a nullable column means the index
+                    // should only have one column.
                     assert_eq!(
                         index.columns.len(),
                         1,

--- a/crates/toasty-core/src/stmt.rs
+++ b/crates/toasty-core/src/stmt.rs
@@ -105,6 +105,9 @@ pub use expr_in_subquery::ExprInSubquery;
 mod expr_intersects;
 pub use expr_intersects::ExprIntersects;
 
+mod expr_is_model;
+pub use expr_is_model::ExprIsModel;
+
 mod expr_is_null;
 pub use expr_is_null::ExprIsNull;
 
@@ -300,6 +303,7 @@ pub mod visit;
 pub use visit::Visit;
 
 mod with;
+
 pub use with::With;
 
 use crate::schema::db::TableId;

--- a/crates/toasty-core/src/stmt/expr.rs
+++ b/crates/toasty-core/src/stmt/expr.rs
@@ -3,10 +3,9 @@ use crate::stmt::{ExprExists, Input};
 use super::{
     Entry, EntryMut, EntryPath, ExprAllOp, ExprAnd, ExprAny, ExprAnyOp, ExprArg, ExprBetween,
     ExprBinaryOp, ExprCast, ExprError, ExprFunc, ExprInList, ExprInSubquery, ExprIntersects,
-    ExprIsModel,
-    ExprIsNull, ExprIsSuperset, ExprIsVariant, ExprLength, ExprLet, ExprLike, ExprList, ExprMap,
-    ExprMatch, ExprNot, ExprOr, ExprProject, ExprRecord, ExprStartsWith, ExprStmt, Node,
-    Projection, Substitute, Value, Visit, VisitMut, expr_reference::ExprReference,
+    ExprIsModel, ExprIsNull, ExprIsSuperset, ExprIsVariant, ExprLength, ExprLet, ExprLike,
+    ExprList, ExprMap, ExprMatch, ExprNot, ExprOr, ExprProject, ExprRecord, ExprStartsWith,
+    ExprStmt, Node, Projection, Substitute, Value, Visit, VisitMut, expr_reference::ExprReference,
 };
 use std::fmt;
 

--- a/crates/toasty-core/src/stmt/expr.rs
+++ b/crates/toasty-core/src/stmt/expr.rs
@@ -3,6 +3,7 @@ use crate::stmt::{ExprExists, Input};
 use super::{
     Entry, EntryMut, EntryPath, ExprAllOp, ExprAnd, ExprAny, ExprAnyOp, ExprArg, ExprBetween,
     ExprBinaryOp, ExprCast, ExprError, ExprFunc, ExprInList, ExprInSubquery, ExprIntersects,
+    ExprIsModel,
     ExprIsNull, ExprIsSuperset, ExprIsVariant, ExprLength, ExprLet, ExprLike, ExprList, ExprMap,
     ExprMatch, ExprNot, ExprOr, ExprProject, ExprRecord, ExprStartsWith, ExprStmt, Node,
     Projection, Substitute, Value, Visit, VisitMut, expr_reference::ExprReference,
@@ -101,6 +102,10 @@ pub enum Expr {
 
     /// Tests whether a value is a specific enum variant. See [`ExprIsVariant`].
     IsVariant(ExprIsVariant),
+
+    /// Tests whether the current row belongs to a specific item-collection
+    /// member model. See [`ExprIsModel`].
+    IsModel(ExprIsModel),
 
     /// Integer: the cardinality of an array (PostgreSQL `cardinality(expr)`).
     /// See [`ExprLength`].
@@ -307,6 +312,7 @@ impl Expr {
             Self::AnyOp(e) => e.lhs.is_stable() && e.rhs.is_stable(),
             Self::AllOp(e) => e.lhs.is_stable() && e.rhs.is_stable(),
             Self::Or(expr_or) => expr_or.iter().all(|expr| expr.is_stable()),
+            Self::IsModel(_) => true,
             Self::IsNull(expr_is_null) => expr_is_null.expr.is_stable(),
             Self::IsVariant(expr_is_variant) => expr_is_variant.expr.is_stable(),
             Self::Not(expr_not) => expr_not.expr.is_stable(),
@@ -428,6 +434,7 @@ impl Expr {
             }
             Self::Not(expr_not) => expr_not.expr.is_const_at_depth(map_depth),
             Self::Or(expr_or) => expr_or.iter().all(|expr| expr.is_const_at_depth(map_depth)),
+            Self::IsModel(_) => false,
             Self::IsNull(expr_is_null) => expr_is_null.expr.is_const_at_depth(map_depth),
             Self::IsVariant(expr_is_variant) => expr_is_variant.expr.is_const_at_depth(map_depth),
             Self::InList(expr_in_list) => {
@@ -514,6 +521,7 @@ impl Expr {
             Self::AllOp(e) => e.lhs.is_eval() && e.rhs.is_eval(),
             Self::Or(expr_or) => expr_or.iter().all(|expr| expr.is_eval()),
             Self::Not(expr_not) => expr_not.expr.is_eval(),
+            Self::IsModel(_) => false,
             Self::IsNull(expr_is_null) => expr_is_null.expr.is_eval(),
             Self::IsVariant(expr_is_variant) => expr_is_variant.expr.is_eval(),
             Self::InList(expr_in_list) => {
@@ -696,6 +704,7 @@ impl fmt::Debug for Expr {
             Self::InList(e) => e.fmt(f),
             Self::InSubquery(e) => e.fmt(f),
             Self::Intersects(e) => e.fmt(f),
+            Self::IsModel(e) => write!(f, "is_model({:?})", e.model),
             Self::IsNull(e) => e.fmt(f),
             Self::IsSuperset(e) => e.fmt(f),
             Self::IsVariant(e) => e.fmt(f),

--- a/crates/toasty-core/src/stmt/expr_is_model.rs
+++ b/crates/toasty-core/src/stmt/expr_is_model.rs
@@ -1,0 +1,26 @@
+use crate::schema::app::ModelId;
+use crate::stmt::Expr;
+
+/// Tests whether the row in the current scope is an instance of `model`.
+///
+/// Emitted during lowering for reads against item-collection child models;
+/// the storage driver enforces it natively (column equality for SQL,
+/// sort-key prefix for DynamoDB).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExprIsModel {
+    /// The model id to check
+    pub model: ModelId,
+}
+
+impl Expr {
+    /// Creates a variant check expression to test the model id
+    pub fn is_model(model: ModelId) -> Self {
+        ExprIsModel { model }.into()
+    }
+}
+
+impl From<ExprIsModel> for Expr {
+    fn from(value: ExprIsModel) -> Self {
+        Self::IsModel(value)
+    }
+}

--- a/crates/toasty-core/src/stmt/insert.rs
+++ b/crates/toasty-core/src/stmt/insert.rs
@@ -39,8 +39,16 @@ impl Insert {
     pub fn merge(&mut self, other: Self) {
         match (&self.target, &other.target) {
             (InsertTarget::Model(a), InsertTarget::Model(b)) if a == b => {}
-            _ => todo!("handle this case"),
-        }
+            (InsertTarget::Scope(a), InsertTarget::Scope(b)) if a == b => {
+                // Same scope-shape: same target model and same parent reference.
+                // Merging is safe — the appended rows bind to the same scope.
+            }
+            (InsertTarget::Scope(_), InsertTarget::Scope(_)) => {
+                // Two scoped inserts with different parent references. Need
+                // per-row scope tracking; not yet supported.
+                todo!("merge of scoped inserts with differing parent scopes")
+            }
+            _ => todo!("merge of mismatched insert targets: {:?} vs {:?}", self.target, other.target),        }
 
         match (&mut self.source.body, other.source.body) {
             (stmt::ExprSet::Values(self_values), stmt::ExprSet::Values(other_values)) => {

--- a/crates/toasty-core/src/stmt/insert.rs
+++ b/crates/toasty-core/src/stmt/insert.rs
@@ -48,7 +48,12 @@ impl Insert {
                 // per-row scope tracking; not yet supported.
                 todo!("merge of scoped inserts with differing parent scopes")
             }
-            _ => todo!("merge of mismatched insert targets: {:?} vs {:?}", self.target, other.target),        }
+            _ => todo!(
+                "merge of mismatched insert targets: {:?} vs {:?}",
+                self.target,
+                other.target
+            ),
+        }
 
         match (&mut self.source.body, other.source.body) {
             (stmt::ExprSet::Values(self_values), stmt::ExprSet::Values(other_values)) => {

--- a/crates/toasty-core/src/stmt/visit.rs
+++ b/crates/toasty-core/src/stmt/visit.rs
@@ -3,7 +3,7 @@
 use super::{
     Assignment, Assignments, Association, Condition, Cte, Delete, Expr, ExprAllOp, ExprAnd,
     ExprAny, ExprAnyOp, ExprArg, ExprBetween, ExprBinaryOp, ExprCast, ExprColumn, ExprError,
-    ExprExists, ExprFunc, ExprInList, ExprInSubquery, ExprIntersects, ExprIsNull, ExprIsSuperset,
+    ExprExists, ExprFunc, ExprInList, ExprInSubquery, ExprIntersects, ExprIsModel, ExprIsNull, ExprIsSuperset,
     ExprIsVariant, ExprLength, ExprLet, ExprLike, ExprList, ExprMap, ExprMatch, ExprNot, ExprOr,
     ExprProject, ExprRecord, ExprReference, ExprSet, ExprSetOp, ExprStartsWith, ExprStmt, Filter,
     FuncCount, FuncLastInsertId, Insert, InsertTarget, Join, JoinOp, Limit, LimitCursor,
@@ -201,6 +201,13 @@ pub trait Visit {
     /// The default implementation delegates to [`visit_expr_intersects`].
     fn visit_expr_intersects(&mut self, i: &ExprIntersects) {
         visit_expr_intersects(self, i);
+    }
+
+    /// Visits an [`ExprIsModel`] node.
+    ///
+    /// The default implementation delegates to [`visit_expr_is_model`].
+    fn visit_expr_is_model(&mut self, i: &ExprIsModel) {
+        visit_expr_is_model(self, i);
     }
 
     /// Visits an [`ExprIsNull`] node.
@@ -912,6 +919,7 @@ where
         Expr::InList(expr) => v.visit_expr_in_list(expr),
         Expr::InSubquery(expr) => v.visit_expr_in_subquery(expr),
         Expr::Intersects(expr) => v.visit_expr_intersects(expr),
+        Expr::IsModel(expr) => v.visit_expr_is_model(expr),
         Expr::IsNull(expr) => v.visit_expr_is_null(expr),
         Expr::IsSuperset(expr) => v.visit_expr_is_superset(expr),
         Expr::IsVariant(expr) => v.visit_expr_is_variant(expr),
@@ -1091,6 +1099,13 @@ where
 {
     v.visit_expr(&node.lhs);
     v.visit_expr(&node.rhs);
+}
+
+/// Default traversal for [`ExprIsModel`] nodes.
+pub fn visit_expr_is_model<V>(v: &mut V, node: &ExprIsModel)
+where
+    V: Visit + ?Sized,
+{
 }
 
 /// Default traversal for [`ExprIsNull`] nodes. Visits the inner expression.

--- a/crates/toasty-core/src/stmt/visit.rs
+++ b/crates/toasty-core/src/stmt/visit.rs
@@ -3,13 +3,13 @@
 use super::{
     Assignment, Assignments, Association, Condition, Cte, Delete, Expr, ExprAllOp, ExprAnd,
     ExprAny, ExprAnyOp, ExprArg, ExprBetween, ExprBinaryOp, ExprCast, ExprColumn, ExprError,
-    ExprExists, ExprFunc, ExprInList, ExprInSubquery, ExprIntersects, ExprIsModel, ExprIsNull, ExprIsSuperset,
-    ExprIsVariant, ExprLength, ExprLet, ExprLike, ExprList, ExprMap, ExprMatch, ExprNot, ExprOr,
-    ExprProject, ExprRecord, ExprReference, ExprSet, ExprSetOp, ExprStartsWith, ExprStmt, Filter,
-    FuncCount, FuncLastInsertId, Insert, InsertTarget, Join, JoinOp, Limit, LimitCursor,
-    LimitOffset, Node, OrderBy, OrderByExpr, Path, Projection, Query, Returning, Select, Source,
-    SourceModel, SourceTable, SourceTableId, Statement, TableDerived, TableFactor, TableRef,
-    TableWithJoins, Type, Update, UpdateTarget, Value, ValueRecord, Values, With,
+    ExprExists, ExprFunc, ExprInList, ExprInSubquery, ExprIntersects, ExprIsModel, ExprIsNull,
+    ExprIsSuperset, ExprIsVariant, ExprLength, ExprLet, ExprLike, ExprList, ExprMap, ExprMatch,
+    ExprNot, ExprOr, ExprProject, ExprRecord, ExprReference, ExprSet, ExprSetOp, ExprStartsWith,
+    ExprStmt, Filter, FuncCount, FuncLastInsertId, Insert, InsertTarget, Join, JoinOp, Limit,
+    LimitCursor, LimitOffset, Node, OrderBy, OrderByExpr, Path, Projection, Query, Returning,
+    Select, Source, SourceModel, SourceTable, SourceTableId, Statement, TableDerived, TableFactor,
+    TableRef, TableWithJoins, Type, Update, UpdateTarget, Value, ValueRecord, Values, With,
 };
 
 /// Immutable visitor trait for the statement AST.

--- a/crates/toasty-core/src/stmt/visit_mut.rs
+++ b/crates/toasty-core/src/stmt/visit_mut.rs
@@ -3,13 +3,13 @@
 use super::{
     Assignment, Assignments, Association, Condition, Cte, Delete, Expr, ExprAllOp, ExprAnd,
     ExprAny, ExprAnyOp, ExprArg, ExprBetween, ExprBinaryOp, ExprCast, ExprColumn, ExprError,
-    ExprExists, ExprFunc, ExprInList, ExprInSubquery, ExprIntersects, ExprIsModel, ExprIsNull, ExprIsSuperset,
-    ExprIsVariant, ExprLength, ExprLet, ExprLike, ExprList, ExprMap, ExprMatch, ExprNot, ExprOr,
-    ExprProject, ExprRecord, ExprReference, ExprSet, ExprSetOp, ExprStartsWith, ExprStmt, Filter,
-    FuncCount, FuncLastInsertId, Insert, InsertTarget, Join, JoinOp, Limit, LimitCursor,
-    LimitOffset, Node, OrderBy, OrderByExpr, Path, Projection, Query, Returning, Select, Source,
-    SourceModel, SourceTable, SourceTableId, Statement, TableDerived, TableFactor, TableRef,
-    TableWithJoins, Type, Update, UpdateTarget, Value, ValueRecord, Values, With,
+    ExprExists, ExprFunc, ExprInList, ExprInSubquery, ExprIntersects, ExprIsModel, ExprIsNull,
+    ExprIsSuperset, ExprIsVariant, ExprLength, ExprLet, ExprLike, ExprList, ExprMap, ExprMatch,
+    ExprNot, ExprOr, ExprProject, ExprRecord, ExprReference, ExprSet, ExprSetOp, ExprStartsWith,
+    ExprStmt, Filter, FuncCount, FuncLastInsertId, Insert, InsertTarget, Join, JoinOp, Limit,
+    LimitCursor, LimitOffset, Node, OrderBy, OrderByExpr, Path, Projection, Query, Returning,
+    Select, Source, SourceModel, SourceTable, SourceTableId, Statement, TableDerived, TableFactor,
+    TableRef, TableWithJoins, Type, Update, UpdateTarget, Value, ValueRecord, Values, With,
 };
 
 /// Mutable visitor trait for the statement AST.

--- a/crates/toasty-core/src/stmt/visit_mut.rs
+++ b/crates/toasty-core/src/stmt/visit_mut.rs
@@ -3,7 +3,7 @@
 use super::{
     Assignment, Assignments, Association, Condition, Cte, Delete, Expr, ExprAllOp, ExprAnd,
     ExprAny, ExprAnyOp, ExprArg, ExprBetween, ExprBinaryOp, ExprCast, ExprColumn, ExprError,
-    ExprExists, ExprFunc, ExprInList, ExprInSubquery, ExprIntersects, ExprIsNull, ExprIsSuperset,
+    ExprExists, ExprFunc, ExprInList, ExprInSubquery, ExprIntersects, ExprIsModel, ExprIsNull, ExprIsSuperset,
     ExprIsVariant, ExprLength, ExprLet, ExprLike, ExprList, ExprMap, ExprMatch, ExprNot, ExprOr,
     ExprProject, ExprRecord, ExprReference, ExprSet, ExprSetOp, ExprStartsWith, ExprStmt, Filter,
     FuncCount, FuncLastInsertId, Insert, InsertTarget, Join, JoinOp, Limit, LimitCursor,
@@ -203,6 +203,13 @@ pub trait VisitMut {
     /// The default implementation delegates to [`visit_expr_intersects_mut`].
     fn visit_expr_intersects_mut(&mut self, i: &mut ExprIntersects) {
         visit_expr_intersects_mut(self, i);
+    }
+
+    /// Visits an [`ExprIsModel`] node mutably.
+    ///
+    /// The default implementation delegates to [`visit_expr_is_model_mut`].
+    fn visit_expr_is_model_mut(&mut self, i: &mut ExprIsModel) {
+        visit_expr_is_model_mut(self, i);
     }
 
     /// Visits an [`ExprIsNull`] node mutably.
@@ -914,6 +921,7 @@ where
         Expr::InList(expr) => v.visit_expr_in_list_mut(expr),
         Expr::InSubquery(expr) => v.visit_expr_in_subquery_mut(expr),
         Expr::Intersects(expr) => v.visit_expr_intersects_mut(expr),
+        Expr::IsModel(expr) => v.visit_expr_is_model_mut(expr),
         Expr::IsNull(expr) => v.visit_expr_is_null_mut(expr),
         Expr::IsSuperset(expr) => v.visit_expr_is_superset_mut(expr),
         Expr::IsVariant(expr) => v.visit_expr_is_variant_mut(expr),
@@ -1093,6 +1101,13 @@ where
 {
     v.visit_expr_mut(&mut node.lhs);
     v.visit_expr_mut(&mut node.rhs);
+}
+
+/// Default mutable traversal for [`ExprIsNull`] nodes. Visits the inner expression.
+pub fn visit_expr_is_model_mut<V>(v: &mut V, node: &mut ExprIsModel)
+where
+    V: VisitMut + ?Sized,
+{
 }
 
 /// Default mutable traversal for [`ExprIsNull`] nodes. Visits the inner expression.

--- a/crates/toasty-core/tests/schema_missing_model.rs
+++ b/crates/toasty-core/tests/schema_missing_model.rs
@@ -41,6 +41,7 @@ fn make_root_model(id: ModelId, name: &str, extra_fields: Vec<Field>) -> Model {
             },
         },
         table_name: None,
+        item_collection: None,
         indices: vec![],
         version_field: None,
     })

--- a/crates/toasty-core/tests/schema_resolve_field.rs
+++ b/crates/toasty-core/tests/schema_resolve_field.rs
@@ -178,6 +178,7 @@ fn schema() -> Schema {
             },
         },
         table_name: None,
+        item_collection: None,
         indices: vec![],
         version_field: None,
     });

--- a/crates/toasty-core/tests/schema_verify_version_field.rs
+++ b/crates/toasty-core/tests/schema_verify_version_field.rs
@@ -45,6 +45,7 @@ fn build_model(fields: Vec<Field>, version_field: Option<FieldId>) -> Model {
             index: pk_index_id,
         },
         table_name: None,
+        item_collection: None,
         indices: vec![Index {
             id: pk_index_id,
             name: None,

--- a/crates/toasty-core/tests/stmt_infer_expr_reference_ty.rs
+++ b/crates/toasty-core/tests/stmt_infer_expr_reference_ty.rs
@@ -102,6 +102,7 @@ fn model_root(id: usize, field_types: &[(Type, &str)]) -> ModelRoot {
             },
         },
         table_name: None,
+        item_collection: None,
         indices: vec![],
         version_field: None,
     }

--- a/crates/toasty-driver-dynamodb/src/lib.rs
+++ b/crates/toasty-driver-dynamodb/src/lib.rs
@@ -25,11 +25,8 @@ use async_trait::async_trait;
 use toasty_core::{
     Error, Result, Schema,
     driver::{Capability, Driver, ExecResponse, operation::Operation},
-    schema::{
-        db::{self, Column, ColumnId, Migration, Table},
-        diff,
-    },
-    stmt::{self, ExprContext},
+    schema::db::{self, Column, ColumnId, IndexScope, Migration, Table},
+    stmt::{self, Expr, ExprContext, Visit},
 };
 
 use aws_sdk_dynamodb::{
@@ -44,6 +41,7 @@ use aws_sdk_dynamodb::{
     },
 };
 use std::{borrow::Cow, collections::HashMap, sync::Arc};
+use toasty_core::schema::diff;
 
 /// A DynamoDB [`Driver`] backed by the AWS SDK.
 ///
@@ -211,17 +209,56 @@ impl Connection {
 
 fn ddb_key(table: &Table, key: &stmt::Value) -> HashMap<String, AttributeValue> {
     let mut ret = HashMap::new();
+    let pk_index = &table.indices[table.primary_key.index.index];
+    let mut sk_values: Vec<(&str, stmt::Value)> = Vec::new();
 
-    for (index, column) in table.primary_key_columns().enumerate() {
+    for (index, index_column) in pk_index.columns.iter().enumerate() {
+        let column = table.column(index_column.column);
         let value = match key {
-            stmt::Value::Record(record) => &record[index],
-            value => value,
+            stmt::Value::Record(record) => record[index].clone(),
+            value => value.clone(),
         };
 
-        ret.insert(column.name.clone(), Value::from(value.clone()).to_ddb());
+        match index_column.scope {
+            IndexScope::Local => {
+                sk_values.push((&column.name, value));
+            }
+            IndexScope::Partition => {
+                ret.insert(column.name.clone(), Value::from(value).to_ddb());
+            }
+        }
+    }
+
+    if sk_values.len() > 1 {
+        // Stop at the first Null — root-model rows (e.g. User) leave child-only
+        // sort-key components absent, so the composite key is a prefix only.
+        let parts: Vec<String> = sk_values
+            .iter()
+            .take_while(|(_, v)| !v.is_null())
+            .map(|(_, v)| value_to_sk_part(v))
+            .collect();
+        assert!(
+            !parts.is_empty(),
+            "at least one sort-key component must be non-null"
+        );
+        let mut sk = parts.join("#");
+        sk.push('#');
+        ret.insert("__sk".to_string(), AttributeValue::S(sk));
+    } else if let Some((name, val)) = sk_values.into_iter().next() {
+        ret.insert(name.to_string(), Value::from(val).to_ddb());
     }
 
     ret
+}
+
+fn value_to_sk_part(val: &stmt::Value) -> String {
+    match val {
+        stmt::Value::String(s) => s.clone(),
+        stmt::Value::Uuid(u) => u.to_string(),
+        stmt::Value::I64(n) => n.to_string(),
+        stmt::Value::U64(n) => n.to_string(),
+        _ => panic!("unsupported sort-key value type: {val:?}"),
+    }
 }
 
 /// Convert a DynamoDB AttributeValue to stmt::Value (type-inferred).
@@ -277,26 +314,23 @@ fn deserialize_ddb_cursor(cursor: &stmt::Value) -> HashMap<String, AttributeValu
     ret
 }
 
-fn ddb_key_schema(
-    partition_columns: &[&Column],
-    range_columns: &[&Column],
-) -> Vec<KeySchemaElement> {
+fn ddb_key_schema(partition: &[&str], range: &[&str]) -> Vec<KeySchemaElement> {
     let mut ks = vec![];
 
-    for col in partition_columns {
+    for name in partition {
         ks.push(
             KeySchemaElement::builder()
-                .attribute_name(&col.name)
+                .attribute_name(*name)
                 .key_type(KeyType::Hash)
                 .build()
                 .unwrap(),
         );
     }
 
-    for col in range_columns {
+    for name in range {
         ks.push(
             KeySchemaElement::builder()
-                .attribute_name(&col.name)
+                .attribute_name(*name)
                 .key_type(KeyType::Range)
                 .build()
                 .unwrap(),
@@ -306,21 +340,180 @@ fn ddb_key_schema(
     ks
 }
 
-fn item_to_record<'a, 'stmt>(
+fn sort_key_columns(table: &Table) -> Vec<ColumnId> {
+    table.indices[table.primary_key.index.index]
+        .columns
+        .iter()
+        .filter(|c| matches!(c.scope, IndexScope::Local))
+        .map(|c| table.column(c.column).id)
+        .collect()
+}
+
+fn item_to_record<'a>(
     item: &HashMap<String, AttributeValue>,
     columns: impl Iterator<Item = &'a Column>,
+    sk_cols: &[ColumnId],
 ) -> Result<stmt::ValueRecord> {
+    // Parse __sk back into individual column values when the table uses a
+    // composite sort key.
+    let mut sk_vals: HashMap<ColumnId, stmt::Value> = HashMap::new();
+    if sk_cols.len() > 1 {
+        if let Some(AttributeValue::S(sk)) = item.get("__sk") {
+            let mut parts: Vec<&str> = sk.split('#').collect();
+            // We write a trailing delimiter so pop the empty tail.
+            if parts.last() == Some(&"") {
+                parts.pop();
+            }
+            for (i, part) in parts.iter().enumerate() {
+                if let Some(&col_id) = sk_cols.get(i) {
+                    sk_vals.insert(col_id, stmt::Value::String((*part).to_string()));
+                }
+            }
+        }
+    }
+
     Ok(stmt::ValueRecord::from_vec(
         columns
             .map(|column| {
                 if let Some(value) = item.get(&column.name) {
                     Value::from_ddb(&column.ty, value).into_inner()
+                } else if let Some(value) = sk_vals.get(&column.id) {
+                    // Re-parse the raw string into the column's proper type.
+                    let attr = AttributeValue::S(match value {
+                        stmt::Value::String(s) => s.clone(),
+                        _ => unreachable!(),
+                    });
+                    Value::from_ddb(&column.ty, &attr).into_inner()
                 } else {
                     stmt::Value::Null
                 }
             })
             .collect(),
     ))
+}
+
+/// Builds the DynamoDB key condition expression for a primary-key query.
+///
+/// For simple tables (single sort key or no sort key) this delegates to
+/// `ddb_expression` unchanged.  For item-collection tables where the sort key
+/// is synthesized as `__sk = "val1#val2#…"` this decomposes the filter into a
+/// hash-key equality condition plus a `begins_with(__sk, prefix)` expression.
+struct BuildKeyExpression<'a> {
+    table: &'a Table,
+    attrs: &'a mut ExprAttrs,
+    /// Column IDs of the Local-scoped PK columns (sort-key components).
+    sk_cols: &'a [ColumnId],
+    /// Accumulated equality conditions keyed by column ID.
+    sk_components: HashMap<ColumnId, stmt::Expr>,
+    /// The partition-key equality sub-expression.
+    pk_component: Option<stmt::Expr>,
+}
+
+impl<'a> BuildKeyExpression<'a> {
+    fn build(mut self, cx: &ExprContext<'_, db::Schema>, expr: &stmt::Expr) -> String {
+        if self.sk_cols.len() <= 1 {
+            // No composite sort key — pass through unchanged.
+            return ddb_expression(cx, self.attrs, true, expr);
+        }
+
+        // Collect sub-expressions per column.
+        self.visit_expr(expr);
+
+        let pk_expr = self
+            .pk_component
+            .as_ref()
+            .expect("key expression must include a hash-key condition");
+        let mut key_expr = ddb_expression(cx, self.attrs, true, pk_expr);
+
+        // Build the sort-key prefix from the collected components.
+        let mut missing = false;
+        let mut sk_prefix = String::new();
+        for &sk_col_id in self.sk_cols {
+            let Some(sk_sub) = self.sk_components.get(&sk_col_id) else {
+                missing = true;
+                continue;
+            };
+
+            assert!(!missing, "gap in sort-key component conditions");
+
+            match sk_sub {
+                stmt::Expr::IsNull(_) => {
+                    // Null-check means this column is absent for this model type; skip.
+                }
+                stmt::Expr::BinaryOp(op) if matches!(op.op, stmt::BinaryOp::Eq) => {
+                    let stmt::Expr::Value(val) = op.rhs.as_ref() else {
+                        todo!("sk_sub rhs = {:#?}", op.rhs);
+                    };
+                    sk_prefix.push_str(&value_to_sk_part(val));
+                    sk_prefix.push('#');
+                }
+                _ => todo!("sk_sub={sk_sub:#?}"),
+            }
+        }
+
+        let sk_prefix_attr = self.attrs.literal(sk_prefix);
+        self.attrs
+            .attr_names
+            .insert("#__sk".to_string(), "__sk".to_string());
+        key_expr.push_str(&format!(" AND begins_with(#__sk, {sk_prefix_attr})"));
+        key_expr
+    }
+}
+
+impl Visit for BuildKeyExpression<'_> {
+    fn visit_expr(&mut self, i: &Expr) {
+        match i {
+            Expr::And(and) => self.visit_expr_and(and),
+            Expr::BinaryOp(binop) => self.visit_expr_binary_op(binop),
+            Expr::IsNull(isnull) => self.visit_expr_is_null(isnull),
+            _ => todo!("BuildKeyExpression::visit_expr: {i:#?}"),
+        }
+    }
+
+    fn visit_expr_binary_op(&mut self, i: &stmt::ExprBinaryOp) {
+        assert!(
+            matches!(i.op, stmt::BinaryOp::Eq),
+            "key condition must be equality; got {i:#?}"
+        );
+        let Expr::Reference(refer) = i.lhs.as_ref() else {
+            todo!("key lhs is not a reference: {i:#?}");
+        };
+
+        // To avoid needing a &ExprContext here we pattern-match on the column
+        // index directly — the reference's column index into the table.
+        let col_idx = match refer {
+            stmt::ExprReference::Column(ec) => ec.column,
+            _ => todo!("key reference is not a column: {refer:#?}"),
+        };
+
+        let col_id = ColumnId {
+            table: self.table.id,
+            index: col_idx,
+        };
+
+        if self.sk_cols.contains(&col_id) {
+            self.sk_components.insert(col_id, Expr::BinaryOp(i.clone()));
+        } else {
+            self.pk_component = Some(Expr::BinaryOp(i.clone()));
+        }
+    }
+
+    fn visit_expr_is_null(&mut self, i: &stmt::ExprIsNull) {
+        let Expr::Reference(refer) = i.expr.as_ref() else {
+            return;
+        };
+        let col_idx = match refer {
+            stmt::ExprReference::Column(ec) => ec.column,
+            _ => return,
+        };
+        let col_id = ColumnId {
+            table: self.table.id,
+            index: col_idx,
+        };
+        if self.sk_cols.contains(&col_id) {
+            self.sk_components.insert(col_id, Expr::IsNull(i.clone()));
+        }
+    }
 }
 
 fn ddb_expression(
@@ -494,6 +687,10 @@ impl ExprAttrs {
             }
             Entry::Occupied(e) => e.into_mut(),
         }
+    }
+
+    fn literal(&mut self, s: impl Into<String>) -> String {
+        self.ddb_value(AttributeValue::S(s.into()))
     }
 
     fn value(&mut self, val: &stmt::Value) -> String {

--- a/crates/toasty-driver-dynamodb/src/lib.rs
+++ b/crates/toasty-driver-dynamodb/src/lib.rs
@@ -407,6 +407,7 @@ struct BuildKeyExpression<'a> {
     sk_components: HashMap<ColumnId, stmt::Expr>,
     /// The partition-key equality sub-expression.
     pk_component: Option<stmt::Expr>,
+    schema: Arc<Schema>,
 }
 
 impl<'a> BuildKeyExpression<'a> {
@@ -440,11 +441,17 @@ impl<'a> BuildKeyExpression<'a> {
                 stmt::Expr::IsNull(_) => {
                     // Null-check means this column is absent for this model type; skip.
                 }
+                // TODO: Something is odd here.
                 stmt::Expr::BinaryOp(op) if matches!(op.op, stmt::BinaryOp::Eq) => {
                     let stmt::Expr::Value(val) = op.rhs.as_ref() else {
                         todo!("sk_sub rhs = {:#?}", op.rhs);
                     };
                     sk_prefix.push_str(&value_to_sk_part(val));
+                    sk_prefix.push('#');
+                }
+                stmt::Expr::IsModel(e) => {
+                    let model_name = self.schema.app.model(e.model).name().upper_camel_case();
+                    sk_prefix.push_str(&model_name);
                     sk_prefix.push('#');
                 }
                 _ => todo!("sk_sub={sk_sub:#?}"),
@@ -466,6 +473,7 @@ impl Visit for BuildKeyExpression<'_> {
             Expr::And(and) => self.visit_expr_and(and),
             Expr::BinaryOp(binop) => self.visit_expr_binary_op(binop),
             Expr::IsNull(isnull) => self.visit_expr_is_null(isnull),
+            Expr::IsModel(model) => self.visit_expr_is_model(model),
             _ => todo!("BuildKeyExpression::visit_expr: {i:#?}"),
         }
     }
@@ -513,6 +521,17 @@ impl Visit for BuildKeyExpression<'_> {
         if self.sk_cols.contains(&col_id) {
             self.sk_components.insert(col_id, Expr::IsNull(i.clone()));
         }
+    }
+
+    fn visit_expr_is_model(&mut self, model: &stmt::ExprIsModel) {
+        // Need the prefix to build the sk == Prefix#id
+        let mapping = self.schema.mapping_for(model.model);
+        let disc_col_id = mapping
+            .item_collection
+            .model_column
+            .expect("IsModel emitted for model without discriminator");
+        self.sk_components
+            .insert(disc_col_id, Expr::IsModel(model.clone()));
     }
 }
 

--- a/crates/toasty-driver-dynamodb/src/lib.rs
+++ b/crates/toasty-driver-dynamodb/src/lib.rs
@@ -360,17 +360,17 @@ fn item_to_record<'a>(
     // Parse __sk back into individual column values when the table uses a
     // composite sort key.
     let mut sk_vals: HashMap<ColumnId, stmt::Value> = HashMap::new();
-    if sk_cols.len() > 1 {
-        if let Some(AttributeValue::S(sk)) = item.get("__sk") {
-            let mut parts: Vec<&str> = sk.split('#').collect();
-            // We write a trailing delimiter so pop the empty tail.
-            if parts.last() == Some(&"") {
-                parts.pop();
-            }
-            for (i, part) in parts.iter().enumerate() {
-                if let Some(&col_id) = sk_cols.get(i) {
-                    sk_vals.insert(col_id, stmt::Value::String((*part).to_string()));
-                }
+    if sk_cols.len() > 1
+        && let Some(AttributeValue::S(sk)) = item.get("__sk")
+    {
+        let mut parts: Vec<&str> = sk.split('#').collect();
+        // We write a trailing delimiter so pop the empty tail.
+        if parts.last() == Some(&"") {
+            parts.pop();
+        }
+        for (i, part) in parts.iter().enumerate() {
+            if let Some(&col_id) = sk_cols.get(i) {
+                sk_vals.insert(col_id, stmt::Value::String((*part).to_string()));
             }
         }
     }

--- a/crates/toasty-driver-dynamodb/src/lib.rs
+++ b/crates/toasty-driver-dynamodb/src/lib.rs
@@ -560,9 +560,9 @@ fn ddb_expression(
 ) -> String {
     match expr {
         stmt::Expr::Between(expr_between) => {
-            let field = ddb_expression(cx, attrs, primary, &expr_between.expr);
-            let low = ddb_expression(cx, attrs, primary, &expr_between.low);
-            let high = ddb_expression(cx, attrs, primary, &expr_between.high);
+            let field = ddb_expression(schema, cx, attrs, primary, &expr_between.expr);
+            let low = ddb_expression(schema, cx, attrs, primary, &expr_between.low);
+            let high = ddb_expression(schema, cx, attrs, primary, &expr_between.high);
             format!("{field} BETWEEN {low} AND {high}")
         }
         stmt::Expr::BinaryOp(expr_binary_op) => {
@@ -694,7 +694,7 @@ fn ddb_expression(
             // (result of `field = true` simplification). In predicate position
             // this means "is true"; the `field = false` case arrives as
             // Not(Cast(col_ref, Bool)) and is handled by the Not arm above.
-            let col_alias = ddb_expression(cx, attrs, primary, &expr_cast.expr);
+            let col_alias = ddb_expression(schema, cx, attrs, primary, &expr_cast.expr);
             let true_val =
                 attrs.ddb_value(aws_sdk_dynamodb::types::AttributeValue::N("1".to_string()));
             format!("{col_alias} = {true_val}")

--- a/crates/toasty-driver-dynamodb/src/lib.rs
+++ b/crates/toasty-driver-dynamodb/src/lib.rs
@@ -25,7 +25,10 @@ use async_trait::async_trait;
 use toasty_core::{
     Error, Result, Schema,
     driver::{Capability, Driver, ExecResponse, operation::Operation},
-    schema::db::{self, Column, ColumnId, IndexScope, Migration, Table},
+    schema::{
+        app::ModelId,
+        db::{self, Column, ColumnId, IndexScope, Migration, Table},
+    },
     stmt::{self, Expr, ExprContext, Visit},
 };
 
@@ -398,13 +401,28 @@ fn item_to_record<'a>(
 /// `ddb_expression` unchanged.  For item-collection tables where the sort key
 /// is synthesized as `__sk = "val1#val2#…"` this decomposes the filter into a
 /// hash-key equality condition plus a `begins_with(__sk, prefix)` expression.
+/// One sort-key segment as resolved during `BuildKeyExpression::visit_expr`.
+///
+/// Each variant captures *what the segment contributes to the SK prefix*,
+/// already in the form the consumer needs — no more re-parsing AST shapes.
+#[derive(Debug)]
+enum SkComponent {
+    /// The column is bound to a literal value; render the value as the segment.
+    Literal(stmt::Value),
+    /// The column is the item-collection discriminator; render the model
+    /// name (in upper-camel case) as the segment.
+    Model(ModelId),
+    /// The column is absent for this model type (matched via `IS NULL`); skip.
+    Skip,
+}
+
 struct BuildKeyExpression<'a> {
     table: &'a Table,
     attrs: &'a mut ExprAttrs,
     /// Column IDs of the Local-scoped PK columns (sort-key components).
     sk_cols: &'a [ColumnId],
-    /// Accumulated equality conditions keyed by column ID.
-    sk_components: HashMap<ColumnId, stmt::Expr>,
+    /// Resolved sort-key segments keyed by column ID.
+    sk_components: HashMap<ColumnId, SkComponent>,
     /// The partition-key equality sub-expression.
     pk_component: Option<stmt::Expr>,
     schema: Arc<Schema>,
@@ -438,23 +456,16 @@ impl<'a> BuildKeyExpression<'a> {
             assert!(!missing, "gap in sort-key component conditions");
 
             match sk_sub {
-                stmt::Expr::IsNull(_) => {
-                    // Null-check means this column is absent for this model type; skip.
-                }
-                // TODO: Something is odd here.
-                stmt::Expr::BinaryOp(op) if matches!(op.op, stmt::BinaryOp::Eq) => {
-                    let stmt::Expr::Value(val) = op.rhs.as_ref() else {
-                        todo!("sk_sub rhs = {:#?}", op.rhs);
-                    };
+                SkComponent::Skip => {}
+                SkComponent::Literal(val) => {
                     sk_prefix.push_str(&value_to_sk_part(val));
                     sk_prefix.push('#');
                 }
-                stmt::Expr::IsModel(e) => {
-                    let model_name = self.schema.app.model(e.model).name().upper_camel_case();
+                SkComponent::Model(model) => {
+                    let model_name = self.schema.app.model(*model).name().upper_camel_case();
                     sk_prefix.push_str(&model_name);
                     sk_prefix.push('#');
                 }
-                _ => todo!("sk_sub={sk_sub:#?}"),
             }
         }
 
@@ -500,7 +511,13 @@ impl Visit for BuildKeyExpression<'_> {
         };
 
         if self.sk_cols.contains(&col_id) {
-            self.sk_components.insert(col_id, Expr::BinaryOp(i.clone()));
+            // Sort-key component: extract the bound literal so the consumer
+            // doesn't have to re-pattern-match the AST.
+            let stmt::Expr::Value(val) = i.rhs.as_ref() else {
+                todo!("sort-key equality must bind a literal value; got {i:#?}");
+            };
+            self.sk_components
+                .insert(col_id, SkComponent::Literal(val.clone()));
         } else {
             self.pk_component = Some(Expr::BinaryOp(i.clone()));
         }
@@ -519,19 +536,18 @@ impl Visit for BuildKeyExpression<'_> {
             index: col_idx,
         };
         if self.sk_cols.contains(&col_id) {
-            self.sk_components.insert(col_id, Expr::IsNull(i.clone()));
+            self.sk_components.insert(col_id, SkComponent::Skip);
         }
     }
 
     fn visit_expr_is_model(&mut self, model: &stmt::ExprIsModel) {
-        // Need the prefix to build the sk == Prefix#id
         let mapping = self.schema.mapping_for(model.model);
         let disc_col_id = mapping
             .item_collection
             .model_column
             .expect("IsModel emitted for model without discriminator");
         self.sk_components
-            .insert(disc_col_id, Expr::IsModel(model.clone()));
+            .insert(disc_col_id, SkComponent::Model(model.model));
     }
 }
 

--- a/crates/toasty-driver-dynamodb/src/lib.rs
+++ b/crates/toasty-driver-dynamodb/src/lib.rs
@@ -182,8 +182,8 @@ impl Connection {
         match op {
             Operation::GetByKey(op) => self.exec_get_by_key(schema, op).await,
             Operation::QueryPk(op) => self.exec_query_pk(schema, op).await,
-            Operation::DeleteByKey(op) => self.exec_delete_by_key(&schema.db, op).await,
-            Operation::UpdateByKey(op) => self.exec_update_by_key(&schema.db, op).await,
+            Operation::DeleteByKey(op) => self.exec_delete_by_key(schema, op).await,
+            Operation::UpdateByKey(op) => self.exec_update_by_key(schema, op).await,
             Operation::FindPkByIndex(op) => self.exec_find_pk_by_index(schema, op).await,
             Operation::QuerySql(op) => {
                 assert!(
@@ -414,7 +414,7 @@ impl<'a> BuildKeyExpression<'a> {
     fn build(mut self, cx: &ExprContext<'_, db::Schema>, expr: &stmt::Expr) -> String {
         if self.sk_cols.len() <= 1 {
             // No composite sort key — pass through unchanged.
-            return ddb_expression(cx, self.attrs, true, expr);
+            return ddb_expression(&self.schema, cx, self.attrs, true, expr);
         }
 
         // Collect sub-expressions per column.
@@ -424,7 +424,7 @@ impl<'a> BuildKeyExpression<'a> {
             .pk_component
             .as_ref()
             .expect("key expression must include a hash-key condition");
-        let mut key_expr = ddb_expression(cx, self.attrs, true, pk_expr);
+        let mut key_expr = ddb_expression(&self.schema, cx, self.attrs, true, pk_expr);
 
         // Build the sort-key prefix from the collected components.
         let mut missing = false;
@@ -536,6 +536,7 @@ impl Visit for BuildKeyExpression<'_> {
 }
 
 fn ddb_expression(
+    schema: &Schema,
     cx: &ExprContext<'_, db::Schema>,
     attrs: &mut ExprAttrs,
     primary: bool,
@@ -549,8 +550,8 @@ fn ddb_expression(
             format!("{field} BETWEEN {low} AND {high}")
         }
         stmt::Expr::BinaryOp(expr_binary_op) => {
-            let lhs = ddb_expression(cx, attrs, primary, &expr_binary_op.lhs);
-            let rhs = ddb_expression(cx, attrs, primary, &expr_binary_op.rhs);
+            let lhs = ddb_expression(schema, cx, attrs, primary, &expr_binary_op.lhs);
+            let rhs = ddb_expression(schema, cx, attrs, primary, &expr_binary_op.rhs);
 
             match expr_binary_op.op {
                 stmt::BinaryOp::Eq => format!("{lhs} = {rhs}"),
@@ -589,7 +590,7 @@ fn ddb_expression(
             let operands = expr_and
                 .operands
                 .iter()
-                .map(|operand| ddb_expression(cx, attrs, primary, operand))
+                .map(|operand| ddb_expression(schema, cx, attrs, primary, operand))
                 .collect::<Vec<_>>();
             operands.join(" AND ")
         }
@@ -597,12 +598,12 @@ fn ddb_expression(
             let operands = expr_or
                 .operands
                 .iter()
-                .map(|operand| ddb_expression(cx, attrs, primary, operand))
+                .map(|operand| ddb_expression(schema, cx, attrs, primary, operand))
                 .collect::<Vec<_>>();
             format!("({})", operands.join(" OR "))
         }
         stmt::Expr::InList(in_list) => {
-            let expr = ddb_expression(cx, attrs, primary, &in_list.expr);
+            let expr = ddb_expression(schema, cx, attrs, primary, &in_list.expr);
 
             // Extract the list items and create individual attribute values
             let items = match &*in_list.list {
@@ -613,7 +614,7 @@ fn ddb_expression(
                     .join(", "),
                 _ => {
                     // If it's not a literal list, treat it as a single expression
-                    ddb_expression(cx, attrs, primary, &in_list.list)
+                    ddb_expression(schema, cx, attrs, primary, &in_list.list)
                 }
             };
 
@@ -628,17 +629,29 @@ fn ddb_expression(
             // `Option<Embed>` presence column — produces invalid syntax.)
             let inner = match &*expr_is_null.expr {
                 stmt::Expr::Reference(expr_reference) => column_alias(cx, attrs, expr_reference).1,
-                other => ddb_expression(cx, attrs, primary, other),
+                other => ddb_expression(schema, cx, attrs, primary, other),
             };
             format!("attribute_not_exists({inner})")
         }
+        stmt::Expr::IsModel(e) => {
+            // On DynamoDB the discriminator column is not stored as a top-level
+            // attribute on rows; it's encoded as the leading segment of the
+            // synthesized __sk. Filter by the SK prefix so scans and other
+            // filter-expression contexts find the right rows.
+            let model_name = schema.app.model(e.model).name().upper_camel_case();
+            let prefix_attr = attrs.value(&stmt::Value::String(format!("{model_name}#")));
+            attrs
+                .attr_names
+                .insert("#__sk".to_string(), "__sk".to_string());
+            format!("begins_with(#__sk, {prefix_attr})")
+        }
         stmt::Expr::Not(expr_not) => {
-            let inner = ddb_expression(cx, attrs, primary, &expr_not.expr);
+            let inner = ddb_expression(schema, cx, attrs, primary, &expr_not.expr);
             format!("(NOT {inner})")
         }
         stmt::Expr::StartsWith(expr_starts_with) => {
-            let expr = ddb_expression(cx, attrs, primary, &expr_starts_with.expr);
-            let prefix = ddb_expression(cx, attrs, primary, &expr_starts_with.prefix);
+            let expr = ddb_expression(schema, cx, attrs, primary, &expr_starts_with.expr);
+            let prefix = ddb_expression(schema, cx, attrs, primary, &expr_starts_with.prefix);
             format!("begins_with({expr}, {prefix})")
         }
         stmt::Expr::Like(_) => {
@@ -650,12 +663,12 @@ fn ddb_expression(
             // `Path::contains(value)` lowers to `value = ANY(col)`. On
             // DynamoDB that's `contains(path, value)` — the standard List
             // membership filter.
-            let value = ddb_expression(cx, attrs, primary, &any.lhs);
-            let path = ddb_expression(cx, attrs, primary, &any.rhs);
+            let value = ddb_expression(schema, cx, attrs, primary, &any.lhs);
+            let path = ddb_expression(schema, cx, attrs, primary, &any.rhs);
             format!("contains({path}, {value})")
         }
         stmt::Expr::Length(expr) => {
-            let inner = ddb_expression(cx, attrs, primary, &expr.expr);
+            let inner = ddb_expression(schema, cx, attrs, primary, &expr.expr);
             format!("size({inner})")
         }
         stmt::Expr::Cast(expr_cast) if expr_cast.ty == stmt::Type::Bool => {

--- a/crates/toasty-driver-dynamodb/src/op/create_table.rs
+++ b/crates/toasty-driver-dynamodb/src/op/create_table.rs
@@ -2,6 +2,7 @@ use super::{
     AttributeDefinition, BillingMode, Connection, GlobalSecondaryIndex, Projection, ProjectionType,
     Result, Table, TypeExt, db, ddb_key_schema,
 };
+use toasty_core::schema::db::IndexScope;
 
 impl Connection {
     pub(crate) async fn create_table(
@@ -30,29 +31,79 @@ impl Connection {
             }
         }
 
-        // Calculate which attributes need to be defined
-        let mut defined_attributes = hashbrown::HashSet::new();
+        let pk_index = &table.indices[table.primary_key.index.index];
+        let all_pk_cols: Vec<&db::Column> = pk_index
+            .columns
+            .iter()
+            .map(|c| table.column(c.column))
+            .collect();
+        let local_cols: Vec<&db::Column> = pk_index
+            .columns
+            .iter()
+            .filter(|c| matches!(c.scope, IndexScope::Local))
+            .map(|c| table.column(c.column))
+            .collect();
 
-        let pk_cols: Vec<&db::Column> = table.primary_key_columns().collect();
-
-        if pk_cols.is_empty() || pk_cols.len() > 2 {
-            return Err(toasty_core::Error::invalid_schema(format!(
-                "table '{}' primary key must have 1 or 2 columns, got {}",
-                table.name,
-                pk_cols.len()
-            )));
-        }
-
-        for col in &pk_cols {
-            defined_attributes.insert(col.id);
-        }
-
-        let pk_partition_cols = &pk_cols[..1];
-        let pk_range_cols = if pk_cols.len() > 1 {
-            &pk_cols[1..]
+        // If there are Local-scoped columns (item-collection / new-style composite key),
+        // the first Partition column is the hash key and Local columns become __sk.
+        // Otherwise fall back to positional: first column = hash, rest = range.
+        let (partition_col, range_name): (&db::Column, Option<String>) = if !local_cols.is_empty() {
+            let partition_cols: Vec<&db::Column> = pk_index
+                .columns
+                .iter()
+                .filter(|c| matches!(c.scope, IndexScope::Partition))
+                .map(|c| table.column(c.column))
+                .collect();
+            assert_eq!(
+                partition_cols.len(),
+                1,
+                "table '{}' must have exactly one partition key",
+                table.name
+            );
+            let range = if local_cols.len() > 1 {
+                Some("__sk".to_string())
+            } else {
+                Some(local_cols[0].name.clone())
+            };
+            (partition_cols[0], range)
         } else {
-            &[][..]
+            // Legacy positional: first = hash, second (if any) = range.
+            assert!(
+                !all_pk_cols.is_empty(),
+                "table '{}' has no primary key columns",
+                table.name
+            );
+            let range = if all_pk_cols.len() > 1 {
+                Some(all_pk_cols[1].name.clone())
+            } else {
+                None
+            };
+            (all_pk_cols[0], range)
         };
+
+        // Collect attributes that need to be declared in the DynamoDB table schema.
+        // Maps attribute name → DynamoDB type string.
+        let mut defined_attributes: std::collections::HashMap<
+            String,
+            aws_sdk_dynamodb::types::ScalarAttributeType,
+        > = std::collections::HashMap::new();
+        defined_attributes.insert(partition_col.name.clone(), partition_col.ty.to_ddb_type());
+        if let Some(ref rn) = range_name {
+            if rn == "__sk" {
+                // __sk is always a String (synthesised composite sort key).
+                defined_attributes.insert(
+                    "__sk".to_string(),
+                    aws_sdk_dynamodb::types::ScalarAttributeType::S,
+                );
+            } else {
+                // Single-column range key: find it by name in all_pk_cols.
+                let range_col = all_pk_cols
+                    .iter()
+                    .find(|c| c.name == *rn)
+                    .expect("range column must be in pk_cols");
+                defined_attributes.insert(range_col.name.clone(), range_col.ty.to_ddb_type());
+            }
+        }
 
         let mut gsis = vec![];
 
@@ -80,48 +131,56 @@ impl Connection {
                 continue;
             }
 
-            let partition_cols: Vec<&db::Column> = index
+            let gsi_partition_cols: Vec<&db::Column> = index
                 .columns
                 .iter()
                 .filter(|ic| ic.scope.is_partition())
                 .map(|ic| table.column(ic.column))
                 .collect();
 
-            let range_cols: Vec<&db::Column> = index
+            let gsi_range_cols: Vec<&db::Column> = index
                 .columns
                 .iter()
                 .filter(|ic| ic.scope.is_local())
                 .map(|ic| table.column(ic.column))
                 .collect();
 
-            if partition_cols.is_empty() || partition_cols.len() > 4 {
+            if gsi_partition_cols.is_empty() || gsi_partition_cols.len() > 4 {
                 return Err(toasty_core::Error::invalid_schema(format!(
                     "GSI '{}' must have 1 to 4 partition (HASH) columns, got {}",
                     index.name,
-                    partition_cols.len()
+                    gsi_partition_cols.len()
                 )));
             }
 
-            if range_cols.len() > 4 {
+            if gsi_range_cols.len() > 4 {
                 return Err(toasty_core::Error::invalid_schema(format!(
                     "GSI '{}' must have at most 4 range (RANGE) columns, got {}",
                     index.name,
-                    range_cols.len()
+                    gsi_range_cols.len()
                 )));
             }
 
-            for col in &partition_cols {
-                defined_attributes.insert(col.id);
+            for col in &gsi_partition_cols {
+                defined_attributes
+                    .entry(col.name.clone())
+                    .or_insert_with(|| col.ty.to_ddb_type());
+            }
+            for col in &gsi_range_cols {
+                defined_attributes
+                    .entry(col.name.clone())
+                    .or_insert_with(|| col.ty.to_ddb_type());
             }
 
-            for col in &range_cols {
-                defined_attributes.insert(col.id);
-            }
+            let gsi_partition_names: Vec<&str> =
+                gsi_partition_cols.iter().map(|c| c.name.as_str()).collect();
+            let gsi_range_names: Vec<&str> =
+                gsi_range_cols.iter().map(|c| c.name.as_str()).collect();
 
             gsis.push(
                 GlobalSecondaryIndex::builder()
                     .index_name(&index.name)
-                    .set_key_schema(Some(ddb_key_schema(&partition_cols, &range_cols)))
+                    .set_key_schema(Some(ddb_key_schema(&gsi_partition_names, &gsi_range_names)))
                     .projection(
                         Projection::builder()
                             .projection_type(ProjectionType::All)
@@ -132,15 +191,12 @@ impl Connection {
             );
         }
 
-        let attribute_definitions = defined_attributes
+        let attribute_definitions: Vec<_> = defined_attributes
             .iter()
-            .map(|column_id| {
-                let column = table.column(*column_id);
-                let ty = column.ty.to_ddb_type();
-
+            .map(|(name, ty)| {
                 AttributeDefinition::builder()
-                    .attribute_name(&column.name)
-                    .attribute_type(ty)
+                    .attribute_name(name)
+                    .attribute_type(ty.clone())
                     .build()
                     .unwrap()
             })
@@ -150,7 +206,10 @@ impl Connection {
             .create_table()
             .table_name(&table.name)
             .set_attribute_definitions(Some(attribute_definitions))
-            .set_key_schema(Some(ddb_key_schema(pk_partition_cols, pk_range_cols)))
+            .set_key_schema(Some(ddb_key_schema(
+                &[partition_col.name.as_str()],
+                &range_name.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
+            )))
             .set_global_secondary_indexes(if gsis.is_empty() { None } else { Some(gsis) })
             .billing_mode(BillingMode::PayPerRequest)
             .send()
@@ -165,7 +224,7 @@ impl Connection {
             self.client
                 .create_table()
                 .table_name(&index.name)
-                .set_key_schema(Some(ddb_key_schema(&[pk], &[])))
+                .set_key_schema(Some(ddb_key_schema(&[pk.name.as_str()], &[])))
                 .attribute_definitions(
                     AttributeDefinition::builder()
                         .attribute_name(&pk.name)

--- a/crates/toasty-driver-dynamodb/src/op/delete_by_key.rs
+++ b/crates/toasty-driver-dynamodb/src/op/delete_by_key.rs
@@ -1,3 +1,5 @@
+use crate::sort_key_columns;
+
 use super::{
     Connection, Delete, ExprAttrs, Result, ReturnValuesOnConditionCheckFailure, SdkError,
     TransactWriteItem, db, ddb_expression, ddb_key, item_to_record, operation,
@@ -14,6 +16,7 @@ impl Connection {
         use aws_sdk_dynamodb::operation::delete_item::DeleteItemError;
 
         let table = schema.table(op.table);
+        let sk_cols = sort_key_columns(table);
         let cx = ExprContext::new_with_target(schema, table);
 
         let mut expr_attrs = ExprAttrs::default();
@@ -82,7 +85,8 @@ impl Connection {
                             // Both filter and condition set — check if filter matched
                             if let Some(old_item) = cce.item() {
                                 let record =
-                                    item_to_record(old_item, table.columns.iter()).unwrap();
+                                    item_to_record(old_item, table.columns.iter(), &sk_cols)
+                                        .unwrap();
                                 use toasty_core::stmt;
                                 struct RecordInput<'a>(&'a stmt::ValueRecord);
                                 impl stmt::Input for RecordInput<'_> {

--- a/crates/toasty-driver-dynamodb/src/op/delete_by_key.rs
+++ b/crates/toasty-driver-dynamodb/src/op/delete_by_key.rs
@@ -1,32 +1,40 @@
 use crate::sort_key_columns;
 
 use super::{
-    Connection, Delete, ExprAttrs, Result, ReturnValuesOnConditionCheckFailure, SdkError,
-    TransactWriteItem, db, ddb_expression, ddb_key, item_to_record, operation,
+    Connection, Delete, ExprAttrs, Result, ReturnValuesOnConditionCheckFailure, Schema, SdkError,
+    TransactWriteItem, ddb_expression, ddb_key, item_to_record, operation,
 };
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 use toasty_core::{driver::ExecResponse, stmt::ExprContext};
 
 impl Connection {
     pub(crate) async fn exec_delete_by_key(
         &mut self,
-        schema: &db::Schema,
+        schema: &Arc<Schema>,
         op: operation::DeleteByKey,
     ) -> Result<ExecResponse> {
         use aws_sdk_dynamodb::operation::delete_item::DeleteItemError;
 
-        let table = schema.table(op.table);
+        let table = schema.db.table(op.table);
         let sk_cols = sort_key_columns(table);
-        let cx = ExprContext::new_with_target(schema, table);
+        let cx = ExprContext::new_with_target(&schema.db, table);
 
         let mut expr_attrs = ExprAttrs::default();
 
         let condition_expression = match (&op.filter, &op.condition) {
-            (Some(filter), None) => Some(ddb_expression(&cx, &mut expr_attrs, false, filter)),
-            (None, Some(condition)) => Some(ddb_expression(&cx, &mut expr_attrs, false, condition)),
+            (Some(filter), None) => {
+                Some(ddb_expression(schema, &cx, &mut expr_attrs, false, filter))
+            }
+            (None, Some(condition)) => Some(ddb_expression(
+                schema,
+                &cx,
+                &mut expr_attrs,
+                false,
+                condition,
+            )),
             (Some(filter), Some(condition)) => {
-                let f = ddb_expression(&cx, &mut expr_attrs, false, filter);
-                let c = ddb_expression(&cx, &mut expr_attrs, false, condition);
+                let f = ddb_expression(schema, &cx, &mut expr_attrs, false, filter);
+                let c = ddb_expression(schema, &cx, &mut expr_attrs, false, condition);
                 Some(format!("({f}) AND ({c})"))
             }
             _ => None,
@@ -187,7 +195,7 @@ impl Connection {
             .columns
             .iter()
             .map(|index_column| {
-                let column = schema.column(index_column.column);
+                let column = schema.db.column(index_column.column);
                 column.name.clone()
             })
             .collect();

--- a/crates/toasty-driver-dynamodb/src/op/find_pk_by_index.rs
+++ b/crates/toasty-driver-dynamodb/src/op/find_pk_by_index.rs
@@ -17,7 +17,7 @@ impl Connection {
         let cx = ExprContext::new_with_target(&schema.db, table);
 
         let mut expr_attrs = ExprAttrs::default();
-        let key_expression = ddb_expression(&cx, &mut expr_attrs, false, &op.filter);
+        let key_expression = ddb_expression(schema, &cx, &mut expr_attrs, false, &op.filter);
 
         let res = if index.unique {
             tracing::trace!(index_name = %index.name, "querying unique index as table");

--- a/crates/toasty-driver-dynamodb/src/op/find_pk_by_index.rs
+++ b/crates/toasty-driver-dynamodb/src/op/find_pk_by_index.rs
@@ -1,3 +1,5 @@
+use crate::sort_key_columns;
+
 use super::{
     Connection, ExprAttrs, Result, Schema, ddb_expression, item_to_record, operation, stmt,
 };
@@ -50,12 +52,13 @@ impl Connection {
                 .map_err(toasty_core::Error::driver_operation_failed)?
         };
 
+        let sk_cols = sort_key_columns(table);
         let schema = schema.clone();
 
         Ok(ExecResponse::value_stream(stmt::ValueStream::from_iter(
             res.items.into_iter().flatten().map(move |item| {
                 let table = schema.db.table(op.table);
-                item_to_record(&item, table.primary_key_columns())
+                item_to_record(&item, table.primary_key_columns(), &sk_cols)
             }),
         )))
     }

--- a/crates/toasty-driver-dynamodb/src/op/get_by_key.rs
+++ b/crates/toasty-driver-dynamodb/src/op/get_by_key.rs
@@ -1,3 +1,5 @@
+use crate::sort_key_columns;
+
 use super::{
     Connection, KeysAndAttributes, Result, Schema, ddb_key, item_to_record, operation, stmt,
 };
@@ -11,6 +13,7 @@ impl Connection {
         op: operation::GetByKey,
     ) -> Result<ExecResponse> {
         let table = schema.db.table(op.table);
+        let sk_cols = sort_key_columns(table);
 
         if op.keys.len() == 1 {
             // TODO: set attributes to get
@@ -25,7 +28,11 @@ impl Connection {
                 .map_err(toasty_core::Error::driver_operation_failed)?;
 
             if let Some(item) = res.item() {
-                let row = item_to_record(item, op.select.iter().map(|id| schema.db.column(*id)))?;
+                let row = item_to_record(
+                    item,
+                    op.select.iter().map(|id| schema.db.column(*id)),
+                    &sk_cols,
+                )?;
                 Ok(ExecResponse::value_stream(stmt::ValueStream::from_value(
                     row,
                 )))
@@ -78,6 +85,7 @@ impl Connection {
                         op.select
                             .iter()
                             .map(|column_id| schema.db.column(*column_id)),
+                        &sk_cols,
                     )
                 }),
             )))

--- a/crates/toasty-driver-dynamodb/src/op/insert.rs
+++ b/crates/toasty-driver-dynamodb/src/op/insert.rs
@@ -1,6 +1,9 @@
+use crate::{sort_key_columns, value_to_sk_part};
+
 use super::{
     Connection, Put, PutRequest, Result, TransactWriteItem, Value, WriteRequest, db, stmt,
 };
+use aws_sdk_dynamodb::types::AttributeValue;
 use std::collections::HashMap;
 use toasty_core::driver::ExecResponse;
 
@@ -35,19 +38,53 @@ impl Connection {
         let mut insert_items = vec![];
 
         let source = insert.source.body.into_values();
+        let sk_cols = sort_key_columns(table);
+        let concat_sk = sk_cols.len() > 1;
 
         for row in source.rows {
             let mut items = HashMap::new();
+            // Collect sort-key component values when using composite __sk encoding.
+            let mut sk_vals: Vec<Option<stmt::Value>> = if concat_sk {
+                vec![None; sk_cols.len()]
+            } else {
+                vec![]
+            };
 
             for (i, column_id) in insert_table.columns.iter().enumerate() {
                 let column = schema.column(*column_id);
                 let entry = row.entry(i).unwrap();
                 let value = entry.as_value_unwrap();
 
+                if concat_sk {
+                    if let Some(sk_pos) = sk_cols.iter().position(|&c| c == *column_id) {
+                        sk_vals[sk_pos] = Some(value.clone());
+                        continue;
+                    }
+                }
+
                 if !value.is_null() {
                     items.insert(column.name.clone(), Value::from(value.clone()).to_ddb());
                 }
             }
+
+            if concat_sk {
+                // Only use the components that are present for this model.
+                // The root model only provides __model; child models provide
+                // __model + their own local PK fields.
+                let sk_parts: Vec<String> = sk_vals
+                    .iter()
+                    .take_while(|v| v.is_some())
+                    .map(|v| value_to_sk_part(v.as_ref().unwrap()))
+                    .collect();
+                assert!(
+                    !sk_parts.is_empty(),
+                    "at least one sort-key component must be present for insert"
+                );
+                let mut sk = sk_parts.join("#");
+                sk.push('#');
+                items.insert("__sk".to_string(), AttributeValue::S(sk));
+            }
+
             insert_items.push(items);
         }
 
@@ -162,10 +199,25 @@ impl Connection {
                     }
 
                     if !nullable {
-                        // Add primary key values
-                        for column in table.primary_key_columns() {
-                            let name = &column.name;
-                            index_insert_items.insert(name.clone(), insert_items[name].clone());
+                        // Add primary key values (including __sk for composite sort keys).
+                        if concat_sk {
+                            // Copy the partition-key column(s) individually and __sk as a unit.
+                            let pk_index = &table.indices[table.primary_key.index.index];
+                            for ic in &pk_index.columns {
+                                if ic.scope.is_partition() {
+                                    let col = schema.column(ic.column);
+                                    index_insert_items
+                                        .insert(col.name.clone(), insert_items[&col.name].clone());
+                                }
+                            }
+                            if let Some(sk_val) = insert_items.get("__sk") {
+                                index_insert_items.insert("__sk".to_string(), sk_val.clone());
+                            }
+                        } else {
+                            for column in table.primary_key_columns() {
+                                let name = &column.name;
+                                index_insert_items.insert(name.clone(), insert_items[name].clone());
+                            }
                         }
 
                         transact_items.push(

--- a/crates/toasty-driver-dynamodb/src/op/insert.rs
+++ b/crates/toasty-driver-dynamodb/src/op/insert.rs
@@ -55,11 +55,9 @@ impl Connection {
                 let entry = row.entry(i).unwrap();
                 let value = entry.as_value_unwrap();
 
-                if concat_sk {
-                    if let Some(sk_pos) = sk_cols.iter().position(|&c| c == *column_id) {
-                        sk_vals[sk_pos] = Some(value.clone());
-                        continue;
-                    }
+                if concat_sk && let Some(sk_pos) = sk_cols.iter().position(|&c| c == *column_id) {
+                    sk_vals[sk_pos] = Some(value.clone());
+                    continue;
                 }
 
                 if !value.is_null() {

--- a/crates/toasty-driver-dynamodb/src/op/query_pk.rs
+++ b/crates/toasty-driver-dynamodb/src/op/query_pk.rs
@@ -32,6 +32,7 @@ impl Connection {
                 sk_cols: &sk_cols,
                 sk_components: HashMap::new(),
                 pk_component: None,
+                schema: schema.clone(),
             }
             .build(&cx, &op.pk_filter)
         } else {
@@ -85,8 +86,7 @@ impl Connection {
                     .transpose()
                     .map_err(toasty_core::Error::driver_operation_failed)?
                 {
-                    rows.push(item_to_record(&item, cols(), &sk_cols)
-                        .map(stmt::Value::from)?);
+                    rows.push(item_to_record(&item, cols(), &sk_cols).map(stmt::Value::from)?);
                 }
 
                 Ok(ExecResponse {
@@ -151,7 +151,9 @@ impl Connection {
                         .map_err(toasty_core::Error::driver_operation_failed)?
                     {
                         Some(item) => {
-                            rows.push(item_to_record(&item, cols(), &sk_cols).map(stmt::Value::from)?);
+                            rows.push(
+                                item_to_record(&item, cols(), &sk_cols).map(stmt::Value::from)?,
+                            );
                         }
                         None => break,
                     }

--- a/crates/toasty-driver-dynamodb/src/op/query_pk.rs
+++ b/crates/toasty-driver-dynamodb/src/op/query_pk.rs
@@ -1,8 +1,10 @@
+use crate::{BuildKeyExpression, sort_key_columns};
+
 use super::{
     Connection, ExprAttrs, Result, Schema, ddb_expression, deserialize_ddb_cursor, item_to_record,
     operation, serialize_ddb_cursor, stmt,
 };
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 use toasty_core::{
     driver::{ExecResponse, operation::Pagination},
     stmt::ExprContext,
@@ -18,10 +20,23 @@ impl Connection {
         let cx = ExprContext::new_with_target(&schema.db, table);
 
         let mut expr_attrs = ExprAttrs::default();
+        let sk_cols = sort_key_columns(table);
 
-        // When querying an index, use index filter logic (not primary key logic)
-        let is_primary_key = op.index.is_none();
-        let key_expression = ddb_expression(&cx, &mut expr_attrs, is_primary_key, &op.pk_filter);
+        // When querying an index, use index filter logic (not primary key logic).
+        // For item-collection tables with a composite sort key, build a
+        // begins_with(__sk, prefix) expression instead of per-column equality.
+        let key_expression = if op.index.is_none() {
+            BuildKeyExpression {
+                table,
+                attrs: &mut expr_attrs,
+                sk_cols: &sk_cols,
+                sk_components: HashMap::new(),
+                pk_component: None,
+            }
+            .build(&cx, &op.pk_filter)
+        } else {
+            ddb_expression(&cx, &mut expr_attrs, false, &op.pk_filter)
+        };
 
         let filter_expression = op
             .filter
@@ -70,7 +85,8 @@ impl Connection {
                     .transpose()
                     .map_err(toasty_core::Error::driver_operation_failed)?
                 {
-                    rows.push(item_to_record(&item, cols()).map(stmt::Value::from)?);
+                    rows.push(item_to_record(&item, cols(), &sk_cols)
+                        .map(stmt::Value::from)?);
                 }
 
                 Ok(ExecResponse {
@@ -96,7 +112,7 @@ impl Connection {
 
                 let mut rows: Vec<stmt::Value> = Vec::new();
                 for item in res.items.into_iter().flatten() {
-                    rows.push(item_to_record(&item, cols()).map(stmt::Value::from)?);
+                    rows.push(item_to_record(&item, cols(), &sk_cols).map(stmt::Value::from)?);
                 }
 
                 Ok(ExecResponse {
@@ -135,7 +151,7 @@ impl Connection {
                         .map_err(toasty_core::Error::driver_operation_failed)?
                     {
                         Some(item) => {
-                            rows.push(item_to_record(&item, cols()).map(stmt::Value::from)?);
+                            rows.push(item_to_record(&item, cols(), &sk_cols).map(stmt::Value::from)?);
                         }
                         None => break,
                     }

--- a/crates/toasty-driver-dynamodb/src/op/query_pk.rs
+++ b/crates/toasty-driver-dynamodb/src/op/query_pk.rs
@@ -36,13 +36,13 @@ impl Connection {
             }
             .build(&cx, &op.pk_filter)
         } else {
-            ddb_expression(&cx, &mut expr_attrs, false, &op.pk_filter)
+            ddb_expression(schema, &cx, &mut expr_attrs, false, &op.pk_filter)
         };
 
         let filter_expression = op
             .filter
             .as_ref()
-            .map(|expr| ddb_expression(&cx, &mut expr_attrs, false, expr));
+            .map(|expr| ddb_expression(schema, &cx, &mut expr_attrs, false, expr));
 
         // Build base query
         let mut query = self

--- a/crates/toasty-driver-dynamodb/src/op/scan.rs
+++ b/crates/toasty-driver-dynamodb/src/op/scan.rs
@@ -8,6 +8,7 @@ use toasty_core::{
     schema::db::ColumnId,
     stmt::ExprContext,
 };
+use crate::sort_key_columns;
 
 impl Connection {
     pub(crate) async fn exec_scan(
@@ -49,7 +50,7 @@ impl Connection {
                 })
             })
         };
-
+        let sk_cols = sort_key_columns(table);
         match op.limit {
             None => {
                 let mut stream = scan.into_paginator().items().send();
@@ -61,7 +62,7 @@ impl Connection {
                     .transpose()
                     .map_err(toasty_core::Error::driver_operation_failed)?
                 {
-                    rows.push(item_to_record(&item, cols()).map(stmt::Value::from)?);
+                    rows.push(item_to_record(&item, cols(), &sk_cols).map(stmt::Value::from)?);
                 }
 
                 Ok(ExecResponse {
@@ -88,7 +89,7 @@ impl Connection {
 
                 let mut rows: Vec<stmt::Value> = Vec::new();
                 for item in res.items.into_iter().flatten() {
-                    rows.push(item_to_record(&item, cols()).map(stmt::Value::from)?);
+                    rows.push(item_to_record(&item, cols(), &sk_cols).map(stmt::Value::from)?);
                 }
 
                 Ok(ExecResponse {
@@ -127,7 +128,7 @@ impl Connection {
                         .map_err(toasty_core::Error::driver_operation_failed)?
                     {
                         Some(item) => {
-                            rows.push(item_to_record(&item, cols()).map(stmt::Value::from)?);
+                            rows.push(item_to_record(&item, cols(), &sk_cols).map(stmt::Value::from)?);
                         }
                         None => break,
                     }

--- a/crates/toasty-driver-dynamodb/src/op/scan.rs
+++ b/crates/toasty-driver-dynamodb/src/op/scan.rs
@@ -24,7 +24,7 @@ impl Connection {
         let filter_expression = op
             .filter
             .as_ref()
-            .map(|expr| ddb_expression(&cx, &mut expr_attrs, false, expr));
+            .map(|expr| ddb_expression(schema, &cx, &mut expr_attrs, false, expr));
 
         tracing::trace!(table_name = %table.name, "scanning table");
 

--- a/crates/toasty-driver-dynamodb/src/op/scan.rs
+++ b/crates/toasty-driver-dynamodb/src/op/scan.rs
@@ -2,13 +2,13 @@ use super::{
     Connection, ExprAttrs, Result, Schema, ddb_expression, deserialize_ddb_cursor, item_to_record,
     operation, serialize_ddb_cursor, stmt,
 };
+use crate::sort_key_columns;
 use std::sync::Arc;
 use toasty_core::{
     driver::{ExecResponse, operation::Pagination},
     schema::db::ColumnId,
     stmt::ExprContext,
 };
-use crate::sort_key_columns;
 
 impl Connection {
     pub(crate) async fn exec_scan(
@@ -128,7 +128,9 @@ impl Connection {
                         .map_err(toasty_core::Error::driver_operation_failed)?
                     {
                         Some(item) => {
-                            rows.push(item_to_record(&item, cols(), &sk_cols).map(stmt::Value::from)?);
+                            rows.push(
+                                item_to_record(&item, cols(), &sk_cols).map(stmt::Value::from)?,
+                            );
                         }
                         None => break,
                     }

--- a/crates/toasty-driver-dynamodb/src/op/update_by_key.rs
+++ b/crates/toasty-driver-dynamodb/src/op/update_by_key.rs
@@ -1,12 +1,12 @@
 use crate::sort_key_columns;
 
 use super::{
-    Connection, Delete, ExprAttrs, Put, Result, ReturnValuesOnConditionCheckFailure, SdkError,
-    TransactWriteItem, TransactWriteItemsError, Update, UpdateItemError, Value, db, ddb_expression,
-    ddb_key, item_to_record, operation, stmt,
+    Connection, Delete, ExprAttrs, Put, Result, ReturnValuesOnConditionCheckFailure, Schema,
+    SdkError, TransactWriteItem, TransactWriteItemsError, Update, UpdateItemError, Value, db,
+    ddb_expression, ddb_key, item_to_record, operation, stmt,
 };
 use aws_sdk_dynamodb::types::{AttributeValue, CancellationReason, ReturnValue};
-use std::{collections::HashMap, fmt::Write};
+use std::{collections::HashMap, fmt::Write, sync::Arc};
 use toasty_core::{driver::ExecResponse, schema::db::ColumnId, stmt::ExprContext};
 
 /// An [`stmt::Input`] that resolves column references into a record produced
@@ -122,12 +122,13 @@ fn on_transaction_cancelled(
 impl Connection {
     pub(crate) async fn exec_update_by_key(
         &mut self,
-        schema: &db::Schema,
+        schema: &Arc<Schema>,
         op: operation::UpdateByKey,
     ) -> Result<ExecResponse> {
-        let table = schema.table(op.table);
+        let db_schema = &schema.db;
+        let table = db_schema.table(op.table);
         let sk_cols = sort_key_columns(table);
-        let cx = ExprContext::new_with_target(schema, table);
+        let cx = ExprContext::new_with_target(db_schema, table);
 
         let mut expr_attrs = ExprAttrs::default();
 
@@ -137,7 +138,7 @@ impl Connection {
             .filter(|index| {
                 if !index.primary_key && index.unique {
                     index.columns.iter().any(|index_column| {
-                        let column = index_column.table_column(schema);
+                        let column = index_column.table_column(db_schema);
                         op.assignments
                             .keys()
                             .any(|projection| *projection == column.id.index)
@@ -149,11 +150,19 @@ impl Connection {
             .collect::<Vec<_>>();
 
         let filter_expression = match (&op.filter, &op.condition) {
-            (Some(filter), None) => Some(ddb_expression(&cx, &mut expr_attrs, false, filter)),
-            (None, Some(condition)) => Some(ddb_expression(&cx, &mut expr_attrs, false, condition)),
+            (Some(filter), None) => {
+                Some(ddb_expression(schema, &cx, &mut expr_attrs, false, filter))
+            }
+            (None, Some(condition)) => Some(ddb_expression(
+                schema,
+                &cx,
+                &mut expr_attrs,
+                false,
+                condition,
+            )),
             (Some(filter), Some(condition)) => {
-                let f = ddb_expression(&cx, &mut expr_attrs, false, filter);
-                let c = ddb_expression(&cx, &mut expr_attrs, false, condition);
+                let f = ddb_expression(schema, &cx, &mut expr_attrs, false, filter);
+                let c = ddb_expression(schema, &cx, &mut expr_attrs, false, condition);
                 Some(format!("({f}) AND ({c})"))
             }
             _ => None,
@@ -455,7 +464,7 @@ impl Connection {
                 let attributes_to_get = index
                     .columns
                     .iter()
-                    .map(|index_column| index_column.table_column(schema).name.clone())
+                    .map(|index_column| index_column.table_column(db_schema).name.clone())
                     .collect();
 
                 // Records that have had their unique values set initially
@@ -536,7 +545,7 @@ impl Connection {
                 }
 
                 for index_column in &index.columns {
-                    let column = index_column.table_column(schema);
+                    let column = index_column.table_column(db_schema);
 
                     for (projection, _) in op.assignments.iter() {
                         if *projection != column.id.index {
@@ -600,12 +609,12 @@ impl Connection {
                     let mut condition_expression = String::new();
 
                     for column_id in set_unique_attrs.keys() {
-                        let column = expr_attrs.column(schema.column(*column_id)).to_string();
+                        let column = expr_attrs.column(db_schema.column(*column_id)).to_string();
                         condition_expression = format!("attribute_not_exists({column})");
                     }
 
                     for (column_id, prev) in &updated_unique_attrs {
-                        let column = expr_attrs.column(schema.column(*column_id)).to_string();
+                        let column = expr_attrs.column(db_schema.column(*column_id)).to_string();
                         let value = expr_attrs.ddb_value(prev.clone());
 
                         condition_expression = format!("{column} = {value}");
@@ -633,7 +642,7 @@ impl Connection {
                     );
 
                     for (column_id, prev) in &updated_unique_attrs {
-                        let name = &schema.column(*column_id).name;
+                        let name = &db_schema.column(*column_id).name;
                         transact_items.push(
                             TransactWriteItem::builder()
                                 .delete(
@@ -648,13 +657,30 @@ impl Connection {
                     }
 
                     for column_id in updated_unique_attrs.keys().chain(set_unique_attrs.keys()) {
-                        let name = &schema.column(*column_id).name;
+                        let name = &db_schema.column(*column_id).name;
 
                         let mut index_insert_items = HashMap::new();
 
                         for index_column in &index.columns {
                             let column = index_column.table_column(schema);
                             let value = &resolved_unique_values[column_id];
+                            let (_, assignment) = op
+                                .assignments
+                                .iter()
+                                .find(|(projection, _)| **projection == column_id.index)
+                                .unwrap();
+
+                            let stmt::Assignment::Set(expr) = assignment else {
+                                unreachable!(
+                                    "unique index assignments are always Set; got {assignment:#?}"
+                                );
+                            };
+                            let stmt::Expr::Value(value) = expr else {
+                                unreachable!(
+                                    "unique index assignment expression is always a Value; got {expr:#?}"
+                                );
+                            };
+
                             if !value.is_null() {
                                 index_insert_items.insert(
                                     column.name.clone(),

--- a/crates/toasty-driver-dynamodb/src/op/update_by_key.rs
+++ b/crates/toasty-driver-dynamodb/src/op/update_by_key.rs
@@ -337,6 +337,7 @@ impl Connection {
                                     cce.item(),
                                     cce.message.as_deref(),
                                     table,
+                                    &sk_cols,
                                     op.filter.as_ref(),
                                     op.returning.is_some(),
                                 );

--- a/crates/toasty-driver-dynamodb/src/op/update_by_key.rs
+++ b/crates/toasty-driver-dynamodb/src/op/update_by_key.rs
@@ -298,7 +298,7 @@ impl Connection {
 
         if let Some(columns) = &op.returning {
             for column_id in columns {
-                let column = schema.column(*column_id);
+                let column = schema.db.column(*column_id);
                 let placeholder = bound_values
                     .get(&column_id.index)
                     .map(|value| (*value).clone())
@@ -504,7 +504,7 @@ impl Connection {
                 // written.
                 let mut resolved_unique_values = HashMap::new();
                 for index_column in &index.columns {
-                    let column = index_column.table_column(schema);
+                    let column = index_column.table_column(&schema.db);
                     for (projection, assignment) in op.assignments.iter() {
                         if *projection != column.id.index {
                             continue;
@@ -662,25 +662,8 @@ impl Connection {
                         let mut index_insert_items = HashMap::new();
 
                         for index_column in &index.columns {
-                            let column = index_column.table_column(schema);
+                            let column = index_column.table_column(&schema.db);
                             let value = &resolved_unique_values[column_id];
-                            let (_, assignment) = op
-                                .assignments
-                                .iter()
-                                .find(|(projection, _)| **projection == column_id.index)
-                                .unwrap();
-
-                            let stmt::Assignment::Set(expr) = assignment else {
-                                unreachable!(
-                                    "unique index assignments are always Set; got {assignment:#?}"
-                                );
-                            };
-                            let stmt::Expr::Value(value) = expr else {
-                                unreachable!(
-                                    "unique index assignment expression is always a Value; got {expr:#?}"
-                                );
-                            };
-
                             if !value.is_null() {
                                 index_insert_items.insert(
                                     column.name.clone(),

--- a/crates/toasty-driver-dynamodb/src/op/update_by_key.rs
+++ b/crates/toasty-driver-dynamodb/src/op/update_by_key.rs
@@ -1,3 +1,5 @@
+use crate::sort_key_columns;
+
 use super::{
     Connection, Delete, ExprAttrs, Put, Result, ReturnValuesOnConditionCheckFailure, SdkError,
     TransactWriteItem, TransactWriteItemsError, Update, UpdateItemError, Value, db, ddb_expression,
@@ -5,7 +7,7 @@ use super::{
 };
 use aws_sdk_dynamodb::types::{AttributeValue, CancellationReason, ReturnValue};
 use std::{collections::HashMap, fmt::Write};
-use toasty_core::{driver::ExecResponse, stmt::ExprContext};
+use toasty_core::{driver::ExecResponse, schema::db::ColumnId, stmt::ExprContext};
 
 /// An [`stmt::Input`] that resolves column references into a record produced
 /// by `item_to_record`. After lowering, filter/condition expressions reference
@@ -46,6 +48,7 @@ impl stmt::Input for RecordInput<'_> {
 fn filter_failed(
     old_item: Option<&HashMap<String, AttributeValue>>,
     table: &db::Table,
+    sk_cols: &[ColumnId],
     filter: Option<&stmt::Expr>,
 ) -> bool {
     let Some(filter) = filter else {
@@ -56,7 +59,7 @@ fn filter_failed(
         return true;
     };
 
-    let record = item_to_record(item, table.columns.iter()).unwrap();
+    let record = item_to_record(item, table.columns.iter(), sk_cols).unwrap();
     !filter.eval_bool(RecordInput(&record)).unwrap_or(false)
 }
 
@@ -67,10 +70,11 @@ fn on_update_item_condition_failed(
     item: Option<&HashMap<String, AttributeValue>>,
     message: Option<&str>,
     table: &db::Table,
+    sk_cols: &[ColumnId],
     filter: Option<&stmt::Expr>,
     returning: bool,
 ) -> Result<ExecResponse> {
-    if filter_failed(item, table, filter) {
+    if filter_failed(item, table, sk_cols, filter) {
         if returning {
             Ok(ExecResponse::empty_value_stream())
         } else {
@@ -93,13 +97,14 @@ fn on_transaction_cancelled(
     reasons: &[CancellationReason],
     message: Option<&str>,
     table: &db::Table,
+    sk_cols: &[ColumnId],
     filter: Option<&stmt::Expr>,
     returning: bool,
 ) -> Result<ExecResponse> {
     let any_condition_failed = reasons
         .iter()
         .filter(|r| r.code() == Some("ConditionalCheckFailed"))
-        .any(|r| !filter_failed(r.item(), table, filter));
+        .any(|r| !filter_failed(r.item(), table, sk_cols, filter));
 
     if any_condition_failed {
         Err(toasty_core::Error::condition_failed(
@@ -121,6 +126,7 @@ impl Connection {
         op: operation::UpdateByKey,
     ) -> Result<ExecResponse> {
         let table = schema.table(op.table);
+        let sk_cols = sort_key_columns(table);
         let cx = ExprContext::new_with_target(schema, table);
 
         let mut expr_attrs = ExprAttrs::default();
@@ -397,6 +403,7 @@ impl Connection {
                                 tce.cancellation_reasons(),
                                 tce.message(),
                                 table,
+                                &sk_cols,
                                 op.filter.as_ref(),
                                 op.returning.is_some(),
                             );
@@ -574,6 +581,7 @@ impl Connection {
                                 cce.item(),
                                 cce.message.as_deref(),
                                 table,
+                                &sk_cols,
                                 op.filter.as_ref(),
                                 op.returning.is_some(),
                             );
@@ -704,6 +712,7 @@ impl Connection {
                                 tce.cancellation_reasons(),
                                 tce.message(),
                                 table,
+                                &sk_cols,
                                 op.filter.as_ref(),
                                 op.returning.is_some(),
                             );
@@ -788,7 +797,7 @@ mod tests {
     #[test]
     fn no_filter_returns_false() {
         let table = make_table();
-        assert!(!filter_failed(None, &table, None));
+        assert!(!filter_failed(None, &table, &[], None));
     }
 
     // Filter present but item is missing (record was deleted between read and check):
@@ -797,7 +806,7 @@ mod tests {
     fn missing_item_with_filter_returns_true() {
         let table = make_table();
         let filter = status_eq_active();
-        assert!(filter_failed(None, &table, Some(&filter)));
+        assert!(filter_failed(None, &table, &[], Some(&filter)));
     }
 
     // Item present and filter matches: the filter was NOT the failing part, so the
@@ -807,7 +816,7 @@ mod tests {
         let table = make_table();
         let filter = status_eq_active();
         let item = item_with_status("active");
-        assert!(!filter_failed(Some(&item), &table, Some(&filter)));
+        assert!(!filter_failed(Some(&item), &table, &[], Some(&filter)));
     }
 
     // Item present but filter does not match: the filter failed → count 0.
@@ -816,6 +825,6 @@ mod tests {
         let table = make_table();
         let filter = status_eq_active();
         let item = item_with_status("inactive");
-        assert!(filter_failed(Some(&item), &table, Some(&filter)));
+        assert!(filter_failed(Some(&item), &table, &[], Some(&filter)));
     }
 }

--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -57,6 +57,7 @@ pub mod infra_pool_config;
 pub mod infra_reset_db;
 pub mod infra_sync_send;
 pub mod item_collection;
+pub mod item_collection_three_tier;
 pub mod key_unsigned;
 pub mod lift_belongs_to_complex_filter;
 pub mod query_count;

--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -56,6 +56,7 @@ pub mod infra_missing_registrations;
 pub mod infra_pool_config;
 pub mod infra_reset_db;
 pub mod infra_sync_send;
+pub mod item_collection;
 pub mod key_unsigned;
 pub mod lift_belongs_to_complex_filter;
 pub mod query_count;

--- a/crates/toasty-driver-integration-suite/src/tests/item_collection.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/item_collection.rs
@@ -1,0 +1,315 @@
+//! Tests for the item collection feature: multiple models sharing one DynamoDB table
+//! via a composite sort key synthesized from FK + own PK fields.
+//!
+//! The `#[item_collection(ParentType)]` attribute on a child model declares that it
+//! should share a table with its parent.  The sort key is never a struct field; it is
+//! built by the driver at write-time from the constituent PK columns.
+
+use crate::prelude::*;
+
+// ---------------------------------------------------------------------------
+// Shared model definitions used across tests in this file
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, toasty::Model)]
+struct User {
+    #[key]
+    #[auto]
+    id: uuid::Uuid,
+
+    #[has_many]
+    todos: toasty::HasMany<Todo>,
+}
+
+/// A todo that belongs to a user and shares the same DynamoDB table.
+///
+/// `#[item_collection(User)]`  — child lives in the same table as User.
+/// `#[key(partition = user_id, local = id)]` — user_id is the hash key
+/// (reuses the User row's PK column), id is the sort-key component owned by
+/// this model.
+#[derive(Debug, toasty::Model)]
+#[item_collection(User)]
+#[key(partition = user_id, local = id)]
+struct Todo {
+    #[auto]
+    id: uuid::Uuid,
+
+    user_id: uuid::Uuid,
+
+    #[belongs_to(key = user_id, references = id)]
+    user: toasty::BelongsTo<User>,
+
+    title: String,
+}
+
+async fn setup(test: &mut Test) -> toasty::Db {
+    test.setup_db(models!(User, Todo)).await
+}
+
+// ---------------------------------------------------------------------------
+// Schema validation tests (no DB needed — fail at setup_db time)
+// ---------------------------------------------------------------------------
+
+/// `#[item_collection]` without a compound `#[key]` (missing `local` component)
+/// must be rejected at schema-build time.
+#[driver_test]
+pub async fn validates_missing_local_key(test: &mut Test) {
+    #[derive(Debug, toasty::Model)]
+    struct Root {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+
+        #[has_many]
+        items: toasty::HasMany<Item>,
+    }
+
+    // No #[key(partition = ..., local = ...)] — only a single-field PK.
+    // An item collection child must have a compound key.
+    #[derive(Debug, toasty::Model)]
+    #[item_collection(Root)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+
+        #[index]
+        root_id: uuid::Uuid,
+
+        #[belongs_to(key = root_id, references = id)]
+        root: toasty::BelongsTo<Root>,
+    }
+
+    assert_err!(test.try_setup_db(models!(Root, Item)).await);
+}
+
+/// The `item_collection` attribute must include the parent model type.
+/// `#[item_collection]` (no argument) should be a compile-time error, but
+/// we test the runtime/schema path: a model with no FK source fields
+/// and a compound key must fail validation.
+#[driver_test]
+pub async fn validates_no_belongs_to_in_pk(test: &mut Test) {
+    #[derive(Debug, toasty::Model)]
+    struct Root {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+
+        #[has_many]
+        items: toasty::HasMany<Item>,
+    }
+
+    // Compound key but neither field references a parent via BelongsTo —
+    // the partition field is just a plain string, not derived from a FK.
+    #[derive(Debug, toasty::Model)]
+    #[item_collection(Root)]
+    #[key(partition = bucket, local = id)]
+    struct Item {
+        #[auto]
+        id: uuid::Uuid,
+
+        bucket: String,
+
+        #[index]
+        root_id: uuid::Uuid,
+
+        #[belongs_to(key = root_id, references = id)]
+        root: toasty::BelongsTo<Root>,
+    }
+
+    assert_err!(test.try_setup_db(models!(Root, Item)).await);
+}
+
+// ---------------------------------------------------------------------------
+// CRUD tests — require a real database with native_starts_with support
+// ---------------------------------------------------------------------------
+
+/// Basic create / read / delete cycle for a user + their todos sharing one table.
+#[driver_test(requires(native_starts_with))]
+pub async fn crud_create_read_delete(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user = User::create().exec(&mut db).await?;
+
+    // New user has no todos
+    assert_eq!(0, user.todos().exec(&mut db).await?.len());
+
+    // Create a todo through the user relation
+    let todo = user
+        .todos()
+        .create()
+        .title("hello world")
+        .exec(&mut db)
+        .await?;
+
+    assert_eq!(todo.user_id, user.id);
+
+    // Reload by full composite key
+    let reloaded = Todo::get_by_user_id_and_id(&mut db, &todo.user_id, &todo.id).await?;
+    assert_eq!(reloaded.title, "hello world");
+
+    // User scope still shows exactly one todo
+    let list = user.todos().exec(&mut db).await?;
+    assert_eq!(1, list.len());
+
+    // Delete the todo
+    todo.delete().exec(&mut db).await?;
+
+    assert_err!(Todo::get_by_user_id_and_id(&mut db, &reloaded.user_id, &reloaded.id).await);
+    assert_eq!(0, user.todos().exec(&mut db).await?.len());
+
+    Ok(())
+}
+
+/// Todos created for user A must not appear in user B's scope.
+#[driver_test(requires(native_starts_with))]
+pub async fn scoped_isolation(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user_a = User::create().exec(&mut db).await?;
+    let user_b = User::create().exec(&mut db).await?;
+
+    let todo_a = user_a
+        .todos()
+        .create()
+        .title("user A todo")
+        .exec(&mut db)
+        .await?;
+
+    // user_b sees no todos
+    assert_eq!(0, user_b.todos().exec(&mut db).await?.len());
+
+    // user_a's todo is not visible via user_b scope
+    assert_none!(
+        user_b
+            .todos()
+            .filter_by_id(todo_a.id)
+            .first()
+            .exec(&mut db)
+            .await?
+    );
+
+    Ok(())
+}
+
+/// Multiple todos under the same user can all be loaded, updated, and deleted.
+#[driver_test(requires(native_starts_with))]
+pub async fn multiple_todos(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user = User::create().exec(&mut db).await?;
+
+    for i in 0..5 {
+        user.todos()
+            .create()
+            .title(format!("todo {i}"))
+            .exec(&mut db)
+            .await?;
+    }
+
+    let list = user.todos().exec(&mut db).await?;
+    assert_eq!(5, list.len());
+
+    Ok(())
+}
+
+/// Scoped filter_by_id returns the right todo when the user matches and
+/// nothing when the user does not match.
+#[driver_test(requires(native_starts_with))]
+pub async fn scoped_filter_by_id(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user1 = User::create().exec(&mut db).await?;
+    let user2 = User::create().exec(&mut db).await?;
+
+    let todo = user1.todos().create().title("hello").exec(&mut db).await?;
+
+    // Correct scope finds the todo
+    let found = user1.todos().get_by_id(&mut db, &todo.id).await?;
+    assert_eq!(found.id, todo.id);
+
+    // Wrong scope does not find it
+    assert_none!(
+        user2
+            .todos()
+            .filter_by_id(todo.id)
+            .first()
+            .exec(&mut db)
+            .await?
+    );
+
+    Ok(())
+}
+
+/// Scoped update modifies only the target todo and leaves others unchanged.
+#[driver_test(requires(native_starts_with))]
+pub async fn scoped_update(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user = User::create().exec(&mut db).await?;
+
+    let todo = user
+        .todos()
+        .create()
+        .title("original")
+        .exec(&mut db)
+        .await?;
+
+    user.todos()
+        .filter_by_id(todo.id)
+        .update()
+        .title("updated")
+        .exec(&mut db)
+        .await?;
+
+    let reloaded = Todo::get_by_user_id_and_id(&mut db, &todo.user_id, &todo.id).await?;
+    assert_eq!(reloaded.title, "updated");
+
+    Ok(())
+}
+
+/// Deleting a user via its own scope does not silently fail.  After deletion
+/// the user and all their todos are gone.
+#[driver_test(requires(native_starts_with))]
+pub async fn delete_user_removes_todos(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user = User::create().exec(&mut db).await?;
+    let todo = user
+        .todos()
+        .create()
+        .title("should disappear")
+        .exec(&mut db)
+        .await?;
+
+    let user_id = user.id;
+    let todo_id = todo.id;
+    let todo_user_id = todo.user_id;
+
+    user.delete().exec(&mut db).await?;
+
+    assert_err!(User::get_by_id(&mut db, &user_id).await);
+    assert_err!(Todo::get_by_user_id_and_id(&mut db, &todo_user_id, &todo_id).await);
+
+    Ok(())
+}
+
+/// `item_collection` field on the app schema model is set to the parent model's id.
+#[driver_test]
+pub async fn schema_item_collection_field_set(test: &mut Test) {
+    use toasty::schema::Register;
+
+    let _db = setup(test).await;
+
+    let todo_ic = <Todo as Register>::schema()
+        .as_root_unwrap()
+        .item_collection;
+
+    assert_eq!(todo_ic, Some(<User as Register>::id()));
+
+    let user_ic = <User as Register>::schema()
+        .as_root_unwrap()
+        .item_collection;
+
+    assert_eq!(user_ic, None);
+}

--- a/crates/toasty-driver-integration-suite/src/tests/item_collection.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/item_collection.rs
@@ -472,3 +472,39 @@ pub async fn update_child_with_filter(test: &mut Test) -> Result<()> {
     Ok(())
 }
 
+/// Batch-create multiple child rows under one parent. Exercises
+/// `Insert::merge` for `InsertTarget::Scope` targets — the planner builds
+/// one INSERT per row and merges them into a single VALUES list before
+/// dispatching to the driver. All rows must round-trip and remain
+/// addressable by the user's scope.
+#[driver_test(requires(native_starts_with))]
+pub async fn batch_create_children(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user = User::create().exec(&mut db).await?;
+
+    let mut builder = Todo::create_many();
+    for i in 0..5 {
+        builder = builder.item(
+            user.todos().create().title(format!("todo {i}")),
+        );
+    }
+    let todos = builder.exec(&mut db).await?;
+    assert_eq!(5, todos.len());
+
+    let mut titles: Vec<String> = user
+        .todos()
+        .exec(&mut db)
+        .await?
+        .into_iter()
+        .map(|t| t.title)
+        .collect();
+    titles.sort();
+    assert_eq!(
+        titles,
+        vec!["todo 0", "todo 1", "todo 2", "todo 3", "todo 4"]
+    );
+
+    Ok(())
+}
+

--- a/crates/toasty-driver-integration-suite/src/tests/item_collection.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/item_collection.rs
@@ -399,12 +399,7 @@ pub async fn delete_child_with_filter(test: &mut Test) -> Result<()> {
         .await?;
     // Sibling under the same user. The filter must narrow to `target`
     // alone — otherwise this row would also disappear.
-    let sibling = user
-        .todos()
-        .create()
-        .title("keep me")
-        .exec(&mut db)
-        .await?;
+    let sibling = user.todos().create().title("keep me").exec(&mut db).await?;
 
     user.todos()
         .filter_by_id(target.id)
@@ -414,8 +409,7 @@ pub async fn delete_child_with_filter(test: &mut Test) -> Result<()> {
         .await?;
 
     assert_err!(Todo::get_by_user_id_and_id(&mut db, &target.user_id, &target.id).await);
-    let survivor =
-        Todo::get_by_user_id_and_id(&mut db, &sibling.user_id, &sibling.id).await?;
+    let survivor = Todo::get_by_user_id_and_id(&mut db, &sibling.user_id, &sibling.id).await?;
     assert_eq!(survivor.title, "keep me");
 
     Ok(())
@@ -508,10 +502,7 @@ pub async fn update_many_children_by_filter(test: &mut Test) -> Result<()> {
         .map(|t| t.title)
         .collect();
     titles.sort();
-    assert_eq!(
-        titles,
-        vec!["skip", "updated", "updated", "updated"],
-    );
+    assert_eq!(titles, vec!["skip", "updated", "updated", "updated"],);
 
     Ok(())
 }
@@ -565,9 +556,7 @@ pub async fn batch_create_children(test: &mut Test) -> Result<()> {
 
     let mut builder = Todo::create_many();
     for i in 0..5 {
-        builder = builder.item(
-            user.todos().create().title(format!("todo {i}")),
-        );
+        builder = builder.item(user.todos().create().title(format!("todo {i}")));
     }
     let todos = builder.exec(&mut db).await?;
     assert_eq!(5, todos.len());
@@ -587,4 +576,3 @@ pub async fn batch_create_children(test: &mut Test) -> Result<()> {
 
     Ok(())
 }
-

--- a/crates/toasty-driver-integration-suite/src/tests/item_collection.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/item_collection.rs
@@ -228,7 +228,10 @@ pub async fn include_todos(test: &mut Test) -> Result<()> {
             .await?;
     }
 
-    let mut users = User::filter_by_id(user.id).include(User::fields().todos()).exec(&mut db).await?;
+    let mut users = User::filter_by_id(user.id)
+        .include(User::fields().todos())
+        .exec(&mut db)
+        .await?;
     assert_eq!(1, users.len());
     let user = users.pop().unwrap();
     assert_eq!(5, user.todos.get().len());

--- a/crates/toasty-driver-integration-suite/src/tests/item_collection.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/item_collection.rs
@@ -125,7 +125,7 @@ pub async fn validates_no_belongs_to_in_pk(test: &mut Test) {
 // ---------------------------------------------------------------------------
 
 /// Basic create / read / delete cycle for a user + their todos sharing one table.
-#[driver_test(requires(native_starts_with))]
+#[driver_test(requires(not(sql)))]
 pub async fn crud_create_read_delete(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -162,7 +162,7 @@ pub async fn crud_create_read_delete(test: &mut Test) -> Result<()> {
 }
 
 /// Todos created for user A must not appear in user B's scope.
-#[driver_test(requires(native_starts_with))]
+#[driver_test(requires(not(sql)))]
 pub async fn scoped_isolation(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -193,7 +193,7 @@ pub async fn scoped_isolation(test: &mut Test) -> Result<()> {
 }
 
 /// Multiple todos under the same user can all be loaded, updated, and deleted.
-#[driver_test(requires(native_starts_with))]
+#[driver_test(requires(not(sql)))]
 pub async fn multiple_todos(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -214,7 +214,7 @@ pub async fn multiple_todos(test: &mut Test) -> Result<()> {
 }
 
 /// Todos can be included on the parent.
-#[driver_test(requires(native_starts_with))]
+#[driver_test(requires(not(sql)))]
 pub async fn include_todos(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -241,7 +241,7 @@ pub async fn include_todos(test: &mut Test) -> Result<()> {
 
 /// Scoped filter_by_id returns the right todo when the user matches and
 /// nothing when the user does not match.
-#[driver_test(requires(native_starts_with))]
+#[driver_test(requires(not(sql)))]
 pub async fn scoped_filter_by_id(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -268,7 +268,7 @@ pub async fn scoped_filter_by_id(test: &mut Test) -> Result<()> {
 }
 
 /// Scoped update modifies only the target todo and leaves others unchanged.
-#[driver_test(requires(native_starts_with))]
+#[driver_test(requires(not(sql)))]
 pub async fn scoped_update(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -296,7 +296,7 @@ pub async fn scoped_update(test: &mut Test) -> Result<()> {
 
 /// Deleting a user via its own scope does not silently fail.  After deletion
 /// the user and all their todos are gone.
-#[driver_test(requires(native_starts_with))]
+#[driver_test(requires(not(sql)))]
 pub async fn delete_user_removes_todos(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -360,7 +360,7 @@ pub async fn schema_item_collection_field_set(test: &mut Test) {
 /// adds an `IsModel(Todo)` conjunct alongside the user filter; the planner
 /// can't promote it to a key condition (no PK column referenced), so it
 /// flows into the scan's filter expression and through `ddb_expression`.
-#[driver_test(requires(native_starts_with), requires(not(sql)))]
+#[driver_test(requires(not(sql)), requires(not(sql)))]
 pub async fn scan_child_model_with_non_key_filter(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -386,7 +386,7 @@ pub async fn scan_child_model_with_non_key_filter(test: &mut Test) -> Result<()>
 /// receives a `DeleteByKey` op whose filter contains `IsModel(Todo) AND
 /// title = "..."` — `ddb_expression` serializes the filter as a DynamoDB
 /// condition expression.
-#[driver_test(requires(native_starts_with))]
+#[driver_test(requires(not(sql)))]
 pub async fn delete_child_with_filter(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -417,7 +417,7 @@ pub async fn delete_child_with_filter(test: &mut Test) -> Result<()> {
 
 /// When the filter does not match, the delete is a no-op: the row remains
 /// in place. Proves the filter is consulted, not silently dropped.
-#[driver_test(requires(native_starts_with))]
+#[driver_test(requires(not(sql)))]
 pub async fn delete_child_with_non_matching_filter(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -445,7 +445,7 @@ pub async fn delete_child_with_non_matching_filter(test: &mut Test) -> Result<()
 /// Update a child model row with a filter on a non-key field. The driver
 /// receives an `UpdateByKey` op whose filter contains `IsModel(Todo) AND
 /// title = "..."` — `ddb_expression` serializes it.
-#[driver_test(requires(native_starts_with))]
+#[driver_test(requires(not(sql)))]
 pub async fn update_child_with_filter(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -470,7 +470,7 @@ pub async fn update_child_with_filter(test: &mut Test) -> Result<()> {
 /// more than one Todo; all matching rows must be updated, non-matching
 /// rows must remain unchanged. Distinct from `update_child_with_filter`,
 /// which targets a single row by composite PK.
-#[driver_test(requires(native_starts_with))]
+#[driver_test(requires(not(sql)))]
 pub async fn update_many_children_by_filter(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -511,7 +511,7 @@ pub async fn update_many_children_by_filter(test: &mut Test) -> Result<()> {
 /// more than one Todo; all matching rows must be deleted, non-matching
 /// rows must survive. Distinct from `delete_child_with_filter`, which
 /// targets a single row by composite PK.
-#[driver_test(requires(native_starts_with))]
+#[driver_test(requires(not(sql)))]
 pub async fn delete_many_children_by_filter(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -548,7 +548,7 @@ pub async fn delete_many_children_by_filter(test: &mut Test) -> Result<()> {
 /// one INSERT per row and merges them into a single VALUES list before
 /// dispatching to the driver. All rows must round-trip and remain
 /// addressable by the user's scope.
-#[driver_test(requires(native_starts_with))]
+#[driver_test(requires(not(sql)))]
 pub async fn batch_create_children(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 

--- a/crates/toasty-driver-integration-suite/src/tests/item_collection.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/item_collection.rs
@@ -339,3 +339,97 @@ pub async fn schema_item_collection_field_set(test: &mut Test) {
 
     assert_eq!(user_ic, None);
 }
+
+// ---------------------------------------------------------------------------
+// Filter-bearing operations on item-collection child models
+//
+// These exercise paths where the discriminator predicate (Expr::IsModel)
+// reaches the driver's general expression serializer rather than the
+// primary-key serializer:
+//
+//   - Scan filter:           query with no PK constraint, just a non-key filter.
+//   - DeleteByKey filter:    delete with both a PK identity and a row filter.
+//   - UpdateByKey filter:    update with both a PK identity and a row filter.
+//
+// On DynamoDB these flow through `ddb_expression`. On other DDB-shaped paths
+// (BuildKeyExpression) the discriminator already gets folded into the SK
+// prefix; these tests cover the second serializer.
+// ---------------------------------------------------------------------------
+
+/// Scan a child model with a filter on a non-key field. The lowering pipeline
+/// adds an `IsModel(Todo)` conjunct alongside the user filter; the planner
+/// can't promote it to a key condition (no PK column referenced), so it
+/// flows into the scan's filter expression and through `ddb_expression`.
+#[driver_test(requires(native_starts_with), requires(not(sql)))]
+pub async fn scan_child_model_with_non_key_filter(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user = User::create().exec(&mut db).await?;
+    user.todos()
+        .create()
+        .title("match me")
+        .exec(&mut db)
+        .await?;
+    user.todos().create().title("skip me").exec(&mut db).await?;
+
+    let results: Vec<Todo> = Todo::filter(Todo::fields().title().eq("match me"))
+        .exec(&mut db)
+        .await?;
+
+    assert_eq!(1, results.len());
+    assert_eq!("match me", results[0].title);
+
+    Ok(())
+}
+
+/// Delete a child model row with a filter on a non-key field. The driver
+/// receives a `DeleteByKey` op whose filter contains `IsModel(Todo) AND
+/// title = "..."` — `ddb_expression` serializes the filter as a DynamoDB
+/// condition expression.
+#[driver_test(requires(native_starts_with))]
+pub async fn delete_child_with_filter(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user = User::create().exec(&mut db).await?;
+    let todo = user
+        .todos()
+        .create()
+        .title("delete me")
+        .exec(&mut db)
+        .await?;
+
+    user.todos()
+        .filter_by_id(todo.id)
+        .filter(Todo::fields().title().eq("delete me"))
+        .delete()
+        .exec(&mut db)
+        .await?;
+
+    assert_err!(Todo::get_by_user_id_and_id(&mut db, &todo.user_id, &todo.id).await);
+
+    Ok(())
+}
+
+/// Update a child model row with a filter on a non-key field. The driver
+/// receives an `UpdateByKey` op whose filter contains `IsModel(Todo) AND
+/// title = "..."` — `ddb_expression` serializes it.
+#[driver_test(requires(native_starts_with))]
+pub async fn update_child_with_filter(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user = User::create().exec(&mut db).await?;
+    let todo = user.todos().create().title("before").exec(&mut db).await?;
+
+    user.todos()
+        .filter_by_id(todo.id)
+        .filter(Todo::fields().title().eq("before"))
+        .update()
+        .title("after")
+        .exec(&mut db)
+        .await?;
+
+    let reloaded = Todo::get_by_user_id_and_id(&mut db, &todo.user_id, &todo.id).await?;
+    assert_eq!(reloaded.title, "after");
+
+    Ok(())
+}

--- a/crates/toasty-driver-integration-suite/src/tests/item_collection.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/item_collection.rs
@@ -472,6 +472,86 @@ pub async fn update_child_with_filter(test: &mut Test) -> Result<()> {
     Ok(())
 }
 
+/// Filter-driven update across multiple child rows. The filter matches
+/// more than one Todo; all matching rows must be updated, non-matching
+/// rows must remain unchanged. Distinct from `update_child_with_filter`,
+/// which targets a single row by composite PK.
+#[driver_test(requires(native_starts_with))]
+pub async fn update_many_children_by_filter(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user = User::create().exec(&mut db).await?;
+
+    let mut todos = vec![];
+    for label in ["match", "match", "match", "skip"] {
+        todos.push(
+            user.todos()
+                .create()
+                .title(label.to_string())
+                .exec(&mut db)
+                .await?,
+        );
+    }
+
+    user.todos()
+        .filter(Todo::fields().title().eq("match"))
+        .update()
+        .title("updated")
+        .exec(&mut db)
+        .await?;
+
+    let mut titles: Vec<String> = user
+        .todos()
+        .exec(&mut db)
+        .await?
+        .into_iter()
+        .map(|t| t.title)
+        .collect();
+    titles.sort();
+    assert_eq!(
+        titles,
+        vec!["skip", "updated", "updated", "updated"],
+    );
+
+    Ok(())
+}
+
+/// Filter-driven delete across multiple child rows. The filter matches
+/// more than one Todo; all matching rows must be deleted, non-matching
+/// rows must survive. Distinct from `delete_child_with_filter`, which
+/// targets a single row by composite PK.
+#[driver_test(requires(native_starts_with))]
+pub async fn delete_many_children_by_filter(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user = User::create().exec(&mut db).await?;
+
+    for label in ["doomed", "doomed", "doomed", "survivor"] {
+        user.todos()
+            .create()
+            .title(label.to_string())
+            .exec(&mut db)
+            .await?;
+    }
+
+    user.todos()
+        .filter(Todo::fields().title().eq("doomed"))
+        .delete()
+        .exec(&mut db)
+        .await?;
+
+    let titles: Vec<String> = user
+        .todos()
+        .exec(&mut db)
+        .await?
+        .into_iter()
+        .map(|t| t.title)
+        .collect();
+    assert_eq!(titles, vec!["survivor".to_string()]);
+
+    Ok(())
+}
+
 /// Batch-create multiple child rows under one parent. Exercises
 /// `Insert::merge` for `InsertTarget::Scope` targets — the planner builds
 /// one INSERT per row and merges them into a single VALUES list before

--- a/crates/toasty-driver-integration-suite/src/tests/item_collection.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/item_collection.rs
@@ -391,21 +391,59 @@ pub async fn delete_child_with_filter(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
     let user = User::create().exec(&mut db).await?;
-    let todo = user
+    let target = user
         .todos()
         .create()
         .title("delete me")
         .exec(&mut db)
         .await?;
+    // Sibling under the same user. The filter must narrow to `target`
+    // alone — otherwise this row would also disappear.
+    let sibling = user
+        .todos()
+        .create()
+        .title("keep me")
+        .exec(&mut db)
+        .await?;
 
     user.todos()
-        .filter_by_id(todo.id)
+        .filter_by_id(target.id)
         .filter(Todo::fields().title().eq("delete me"))
         .delete()
         .exec(&mut db)
         .await?;
 
-    assert_err!(Todo::get_by_user_id_and_id(&mut db, &todo.user_id, &todo.id).await);
+    assert_err!(Todo::get_by_user_id_and_id(&mut db, &target.user_id, &target.id).await);
+    let survivor =
+        Todo::get_by_user_id_and_id(&mut db, &sibling.user_id, &sibling.id).await?;
+    assert_eq!(survivor.title, "keep me");
+
+    Ok(())
+}
+
+/// When the filter does not match, the delete is a no-op: the row remains
+/// in place. Proves the filter is consulted, not silently dropped.
+#[driver_test(requires(native_starts_with))]
+pub async fn delete_child_with_non_matching_filter(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user = User::create().exec(&mut db).await?;
+    let todo = user
+        .todos()
+        .create()
+        .title("actual title")
+        .exec(&mut db)
+        .await?;
+
+    user.todos()
+        .filter_by_id(todo.id)
+        .filter(Todo::fields().title().eq("wrong title"))
+        .delete()
+        .exec(&mut db)
+        .await?;
+
+    let survivor = Todo::get_by_user_id_and_id(&mut db, &todo.user_id, &todo.id).await?;
+    assert_eq!(survivor.title, "actual title");
 
     Ok(())
 }
@@ -433,3 +471,4 @@ pub async fn update_child_with_filter(test: &mut Test) -> Result<()> {
 
     Ok(())
 }
+

--- a/crates/toasty-driver-integration-suite/src/tests/item_collection.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/item_collection.rs
@@ -213,6 +213,29 @@ pub async fn multiple_todos(test: &mut Test) -> Result<()> {
     Ok(())
 }
 
+/// Todos can be included on the parent.
+#[driver_test(requires(native_starts_with))]
+pub async fn include_todos(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user = User::create().exec(&mut db).await?;
+
+    for i in 0..5 {
+        user.todos()
+            .create()
+            .title(format!("todo {i}"))
+            .exec(&mut db)
+            .await?;
+    }
+
+    let mut users = User::filter_by_id(user.id).include(User::fields().todos()).exec(&mut db).await?;
+    assert_eq!(1, users.len());
+    let user = users.pop().unwrap();
+    assert_eq!(5, user.todos.get().len());
+
+    Ok(())
+}
+
 /// Scoped filter_by_id returns the right todo when the user matches and
 /// nothing when the user does not match.
 #[driver_test(requires(native_starts_with))]

--- a/crates/toasty-driver-integration-suite/src/tests/item_collection.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/item_collection.rs
@@ -18,7 +18,7 @@ struct User {
     id: uuid::Uuid,
 
     #[has_many]
-    todos: toasty::HasMany<Todo>,
+    todos: toasty::Deferred<Vec<Todo>>,
 }
 
 /// A todo that belongs to a user and shares the same DynamoDB table.
@@ -37,7 +37,7 @@ struct Todo {
     user_id: uuid::Uuid,
 
     #[belongs_to(key = user_id, references = id)]
-    user: toasty::BelongsTo<User>,
+    user: toasty::Deferred<User>,
 
     title: String,
 }
@@ -61,7 +61,7 @@ pub async fn validates_missing_local_key(test: &mut Test) {
         id: uuid::Uuid,
 
         #[has_many]
-        items: toasty::HasMany<Item>,
+        items: toasty::Deferred<Vec<Item>>,
     }
 
     // No #[key(partition = ..., local = ...)] — only a single-field PK.
@@ -77,7 +77,7 @@ pub async fn validates_missing_local_key(test: &mut Test) {
         root_id: uuid::Uuid,
 
         #[belongs_to(key = root_id, references = id)]
-        root: toasty::BelongsTo<Root>,
+        root: toasty::Deferred<Root>,
     }
 
     assert_err!(test.try_setup_db(models!(Root, Item)).await);
@@ -96,7 +96,7 @@ pub async fn validates_no_belongs_to_in_pk(test: &mut Test) {
         id: uuid::Uuid,
 
         #[has_many]
-        items: toasty::HasMany<Item>,
+        items: toasty::Deferred<Vec<Item>>,
     }
 
     // Compound key but neither field references a parent via BelongsTo —
@@ -114,7 +114,7 @@ pub async fn validates_no_belongs_to_in_pk(test: &mut Test) {
         root_id: uuid::Uuid,
 
         #[belongs_to(key = root_id, references = id)]
-        root: toasty::BelongsTo<Root>,
+        root: toasty::Deferred<Root>,
     }
 
     assert_err!(test.try_setup_db(models!(Root, Item)).await);
@@ -323,19 +323,15 @@ pub async fn delete_user_removes_todos(test: &mut Test) -> Result<()> {
 /// `item_collection` field on the app schema model is set to the parent model's id.
 #[driver_test]
 pub async fn schema_item_collection_field_set(test: &mut Test) {
-    use toasty::schema::Register;
+    use toasty::schema::Model;
 
     let _db = setup(test).await;
 
-    let todo_ic = <Todo as Register>::schema()
-        .as_root_unwrap()
-        .item_collection;
+    let todo_ic = <Todo as Model>::schema().as_root_unwrap().item_collection;
 
-    assert_eq!(todo_ic, Some(<User as Register>::id()));
+    assert_eq!(todo_ic, Some(<User as Model>::id()));
 
-    let user_ic = <User as Register>::schema()
-        .as_root_unwrap()
-        .item_collection;
+    let user_ic = <User as Model>::schema().as_root_unwrap().item_collection;
 
     assert_eq!(user_ic, None);
 }

--- a/crates/toasty-driver-integration-suite/src/tests/item_collection_three_tier.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/item_collection_three_tier.rs
@@ -1,0 +1,326 @@
+//! Three-tier item-collection: Tenant -> User -> Todo
+//!
+//! The 2-tier suite in `item_collection.rs` uses single-field FKs throughout
+//! (Todo.user_id -> User.id). The 3-tier shape forces composite FKs on every
+//! level: User has FK (tenant_id) -> Tenant.id, Todo has FK (tenant_id,
+//! user_id) -> User PK. This catches engine paths the 2-tier shape never
+//! exercises:
+//!
+//!   - composite-FK lowering (eq/ne operand rewrite, IN-subquery lift)
+//!   - composite-FK index_match against the shared SK prefix
+//!   - nested_merge qualifiers when the child FK is a record, not a scalar
+//!   - multi-level .include() chains
+
+use crate::prelude::*;
+
+#[derive(Debug, toasty::Model)]
+struct Tenant {
+    #[key]
+    #[auto]
+    id: uuid::Uuid,
+
+    name: String,
+
+    #[has_many]
+    users: toasty::HasMany<User>,
+}
+
+#[derive(Debug, toasty::Model)]
+#[item_collection(Tenant)]
+#[key(partition = tenant_id, local = id)]
+struct User {
+    id: String,
+
+    tenant_id: uuid::Uuid,
+
+    #[belongs_to(key = tenant_id, references = id)]
+    tenant: toasty::BelongsTo<Tenant>,
+
+    name: String,
+
+    #[has_many]
+    todos: toasty::HasMany<Todo>,
+}
+
+#[derive(Debug, toasty::Model)]
+#[item_collection(User)]
+#[key(partition = tenant_id, local = [user_id, id])]
+#[index(tenant_id, user_id)]
+struct Todo {
+    id: String,
+
+    tenant_id: uuid::Uuid,
+    user_id: String,
+
+    #[belongs_to(key = [tenant_id, user_id], references = [tenant_id, id])]
+    user: toasty::BelongsTo<User>,
+
+    title: String,
+}
+
+async fn setup(test: &mut Test) -> toasty::Db {
+    test.setup_db(models!(Tenant, User, Todo)).await
+}
+
+/// Schema build round-trips: registering Tenant, User, Todo with their
+/// composite-FK relations and chained item_collection annotations is
+/// accepted by the schema validator.
+#[driver_test(requires(native_starts_with))]
+pub async fn three_tier_setup(test: &mut Test) -> Result<()> {
+    let _db = setup(test).await;
+    Ok(())
+}
+
+/// Create a Tenant, a scoped User under it, and a scoped Todo under that
+/// User. Verify each round-trips by primary key. Exercises the insert
+/// path for composite-FK child models at two depths.
+#[driver_test(requires(native_starts_with))]
+pub async fn three_tier_create_each_tier(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let acme = toasty::create!(Tenant { name: "Acme" })
+        .exec(&mut db)
+        .await?;
+
+    let alice = toasty::create!(in acme.users() {
+        id: "alice".to_string(),
+        name: "Alice",
+    })
+    .exec(&mut db)
+    .await?;
+
+    let todo = toasty::create!(in alice.todos() {
+        id: "t1".to_string(),
+        title: "ship it",
+    })
+    .exec(&mut db)
+    .await?;
+
+    let reloaded_user =
+        User::get_by_tenant_id_and_id(&mut db, &alice.tenant_id, &alice.id).await?;
+    assert_eq!(reloaded_user.name, "Alice");
+
+    let reloaded_todo = Todo::get_by_tenant_id_and_user_id_and_id(
+        &mut db,
+        &todo.tenant_id,
+        &todo.user_id,
+        &todo.id,
+    )
+    .await?;
+    assert_eq!(reloaded_todo.title, "ship it");
+
+    Ok(())
+}
+
+/// Read each tier through its parent's scoped relation. Exercises the
+/// query-planning path that translates a parent reference into a
+/// composite-FK + SK-prefix DDB query.
+#[driver_test(requires(native_starts_with))]
+pub async fn three_tier_scoped_reads(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let acme = toasty::create!(Tenant { name: "Acme" })
+        .exec(&mut db)
+        .await?;
+
+    let alice = toasty::create!(in acme.users() {
+        id: "alice".to_string(),
+        name: "Alice",
+    })
+    .exec(&mut db)
+    .await?;
+
+    let _bob = toasty::create!(in acme.users() {
+        id: "bob".to_string(),
+        name: "Bob",
+    })
+    .exec(&mut db)
+    .await?;
+
+    for i in 0..3 {
+        toasty::create!(in alice.todos() {
+            id: format!("t{i}"),
+            title: format!("todo {i}"),
+        })
+        .exec(&mut db)
+        .await?;
+    }
+
+    let users = acme.users().exec(&mut db).await?;
+    assert_eq!(2, users.len());
+
+    let todos = alice.todos().exec(&mut db).await?;
+    assert_eq!(3, todos.len());
+
+    Ok(())
+}
+
+/// Filter by partial composite key on the deepest model. Exercises the
+/// composite-FK index match: (tenant_id, user_id) is a prefix of the
+/// PK, so the planner should drive a single-partition query instead of
+/// a scan.
+#[driver_test(requires(native_starts_with))]
+pub async fn three_tier_filter_by_partial_composite_key(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let acme = toasty::create!(Tenant { name: "Acme" })
+        .exec(&mut db)
+        .await?;
+
+    let alice = toasty::create!(in acme.users() {
+        id: "alice".to_string(),
+        name: "Alice",
+    })
+    .exec(&mut db)
+    .await?;
+
+    for i in 0..3 {
+        toasty::create!(in alice.todos() {
+            id: format!("t{i}"),
+            title: format!("todo {i}"),
+        })
+        .exec(&mut db)
+        .await?;
+    }
+
+    let todos = Todo::filter_by_tenant_id(acme.id)
+        .filter_by_user_id(&alice.id)
+        .exec(&mut db)
+        .await?;
+    assert_eq!(3, todos.len());
+
+    Ok(())
+}
+
+/// Include the deepest tier's children on a middle-tier query. The
+/// User query supplies (tenant_id, id) as the composite PK; the include
+/// subquery joins Todo through that composite key. This is the path
+/// the example exercises and the original failure mode that drove the
+/// IsModel work.
+#[driver_test(requires(native_starts_with))]
+pub async fn three_tier_include_deepest(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let acme = toasty::create!(Tenant { name: "Acme" })
+        .exec(&mut db)
+        .await?;
+
+    let alice = toasty::create!(in acme.users() {
+        id: "alice".to_string(),
+        name: "Alice",
+    })
+    .exec(&mut db)
+    .await?;
+
+    for i in 0..3 {
+        toasty::create!(in alice.todos() {
+            id: format!("t{i}"),
+            title: format!("todo {i}"),
+        })
+        .exec(&mut db)
+        .await?;
+    }
+
+    let mut users = User::filter_by_tenant_id(acme.id)
+        .filter_by_id(&alice.id)
+        .include(User::fields().todos())
+        .exec(&mut db)
+        .await?;
+    assert_eq!(1, users.len());
+    let from_db = users.pop().unwrap();
+    assert_eq!(3, from_db.todos.get().len());
+
+    Ok(())
+}
+
+/// Update the deepest tier through a chained scope. Exercises the
+/// update path against a composite-PK shared table.
+#[driver_test(requires(native_starts_with))]
+pub async fn three_tier_scoped_update(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let acme = toasty::create!(Tenant { name: "Acme" })
+        .exec(&mut db)
+        .await?;
+
+    let alice = toasty::create!(in acme.users() {
+        id: "alice".to_string(),
+        name: "Alice",
+    })
+    .exec(&mut db)
+    .await?;
+
+    let todo = toasty::create!(in alice.todos() {
+        id: "t1".to_string(),
+        title: "before",
+    })
+    .exec(&mut db)
+    .await?;
+
+    alice
+        .todos()
+        .filter_by_id(&todo.id)
+        .update()
+        .title("after")
+        .exec(&mut db)
+        .await?;
+
+    let reloaded = Todo::get_by_tenant_id_and_user_id_and_id(
+        &mut db,
+        &todo.tenant_id,
+        &todo.user_id,
+        &todo.id,
+    )
+    .await?;
+    assert_eq!(reloaded.title, "after");
+
+    Ok(())
+}
+
+/// Cascade delete from the root: deleting a Tenant removes its Users
+/// and their Todos. Verifies the cascade chain reaches two levels deep.
+#[driver_test(requires(native_starts_with))]
+pub async fn three_tier_cascade_delete(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let acme = toasty::create!(Tenant { name: "Acme" })
+        .exec(&mut db)
+        .await?;
+
+    let alice = toasty::create!(in acme.users() {
+        id: "alice".to_string(),
+        name: "Alice",
+    })
+    .exec(&mut db)
+    .await?;
+
+    let todo = toasty::create!(in alice.todos() {
+        id: "t1".to_string(),
+        title: "doomed",
+    })
+    .exec(&mut db)
+    .await?;
+
+    let tenant_id = acme.id;
+    let alice_tenant_id = alice.tenant_id;
+    let alice_id = alice.id.clone();
+    let todo_tenant_id = todo.tenant_id;
+    let todo_user_id = todo.user_id.clone();
+    let todo_id = todo.id.clone();
+
+    acme.delete().exec(&mut db).await?;
+
+    assert_err!(Tenant::get_by_id(&mut db, &tenant_id).await);
+    assert_err!(User::get_by_tenant_id_and_id(&mut db, &alice_tenant_id, &alice_id).await);
+    assert_err!(
+        Todo::get_by_tenant_id_and_user_id_and_id(
+            &mut db,
+            &todo_tenant_id,
+            &todo_user_id,
+            &todo_id,
+        )
+        .await
+    );
+
+    Ok(())
+}

--- a/crates/toasty-driver-integration-suite/src/tests/item_collection_three_tier.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/item_collection_three_tier.rs
@@ -277,6 +277,86 @@ pub async fn three_tier_scoped_update(test: &mut Test) -> Result<()> {
     Ok(())
 }
 
+/// Batch-create children at the deepest tier. Each row's scope is
+/// `alice.todos()` — the same parent Scope target — so `Insert::merge`
+/// must collapse them into one VALUES list. The composite FK (tenant_id,
+/// user_id) on Todo is what stresses the merge path beyond the 2-tier case.
+#[driver_test(requires(native_starts_with))]
+pub async fn three_tier_batch_create_deepest(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let acme = toasty::create!(Tenant { name: "Acme" })
+        .exec(&mut db)
+        .await?;
+
+    let alice = toasty::create!(in acme.users() {
+        id: "alice".to_string(),
+        name: "Alice",
+    })
+    .exec(&mut db)
+    .await?;
+
+    let mut builder = Todo::create_many();
+    for i in 0..5 {
+        builder = builder.item(toasty::create!(in alice.todos() {
+            id: format!("t{i}"),
+            title: format!("todo {i}"),
+        }));
+    }
+    let todos = builder.exec(&mut db).await?;
+    assert_eq!(5, todos.len());
+
+    let mut titles: Vec<String> = alice
+        .todos()
+        .exec(&mut db)
+        .await?
+        .into_iter()
+        .map(|t| t.title)
+        .collect();
+    titles.sort();
+    assert_eq!(
+        titles,
+        vec!["todo 0", "todo 1", "todo 2", "todo 3", "todo 4"]
+    );
+
+    Ok(())
+}
+
+/// Batch-create middle-tier children under a Tenant. Single-FK scope
+/// (tenant_id only). Confirms the 2-tier merge fix continues to work
+/// when the Scope target is one level deep, even though the schema also
+/// has a deeper tier defined.
+#[driver_test(requires(native_starts_with))]
+pub async fn three_tier_batch_create_middle(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let acme = toasty::create!(Tenant { name: "Acme" })
+        .exec(&mut db)
+        .await?;
+
+    let mut builder = User::create_many();
+    for name in ["Alice", "Bob", "Carol"] {
+        builder = builder.item(toasty::create!(in acme.users() {
+            id: name.to_lowercase(),
+            name: name,
+        }));
+    }
+    let users = builder.exec(&mut db).await?;
+    assert_eq!(3, users.len());
+
+    let mut names: Vec<String> = acme
+        .users()
+        .exec(&mut db)
+        .await?
+        .into_iter()
+        .map(|u| u.name)
+        .collect();
+    names.sort();
+    assert_eq!(names, vec!["Alice", "Bob", "Carol"]);
+
+    Ok(())
+}
+
 /// Cascade delete from the root: deleting a Tenant removes its Users
 /// and their Todos. Verifies the cascade chain reaches two levels deep.
 #[driver_test(requires(native_starts_with))]

--- a/crates/toasty-driver-integration-suite/src/tests/item_collection_three_tier.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/item_collection_three_tier.rs
@@ -65,7 +65,7 @@ async fn setup(test: &mut Test) -> toasty::Db {
 /// Schema build round-trips: registering Tenant, User, Todo with their
 /// composite-FK relations and chained item_collection annotations is
 /// accepted by the schema validator.
-#[driver_test(requires(native_starts_with))]
+#[driver_test(requires(not(sql)))]
 pub async fn three_tier_setup(test: &mut Test) -> Result<()> {
     let _db = setup(test).await;
     Ok(())
@@ -74,7 +74,7 @@ pub async fn three_tier_setup(test: &mut Test) -> Result<()> {
 /// Create a Tenant, a scoped User under it, and a scoped Todo under that
 /// User. Verify each round-trips by primary key. Exercises the insert
 /// path for composite-FK child models at two depths.
-#[driver_test(requires(native_starts_with))]
+#[driver_test(requires(not(sql)))]
 pub async fn three_tier_create_each_tier(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -114,7 +114,7 @@ pub async fn three_tier_create_each_tier(test: &mut Test) -> Result<()> {
 /// Read each tier through its parent's scoped relation. Exercises the
 /// query-planning path that translates a parent reference into a
 /// composite-FK + SK-prefix DDB query.
-#[driver_test(requires(native_starts_with))]
+#[driver_test(requires(not(sql)))]
 pub async fn three_tier_scoped_reads(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -158,7 +158,7 @@ pub async fn three_tier_scoped_reads(test: &mut Test) -> Result<()> {
 /// composite-FK index match: (tenant_id, user_id) is a prefix of the
 /// PK, so the planner should drive a single-partition query instead of
 /// a scan.
-#[driver_test(requires(native_starts_with))]
+#[driver_test(requires(not(sql)))]
 pub async fn three_tier_filter_by_partial_composite_key(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -196,7 +196,7 @@ pub async fn three_tier_filter_by_partial_composite_key(test: &mut Test) -> Resu
 /// subquery joins Todo through that composite key. This is the path
 /// the example exercises and the original failure mode that drove the
 /// IsModel work.
-#[driver_test(requires(native_starts_with))]
+#[driver_test(requires(not(sql)))]
 pub async fn three_tier_include_deepest(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -234,7 +234,7 @@ pub async fn three_tier_include_deepest(test: &mut Test) -> Result<()> {
 
 /// Update the deepest tier through a chained scope. Exercises the
 /// update path against a composite-PK shared table.
-#[driver_test(requires(native_starts_with))]
+#[driver_test(requires(not(sql)))]
 pub async fn three_tier_scoped_update(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -280,7 +280,7 @@ pub async fn three_tier_scoped_update(test: &mut Test) -> Result<()> {
 /// The filter matches more than one Todo; all matching rows must be
 /// updated, non-matching rows must remain unchanged. Exercises the
 /// composite-FK + filter mutation path at the deepest tier.
-#[driver_test(requires(native_starts_with))]
+#[driver_test(requires(not(sql)))]
 pub async fn three_tier_update_many_deepest_by_filter(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -329,7 +329,7 @@ pub async fn three_tier_update_many_deepest_by_filter(test: &mut Test) -> Result
 /// The filter matches more than one Todo; all matching rows must be
 /// deleted, non-matching rows must survive. Exercises the composite-FK +
 /// filter mutation path at the deepest tier.
-#[driver_test(requires(native_starts_with))]
+#[driver_test(requires(not(sql)))]
 pub async fn three_tier_delete_many_deepest_by_filter(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -379,7 +379,7 @@ pub async fn three_tier_delete_many_deepest_by_filter(test: &mut Test) -> Result
 /// `alice.todos()` — the same parent Scope target — so `Insert::merge`
 /// must collapse them into one VALUES list. The composite FK (tenant_id,
 /// user_id) on Todo is what stresses the merge path beyond the 2-tier case.
-#[driver_test(requires(native_starts_with))]
+#[driver_test(requires(not(sql)))]
 pub async fn three_tier_batch_create_deepest(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -424,7 +424,7 @@ pub async fn three_tier_batch_create_deepest(test: &mut Test) -> Result<()> {
 /// (tenant_id only). Confirms the 2-tier merge fix continues to work
 /// when the Scope target is one level deep, even though the schema also
 /// has a deeper tier defined.
-#[driver_test(requires(native_starts_with))]
+#[driver_test(requires(not(sql)))]
 pub async fn three_tier_batch_create_middle(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -457,7 +457,7 @@ pub async fn three_tier_batch_create_middle(test: &mut Test) -> Result<()> {
 
 /// Cascade delete from the root: deleting a Tenant removes its Users
 /// and their Todos. Verifies the cascade chain reaches two levels deep.
-#[driver_test(requires(native_starts_with))]
+#[driver_test(requires(not(sql)))]
 pub async fn three_tier_cascade_delete(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 

--- a/crates/toasty-driver-integration-suite/src/tests/item_collection_three_tier.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/item_collection_three_tier.rs
@@ -277,6 +277,105 @@ pub async fn three_tier_scoped_update(test: &mut Test) -> Result<()> {
     Ok(())
 }
 
+/// Filter-driven update across multiple Todos under one user.
+/// The filter matches more than one Todo; all matching rows must be
+/// updated, non-matching rows must remain unchanged. Exercises the
+/// composite-FK + filter mutation path at the deepest tier.
+#[driver_test(requires(native_starts_with))]
+pub async fn three_tier_update_many_deepest_by_filter(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let acme = toasty::create!(Tenant { name: "Acme" })
+        .exec(&mut db)
+        .await?;
+
+    let alice = toasty::create!(in acme.users() {
+        id: "alice".to_string(),
+        name: "Alice",
+    })
+    .exec(&mut db)
+    .await?;
+
+    for (i, label) in ["match", "match", "match", "skip"].iter().enumerate() {
+        toasty::create!(in alice.todos() {
+            id: format!("t{i}"),
+            title: label.to_string(),
+        })
+        .exec(&mut db)
+        .await?;
+    }
+
+    alice
+        .todos()
+        .filter(Todo::fields().title().eq("match"))
+        .update()
+        .title("updated")
+        .exec(&mut db)
+        .await?;
+
+    let mut titles: Vec<String> = alice
+        .todos()
+        .exec(&mut db)
+        .await?
+        .into_iter()
+        .map(|t| t.title)
+        .collect();
+    titles.sort();
+    assert_eq!(
+        titles,
+        vec!["skip", "updated", "updated", "updated"],
+    );
+
+    Ok(())
+}
+
+/// Filter-driven delete across multiple Todos under one user.
+/// The filter matches more than one Todo; all matching rows must be
+/// deleted, non-matching rows must survive. Exercises the composite-FK +
+/// filter mutation path at the deepest tier.
+#[driver_test(requires(native_starts_with))]
+pub async fn three_tier_delete_many_deepest_by_filter(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let acme = toasty::create!(Tenant { name: "Acme" })
+        .exec(&mut db)
+        .await?;
+
+    let alice = toasty::create!(in acme.users() {
+        id: "alice".to_string(),
+        name: "Alice",
+    })
+    .exec(&mut db)
+    .await?;
+
+    for (i, label) in ["doomed", "doomed", "doomed", "survivor"].iter().enumerate() {
+        toasty::create!(in alice.todos() {
+            id: format!("t{i}"),
+            title: label.to_string(),
+        })
+        .exec(&mut db)
+        .await?;
+    }
+
+    alice
+        .todos()
+        .filter(Todo::fields().title().eq("doomed"))
+        .delete()
+        .exec(&mut db)
+        .await?;
+
+    let titles: Vec<String> = alice
+        .todos()
+        .exec(&mut db)
+        .await?
+        .into_iter()
+        .map(|t| t.title)
+        .collect();
+    assert_eq!(titles, vec!["survivor".to_string()]);
+
+    Ok(())
+}
+
 /// Batch-create children at the deepest tier. Each row's scope is
 /// `alice.todos()` — the same parent Scope target — so `Insert::merge`
 /// must collapse them into one VALUES list. The composite FK (tenant_id,

--- a/crates/toasty-driver-integration-suite/src/tests/item_collection_three_tier.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/item_collection_three_tier.rs
@@ -96,8 +96,7 @@ pub async fn three_tier_create_each_tier(test: &mut Test) -> Result<()> {
     .exec(&mut db)
     .await?;
 
-    let reloaded_user =
-        User::get_by_tenant_id_and_id(&mut db, &alice.tenant_id, &alice.id).await?;
+    let reloaded_user = User::get_by_tenant_id_and_id(&mut db, &alice.tenant_id, &alice.id).await?;
     assert_eq!(reloaded_user.name, "Alice");
 
     let reloaded_todo = Todo::get_by_tenant_id_and_user_id_and_id(
@@ -321,10 +320,7 @@ pub async fn three_tier_update_many_deepest_by_filter(test: &mut Test) -> Result
         .map(|t| t.title)
         .collect();
     titles.sort();
-    assert_eq!(
-        titles,
-        vec!["skip", "updated", "updated", "updated"],
-    );
+    assert_eq!(titles, vec!["skip", "updated", "updated", "updated"],);
 
     Ok(())
 }
@@ -348,7 +344,10 @@ pub async fn three_tier_delete_many_deepest_by_filter(test: &mut Test) -> Result
     .exec(&mut db)
     .await?;
 
-    for (i, label) in ["doomed", "doomed", "doomed", "survivor"].iter().enumerate() {
+    for (i, label) in ["doomed", "doomed", "doomed", "survivor"]
+        .iter()
+        .enumerate()
+    {
         toasty::create!(in alice.todos() {
             id: format!("t{i}"),
             title: label.to_string(),

--- a/crates/toasty-driver-integration-suite/src/tests/item_collection_three_tier.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/item_collection_three_tier.rs
@@ -22,7 +22,7 @@ struct Tenant {
     name: String,
 
     #[has_many]
-    users: toasty::HasMany<User>,
+    users: toasty::Deferred<Vec<User>>,
 }
 
 #[derive(Debug, toasty::Model)]
@@ -34,12 +34,12 @@ struct User {
     tenant_id: uuid::Uuid,
 
     #[belongs_to(key = tenant_id, references = id)]
-    tenant: toasty::BelongsTo<Tenant>,
+    tenant: toasty::Deferred<Tenant>,
 
     name: String,
 
     #[has_many]
-    todos: toasty::HasMany<Todo>,
+    todos: toasty::Deferred<Vec<Todo>>,
 }
 
 #[derive(Debug, toasty::Model)]
@@ -53,7 +53,7 @@ struct Todo {
     user_id: String,
 
     #[belongs_to(key = [tenant_id, user_id], references = [tenant_id, id])]
-    user: toasty::BelongsTo<User>,
+    user: toasty::Deferred<User>,
 
     title: String,
 }

--- a/crates/toasty-macros/src/lib.rs
+++ b/crates/toasty-macros/src/lib.rs
@@ -713,7 +713,7 @@ use proc_macro::TokenStream;
     Model,
     attributes(
         key, auto, default, update, column, index, unique, table, has_many, has_one, belongs_to,
-        version
+        serialize, version, deferred, item_collection
     )
 )]
 pub fn derive_model(input: TokenStream) -> TokenStream {

--- a/crates/toasty-macros/src/lib.rs
+++ b/crates/toasty-macros/src/lib.rs
@@ -712,8 +712,21 @@ use proc_macro::TokenStream;
 #[proc_macro_derive(
     Model,
     attributes(
-        key, auto, default, update, column, index, unique, table, has_many, has_one, belongs_to,
-        serialize, version, deferred, item_collection
+        key,
+        auto,
+        default,
+        update,
+        column,
+        index,
+        unique,
+        table,
+        has_many,
+        has_one,
+        belongs_to,
+        serialize,
+        version,
+        deferred,
+        item_collection
     )
 )]
 pub fn derive_model(input: TokenStream) -> TokenStream {

--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -29,6 +29,7 @@ impl Expand<'_> {
                     }
                     None => quote! { None },
                 };
+                let item_collection = self.expand_item_collection();
                 quote! {
                     #toasty::core::schema::app::Model::Root(
                         #toasty::core::schema::app::ModelRoot {
@@ -37,6 +38,7 @@ impl Expand<'_> {
                             fields: #fields,
                             primary_key: #primary_key,
                             table_name: #table_name,
+                            item_collection: #item_collection,
                             indices: #indices,
                             version_field: #version_field,
                         }
@@ -356,6 +358,15 @@ impl Expand<'_> {
         if let Some(table_name) = &self.model.table {
             let table_name = table_name.value();
             quote! { Some(#table_name.to_string()) }
+        } else {
+            quote! { None }
+        }
+    }
+
+    fn expand_item_collection(&self) -> TokenStream {
+        let toasty = &self.toasty;
+        if let Some(ty) = &self.model.item_collection {
+            quote! { Some(<#ty as #toasty::Register>::id()) }
         } else {
             quote! { None }
         }

--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -366,7 +366,7 @@ impl Expand<'_> {
     fn expand_item_collection(&self) -> TokenStream {
         let toasty = &self.toasty;
         if let Some(ty) = &self.model.item_collection {
-            quote! { Some(<#ty as #toasty::Register>::id()) }
+            quote! { Some(<#ty as #toasty::Model>::id()) }
         } else {
             quote! { None }
         }

--- a/crates/toasty-macros/src/model/schema/model.rs
+++ b/crates/toasty-macros/src/model/schema/model.rs
@@ -145,6 +145,10 @@ pub(crate) struct Model {
 
     /// Optional table to map the model to
     pub(crate) table: Option<syn::LitStr>,
+
+    /// Parent model type for item collection (single-table design).
+    /// Comes from `#[item_collection(ParentType)]` on the struct.
+    pub(crate) item_collection: Option<syn::Type>,
 }
 
 impl Model {
@@ -350,6 +354,7 @@ impl Model {
             kind,
             indices,
             table: model_attr.table,
+            item_collection: model_attr.item_collection,
         })
     }
 
@@ -540,6 +545,7 @@ impl Model {
             }),
             indices,
             table: None,
+            item_collection: None,
         })
     }
 }

--- a/crates/toasty-macros/src/model/schema/model_attr.rs
+++ b/crates/toasty-macros/src/model/schema/model_attr.rs
@@ -10,6 +10,10 @@ pub(crate) struct ModelAttr {
 
     /// Optional database table name to map the model to
     pub(crate) table: Option<syn::LitStr>,
+
+    /// Parent model type for item collection (single-table design).
+    /// Set when `#[item_collection(ParentType)]` is present on the model.
+    pub(crate) item_collection: Option<syn::Type>,
 }
 
 impl ModelAttr {
@@ -73,6 +77,18 @@ impl ModelAttr {
                 };
 
                 self.table = Some(lit.clone());
+            } else if attr.path().is_ident("item_collection") {
+                if self.item_collection.is_some() {
+                    errs.push(syn::Error::new_spanned(
+                        attr,
+                        "duplicate #[item_collection] attribute",
+                    ));
+                } else {
+                    match attr.parse_args::<syn::Type>() {
+                        Ok(ty) => self.item_collection = Some(ty),
+                        Err(e) => errs.push(e),
+                    }
+                }
             }
         }
 

--- a/crates/toasty/src/engine/eval.rs
+++ b/crates/toasty/src/engine/eval.rs
@@ -96,6 +96,7 @@ fn verify_expr(expr: &stmt::Expr) -> bool {
         Reference(_) => false,
         Func(_) => false,
         Value(_) => true,
+        IsModel(_) => false,
         _ => todo!("expr={expr:#?}"),
     }
 }

--- a/crates/toasty/src/engine/fold.rs
+++ b/crates/toasty/src/engine/fold.rs
@@ -85,6 +85,7 @@ fn fold_one(i: &mut Expr) -> Option<Expr> {
         | Expr::Exists(_)
         | Expr::Func(_)
         | Expr::Ident(_)
+        | Expr::IsModel(_)
         | Expr::InSubquery(_)
         | Expr::IsVariant(_)
         | Expr::Length(_)

--- a/crates/toasty/src/engine/index.rs
+++ b/crates/toasty/src/engine/index.rs
@@ -362,7 +362,9 @@ fn extract_pre_filter(expr: &stmt::Expr) -> (Option<stmt::Expr>, stmt::Expr) {
 fn references_column(expr: &stmt::Expr) -> bool {
     let mut found = false;
     stmt::visit::for_each_expr(expr, |e| {
-        if matches!(e, stmt::Expr::Reference(stmt::ExprReference::Column(_))) {
+        if matches!(e, stmt::Expr::Reference(stmt::ExprReference::Column(_)))
+            || matches!(e, stmt::Expr::IsModel(_))
+        {
             found = true;
         }
     });

--- a/crates/toasty/src/engine/index/index_match.rs
+++ b/crates/toasty/src/engine/index/index_match.rs
@@ -77,6 +77,25 @@ impl<'stmt> IndexMatch<'stmt> {
                 }
                 _ => todo!("expr={:#?}", expr),
             },
+            IsModel(e) => {
+                let model = cx.schema().mapping_for(e.model);
+                let Some(disc_col_id) = model.item_collection.model_column else {
+                    // Model has no discriminator column — shouldn't2 happen if lowering
+                    // emitted IsModel correctly.
+                    return false;
+                };
+                let mut matched = false;
+                for (i, index_column) in self.index.columns.iter().enumerate() {
+                    if disc_col_id != index_column.column {
+                        continue;
+                    }
+                    self.columns[i]
+                        .exprs
+                        .insert(ByAddress(expr), ExprMatch { eq: true });
+                    matched = true;
+                }
+                matched
+            }
             And(and_exprs) => {
                 let matched = self.match_all_restrictions(cx, and_exprs);
 
@@ -451,6 +470,8 @@ impl<'stmt> IndexMatch<'stmt> {
                     (true.into(), true.into())
                 }
             }
+            // IsModel is always part of the sort key.
+            IsModel(_) => (expr.clone(), true.into()),
             _ => todo!("partition_filter={:#?}", expr),
         }
     }

--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -1181,6 +1181,8 @@ impl visit_mut::VisitMut for LowerStatement<'_, '_> {
             lower.visit_expr_mut(expr);
         }
 
+        lower.apply_lowering_filter_constraint(&mut stmt.filter);
+
         if let Some(returning) = &mut stmt.returning {
             lower.visit_returning_mut(returning);
             // Use the lowered assignments (which are now column-indexed)
@@ -1493,7 +1495,33 @@ impl<'a, 'b> LowerStatement<'a, 'b> {
         }
     }
 
-    fn apply_lowering_filter_constraint(&self, _filter: &mut stmt::Filter) {}
+    fn apply_lowering_filter_constraint(&self, filter: &mut stmt::Filter) {
+        let Some(model) = self.model() else { return };
+        let mapping = self.state.engine.schema.mapping_for(model);
+
+        let Some(model_col_id) = mapping.item_collection.model_column else {
+            return;
+        };
+
+        let model_name = self
+            .state
+            .engine
+            .schema
+            .app
+            .model(model.id)
+            .name()
+            .upper_camel_case()
+            .to_string();
+
+        let col_expr = stmt::Expr::column(stmt::ExprColumn {
+            nesting: 0,
+            table: 0,
+            column: model_col_id.index,
+        });
+        let discriminator_cond = stmt::Expr::eq(col_expr, stmt::Value::String(model_name));
+
+        filter.add_filter(discriminator_cond);
+    }
 
     fn lower_expr_field(&self, nesting: usize, index: usize) -> stmt::Expr {
         match self.cx {

--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -1499,28 +1499,11 @@ impl<'a, 'b> LowerStatement<'a, 'b> {
         let Some(model) = self.model() else { return };
         let mapping = self.state.engine.schema.mapping_for(model);
 
-        let Some(model_col_id) = mapping.item_collection.model_column else {
+        let Some(_) = mapping.item_collection.model_column else {
             return;
         };
 
-        let model_name = self
-            .state
-            .engine
-            .schema
-            .app
-            .model(model.id)
-            .name()
-            .upper_camel_case()
-            .to_string();
-
-        let col_expr = stmt::Expr::column(stmt::ExprColumn {
-            nesting: 0,
-            table: 0,
-            column: model_col_id.index,
-        });
-        let discriminator_cond = stmt::Expr::eq(col_expr, stmt::Value::String(model_name));
-
-        filter.add_filter(discriminator_cond);
+        filter.add_filter(stmt::Expr::is_model(model.id));
     }
 
     fn lower_expr_field(&self, nesting: usize, index: usize) -> stmt::Expr {

--- a/crates/toasty/src/engine/plan/nested_merge.rs
+++ b/crates/toasty/src/engine/plan/nested_merge.rs
@@ -384,6 +384,12 @@ impl NestedMergePlanner<'_> {
                 let index = selection.get_index_of_expr_reference(*expr_reference);
                 *expr = stmt::Expr::arg_project(depth, [index]);
             }
+            stmt::Expr::IsModel(_) => {
+                // The discriminator was already enforced by the storage driver
+                // when these child rows were loaded; in-memory qualification has
+                // no column to evaluate against.
+                *expr = stmt::Expr::Value(stmt::Value::Bool(true));
+            }
             _ => {}
         });
 

--- a/examples/item-collection/Cargo.toml
+++ b/examples/item-collection/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "example-item-collection"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+publish = false
+
+[features]
+default = [ "dynamodb" ]
+dynamodb = [ "toasty/dynamodb" ]
+postgresql = [ "toasty/postgresql" ]
+sqlite = [ "toasty/sqlite" ]
+
+[dependencies]
+toasty.workspace = true
+tokio.workspace = true
+uuid.workspace = true
+
+[lints]
+workspace = true

--- a/examples/item-collection/src/main.rs
+++ b/examples/item-collection/src/main.rs
@@ -146,9 +146,9 @@ async fn populate_users(db: &mut Db, tenant: &Tenant) -> Result<Vec<User>> {
             name: name,
         }));
     }
-    Ok(builder.exec(db).await?)
+    builder.exec(db).await
 }
-async fn populate_todos(db: &mut Db, user: &User) -> Result<()> {
+async fn populate_todos(db: &mut Db, user: &User) -> Result<Vec<Todo>> {
     let mut many = Todo::create_many();
     for i in 0..10 {
         many = many.item(toasty::create!(in user.todos() {
@@ -156,6 +156,5 @@ async fn populate_todos(db: &mut Db, user: &User) -> Result<()> {
             title: format!("Todo {} for {}", i, user.name)
         }))
     }
-    many.exec(db).await?;
-    Ok(())
+    many.exec(db).await
 }

--- a/examples/item-collection/src/main.rs
+++ b/examples/item-collection/src/main.rs
@@ -1,0 +1,161 @@
+//! Three-level item collection: Tenant -> User -> Todo.
+//!
+//! All three models share a single DynamoDB table. The partition key is
+//! `tenant_id`; the sort key is composed by the driver from `__model` plus
+//! each model's own local PK fields:
+//!
+//!   Tenant row: __sk = "Tenant#"
+//!   User row:   __sk = "User#<user_id>#"
+//!   Todo row:   __sk = "Todo#<user_id>#<todo_id>#"
+//!
+//! Querying `tenant.users()` becomes `begins_with(__sk, "User#")` and
+//! `user.todos()` becomes `begins_with(__sk, "Todo#<user_id>#")` — both
+//! single-partition queries with no scan.
+//! Assuming local DDB is running on port 8080:
+//! ```bash
+//!  AWS_ENDPOINT_URL_DYNAMODB=http://localhost:8000 \
+//!   AWS_ACCESS_KEY_ID=test \
+//!   AWS_SECRET_ACCESS_KEY=test \
+//!   AWS_REGION=us-east-1 \
+//!   TOASTY_CONNECTION_URL="dynamodb://us-east-1" \
+//!   cargo run -p example-item-collection
+//! ```
+
+use toasty::Db;
+use toasty::Result;
+use uuid::Uuid;
+
+#[derive(Debug, toasty::Model)]
+struct Tenant {
+    #[key]
+    #[auto]
+    id: uuid::Uuid,
+
+    name: String,
+
+    #[has_many]
+    users: toasty::HasMany<User>,
+}
+
+#[derive(Debug, toasty::Model)]
+#[item_collection(Tenant)]
+#[key(partition = tenant_id, local = id)]
+struct User {
+    id: String,
+
+    tenant_id: uuid::Uuid,
+
+    #[belongs_to(key = tenant_id, references = id)]
+    tenant: toasty::BelongsTo<Tenant>,
+
+    name: String,
+
+    #[has_many]
+    todos: toasty::HasMany<Todo>,
+}
+
+#[derive(Debug, toasty::Model)]
+#[item_collection(User)]
+#[key(partition = tenant_id, local = [user_id, id])]
+#[index(tenant_id, user_id)]
+struct Todo {
+    id: uuid::Uuid,
+
+    tenant_id: uuid::Uuid,
+    user_id: String,
+
+    #[belongs_to(key = [tenant_id, user_id], references = [tenant_id, id])]
+    user: toasty::BelongsTo<User>,
+
+    title: String,
+}
+
+#[tokio::main]
+async fn main() -> toasty::Result<()> {
+    let mut db = toasty::Db::builder()
+        // Order matters: each child model's table mapping is resolved against
+        // its parent's, so parents must be registered first.
+        .models(toasty::models!(Tenant, User, Todo))
+        .connect(
+            std::env::var("TOASTY_CONNECTION_URL")
+                .as_deref()
+                .unwrap_or("sqlite::memory:"),
+        )
+        .await?;
+
+    db.push_schema().await?;
+
+    let acme = toasty::create!(Tenant { name: "Acme" })
+        .exec(&mut db)
+        .await?;
+
+    println!("created tenant; name={:?}", acme.name);
+
+    let alice =
+        toasty::create!(in acme.users() { name: "Alice", id: format!("{}", Uuid::new_v4()),})
+            .exec(&mut db)
+            .await?;
+    let bob = toasty::create!(in acme.users() { name: "Bob", id: format!("{}", Uuid::new_v4()) })
+        .exec(&mut db)
+        .await?;
+
+    // tier 2 create_many
+    let _users = populate_users(&mut db, &acme).await?;
+
+    println!("created users; alice={:?}, bob={:?}", alice.name, bob.name);
+
+    // Scoped query: every user under Acme.
+    // For DynamoDB this is a single Query with `begins_with(__sk, "User#")`.
+    println!("====================");
+    println!("--- ACME USERS ---");
+    println!("====================");
+
+    let users = acme.users().exec(&mut db).await?;
+    for user in users {
+        println!("USER name={:?}, id={}", user.name, user.id);
+    }
+
+    populate_todos(&mut db, &alice).await?;
+    populate_todos(&mut db, &bob).await?;
+
+    println!("================");
+    println!("--- Alice's todos -----");
+    println!("================");
+    // The schema build, table layout, and __sk encoding for Todo are all
+    // already in place — see the table inspection below.
+    // -------------------------------------------------------------------
+
+    let mut users = User::filter_by_tenant_id(acme.id)
+        .filter_by_id(&alice.id)
+        .include(User::fields().todos())
+        .exec(&mut db)
+        .await?;
+    let from_db = users.pop().expect("Should have found a user");
+    assert_eq!(10, from_db.todos.get().len());
+    for t in from_db.todos.get() {
+        println!("Todo ID={:?}, TITLE: {}", t.id, t.title);
+    }
+    Ok(())
+}
+
+async fn populate_users(db: &mut Db, tenant: &Tenant) -> Result<Vec<User>> {
+    let mut builder = User::create_many();
+    for name in ["Carol", "Eric", "Frank"] {
+        builder = builder.item(toasty::create!(in tenant.users() {
+            id: format!("{}", Uuid::new_v4()),
+            name: name,
+        }));
+    }
+    Ok(builder.exec(db).await?)
+}
+async fn populate_todos(db: &mut Db, user: &User) -> Result<()> {
+    let mut many = Todo::create_many();
+    for i in 0..10 {
+        many = many.item(toasty::create!(in user.todos() {
+            id:  Uuid::new_v4(),
+            title: format!("Todo {} for {}", i, user.name)
+        }))
+    }
+    many.exec(db).await?;
+    Ok(())
+}

--- a/examples/item-collection/src/main.rs
+++ b/examples/item-collection/src/main.rs
@@ -34,7 +34,7 @@ struct Tenant {
     name: String,
 
     #[has_many]
-    users: toasty::HasMany<User>,
+    users: toasty::Deferred<Vec<User>>,
 }
 
 #[derive(Debug, toasty::Model)]
@@ -46,12 +46,12 @@ struct User {
     tenant_id: uuid::Uuid,
 
     #[belongs_to(key = tenant_id, references = id)]
-    tenant: toasty::BelongsTo<Tenant>,
+    tenant: toasty::Deferred<Tenant>,
 
     name: String,
 
     #[has_many]
-    todos: toasty::HasMany<Todo>,
+    todos: toasty::Deferred<Vec<Todo>>,
 }
 
 #[derive(Debug, toasty::Model)]
@@ -65,7 +65,7 @@ struct Todo {
     user_id: String,
 
     #[belongs_to(key = [tenant_id, user_id], references = [tenant_id, id])]
-    user: toasty::BelongsTo<User>,
+    user: toasty::Deferred<User>,
 
     title: String,
 }

--- a/tests/tests/mysql.rs
+++ b/tests/tests/mysql.rs
@@ -45,6 +45,7 @@ impl toasty_driver_integration_suite::Setup for MySqlSetup {
 
 // Generate all driver tests
 toasty_driver_integration_suite::generate_driver_tests!(MySqlSetup::new(),
+    native_starts_with: false,
     decimal_arbitrary_precision: false,
     native_ilike: false,
     native_array: false,

--- a/tests/tests/sqlite.rs
+++ b/tests/tests/sqlite.rs
@@ -22,6 +22,7 @@ impl toasty_driver_integration_suite::Setup for SqliteSetup {
 // Generate all driver tests
 toasty_driver_integration_suite::generate_driver_tests!(
     SqliteSetup::new(),
+    native_starts_with: false,
     native_decimal: false,
     bigdecimal_implemented: false,
     decimal_arbitrary_precision: false,


### PR DESCRIPTION
<!--
PR title uses Conventional Commits, e.g.
    feat: add upsert support
    fix: handle composite key in IN-list rewrite
See CONTRIBUTING.md for the full process.
-->

## Summary
First revision for DynamoDB Single Table Support

This change adds the item_collection attribute that enables multiple toasty::Models to be stored in a single DynamoDB table under a parent's partition key. 

This first draft is only for DynamoDB. 
`examples/item-collection/src/main.rs` shows how to create and query items from a single table. 

All user facing APIs should be supported. 
Delete is currently not atomic. Deletes use the current behavior of belongs_to/has_many. Children will be deleted one by one and not with a transaction. There will be follow up work to address delete specifically. 

This change does not address the feedback from the design PR. I wanted to get this out for review, then I'll address the design comments and update this PR as necessary. 

<!-- What does this change and why? Link the issue it closes. -->
Draft implementation of PR #869 

## Type of change

<!-- Check one. -->

- [ ] Small / obvious change — bug fix, docs, internal cleanup, or test
- [x] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`):
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers

<!-- Anything reviewers should focus on. -->
