### PR TITLE
fix(dynamodb): omit empty ExpressionAttributeValues on IS NULL / IS NOT NULL scans

### DIFF
--- a/crates/toasty-driver-dynamodb/src/op/find_pk_by_index.rs
+++ b/crates/toasty-driver-dynamodb/src/op/find_pk_by_index.rs
@@ -23,8 +23,12 @@ impl Connection {
                 .query()
                 .table_name(&index.name)
                 .key_condition_expression(key_expression)
-                .set_expression_attribute_names(Some(expr_attrs.attr_names))
-                .set_expression_attribute_values(Some(expr_attrs.attr_values))
+                .set_expression_attribute_names(
+                    (!expr_attrs.attr_names.is_empty()).then_some(expr_attrs.attr_names),
+                )
+                .set_expression_attribute_values(
+                    (!expr_attrs.attr_values.is_empty()).then_some(expr_attrs.attr_values),
+                )
                 .send()
                 .await
                 .map_err(toasty_core::Error::driver_operation_failed)?
@@ -35,8 +39,12 @@ impl Connection {
                 .table_name(&table.name)
                 .index_name(&index.name)
                 .key_condition_expression(key_expression)
-                .set_expression_attribute_names(Some(expr_attrs.attr_names))
-                .set_expression_attribute_values(Some(expr_attrs.attr_values))
+                .set_expression_attribute_names(
+                    (!expr_attrs.attr_names.is_empty()).then_some(expr_attrs.attr_names),
+                )
+                .set_expression_attribute_values(
+                    (!expr_attrs.attr_values.is_empty()).then_some(expr_attrs.attr_values),
+                )
                 .send()
                 .await
                 .map_err(toasty_core::Error::driver_operation_failed)?

--- a/crates/toasty-driver-dynamodb/src/op/scan.rs
+++ b/crates/toasty-driver-dynamodb/src/op/scan.rs
@@ -32,8 +32,12 @@ impl Connection {
             .scan()
             .table_name(&table.name)
             .set_filter_expression(filter_expression)
-            .set_expression_attribute_names(Some(expr_attrs.attr_names))
-            .set_expression_attribute_values(Some(expr_attrs.attr_values));
+            .set_expression_attribute_names(
+                (!expr_attrs.attr_names.is_empty()).then_some(expr_attrs.attr_names),
+            )
+            .set_expression_attribute_values(
+                (!expr_attrs.attr_values.is_empty()).then_some(expr_attrs.attr_values),
+            );
 
         let table_id = op.table;
         let col_indices = op.columns;

--- a/crates/toasty-driver-integration-suite/src/tests/crud_option_filter.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/crud_option_filter.rs
@@ -1,13 +1,8 @@
 //! Test filtering models by Option fields using is_some() and is_none().
-//!
-//! Gated on `requires(sql)` until [#854] is fixed — `IS NULL` / `IS NOT NULL`
-//! currently fail on DynamoDB scan with an empty `ExpressionAttributeValues`.
-//!
-//! [#854]: https://github.com/tokio-rs/toasty/issues/854
 
 use crate::prelude::*;
 
-#[driver_test(id(ID), requires(sql))]
+#[driver_test(id(ID), requires(scan))]
 pub async fn filter_option_is_none(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     struct User {
@@ -48,7 +43,7 @@ pub async fn filter_option_is_none(test: &mut Test) -> Result<()> {
     Ok(())
 }
 
-#[driver_test(id(ID), requires(sql))]
+#[driver_test(id(ID), requires(scan))]
 pub async fn filter_option_is_some(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     struct User {
@@ -91,7 +86,7 @@ pub async fn filter_option_is_some(test: &mut Test) -> Result<()> {
     Ok(())
 }
 
-#[driver_test(id(ID), requires(sql))]
+#[driver_test(id(ID), requires(scan))]
 pub async fn filter_option_combined_with_other_filters(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     struct User {
@@ -156,7 +151,7 @@ pub async fn filter_option_combined_with_other_filters(test: &mut Test) -> Resul
     Ok(())
 }
 
-#[driver_test(id(ID), requires(sql))]
+#[driver_test(id(ID), requires(scan))]
 pub async fn filter_option_multiple_nullable_fields(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     struct Article {
@@ -325,7 +320,7 @@ pub async fn filter_option_with_partition_key(test: &mut Test) -> Result<()> {
 /// `is_none()` on an `Option<ID>` field panics because the lowering phase
 /// does not strip the `ExprCast` wrapper from the column expression inside
 /// `IsNull`. The cast leaks into the SQL serializer which does not handle it.
-#[driver_test(id(ID), requires(sql))]
+#[driver_test(id(ID), requires(scan))]
 pub async fn filter_option_id_is_none(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     struct Player {


### PR DESCRIPTION
## Summary

Fixes `IS NULL` / `IS NOT NULL` scan filters on DynamoDB. Filtering by `is_none()` or `is_some()` on a non-indexed field produced:

```
ValidationException: ExpressionAttributeValues must not be empty
```

The DynamoDB equivalents — `attribute_not_exists(path)` and `attribute_exists(path)` — are pure function calls with no placeholdervalues. When the filter contained only these predicates, `attr_values` stayed empty. The driver passed `Some(empty_map)` unconditionally; DynamoDB rejects that.

Guard `ExpressionAttributeNames` and `ExpressionAttributeValues` with `.then_some()` so they are only sent when non-empty. Applied in `exec_scan` and both branches of `exec_find_pk_by_index`. The five tests in `crud_option_filter` gated on `requires(sql)` to avoid this panic are flipped to `requires(scan)`.

Closes #854

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [ ] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [ ] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers

`attr_names` is guarded for the same reason as `attr_values`: an `IS NULL`-only filter populates `attr_names` (the column alias `#col_0`) but adds nothing to `attr_values`, and a request with an empty values map still triggers the error even when names are present.
