### PR TITLE
feat: expose migration core from toasty

### DIFF
--- a/crates/toasty-cli/Cargo.toml
+++ b/crates/toasty-cli/Cargo.toml
@@ -14,9 +14,7 @@ readme.workspace = true
 documentation = "https://docs.rs/toasty-cli"
 
 [dependencies]
-toasty.workspace = true
-toasty-core = { workspace = true, features = ["serde"] }
-toasty-sql.workspace = true
+toasty = { workspace = true, features = ["migration"] }
 
 anyhow = "1.0.102"
 clap.workspace = true
@@ -27,7 +25,6 @@ jiff.workspace = true
 rand.workspace = true
 serde.workspace = true
 toml.workspace = true
-toml_edit = { workspace = true, features = ["serde"] }
 url.workspace = true
 
 [dev-dependencies]

--- a/crates/toasty-cli/src/lib.rs
+++ b/crates/toasty-cli/src/lib.rs
@@ -6,9 +6,9 @@
 //! apply, drop, reset, snapshot). It uses [clap] for argument parsing and
 //! [dialoguer] for interactive prompts.
 //!
-//! The crate also exposes the underlying configuration and file types so that
-//! custom tooling can read and manipulate migration history and snapshots
-//! directly.
+//! The crate also exposes the underlying configuration used by the command
+//! runner. Reusable migration history, snapshot, and generation types live in
+//! [`toasty::migration`].
 //!
 //! # Main types
 //!
@@ -19,7 +19,8 @@
 //!   programmatically.
 //! - [`toasty::migration::History`] / [`toasty::migration::HistoryEntry`] —
 //!   read and write the TOML history that tracks which migrations exist.
-//! - [`SnapshotFile`] — read and write schema snapshot TOML files.
+//! - [`toasty::migration::Snapshot`] — read and write schema snapshot TOML
+//!   files.
 //!
 //! # Examples
 //!
@@ -39,7 +40,7 @@ mod utility;
 pub use config::Config;
 pub use migration::{
     ApplyCommand, DropCommand, GenerateCommand, MigrationCommand, MigrationConfig,
-    MigrationPrefixStyle, ResetCommand, SnapshotCommand, SnapshotFile,
+    MigrationPrefixStyle, ResetCommand, SnapshotCommand,
 };
 
 use anyhow::Result;

--- a/crates/toasty-cli/src/migration.rs
+++ b/crates/toasty-cli/src/migration.rs
@@ -4,7 +4,6 @@ mod drop;
 mod generate;
 mod reset;
 mod snapshot;
-mod snapshot_file;
 
 pub use apply::ApplyCommand;
 pub use config::{MigrationConfig, MigrationPrefixStyle};
@@ -12,7 +11,6 @@ pub use drop::DropCommand;
 pub use generate::GenerateCommand;
 pub use reset::ResetCommand;
 pub use snapshot::SnapshotCommand;
-pub use snapshot_file::SnapshotFile;
 
 use crate::Config;
 use anyhow::Result;

--- a/crates/toasty-cli/src/migration/generate.rs
+++ b/crates/toasty-cli/src/migration/generate.rs
@@ -1,4 +1,3 @@
-use super::SnapshotFile;
 use crate::{Config, theme::dialoguer_theme};
 use anyhow::Result;
 use clap::Parser;
@@ -7,7 +6,7 @@ use dialoguer::Select;
 use hashbrown::{HashMap, HashSet};
 use rand::RngExt;
 use std::fs;
-use toasty::migration::{History, HistoryEntry};
+use toasty::migration::{self, History, HistoryEntry, Snapshot};
 use toasty::{
     Db,
     schema::{
@@ -248,9 +247,7 @@ impl GenerateCommand {
         let previous_snapshot = history
             .entries()
             .last()
-            .map(|f| {
-                SnapshotFile::load(config.migration.get_snapshots_dir().join(&f.snapshot_name))
-            })
+            .map(|f| Snapshot::load(config.migration.get_snapshots_dir().join(&f.snapshot_name)))
             .transpose()?;
         let previous_schema = previous_snapshot
             .map(|snapshot| snapshot.schema)
@@ -259,9 +256,9 @@ impl GenerateCommand {
         let schema = toasty::schema::db::Schema::clone(&db.schema().db);
 
         let rename_hints = collect_rename_hints(&previous_schema, &schema)?;
-        let diff = diff::Schema::from(&previous_schema, &schema, &rename_hints);
-
-        if diff.is_empty() {
+        let Some(generated) =
+            migration::generate(db.driver(), &previous_schema, &schema, &rename_hints)
+        else {
             println!(
                 "  {}",
                 style("The current schema matches the previous snapshot. No migration needed.")
@@ -270,9 +267,8 @@ impl GenerateCommand {
             );
             println!();
             return Ok(());
-        }
+        };
 
-        let snapshot = SnapshotFile::new(schema.clone());
         let migration_prefix = match config.migration.prefix_style {
             crate::MigrationPrefixStyle::Sequential => {
                 format!("{:04}", history.next_migration_number())
@@ -291,8 +287,6 @@ impl GenerateCommand {
         );
         let migration_path = config.migration.get_migrations_dir().join(&migration_name);
 
-        let migration = db.driver().generate_migration(&diff);
-
         history.add_entry(HistoryEntry {
             // Some databases only supported signed 64-bit integers.
             id: rand::rng().random_range(0..i64::MAX) as u64,
@@ -301,6 +295,7 @@ impl GenerateCommand {
             checksum: None,
         });
 
+        let migration = generated.migration;
         let Migration::Sql(sql) = migration;
         std::fs::write(&migration_path, format!("{sql}\n"))?;
         println!(
@@ -309,7 +304,7 @@ impl GenerateCommand {
             style(format!("Created migration file: {}", migration_name)).dim()
         );
 
-        snapshot.save(&snapshot_path)?;
+        generated.snapshot.save(&snapshot_path)?;
         println!(
             "  {} {}",
             style("✓").green().bold(),

--- a/crates/toasty-cli/src/migration/snapshot.rs
+++ b/crates/toasty-cli/src/migration/snapshot.rs
@@ -1,14 +1,14 @@
-use super::SnapshotFile;
 use crate::Config;
 use anyhow::Result;
 use clap::Parser;
 use console::style;
 use toasty::Db;
+use toasty::migration::Snapshot;
 
 /// Prints the current schema as a TOML snapshot to stdout.
 ///
 /// Reads the schema registered on the [`Db`] and formats it as a
-/// [`SnapshotFile`]. Table headers, key-value pairs, and whitespace are
+/// [`Snapshot`]. Table headers, key-value pairs, and whitespace are
 /// syntax-highlighted for terminal display.
 #[derive(Parser, Debug)]
 pub struct SnapshotCommand {
@@ -24,10 +24,10 @@ impl SnapshotCommand {
         );
         println!();
 
-        let snapshot_file = SnapshotFile::new(toasty::schema::db::Schema::clone(&db.schema().db));
+        let snapshot = Snapshot::new(toasty::schema::db::Schema::clone(&db.schema().db));
 
         // Print the snapshot with nice formatting
-        let snapshot_str = snapshot_file.to_string();
+        let snapshot_str = snapshot.to_string();
         for line in snapshot_str.lines() {
             if line.starts_with('[') {
                 println!("  {}", style(line).yellow().bold());

--- a/crates/toasty-core/src/schema/db/migration.rs
+++ b/crates/toasty-core/src/schema/db/migration.rs
@@ -12,6 +12,7 @@
 /// let m = Migration::new_sql("CREATE TABLE users (id INTEGER PRIMARY KEY)".to_string());
 /// assert_eq!(m.statements(), vec!["CREATE TABLE users (id INTEGER PRIMARY KEY)"]);
 /// ```
+#[derive(Debug)]
 pub enum Migration {
     /// A SQL migration containing one or more statements.
     Sql(String),

--- a/crates/toasty/Cargo.toml
+++ b/crates/toasty/Cargo.toml
@@ -16,6 +16,7 @@ documentation = "https://docs.rs/toasty"
 [features]
 default = []
 dynamodb = ["dep:toasty-driver-dynamodb"]
+migration = ["dep:serde", "dep:toml", "dep:toml_edit", "toasty-core/serde"]
 mysql = ["dep:toasty-driver-mysql"]
 postgresql = ["dep:toasty-driver-postgresql"]
 sqlite = ["dep:toasty-driver-sqlite"]
@@ -66,9 +67,10 @@ uuid.workspace = true
 indexmap.workspace = true
 index_vec.workspace = true
 inventory.workspace = true
-serde = { workspace = true }
+serde = { workspace = true, optional = true }
 tokio.workspace = true
-toml.workspace = true
+toml = { workspace = true, optional = true }
+toml_edit = { workspace = true, features = ["serde"], optional = true }
 tracing.workspace = true
 url.workspace = true
 

--- a/crates/toasty/src/lib.rs
+++ b/crates/toasty/src/lib.rs
@@ -115,8 +115,8 @@ pub use db::{Connection, Db, Executor, Transaction, TransactionBuilder};
 
 mod engine;
 
-/// Schema migration types: history files, snapshots, and supporting
-/// configuration.
+/// Schema migration types: history files, snapshots, and generation helpers.
+#[cfg(feature = "migration")]
 pub mod migration;
 
 /// Model, relation, and schema inspection types.

--- a/crates/toasty/src/migration.rs
+++ b/crates/toasty/src/migration.rs
@@ -6,5 +6,10 @@
 //! in-memory representation of the TOML history file; each [`HistoryEntry`]
 //! records one generated migration.
 
+mod generate;
 mod history;
+mod snapshot;
+
+pub use generate::{Generated, generate};
 pub use history::{History, HistoryEntry};
+pub use snapshot::Snapshot;

--- a/crates/toasty/src/migration/generate.rs
+++ b/crates/toasty/src/migration/generate.rs
@@ -1,0 +1,42 @@
+use crate::{
+    db::Driver,
+    schema::{db, diff},
+};
+
+use super::Snapshot;
+
+/// A generated database migration and the schema snapshot it advances to.
+///
+/// This is the reusable core of migration generation. It deliberately does not
+/// include filenames, history IDs, or persistence decisions; callers own those
+/// policies.
+#[derive(Debug)]
+pub struct Generated {
+    /// The driver-specific migration statements.
+    pub migration: db::Migration,
+
+    /// Snapshot of the schema after the migration is applied.
+    pub snapshot: Snapshot,
+}
+
+/// Generate a database migration from `previous` to `next`.
+///
+/// Returns `None` when the schemas are equivalent after applying
+/// `rename_hints`.
+pub fn generate(
+    driver: &dyn Driver,
+    previous: &db::Schema,
+    next: &db::Schema,
+    rename_hints: &diff::RenameHints,
+) -> Option<Generated> {
+    let schema_diff = diff::Schema::from(previous, next, rename_hints);
+
+    if schema_diff.is_empty() {
+        return None;
+    }
+
+    Some(Generated {
+        migration: driver.generate_migration(&schema_diff),
+        snapshot: Snapshot::new(next.clone()),
+    })
+}

--- a/crates/toasty/src/migration/snapshot.rs
+++ b/crates/toasty/src/migration/snapshot.rs
@@ -1,95 +1,49 @@
+use crate::{Error, Result, schema::db::Schema};
 use serde::{Deserialize, Serialize};
-use std::fmt;
-use std::path::Path;
-use std::str::FromStr;
-use toasty::{Error, Result};
-use toasty_core::schema::db::Schema;
+use std::{fmt, path::Path, str::FromStr};
 use toml_edit::{DocumentMut, Item};
 
-const SNAPSHOT_FILE_VERSION: u32 = 1;
+const SNAPSHOT_VERSION: u32 = 1;
 
-/// A TOML-serializable snapshot of the database schema at a point in time.
+/// A TOML-serializable snapshot of a database schema.
 ///
-/// Each time a migration is generated, a corresponding snapshot is written
-/// alongside it. The next `generate` run loads the most recent snapshot to
-/// compute a diff against the current schema.
-///
-/// The file carries a version number. [`SnapshotFile::load`] and the
-/// [`FromStr`] implementation reject files whose version does not match the
-/// current format.
-///
-/// # Examples
-///
-/// ```
-/// use toasty_cli::SnapshotFile;
-/// use toasty_core::schema::db::Schema;
-///
-/// let snapshot = SnapshotFile::new(Schema::default());
-///
-/// // Serialize to TOML via the serde impl
-/// let toml_str = toml::to_string_pretty(&snapshot).unwrap();
-/// let restored: SnapshotFile = toml::from_str(&toml_str).unwrap();
-/// ```
+/// Snapshots capture the schema after a generated migration. The next
+/// generation compares the most recent snapshot against the current schema to
+/// build a diff.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SnapshotFile {
-    /// Snapshot file format version
+pub struct Snapshot {
+    /// Snapshot format version.
     version: u32,
 
-    /// The database schema
+    /// The database schema captured by this snapshot.
     pub schema: Schema,
 }
 
-impl SnapshotFile {
-    /// Create a new snapshot file with the given schema
+impl Snapshot {
+    /// Create a new snapshot for `schema`.
     pub fn new(schema: Schema) -> Self {
         Self {
-            version: SNAPSHOT_FILE_VERSION,
+            version: SNAPSHOT_VERSION,
             schema,
         }
     }
 
-    /// Load a snapshot file from a TOML file
+    /// Load a snapshot from a TOML file.
     pub fn load(path: impl AsRef<Path>) -> Result<Self> {
         let contents = std::fs::read_to_string(path.as_ref())?;
         contents.parse()
     }
 
-    /// Save the snapshot file to a TOML file
+    /// Save the snapshot to a TOML file.
     pub fn save(&self, path: impl AsRef<Path>) -> Result<()> {
         std::fs::write(path.as_ref(), self.to_string())?;
         Ok(())
     }
-}
 
-impl FromStr for SnapshotFile {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self> {
-        let file: SnapshotFile =
-            toml::from_str(s).map_err(|err| Error::from_args(format_args!("{err}")))?;
-
-        if file.version != SNAPSHOT_FILE_VERSION {
-            return Err(Error::from_args(format_args!(
-                "unsupported snapshot file version: {}. Expected version {}",
-                file.version, SNAPSHOT_FILE_VERSION
-            )));
-        }
-
-        Ok(file)
-    }
-}
-
-impl fmt::Display for SnapshotFile {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let doc = self.to_toml_document().map_err(|_| fmt::Error)?;
-        write!(f, "{}", doc)
-    }
-}
-
-impl SnapshotFile {
     fn to_toml_document(&self) -> Result<DocumentMut> {
         let mut doc = toml_edit::ser::to_document(self)
             .map_err(|err| Error::from_args(format_args!("{err}")))?;
+
         for (_key, item) in doc.as_table_mut().iter_mut() {
             if item.is_inline_table() {
                 let mut placeholder = Item::None;
@@ -122,5 +76,30 @@ impl SnapshotFile {
         }
 
         Ok(doc)
+    }
+}
+
+impl FromStr for Snapshot {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let snapshot: Snapshot =
+            toml::from_str(s).map_err(|err| Error::from_args(format_args!("{err}")))?;
+
+        if snapshot.version != SNAPSHOT_VERSION {
+            return Err(Error::from_args(format_args!(
+                "unsupported snapshot version: {}. Expected version {}",
+                snapshot.version, SNAPSHOT_VERSION
+            )));
+        }
+
+        Ok(snapshot)
+    }
+}
+
+impl fmt::Display for Snapshot {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let doc = self.to_toml_document().map_err(|_| fmt::Error)?;
+        write!(f, "{doc}")
     }
 }

--- a/crates/toasty/tests/migration_generate.rs
+++ b/crates/toasty/tests/migration_generate.rs
@@ -1,0 +1,65 @@
+#![cfg(feature = "migration")]
+
+use toasty::migration;
+use toasty::schema::{db, diff};
+use toasty_core::stmt;
+use toasty_driver_sqlite::Sqlite;
+
+fn users_schema() -> db::Schema {
+    let table_id = db::TableId(0);
+    let id = db::ColumnId {
+        table: table_id,
+        index: 0,
+    };
+
+    db::Schema {
+        tables: vec![db::Table {
+            id: table_id,
+            name: "users".to_string(),
+            columns: vec![db::Column {
+                id,
+                name: "id".to_string(),
+                ty: stmt::Type::I64,
+                storage_ty: db::Type::Integer(8),
+                nullable: false,
+                primary_key: true,
+                auto_increment: false,
+                versionable: false,
+            }],
+            primary_key: db::PrimaryKey {
+                columns: vec![id],
+                index: db::IndexId {
+                    table: table_id,
+                    index: 0,
+                },
+            },
+            indices: vec![],
+        }],
+    }
+}
+
+#[test]
+fn generate_returns_none_for_empty_diff() {
+    let schema = users_schema();
+    let hints = diff::RenameHints::new();
+    let driver = Sqlite::in_memory();
+
+    let generated = migration::generate(&driver, &schema, &schema, &hints);
+
+    assert!(generated.is_none());
+}
+
+#[test]
+fn generate_returns_migration_and_next_snapshot() {
+    let previous = db::Schema::default();
+    let next = users_schema();
+    let hints = diff::RenameHints::new();
+    let driver = Sqlite::in_memory();
+
+    let generated = migration::generate(&driver, &previous, &next, &hints).unwrap();
+
+    assert_eq!(generated.snapshot.schema.tables[0].name, "users");
+    let db::Migration::Sql(sql) = generated.migration;
+    assert!(sql.contains("CREATE TABLE"));
+    assert!(sql.contains("users"));
+}


### PR DESCRIPTION
## Summary

Move the reusable migration snapshot and generation pieces from `toasty-cli` into `toasty::migration` so non-CLI callers can build migrations as a library API.

The migration module is behind the non-default `migration` feature. `toasty-cli` opts into that feature and stays responsible for paths, terminal output, prompts, migration IDs, and file writes.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] `cargo fmt` and `cargo clippy` are clean
- [ ] `cargo test` passes
- [ ] Touches a public API → a design doc under `docs/dev/design/` describes the behavior

## Notes for reviewers

Validated with:

- `cargo fmt`
- `cargo check -p toasty`
- `cargo check -p toasty-cli`
- `cargo test -p toasty --features migration --test migration_generate`
- `cargo check -p toasty --all-features`

I did not run full workspace tests or `cargo clippy`. The public API is a narrow extraction of existing migration behavior behind a non-default feature; no design doc is included in this branch.