### PR TITLE
test(turso): set native_ilike capability and drop unused mut

### DIFF
--- a/tests/tests/turso.rs
+++ b/tests/tests/turso.rs
@@ -33,6 +33,7 @@ toasty_driver_integration_suite::generate_driver_tests!(
     native_time: false,
     native_datetime: false,
     native_array: false,
+    native_ilike: false,
     vec_scalar: true,
     vec_remove: false,
     vec_pop: false,
@@ -194,7 +195,7 @@ async fn immediate_mode_overrides_begin_concurrent() {
         tally: i64,
     }
 
-    let mut db = toasty::Db::builder()
+    let db = toasty::Db::builder()
         .models(toasty::models!(Counter))
         .max_pool_size(4)
         .build(Turso::in_memory().concurrent_writes())
@@ -243,7 +244,7 @@ async fn immediate_mode_overrides_begin_concurrent() {
 /// exclusion is what the test pins down.)
 #[tokio::test]
 async fn exclusive_mode_overrides_begin_concurrent() {
-    let mut db = toasty::Db::builder()
+    let db = toasty::Db::builder()
         .models(toasty::models!())
         .max_pool_size(4)
         .build(Turso::in_memory().concurrent_writes())


### PR DESCRIPTION
## Summary

`cargo test -p tests --all-features --test turso` failed on five tests
(`validate_driver_capabilities` and four `filter_ilike::*`). The
driver-test macro defaults every capability to `true`, so omitting
`native_ilike` made the suite expect Turso to support ILIKE — but Turso
inherits `Capability::SQLITE`, where `native_ilike` is `false`. Declare
it explicitly, matching the sqlite/mysql/dynamodb test setups.

Also drops two unnecessary `mut db` bindings that produced
`unused_mut` warnings.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes