### PR TITLE
refactor: split relation field traits from targets

### DIFF
--- a/crates/toasty-macros/src/model/expand.rs
+++ b/crates/toasty-macros/src/model/expand.rs
@@ -407,10 +407,11 @@ impl Expand<'_> {
     }
 
     /// Generates a field accessor method for a `BelongsTo` or `HasOne`
-    /// relation using `Relation::OneField`.
+    /// relation using the target's `Relation::OneField`.
     fn expand_one_relation_field_method(
         &self,
         field_ident: &syn::Ident,
+        field_trait: TokenStream,
         ty: &syn::Type,
         field_offset: &TokenStream,
     ) -> TokenStream {
@@ -420,8 +421,8 @@ impl Expand<'_> {
         let span = field_ident.span();
 
         quote_spanned! { span=>
-            #vis fn #field_ident(&self) -> <#ty as #toasty::Relation>::OneField<__Origin> {
-                <#ty as #toasty::Relation>::OneField::from_path(
+            #vis fn #field_ident(&self) -> <<#ty as #field_trait>::Target as #toasty::Relation>::OneField<__Origin> {
+                <<#ty as #field_trait>::Target as #toasty::Relation>::OneField::from_path(
                     self.path().chain(
                         #toasty::Path::<#model_ident, _>::from_field_index(#field_offset)
                     )

--- a/crates/toasty-macros/src/model/expand/create.rs
+++ b/crates/toasty-macros/src/model/expand/create.rs
@@ -143,9 +143,10 @@ impl Expand<'_> {
                 match &field.ty {
                     FieldTy::BelongsTo(rel) => {
                         let ty = &rel.ty;
+                        let target = quote!(<#ty as #toasty::BelongsToField>::Target);
 
                         quote! {
-                            #vis fn #name(mut self, #name: impl #toasty::IntoExpr<<#ty as #toasty::Relation>::Expr>) -> Self {
+                            #vis fn #name(mut self, #name: impl #toasty::IntoExpr<<#target as #toasty::Relation>::Expr>) -> Self {
                                 // Silences unused field warning when the field is set on creation.
                                 if false {
                                     let m = <#model_ident as #toasty::Load>::load(Default::default()).unwrap();
@@ -161,14 +162,15 @@ impl Expand<'_> {
                         let singular = &rel.singular.ident;
                         let plural = name;
                         let ty = &rel.ty;
+                        let target = quote!(<#ty as #toasty::HasManyField>::Target);
 
                         quote! {
-                            #vis fn #singular(mut self, #singular: impl #toasty::IntoExpr<<#ty as #toasty::Relation>::Expr>) -> Self {
+                            #vis fn #singular(mut self, #singular: impl #toasty::IntoExpr<<#target as #toasty::Relation>::Expr>) -> Self {
                                 self.stmt.insert(#index_tokenized, #singular.into_expr());
                                 self
                             }
 
-                            #vis fn #plural(mut self, #plural: impl #toasty::IntoExpr<#toasty::List<<#ty as #toasty::Relation>::Model>>) -> Self {
+                            #vis fn #plural(mut self, #plural: impl #toasty::IntoExpr<#toasty::List<<#target as #toasty::Relation>::Model>>) -> Self {
                                 self.stmt.insert_all(#index_tokenized, #plural.into_expr());
                                 self
                             }
@@ -176,9 +178,10 @@ impl Expand<'_> {
                     }
                     FieldTy::HasOne(rel) => {
                         let ty = &rel.ty;
+                        let target = quote!(<#ty as #toasty::HasOneField>::Target);
 
                         quote! {
-                            #vis fn #name(mut self, #name: impl #toasty::IntoExpr<<#ty as #toasty::Relation>::Expr>) -> Self {
+                            #vis fn #name(mut self, #name: impl #toasty::IntoExpr<<#target as #toasty::Relation>::Expr>) -> Self {
                                 self.stmt.set(#index_tokenized, #name.into_expr());
                                 self
                             }

--- a/crates/toasty-macros/src/model/expand/fields.rs
+++ b/crates/toasty-macros/src/model/expand/fields.rs
@@ -73,10 +73,20 @@ impl Expand<'_> {
                         self.expand_primitive_field_method(field_ident, ty, &field_offset)
                     }
                     BelongsTo(rel) => {
-                        self.expand_one_relation_field_method(field_ident, &rel.ty, &field_offset)
+                        self.expand_one_relation_field_method(
+                            field_ident,
+                            quote!(#toasty::BelongsToField),
+                            &rel.ty,
+                            &field_offset,
+                        )
                     }
                     HasOne(rel) => {
-                        self.expand_one_relation_field_method(field_ident, &rel.ty, &field_offset)
+                        self.expand_one_relation_field_method(
+                            field_ident,
+                            quote!(#toasty::HasOneField),
+                            &rel.ty,
+                            &field_offset,
+                        )
                     }
                     HasMany(rel) => {
                         let ty = &rel.ty;
@@ -86,8 +96,8 @@ impl Expand<'_> {
                         };
 
                         quote_spanned! { span=>
-                            #vis fn #field_ident(&self) -> <#ty as #toasty::Relation>::ManyField<__Origin> {
-                                <#ty as #toasty::Relation>::ManyField::from_path(#path)
+                            #vis fn #field_ident(&self) -> <<#ty as #toasty::HasManyField>::Target as #toasty::Relation>::ManyField<__Origin> {
+                                <<#ty as #toasty::HasManyField>::Target as #toasty::Relation>::ManyField::from_path(#path)
                             }
                         }
                     }
@@ -175,15 +185,30 @@ impl Expand<'_> {
                     // All relations from a list context return the list variant
                     BelongsTo(rel) => {
                         let ty = &rel.ty;
-                        self.expand_list_relation_field_method(field_ident, ty, &field_offset)
+                        self.expand_list_relation_field_method(
+                            field_ident,
+                            quote!(#toasty::BelongsToField),
+                            ty,
+                            &field_offset,
+                        )
                     }
                     HasOne(rel) => {
                         let ty = &rel.ty;
-                        self.expand_list_relation_field_method(field_ident, ty, &field_offset)
+                        self.expand_list_relation_field_method(
+                            field_ident,
+                            quote!(#toasty::HasOneField),
+                            ty,
+                            &field_offset,
+                        )
                     }
                     HasMany(rel) => {
                         let ty = &rel.ty;
-                        self.expand_list_relation_field_method(field_ident, ty, &field_offset)
+                        self.expand_list_relation_field_method(
+                            field_ident,
+                            quote!(#toasty::HasManyField),
+                            ty,
+                            &field_offset,
+                        )
                     }
                 }
             });
@@ -358,6 +383,7 @@ impl Expand<'_> {
     fn expand_list_relation_field_method(
         &self,
         field_ident: &syn::Ident,
+        field_trait: TokenStream,
         ty: &syn::Type,
         field_offset: &TokenStream,
     ) -> TokenStream {
@@ -367,8 +393,8 @@ impl Expand<'_> {
         let span = field_ident.span();
 
         quote_spanned! { span=>
-            #vis fn #field_ident(&self) -> <#ty as #toasty::Relation>::ManyField<__Origin> {
-                <#ty as #toasty::Relation>::ManyField::from_path(
+            #vis fn #field_ident(&self) -> <<#ty as #field_trait>::Target as #toasty::Relation>::ManyField<__Origin> {
+                <<#ty as #field_trait>::Target as #toasty::Relation>::ManyField::from_path(
                     self.path().chain(
                         #toasty::Path::<#model_ident, _>::from_field_index(#field_offset)
                     )

--- a/crates/toasty-macros/src/model/expand/query.rs
+++ b/crates/toasty-macros/src/model/expand/query.rs
@@ -161,7 +161,8 @@ impl Expand<'_> {
     fn expand_belongs_to_method(&self, field: &Field, rel: &BelongsTo) -> TokenStream {
         let toasty = &self.toasty;
         let vis = &self.model.vis;
-        let target = &rel.ty;
+        let ty = &rel.ty;
+        let target = quote!(<#ty as #toasty::BelongsToField>::Target);
         let model_ident = &self.model.ident;
         let field_ident = &field.name.ident;
 
@@ -180,7 +181,8 @@ impl Expand<'_> {
     fn expand_has_many_method(&self, field: &Field, rel: &HasMany) -> TokenStream {
         let toasty = &self.toasty;
         let vis = &self.model.vis;
-        let target = &rel.ty;
+        let ty = &rel.ty;
+        let target = quote!(<#ty as #toasty::HasManyField>::Target);
         let model_ident = &self.model.ident;
         let field_ident = &field.name.ident;
 
@@ -199,7 +201,8 @@ impl Expand<'_> {
     fn expand_has_one_method(&self, field: &Field, rel: &HasOne) -> TokenStream {
         let toasty = &self.toasty;
         let vis = &self.model.vis;
-        let target = &rel.ty;
+        let ty = &rel.ty;
+        let target = quote!(<#ty as #toasty::HasOneField>::Target);
         let model_ident = &self.model.ident;
         let field_ident = &field.name.ident;
 

--- a/crates/toasty-macros/src/model/expand/relation.rs
+++ b/crates/toasty-macros/src/model/expand/relation.rs
@@ -4,6 +4,16 @@ use crate::model::schema::{BelongsTo, Field, FieldTy, HasMany, HasOne};
 use proc_macro2::TokenStream;
 use quote::quote;
 
+struct PairBelongsToCheck<'a> {
+    pair_ident: &'a syn::Ident,
+    field_ident: &'a syn::Ident,
+    ty: &'a syn::Type,
+    field_trait: TokenStream,
+    rel_span: proc_macro2::Span,
+    relation_kind: &'static str,
+    label: &'static str,
+}
+
 impl Expand<'_> {
     pub(super) fn expand_relation_structs(&self) -> TokenStream {
         let toasty = &self.toasty;
@@ -214,18 +224,18 @@ impl Expand<'_> {
             .fields
             .iter()
             .filter_map(|field| {
-                let ty = match &field.ty {
-                    FieldTy::BelongsTo(rel) => &rel.ty,
-                    FieldTy::HasMany(rel) => &rel.ty,
-                    FieldTy::HasOne(rel) => &rel.ty,
+                let (ty, field_trait) = match &field.ty {
+                    FieldTy::BelongsTo(rel) => (&rel.ty, quote!(#toasty::BelongsToField)),
+                    FieldTy::HasMany(rel) => (&rel.ty, quote!(#toasty::HasManyField)),
+                    FieldTy::HasOne(rel) => (&rel.ty, quote!(#toasty::HasOneField)),
                     FieldTy::Primitive(_) => return None,
                 };
                 let field_ident = &field.name.ident;
                 let field_offset = util::int(field.id);
 
                 Some(quote! {
-                    #vis fn #field_ident(self) -> <#ty as #toasty::Relation>::Many {
-                        <#ty as #toasty::Relation>::Many::from_stmt(
+                    #vis fn #field_ident(self) -> <<#ty as #field_trait>::Target as #toasty::Relation>::Many {
+                        <<#ty as #field_trait>::Target as #toasty::Relation>::Many::from_stmt(
                             self.stmt.chain_field(#field_offset)
                         )
                     }
@@ -291,13 +301,14 @@ impl Expand<'_> {
         let vis = &self.model.vis;
         let field_ident = &field.name.ident;
         let ty = &rel.ty;
+        let target_ty = quote!(<#ty as #toasty::BelongsToField>::Target);
 
         let operands = rel.foreign_key.iter().map(|fk_field| {
             let source = &self.model.fields[fk_field.source];
             let source_field_ident = &source.name.ident;
-            let target = &fk_field.target;
+            let target_field = &fk_field.target;
 
-            // `fields().#target()` returns the target field's
+            // `fields().#target_field()` returns the target field's
             // `<Field>::Path<Origin>` — `Path<Origin, T>` for primitives and a
             // wrapping `{Embed}Fields<Origin>` for embedded types. Both
             // convert into `Path<Origin, T>` via `Into`, which is what
@@ -305,7 +316,7 @@ impl Expand<'_> {
             quote! {
                 #toasty::Field::key_constraint(
                     &self.#source_field_ident,
-                    <#ty as #toasty::Relation>::Model::fields().#target().into(),
+                    <#target_ty as #toasty::Relation>::Model::fields().#target_field().into(),
                 )
             }
         });
@@ -331,7 +342,7 @@ impl Expand<'_> {
         );
 
         quote! {
-            #vis fn #field_ident(&self) -> <#ty as #toasty::Relation>::One {
+            #vis fn #field_ident(&self) -> <#target_ty as #toasty::Relation>::One {
                 // Suppress the unused field warning
                 if false {
                     let _ = &self.#field_ident;
@@ -339,8 +350,8 @@ impl Expand<'_> {
 
                 {
                     use #toasty::IntoStatement;
-                    <#ty as #toasty::Relation>::One::from_stmt(
-                        <#ty as #toasty::Relation>::Model::filter(#filter).into_statement().into_query().unwrap()
+                    <#target_ty as #toasty::Relation>::One::from_stmt(
+                        <#target_ty as #toasty::Relation>::Model::filter(#filter).into_statement().into_query().unwrap()
                     )
                 }
             }
@@ -360,6 +371,7 @@ impl Expand<'_> {
         let vis = &self.model.vis;
         let field_ident = &field.name.ident;
         let ty = &rel.ty;
+        let target = quote!(<#ty as #toasty::HasManyField>::Target);
 
         // A `via` relation reaches its target through a path of existing
         // relations; it has no paired `BelongsTo`, so skip the back-reference
@@ -371,18 +383,19 @@ impl Expand<'_> {
                 &self.model.name.ident.to_string(),
                 rel.span,
             ));
-            self.expand_pair_belongs_to_check(
-                &pair_ident,
+            self.expand_pair_belongs_to_check(PairBelongsToCheck {
+                pair_ident: &pair_ident,
                 field_ident,
                 ty,
-                rel.span,
-                "HasMany",
-                "Has many associations require the target to include a back-reference",
-            )
+                field_trait: quote!(#toasty::HasManyField),
+                rel_span: rel.span,
+                relation_kind: "HasMany",
+                label: "Has many associations require the target to include a back-reference",
+            })
         };
 
         quote! {
-            #vis fn #field_ident(&self) -> <#ty as #toasty::Relation>::Many {
+            #vis fn #field_ident(&self) -> <#target as #toasty::Relation>::Many {
                 // Suppress the unused field warning
                 if false {
                     let _ = &self.#field_ident;
@@ -392,7 +405,7 @@ impl Expand<'_> {
 
                 {
                     use #toasty::IntoStatement;
-                    <#ty as #toasty::Relation>::Many::from_stmt(
+                    <#target as #toasty::Relation>::Many::from_stmt(
                         #toasty::stmt::Association::many(
                             self.into_statement().into_query().unwrap().to_list(),
                             Self::fields().#field_ident().into()
@@ -408,6 +421,7 @@ impl Expand<'_> {
         let vis = &self.model.vis;
         let field_ident = &field.name.ident;
         let ty = &rel.ty;
+        let target = quote!(<#ty as #toasty::HasOneField>::Target);
 
         // A `via` relation reaches its target through a path of existing
         // relations; it has no paired `BelongsTo`, so skip the back-reference
@@ -419,18 +433,19 @@ impl Expand<'_> {
                 &self.model.name.ident.to_string(),
                 rel.span,
             ));
-            self.expand_pair_belongs_to_check(
-                &pair_ident,
+            self.expand_pair_belongs_to_check(PairBelongsToCheck {
+                pair_ident: &pair_ident,
                 field_ident,
                 ty,
-                rel.span,
-                "HasOne",
-                "Has one associations require the target to include a back-reference",
-            )
+                field_trait: quote!(#toasty::HasOneField),
+                rel_span: rel.span,
+                relation_kind: "HasOne",
+                label: "Has one associations require the target to include a back-reference",
+            })
         };
 
         quote! {
-            #vis fn #field_ident(&self) -> <#ty as #toasty::Relation>::One {
+            #vis fn #field_ident(&self) -> <#target as #toasty::Relation>::One {
                 // Suppress the unused field warning
                 if false {
                     let _ = &self.#field_ident;
@@ -440,7 +455,7 @@ impl Expand<'_> {
 
                 {
                     use #toasty::IntoStatement;
-                    <#ty as #toasty::Relation>::One::from_stmt(
+                    <#target as #toasty::Relation>::One::from_stmt(
                         #toasty::stmt::Association::one(
                             self.into_statement().into_query().unwrap().to_list(),
                             Self::fields().#field_ident().into()
@@ -455,17 +470,18 @@ impl Expand<'_> {
     /// (or `BelongsTo<Option<Self>>`) field named `pair_ident`. Shared by the
     /// has-many and has-one accessor expansions; the relation kind ("HasMany"
     /// / "HasOne") and `label` are woven into the `on_unimplemented` diagnostic.
-    fn expand_pair_belongs_to_check(
-        &self,
-        pair_ident: &syn::Ident,
-        field_ident: &syn::Ident,
-        ty: &syn::Type,
-        rel_span: proc_macro2::Span,
-        relation_kind: &str,
-        label: &str,
-    ) -> TokenStream {
+    fn expand_pair_belongs_to_check(&self, check: PairBelongsToCheck<'_>) -> TokenStream {
         let toasty = &self.toasty;
         let model_ident = &self.model.ident;
+        let PairBelongsToCheck {
+            pair_ident,
+            field_ident,
+            ty,
+            field_trait,
+            rel_span,
+            relation_kind,
+            label,
+        } = check;
 
         let verify_pair_belongs_to_exists_for_field = syn::Ident::new(
             &format!("verify_pair_belongs_to_exists_for_{pair_ident}"),
@@ -507,8 +523,8 @@ impl Expand<'_> {
                 fn verify<#verify_t: Verify<#verify_a>, #verify_a>(_: &#verify_t) {
                 }
 
-                let instance = load::<<#ty as #toasty::Relation>::Model>();
-                verify::<_, <#ty as #toasty::Relation>::Model>(instance.#verify_pair_belongs_to_exists_for_field());
+                let instance = load::<<<#ty as #field_trait>::Target as #toasty::Relation>::Model>();
+                verify::<_, <<#ty as #field_trait>::Target as #toasty::Relation>::Model>(instance.#verify_pair_belongs_to_exists_for_field());
             }
         }
     }

--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -134,13 +134,16 @@ impl Expand<'_> {
                                     model: #model_ident::id(),
                                     index: #source,
                                 },
-                                target: <#ty as #toasty::Relation>::field_name_to_id(#target),
+                                target: {
+                                    type __RelationTarget = <#ty as #toasty::BelongsToField>::Target;
+                                    <__RelationTarget as #toasty::Relation>::field_name_to_id(#target)
+                                },
                             }
                         }
                     });
 
-                    nullable = quote!(<#ty as #toasty::Relation>::nullable());
-                    field_ty = quote!(<#ty as #toasty::Relation>::belongs_to_field_ty(
+                    nullable = quote!(<#ty as #toasty::BelongsToField>::nullable());
+                    field_ty = quote!(<#ty as #toasty::BelongsToField>::belongs_to_field_ty(
                         #toasty::core::schema::app::ForeignKey {
                             fields: vec![ #( #fk_fields ),* ],
                         },
@@ -149,19 +152,19 @@ impl Expand<'_> {
                 FieldTy::HasMany(rel) => {
                     let ty = &rel.ty;
                     let singular_name = expand_name(toasty, &rel.singular);
-                    let pair = expand_pair(toasty, ty, rel.pair.as_ref());
+                    let pair = expand_pair(toasty, quote!(#toasty::HasManyField), ty, rel.pair.as_ref());
                     let via = expand_via(toasty, model_ident, rel.via.as_ref());
 
-                    nullable = quote!(<#ty as #toasty::Relation>::nullable());
-                    field_ty = quote!(<#ty as #toasty::Relation>::has_many_field_ty(#singular_name, #pair, #via));
+                    nullable = quote!(<#ty as #toasty::HasManyField>::nullable());
+                    field_ty = quote!(<#ty as #toasty::HasManyField>::has_many_field_ty(#singular_name, #pair, #via));
                 }
                 FieldTy::HasOne(rel) => {
                     let ty = &rel.ty;
-                    let pair = expand_pair(toasty, ty, rel.pair.as_ref());
+                    let pair = expand_pair(toasty, quote!(#toasty::HasOneField), ty, rel.pair.as_ref());
                     let via = expand_via(toasty, model_ident, rel.via.as_ref());
 
-                    nullable = quote!(<#ty as #toasty::Relation>::nullable());
-                    field_ty = quote!(<#ty as #toasty::Relation>::has_one_field_ty(#pair, #via));
+                    nullable = quote!(<#ty as #toasty::HasOneField>::nullable());
+                    field_ty = quote!(<#ty as #toasty::HasOneField>::has_one_field_ty(#pair, #via));
                 }
             }
 
@@ -443,19 +446,28 @@ impl Expand<'_> {
                 FieldTy::BelongsTo(rel) => {
                     let ty = &rel.ty;
                     quote! {
-                        <<#ty as #toasty::Relation>::Model as #toasty::Register>::register(model_set);
+                        {
+                            type __RelationTarget = <#ty as #toasty::BelongsToField>::Target;
+                            <<__RelationTarget as #toasty::Relation>::Model as #toasty::Register>::register(model_set);
+                        }
                     }
                 }
                 FieldTy::HasMany(rel) => {
                     let ty = &rel.ty;
                     quote! {
-                        <<#ty as #toasty::Relation>::Model as #toasty::Register>::register(model_set);
+                        {
+                            type __RelationTarget = <#ty as #toasty::HasManyField>::Target;
+                            <<__RelationTarget as #toasty::Relation>::Model as #toasty::Register>::register(model_set);
+                        }
                     }
                 }
                 FieldTy::HasOne(rel) => {
                     let ty = &rel.ty;
                     quote! {
-                        <<#ty as #toasty::Relation>::Model as #toasty::Register>::register(model_set);
+                        {
+                            type __RelationTarget = <#ty as #toasty::HasOneField>::Target;
+                            <<__RelationTarget as #toasty::Relation>::Model as #toasty::Register>::register(model_set);
+                        }
                     }
                 }
             })
@@ -478,13 +490,19 @@ pub(super) fn expand_name(toasty: &TokenStream, name: &Name) -> TokenStream {
 
 fn expand_pair(
     toasty: &TokenStream,
+    field_trait: TokenStream,
     target_ty: &syn::Type,
     pair: Option<&syn::Ident>,
 ) -> TokenStream {
     match pair {
         Some(ident) => {
             let name = ident.to_string();
-            quote! { Some(<#target_ty as #toasty::Relation>::field_name_to_id(#name)) }
+            quote! {
+                Some({
+                    type __RelationTarget = <#target_ty as #field_trait>::Target;
+                    <__RelationTarget as #toasty::Relation>::field_name_to_id(#name)
+                })
+            }
         }
         None => quote! { None },
     }

--- a/crates/toasty-macros/src/model/expand/update.rs
+++ b/crates/toasty-macros/src/model/expand/update.rs
@@ -51,14 +51,15 @@ impl Expand<'_> {
             match &field.ty {
             FieldTy::BelongsTo(rel) => {
                 let ty = &rel.ty;
+                let target = quote!(<#ty as #toasty::BelongsToField>::Target);
 
                 quote! {
-                    #vis fn #field_ident(mut self, #field_ident: impl #toasty::Assign<<#ty as #toasty::Relation>::Expr>) -> Self {
+                    #vis fn #field_ident(mut self, #field_ident: impl #toasty::Assign<<#target as #toasty::Relation>::Expr>) -> Self {
                         self.#set_field_ident(#field_ident);
                         self
                     }
 
-                    #vis fn #set_field_ident(&mut self, #field_ident: impl #toasty::Assign<<#ty as #toasty::Relation>::Expr>) -> &mut Self {
+                    #vis fn #set_field_ident(&mut self, #field_ident: impl #toasty::Assign<<#target as #toasty::Relation>::Expr>) -> &mut Self {
                         let projection = #projection;
                         #field_ident.assign(&mut self.assignments, projection);
                         self
@@ -67,14 +68,15 @@ impl Expand<'_> {
             }
             FieldTy::HasMany(rel) => {
                 let ty = &rel.ty;
+                let target = quote!(<#ty as #toasty::HasManyField>::Target);
 
                 quote! {
-                    #vis fn #field_ident(mut self, #field_ident: impl #toasty::Assign<#toasty::List<<#ty as #toasty::Relation>::Expr>>) -> Self {
+                    #vis fn #field_ident(mut self, #field_ident: impl #toasty::Assign<#toasty::List<<#target as #toasty::Relation>::Expr>>) -> Self {
                         self.#set_field_ident(#field_ident);
                         self
                     }
 
-                    #vis fn #set_field_ident(&mut self, #field_ident: impl #toasty::Assign<#toasty::List<<#ty as #toasty::Relation>::Expr>>) -> &mut Self {
+                    #vis fn #set_field_ident(&mut self, #field_ident: impl #toasty::Assign<#toasty::List<<#target as #toasty::Relation>::Expr>>) -> &mut Self {
                         let projection = #projection;
                         #field_ident.assign(&mut self.assignments, projection);
                         self
@@ -83,14 +85,15 @@ impl Expand<'_> {
             }
             FieldTy::HasOne(rel) => {
                 let ty = &rel.ty;
+                let target = quote!(<#ty as #toasty::HasOneField>::Target);
 
                 quote! {
-                    #vis fn #field_ident(mut self, #field_ident: impl #toasty::Assign<<#ty as #toasty::Relation>::Expr>) -> Self {
+                    #vis fn #field_ident(mut self, #field_ident: impl #toasty::Assign<<#target as #toasty::Relation>::Expr>) -> Self {
                         self.#set_field_ident(#field_ident);
                         self
                     }
 
-                    #vis fn #set_field_ident(&mut self, #field_ident: impl #toasty::Assign<<#ty as #toasty::Relation>::Expr>) -> &mut Self {
+                    #vis fn #set_field_ident(&mut self, #field_ident: impl #toasty::Assign<<#target as #toasty::Relation>::Expr>) -> &mut Self {
                         let projection = #projection;
                         #field_ident.assign(&mut self.assignments, projection);
                         self

--- a/crates/toasty/src/codegen_support.rs
+++ b/crates/toasty/src/codegen_support.rs
@@ -14,9 +14,9 @@ pub use crate::{
     Db, Error, Executor, Result, Statement,
     schema::create_meta::{assert_create_fields, const_contains},
     schema::{
-        Auto, BelongsTo, CreateField, CreateMeta, Defer, Deferred, DiscoverItem, Embed, Field,
-        HasMany, HasOne, Load, Model, Register, Relation, Scope, ValidateCreate,
-        build_deferred_load, generate_unique_id,
+        Auto, BelongsTo, BelongsToField, CreateField, CreateMeta, Defer, Deferred, DiscoverItem,
+        Embed, Field, HasMany, HasManyField, HasOne, HasOneField, Load, Model, Register, Relation,
+        Scope, ValidateCreate, build_deferred_load, generate_unique_id,
     },
     stmt::CreateMany,
     stmt::{self, Assign, IntoExpr, IntoInsert, IntoStatement, List, Path},

--- a/crates/toasty/src/schema.rs
+++ b/crates/toasty/src/schema.rs
@@ -43,7 +43,7 @@ pub use register::{DiscoverItem, Register, generate_unique_id};
 mod num;
 
 mod relation;
-pub use relation::Relation;
+pub use relation::{BelongsToField, HasManyField, HasOneField, Relation};
 
 mod scope;
 pub use scope::Scope;

--- a/crates/toasty/src/schema/belongs_to.rs
+++ b/crates/toasty/src/schema/belongs_to.rs
@@ -1,4 +1,4 @@
-use super::{Load, Register, Relation, lazy_slot};
+use super::{BelongsToField, Load, Register, Relation, lazy_slot};
 
 use toasty_core::schema::app::{self, FieldTy, ForeignKey};
 use toasty_core::stmt::{self, Value};
@@ -86,26 +86,8 @@ impl<T: Relation> BelongsTo<T> {
     }
 }
 
-impl<T: Relation> Relation for BelongsTo<T> {
-    type Model = T::Model;
-    type Expr = T::Expr;
-    type Query = T::Query;
-    type Create = T::Create;
-    type Many = T::Many;
-    type ManyField<__Origin> = T::ManyField<__Origin>;
-    type One = T::One;
-    type OneField<__Origin> = T::OneField<__Origin>;
-    type OptionOne = T::OptionOne;
-
-    fn new_many_field<__Origin>(
-        path: crate::stmt::Path<__Origin, crate::stmt::List<Self::Model>>,
-    ) -> Self::ManyField<__Origin> {
-        T::new_many_field(path)
-    }
-
-    fn field_name_to_id(name: &str) -> toasty_core::schema::app::FieldId {
-        T::field_name_to_id(name)
-    }
+impl<T: Relation> BelongsToField for BelongsTo<T> {
+    type Target = T;
 
     fn nullable() -> bool {
         T::nullable()

--- a/crates/toasty/src/schema/has_many.rs
+++ b/crates/toasty/src/schema/has_many.rs
@@ -1,4 +1,4 @@
-use super::{Load, Register, Relation, Scope, lazy_slot};
+use super::{HasManyField, Load, Register, Relation, Scope, lazy_slot};
 
 use toasty_core::schema::Name;
 use toasty_core::schema::app::{self, FieldId, FieldTy, ModelId};
@@ -99,26 +99,8 @@ impl<T: Relation> HasMany<T> {
     }
 }
 
-impl<T: Relation> Relation for HasMany<T> {
-    type Model = T::Model;
-    type Expr = T::Expr;
-    type Query = T::Query;
-    type Create = T::Create;
-    type Many = T::Many;
-    type ManyField<__Origin> = T::ManyField<__Origin>;
-    type One = T::One;
-    type OneField<__Origin> = T::OneField<__Origin>;
-    type OptionOne = T::OptionOne;
-
-    fn new_many_field<__Origin>(
-        path: crate::stmt::Path<__Origin, crate::stmt::List<Self::Model>>,
-    ) -> Self::ManyField<__Origin> {
-        T::new_many_field(path)
-    }
-
-    fn field_name_to_id(name: &str) -> toasty_core::schema::app::FieldId {
-        T::field_name_to_id(name)
-    }
+impl<T: Relation> HasManyField for HasMany<T> {
+    type Target = T;
 
     fn nullable() -> bool {
         T::nullable()

--- a/crates/toasty/src/schema/has_one.rs
+++ b/crates/toasty/src/schema/has_one.rs
@@ -1,5 +1,5 @@
 use super::has_many::has_kind;
-use super::{Load, Register, Relation, lazy_slot};
+use super::{HasOneField, Load, Register, Relation, lazy_slot};
 
 use toasty_core::schema::app::{self, FieldId, FieldTy};
 use toasty_core::stmt::{self, Value};
@@ -90,26 +90,8 @@ impl<T: Relation> HasOne<T> {
     }
 }
 
-impl<T: Relation> Relation for HasOne<T> {
-    type Model = T::Model;
-    type Expr = T::Expr;
-    type Query = T::Query;
-    type Create = T::Create;
-    type Many = T::Many;
-    type ManyField<__Origin> = T::ManyField<__Origin>;
-    type One = T::One;
-    type OneField<__Origin> = T::OneField<__Origin>;
-    type OptionOne = T::OptionOne;
-
-    fn new_many_field<__Origin>(
-        path: crate::stmt::Path<__Origin, crate::stmt::List<Self::Model>>,
-    ) -> Self::ManyField<__Origin> {
-        T::new_many_field(path)
-    }
-
-    fn field_name_to_id(name: &str) -> toasty_core::schema::app::FieldId {
-        T::field_name_to_id(name)
-    }
+impl<T: Relation> HasOneField for HasOne<T> {
+    type Target = T;
 
     fn nullable() -> bool {
         T::nullable()

--- a/crates/toasty/src/schema/relation.rs
+++ b/crates/toasty/src/schema/relation.rs
@@ -62,18 +62,24 @@ pub trait Relation: Load<Output = Self> {
     fn nullable() -> bool {
         false
     }
+}
 
-    /// Build the [`FieldTy`] for a `BelongsTo` relation wrapper, given the
-    /// foreign key resolved from the field's `#[belongs_to(...)]` attribute.
-    ///
-    /// Only [`BelongsTo`](super::BelongsTo) overrides this; the default
-    /// panics so that misuse (e.g. applying `#[belongs_to]` to a field whose
-    /// type is not a `BelongsTo<T>`) fails loudly.
-    fn belongs_to_field_ty(_foreign_key: ForeignKey) -> FieldTy {
-        unimplemented!("not a BelongsTo relation wrapper")
+/// A Rust field type that represents a `#[has_many]` relation.
+///
+/// This is implemented by relation field containers such as
+/// [`HasMany`](super::HasMany). The target model/query-builder metadata stays
+/// on [`Relation`]; this trait only describes how the field itself contributes
+/// relation schema metadata.
+pub trait HasManyField: Load<Output = Self> {
+    /// The relation target type carried by this field.
+    type Target: Relation;
+
+    /// Returns `true` if this relation field is nullable.
+    fn nullable() -> bool {
+        Self::Target::nullable()
     }
 
-    /// Build the [`FieldTy`] for a `HasMany` relation wrapper, given the
+    /// Build the [`FieldTy`] for a `HasMany` relation field, given the
     /// singular name derived from the field identifier and an optional
     /// paired `BelongsTo` field on the target model resolved from
     /// `#[has_many(pair = <field>)]`. When `None`, the linker selects the
@@ -83,17 +89,21 @@ pub trait Relation: Load<Output = Self> {
     /// `via` carries the fully resolved [`stmt::Path`] of a
     /// `#[has_many(via = a.b)]` multi-step relation, rooted at the declaring
     /// model. A `via` relation has no pair.
-    ///
-    /// Only [`HasMany`](super::HasMany) overrides this.
-    fn has_many_field_ty(
-        _singular: Name,
-        _pair: Option<FieldId>,
-        _via: Option<stmt::Path>,
-    ) -> FieldTy {
-        unimplemented!("not a HasMany relation wrapper")
+    fn has_many_field_ty(singular: Name, pair: Option<FieldId>, via: Option<stmt::Path>)
+    -> FieldTy;
+}
+
+/// A Rust field type that represents a `#[has_one]` relation.
+pub trait HasOneField: Load<Output = Self> {
+    /// The relation target type carried by this field.
+    type Target: Relation;
+
+    /// Returns `true` if this relation field is nullable.
+    fn nullable() -> bool {
+        Self::Target::nullable()
     }
 
-    /// Build the [`FieldTy`] for a `HasOne` relation wrapper, given an
+    /// Build the [`FieldTy`] for a `HasOne` relation field, given an
     /// optional paired `BelongsTo` field on the target model resolved
     /// from `#[has_one(pair = <field>)]`. When `None`, the linker selects
     /// the pair by searching the target for a unique `BelongsTo` back to
@@ -102,9 +112,20 @@ pub trait Relation: Load<Output = Self> {
     /// `via` carries the fully resolved [`stmt::Path`] of a
     /// `#[has_one(via = a.b)]` multi-step relation, rooted at the declaring
     /// model. A `via` relation has no pair.
-    ///
-    /// Only [`HasOne`](super::HasOne) overrides this.
-    fn has_one_field_ty(_pair: Option<FieldId>, _via: Option<stmt::Path>) -> FieldTy {
-        unimplemented!("not a HasOne relation wrapper")
+    fn has_one_field_ty(pair: Option<FieldId>, via: Option<stmt::Path>) -> FieldTy;
+}
+
+/// A Rust field type that represents a `#[belongs_to]` relation.
+pub trait BelongsToField: Load<Output = Self> {
+    /// The relation target type carried by this field.
+    type Target: Relation;
+
+    /// Returns `true` if this relation field is nullable.
+    fn nullable() -> bool {
+        Self::Target::nullable()
     }
+
+    /// Build the [`FieldTy`] for a `BelongsTo` relation field, given the
+    /// foreign key resolved from the field's `#[belongs_to(...)]` attribute.
+    fn belongs_to_field_ty(foreign_key: ForeignKey) -> FieldTy;
 }

--- a/docs/dev/design/deferred-relations.md
+++ b/docs/dev/design/deferred-relations.md
@@ -201,9 +201,9 @@ the public relation syntax changes.
 3. Done: remove the nullable single-relation special case. Encode loaded
    `None` for nullable has-one and belongs-to relations as `Record([Null])`.
 
-4. Split relation target traits from relation field traits. Keep the model
-   target/query-builder information on a `Relation`-like trait, and introduce
-   field-level traits for `has_many`, `has_one`, and `belongs_to` fields.
+4. Done: split relation target traits from relation field traits. Model
+   target/query-builder information stays on `Relation`; field schema
+   construction moved to `HasManyField`, `HasOneField`, and `BelongsToField`.
 
 5. Implement the field-level relation traits for both old and new field shapes.
    The compatibility set should include `HasMany<T>`, `HasOne<T>`,
@@ -227,6 +227,16 @@ the public relation syntax changes.
 10. Deprecate, then remove, `HasMany<T>`, `HasOne<T>`, and `BelongsTo<T>` from
     the public API.
 
+11. Cleanup: investigate folding some or all `Relation` associated types into
+    the relation field traits. The step 4 split currently requires generated
+    code to hop from a field type through `HasManyField::Target`,
+    `HasOneField::Target`, or `BelongsToField::Target` before reaching
+    `Relation` associated types such as `Model`, `Expr`, `Query`, `Many`, and
+    `One`. Also investigate whether generated local type aliases such as
+    `type __RelationTarget = <#target_ty as #field_trait>::Target;` are enough
+    to keep the expansion readable without changing trait ownership. Compare
+    the options by checking generated rustdocs and compiler error messages.
+
 ## Alternatives considered
 
 Keep the existing wrappers and add eager wrapper variants. This would avoid a
@@ -244,8 +254,6 @@ without overloading `Option`.
 
 ## Open questions
 
-- Blocking implementation: what exact trait names should replace the wrapper
-  side of `Relation`?
 - Blocking implementation: should eager `belongs_to` be allowed for required
   relations only, or also for nullable `Option<T>`?
 - Blocking implementation: should eager relation cycle detection reject every


### PR DESCRIPTION
## Summary

- Split relation target metadata from relation field schema construction.
- Add `HasManyField`, `HasOneField`, and `BelongsToField` while keeping target/query-builder metadata on `Relation`.
- Update derive expansion to use relation field traits and mark deferred-relations step 4 done.

## Type of change

- [x] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`): `docs/dev/design/deferred-relations.md`

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [ ] `cargo test` passes (`cargo test -p toasty --lib --tests` passes; `cargo test -p toasty` fails one sqlite-feature doctest)
- [x] Touches a public API -> a design doc under `docs/dev/design/` describes the behavior

## Notes for reviewers

The full `cargo test -p toasty` run fails in `db::builder::Builder::connect` doctest with `unsupported feature: sqlite feature not enabled`. Non-doctest package tests pass.