### PR TITLE
test: gate sqlite connect doctest

### DIFF
--- a/crates/toasty/src/db/builder.rs
+++ b/crates/toasty/src/db/builder.rs
@@ -222,6 +222,7 @@ impl Builder {
     /// #     id: i64,
     /// #     name: String,
     /// # }
+    /// # #[cfg(feature = "sqlite")]
     /// let db = toasty::Db::builder()
     ///     .models(toasty::models!(User))
     ///     .connect("sqlite://memory")


### PR DESCRIPTION
## Summary

Gate the `Builder::connect` SQLite doctest statement on the `sqlite` feature so the default no-feature doctest build compiles without executing a missing-driver connection path. The rendered example still shows the normal `connect("sqlite://memory")` usage.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` is clean
- [x] `cargo test -p toasty --doc` passes

## Notes for reviewers

This keeps the example runnable when the `sqlite` feature is enabled and lets default doctests skip the SQLite-specific statement.