### PR TITLE
docs(examples): fix comment typos and println mismatches

### DIFF
--- a/examples/hello-toasty/src/main.rs
+++ b/examples/hello-toasty/src/main.rs
@@ -41,7 +41,7 @@ async fn main() -> toasty::Result<()> {
         )
         .await?;
 
-    // For now, reset!s
+    // For now, resets
     db.push_schema().await?;
 
     println!("==> let u1 = create!(User)");
@@ -61,12 +61,12 @@ async fn main() -> toasty::Result<()> {
     .await?;
 
     // Find by ID
-    println!("==> let user = User::find_by_id(&u1.id)");
+    println!("==> let user = User::get_by_id(&u1.id)");
     let user = User::get_by_id(&mut db, &u1.id).await?;
     println!("USER = {user:#?}");
 
-    // Find by email!
-    println!("==> let user = User::find_by_email(&u1.email)");
+    // Find by email
+    println!("==> let user = User::get_by_email(&u1.email)");
     let mut user = User::get_by_email(&mut db, &u1.email).await?;
     println!("USER = {user:#?}");
 
@@ -116,7 +116,7 @@ async fn main() -> toasty::Result<()> {
     .exec(&mut db)
     .await?;
 
-    // Lets create a new user. This time, we will batch create todos for the
+    // Let's create a new user. This time, we will batch create todos for the
     // user
     let mut user = toasty::create!(User {
         name: "Ann Chovey",


### PR DESCRIPTION
## Summary

This PR cleans up minor typos and inconsistent print statements in the `hello-toasty` example `main.rs`:
* Updates `println!` macros to say `get_by_*` instead of `find_by_*` to accurately mirror the codebase's actual generated API methods.
* Fixes minor grammatical typos (`Lets` -> `Let's`, and `reset!s` -> `resets`).

These small changes ensure the introductory example code is completely accurate and polished for newcomers reading through the repository.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test
- [ ] Implements a previously accepted design
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [ ] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [ ] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers

These are strictly documentation and example string fixes; no functional application logic or public API surfaces were modified.