### PR TITLE
ci: release Turso driver with workspace crates

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -51,6 +51,10 @@ name = "toasty-driver-sqlite"
 version_group = "toasty"
 
 [[package]]
+name = "toasty-driver-turso"
+version_group = "toasty"
+
+[[package]]
 name = "toasty-driver-integration-suite"
 version_group = "toasty"
 


### PR DESCRIPTION
## Summary

Add `toasty-driver-turso` to the shared `toasty` release-plz version group so release-plz bumps and verifies it with the workspace crates it depends on.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] `cargo fmt` and `cargo clippy` are clean

## Notes for reviewers

Verified `cargo fmt`, `cargo check -p toasty-driver-turso`, and a disposable `release-plz update --allow-dirty --no-changelog` run. Did not run `cargo clippy` or the full test suite for this release config-only change.