### PR TITLE
feat: support eager relation fields

### DIFF
--- a/crates/toasty-core/src/schema/app/schema.rs
+++ b/crates/toasty-core/src/schema/app/schema.rs
@@ -2,6 +2,7 @@ use super::{EnumVariant, Field, FieldId, FieldTy, HasKind, Model, ModelId, Varia
 
 use crate::{Result, stmt};
 use indexmap::IndexMap;
+use std::collections::HashSet;
 
 /// The result of resolving a [`stmt::Projection`] through the application
 /// schema.
@@ -224,8 +225,85 @@ impl Builder {
         // All models have been discovered and initialized at some level, now do
         // the relation linking.
         self.link_relations()?;
+        self.verify_no_eager_load_cycles()?;
 
         Ok(())
+    }
+
+    fn verify_no_eager_load_cycles(&self) -> crate::Result<()> {
+        let mut visited = HashSet::new();
+        let mut model_stack = Vec::new();
+        let mut field_stack = Vec::new();
+
+        for model in self.models.values() {
+            if model.is_embedded() {
+                continue;
+            }
+            self.visit_eager_load_graph(
+                model.id(),
+                &mut visited,
+                &mut model_stack,
+                &mut field_stack,
+            )?;
+        }
+
+        Ok(())
+    }
+
+    fn visit_eager_load_graph(
+        &self,
+        model_id: ModelId,
+        visited: &mut HashSet<ModelId>,
+        model_stack: &mut Vec<ModelId>,
+        field_stack: &mut Vec<FieldId>,
+    ) -> crate::Result<()> {
+        if model_stack.contains(&model_id) {
+            return Ok(());
+        }
+
+        if !visited.insert(model_id) {
+            return Ok(());
+        }
+
+        model_stack.push(model_id);
+
+        let model = self.models[&model_id].as_root_unwrap();
+        for field in &model.fields {
+            let Some(target) = eager_relation_target(field) else {
+                continue;
+            };
+
+            if let Some(pos) = model_stack.iter().position(|id| *id == target) {
+                let mut cycle = field_stack[pos..].to_vec();
+                cycle.push(field.id);
+                return Err(crate::Error::invalid_schema(format!(
+                    "eager relation cycle detected: {}",
+                    self.format_eager_load_cycle(&cycle, target)
+                )));
+            }
+
+            field_stack.push(field.id);
+            self.visit_eager_load_graph(target, visited, model_stack, field_stack)?;
+            field_stack.pop();
+        }
+
+        model_stack.pop();
+        Ok(())
+    }
+
+    fn format_eager_load_cycle(&self, fields: &[FieldId], target: ModelId) -> String {
+        let mut parts = Vec::new();
+        for field_id in fields {
+            let model = &self.models[&field_id.model];
+            let field = &model.as_root_unwrap().fields[field_id.index];
+            parts.push(format!(
+                "{}::{}",
+                model.name().upper_camel_case(),
+                field.name.app_unwrap()
+            ));
+        }
+        parts.push(self.models[&target].name().upper_camel_case());
+        parts.join(" -> ")
     }
 
     /// Go through all relations and link them to their pairs
@@ -494,4 +572,12 @@ impl Builder {
             ))),
         }
     }
+}
+
+fn eager_relation_target(field: &Field) -> Option<ModelId> {
+    if field.deferred {
+        return None;
+    }
+
+    field.relation_target_id()
 }

--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -63,6 +63,7 @@ pub mod relation_belongs_to_one_way;
 pub mod relation_belongs_to_self_referential;
 pub mod relation_chain;
 pub mod relation_chain_composite_key;
+pub mod relation_eager;
 pub mod relation_filter_association;
 pub mod relation_has_many_batch_create;
 pub mod relation_has_many_boxed_fk;

--- a/crates/toasty-driver-integration-suite/src/tests/relation_eager.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_eager.rs
@@ -1,0 +1,470 @@
+use crate::prelude::*;
+
+use toasty::schema::Model;
+use toasty_core::stmt;
+
+#[driver_test]
+pub async fn eager_has_many_and_has_one_load_without_include(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        id: uuid::Uuid,
+        name: String,
+
+        #[has_many]
+        posts: Vec<Post>,
+
+        #[has_one]
+        profile: Option<Profile>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Post {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+        title: String,
+
+        #[index]
+        user_id: uuid::Uuid,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: toasty::Deferred<User>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Profile {
+        #[key]
+        id: uuid::Uuid,
+        bio: String,
+
+        #[unique]
+        user_id: uuid::Uuid,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: toasty::Deferred<Option<User>>,
+    }
+
+    let mut db = t.setup_db(models!(User, Post, Profile)).await;
+    let user_id = uuid::Uuid::from_u128(1);
+
+    insert_row::<User>(
+        &mut db,
+        vec![
+            stmt::Value::Uuid(user_id).into(),
+            stmt::Value::from("Alice").into(),
+            stmt::Value::Null.into(),
+            stmt::Value::Null.into(),
+        ],
+    )
+    .await?;
+    insert_row::<Post>(
+        &mut db,
+        vec![
+            stmt::Value::Uuid(uuid::Uuid::from_u128(2)).into(),
+            stmt::Value::from("hello").into(),
+            stmt::Value::Uuid(user_id).into(),
+            stmt::Value::Null.into(),
+        ],
+    )
+    .await?;
+    insert_row::<Profile>(
+        &mut db,
+        vec![
+            stmt::Value::Uuid(uuid::Uuid::from_u128(3)).into(),
+            stmt::Value::from("writer").into(),
+            stmt::Value::Uuid(user_id).into(),
+            stmt::Value::Null.into(),
+        ],
+    )
+    .await?;
+
+    let user = User::filter_by_id(user_id).get(&mut db).await?;
+
+    assert_eq!(user.posts.len(), 1);
+    assert_eq!(user.posts[0].title, "hello");
+    assert_eq!(user.profile.as_ref().unwrap().bio, "writer");
+
+    Ok(())
+}
+
+#[driver_test]
+pub async fn eager_belongs_to_loads_without_include(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        id: uuid::Uuid,
+        name: String,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Post {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+        title: String,
+
+        #[index]
+        user_id: uuid::Uuid,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: User,
+    }
+
+    let mut db = t.setup_db(models!(User, Post)).await;
+    let user_id = uuid::Uuid::from_u128(4);
+    let post_id = uuid::Uuid::from_u128(5);
+
+    insert_row::<User>(
+        &mut db,
+        vec![
+            stmt::Value::Uuid(user_id).into(),
+            stmt::Value::from("Alice").into(),
+        ],
+    )
+    .await?;
+    insert_row::<Post>(
+        &mut db,
+        vec![
+            stmt::Value::Uuid(post_id).into(),
+            stmt::Value::from("hello").into(),
+            stmt::Value::Uuid(user_id).into(),
+            stmt::Value::Null.into(),
+        ],
+    )
+    .await?;
+
+    let post = Post::filter_by_id(post_id).get(&mut db).await?;
+
+    assert_eq!(post.title, "hello");
+    assert_eq!(post.user.name, "Alice");
+
+    Ok(())
+}
+
+#[driver_test(id(ID))]
+pub async fn eager_has_many_create_returning_loads_relations(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+        name: String,
+
+        #[has_many]
+        posts: Vec<Post>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Post {
+        #[key]
+        #[auto]
+        id: ID,
+        title: String,
+
+        #[index]
+        user_id: ID,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: toasty::Deferred<User>,
+    }
+
+    let mut db = t.setup_db(models!(User, Post)).await;
+
+    let user = User::create()
+        .name("Alice")
+        .post(Post::create().title("hello"))
+        .exec(&mut db)
+        .await?;
+
+    assert_eq!(user.name, "Alice");
+    assert_eq!(user.posts.len(), 1);
+    assert_eq!(user.posts[0].title, "hello");
+
+    Ok(())
+}
+
+#[driver_test]
+pub async fn eager_nested_relations_load_without_include(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        id: uuid::Uuid,
+        name: String,
+
+        #[has_many]
+        posts: Vec<Post>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Post {
+        #[key]
+        id: uuid::Uuid,
+        title: String,
+
+        #[index]
+        user_id: uuid::Uuid,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: toasty::Deferred<User>,
+
+        #[has_many]
+        comments: Vec<Comment>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Comment {
+        #[key]
+        id: uuid::Uuid,
+        body: String,
+
+        #[index]
+        post_id: uuid::Uuid,
+
+        #[belongs_to(key = post_id, references = id)]
+        post: toasty::Deferred<Post>,
+    }
+
+    let mut db = t.setup_db(models!(User, Post, Comment)).await;
+    let user_id = uuid::Uuid::from_u128(10);
+    let post_id = uuid::Uuid::from_u128(11);
+
+    insert_row::<User>(
+        &mut db,
+        vec![
+            stmt::Value::Uuid(user_id).into(),
+            stmt::Value::from("Alice").into(),
+            stmt::Value::Null.into(),
+        ],
+    )
+    .await?;
+    insert_row::<Post>(
+        &mut db,
+        vec![
+            stmt::Value::Uuid(post_id).into(),
+            stmt::Value::from("hello").into(),
+            stmt::Value::Uuid(user_id).into(),
+            stmt::Value::Null.into(),
+            stmt::Value::Null.into(),
+        ],
+    )
+    .await?;
+    insert_row::<Comment>(
+        &mut db,
+        vec![
+            stmt::Value::Uuid(uuid::Uuid::from_u128(12)).into(),
+            stmt::Value::from("first").into(),
+            stmt::Value::Uuid(post_id).into(),
+            stmt::Value::Null.into(),
+        ],
+    )
+    .await?;
+
+    let user = User::filter_by_id(user_id).get(&mut db).await?;
+
+    assert_eq!(user.posts.len(), 1);
+    assert_eq!(user.posts[0].title, "hello");
+    assert_eq!(user.posts[0].comments.len(), 1);
+    assert_eq!(user.posts[0].comments[0].body, "first");
+
+    Ok(())
+}
+
+#[driver_test]
+pub async fn eager_relations_reload_after_update(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        id: uuid::Uuid,
+        name: String,
+
+        #[has_many]
+        posts: Vec<Post>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Post {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+        title: String,
+
+        #[index]
+        user_id: uuid::Uuid,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: toasty::Deferred<User>,
+    }
+
+    let mut db = t.setup_db(models!(User, Post)).await;
+    let user_id = uuid::Uuid::from_u128(20);
+
+    insert_row::<User>(
+        &mut db,
+        vec![
+            stmt::Value::Uuid(user_id).into(),
+            stmt::Value::from("Alice").into(),
+            stmt::Value::Null.into(),
+        ],
+    )
+    .await?;
+
+    let mut user = User::filter_by_id(user_id).get(&mut db).await?;
+    assert!(user.posts.is_empty());
+
+    user.update()
+        .name("Alice Updated")
+        .posts(toasty::stmt::insert(Post::create().title("first")))
+        .exec(&mut db)
+        .await?;
+
+    let mut titles = user
+        .posts
+        .iter()
+        .map(|post| post.title.as_str())
+        .collect::<Vec<_>>();
+    titles.sort_unstable();
+
+    assert_eq!(user.name, "Alice Updated");
+    assert_eq!(titles, vec!["first"]);
+
+    Ok(())
+}
+
+#[driver_test(id(ID))]
+pub async fn eager_relation_cycle_is_rejected(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+
+        #[has_many]
+        posts: Vec<Post>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Post {
+        #[key]
+        #[auto]
+        id: ID,
+
+        #[index]
+        user_id: ID,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: User,
+    }
+
+    let err = t.try_setup_db(models!(User, Post)).await.unwrap_err();
+    let msg = err.to_string();
+
+    assert!(
+        msg.contains("eager relation cycle"),
+        "expected eager relation cycle error, got: {msg}"
+    );
+
+    Ok(())
+}
+
+#[driver_test(id(ID))]
+pub async fn eager_relation_self_cycle_is_rejected(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Node {
+        #[key]
+        #[auto]
+        id: ID,
+
+        #[index]
+        parent_id: Option<ID>,
+
+        #[belongs_to(key = parent_id, references = id)]
+        parent: toasty::Deferred<Option<Node>>,
+
+        #[has_many(pair = parent)]
+        children: Vec<Node>,
+    }
+
+    let err = t.try_setup_db(models!(Node)).await.unwrap_err();
+    let msg = err.to_string();
+
+    assert!(
+        msg.contains("eager relation cycle"),
+        "expected eager relation cycle error, got: {msg}"
+    );
+
+    Ok(())
+}
+
+#[driver_test(id(ID))]
+pub async fn eager_relation_long_cycle_is_rejected(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+
+        #[has_many]
+        posts: Vec<Post>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Post {
+        #[key]
+        #[auto]
+        id: ID,
+
+        #[index]
+        user_id: ID,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: toasty::Deferred<User>,
+
+        #[has_one]
+        detail: Option<Detail>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Detail {
+        #[key]
+        #[auto]
+        id: ID,
+
+        #[unique]
+        post_id: ID,
+
+        #[belongs_to(key = post_id, references = id)]
+        post: toasty::Deferred<Post>,
+
+        #[index]
+        user_id: ID,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: User,
+    }
+
+    let err = t
+        .try_setup_db(models!(User, Post, Detail))
+        .await
+        .unwrap_err();
+    let msg = err.to_string();
+
+    assert!(
+        msg.contains("eager relation cycle"),
+        "expected eager relation cycle error, got: {msg}"
+    );
+
+    Ok(())
+}
+
+async fn insert_row<M: Model>(db: &mut toasty::Db, fields: Vec<stmt::Expr>) -> Result<()> {
+    let insert = stmt::Insert {
+        target: stmt::InsertTarget::Model(<M as toasty::schema::Register>::id()),
+        source: stmt::Query::new_single(vec![stmt::Expr::record(fields)]),
+        returning: None,
+    };
+
+    toasty::Statement::<()>::from_untyped_stmt(insert.into())
+        .exec(db)
+        .await
+}

--- a/crates/toasty-macros/src/lib.rs
+++ b/crates/toasty-macros/src/lib.rs
@@ -335,6 +335,21 @@ use proc_macro::TokenStream;
 ///
 /// # Relation attributes
 ///
+/// Relation fields can be lazy or eager. Wrap the relation value in
+/// `toasty::Deferred<_>` for lazy loading; ordinary queries leave the field
+/// unloaded until the generated relation accessor or `.include(...)` loads it.
+/// Use the relation value directly for eager loading; every query that returns
+/// the model loads the relation as if the query included that field.
+///
+/// | Attribute | Lazy field type | Eager field type |
+/// |-----------|-----------------|------------------|
+/// | `#[belongs_to]` | `toasty::Deferred<T>` or `toasty::Deferred<Option<T>>` | `T` or `Option<T>` |
+/// | `#[has_many]` | `toasty::Deferred<Vec<T>>` | `Vec<T>` |
+/// | `#[has_one]` | `toasty::Deferred<T>` or `toasty::Deferred<Option<T>>` | `T` or `Option<T>` |
+///
+/// Toasty rejects schemas with eager-load cycles. If two relation paths point
+/// back to each other, wrap at least one field in `toasty::Deferred<_>`.
+///
 /// ## `#[belongs_to(...)]` — foreign-key reference
 ///
 /// Declares a many-to-one (or one-to-one) association through a foreign
@@ -357,6 +372,13 @@ use proc_macro::TokenStream;
 /// #[belongs_to(key = user_id, references = id)]
 /// user: toasty::Deferred<User>,
 /// # }
+/// ```
+///
+/// To load the relation with every `Example` query, omit `Deferred`:
+///
+/// ```ignore
+/// #[belongs_to(key = user_id, references = id)]
+/// user: User,
 /// ```
 ///
 /// | Parameter | Meaning |
@@ -437,6 +459,13 @@ use proc_macro::TokenStream;
 /// #[has_many]
 /// posts: toasty::Deferred<Vec<Post>>,
 /// # }
+/// ```
+///
+/// To load the collection with every `Example` query, use `Vec<Post>`:
+///
+/// ```ignore
+/// #[has_many]
+/// posts: Vec<Post>,
 /// ```
 ///
 /// Toasty generates an accessor method (e.g. `.posts()`) and an insert
@@ -544,6 +573,13 @@ use proc_macro::TokenStream;
 /// # }
 /// ```
 ///
+/// To load the relation with every `Example` query, omit `Deferred`:
+///
+/// ```ignore
+/// #[has_one]
+/// profile: Profile,
+/// ```
+///
 /// Wrap in `Option` for an optional association:
 ///
 /// ```
@@ -567,6 +603,8 @@ use proc_macro::TokenStream;
 /// profile: toasty::Deferred<Option<Profile>>,
 /// # }
 /// ```
+///
+/// The eager optional form is `Option<Profile>`.
 ///
 /// ### `via` — multi-step relations
 ///
@@ -624,6 +662,8 @@ use proc_macro::TokenStream;
 /// - `#[column]`, `#[default]`, and `#[update]` cannot be used on relation
 ///   fields (`BelongsTo`, `HasMany`, `HasOne`).
 /// - A field can have at most one relation attribute.
+/// - Eager relation fields cannot form a cycle. Use `toasty::Deferred<_>` on at
+///   least one edge of a bidirectional relation.
 /// - `Self` can be used as a type in relation fields for self-referential
 ///   models.
 ///
@@ -1765,9 +1805,9 @@ pub fn query(input: TokenStream) -> TokenStream {
 /// | `Option<T>` | Defaults to `None` (`NULL`) |
 /// | `#[default(expr)]` | Uses the default expression |
 /// | `#[update(expr)]` | Uses the expression as the initial value |
-/// | `#[has_many] Deferred<Vec<T>>` | No related records created |
-/// | `#[has_one] Deferred<Option<T>>` | No related record created |
-/// | `#[belongs_to] Deferred<Option<T>>` | Foreign key set to `NULL` |
+/// | `#[has_many] Deferred<Vec<T>>` or `#[has_many] Vec<T>` | No related records created |
+/// | `#[has_one] Deferred<Option<T>>` or `#[has_one] Option<T>` | No related record created |
+/// | `#[belongs_to] Deferred<Option<T>>` or `#[belongs_to] Option<T>` | Foreign key set to `NULL` |
 ///
 /// Required fields (`String`, `i64`, non-optional `BelongsTo`, etc.) that are
 /// missing do not cause a compile-time error. The insert fails at runtime with

--- a/crates/toasty-macros/src/model/expand/model.rs
+++ b/crates/toasty-macros/src/model/expand/model.rs
@@ -561,8 +561,17 @@ impl Expand<'_> {
                     FieldTy::Primitive(ty) => {
                         quote!(#i => <#ty as #toasty::Load>::reload(&mut #field_access, value)?,)
                     }
-                    _ => {
-                        quote!(#i => #field_access.unload(),)
+                    FieldTy::BelongsTo(rel) => {
+                        let ty = &rel.ty;
+                        quote!(#i => <#ty as #toasty::BelongsToField>::reload(&mut #field_access, value)?,)
+                    }
+                    FieldTy::HasMany(rel) => {
+                        let ty = &rel.ty;
+                        quote!(#i => <#ty as #toasty::HasManyField>::reload(&mut #field_access, value)?,)
+                    }
+                    FieldTy::HasOne(rel) => {
+                        let ty = &rel.ty;
+                        quote!(#i => <#ty as #toasty::HasOneField>::reload(&mut #field_access, value)?,)
                     }
                 }
             })

--- a/crates/toasty-macros/src/model/expand/relation.rs
+++ b/crates/toasty-macros/src/model/expand/relation.rs
@@ -493,7 +493,7 @@ impl Expand<'_> {
         let verify_t = util::ident("T");
 
         let msg = format!(
-            "{relation_kind} requires the {{{verify_a}}}::{pair_ident} field to be of type `Deferred<Self>`, but it was `{{Self}}` instead"
+            "{relation_kind} requires the {{{verify_a}}}::{pair_ident} field to be a relation to `Self`, but it was `{{Self}}` instead"
         );
 
         quote::quote_spanned! {rel_span=>
@@ -519,6 +519,14 @@ impl Expand<'_> {
 
                 #[diagnostic::do_not_recommend]
                 impl<#verify_a> Verify<#verify_a> for #toasty::Deferred<Option<#model_ident>> {
+                }
+
+                #[diagnostic::do_not_recommend]
+                impl<#verify_a> Verify<#verify_a> for #model_ident {
+                }
+
+                #[diagnostic::do_not_recommend]
+                impl<#verify_a> Verify<#verify_a> for Option<#model_ident> {
                 }
 
                 fn verify<#verify_t: Verify<#verify_a>, #verify_a>(_: &#verify_t) {

--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -77,6 +77,7 @@ impl Expand<'_> {
             let index_tokenized = util::int(index);
             let field_ty;
             let nullable;
+            let deferred;
 
             let field_named = match &self.model.kind {
                 ModelKind::Root(_) => true,
@@ -119,6 +120,8 @@ impl Expand<'_> {
                     };
 
                     nullable = quote!(<#ty as #toasty::Field>::NULLABLE);
+                    let deferred_attr = field.attrs.deferred;
+                    deferred = quote!(#deferred_attr);
                     field_ty = quote!(<#ty as #toasty::Field>::field_ty(#storage_ty));
                 }
                 FieldTy::BelongsTo(rel) => {
@@ -143,6 +146,7 @@ impl Expand<'_> {
                     });
 
                     nullable = quote!(<#ty as #toasty::BelongsToField>::nullable());
+                    deferred = quote!(<#ty as #toasty::BelongsToField>::DEFERRED);
                     field_ty = quote!(<#ty as #toasty::BelongsToField>::belongs_to_field_ty(
                         #toasty::core::schema::app::ForeignKey {
                             fields: vec![ #( #fk_fields ),* ],
@@ -156,6 +160,7 @@ impl Expand<'_> {
                     let via = expand_via(toasty, model_ident, rel.via.as_ref());
 
                     nullable = quote!(<#ty as #toasty::HasManyField>::nullable());
+                    deferred = quote!(<#ty as #toasty::HasManyField>::DEFERRED);
                     field_ty = quote!(<#ty as #toasty::HasManyField>::has_many_field_ty(#singular_name, #pair, #via));
                 }
                 FieldTy::HasOne(rel) => {
@@ -164,6 +169,7 @@ impl Expand<'_> {
                     let via = expand_via(toasty, model_ident, rel.via.as_ref());
 
                     nullable = quote!(<#ty as #toasty::HasOneField>::nullable());
+                    deferred = quote!(<#ty as #toasty::HasOneField>::DEFERRED);
                     field_ty = quote!(<#ty as #toasty::HasOneField>::has_one_field_ty(#pair, #via));
                 }
             }
@@ -190,7 +196,6 @@ impl Expand<'_> {
             };
 
             let versionable = field.attrs.versionable;
-            let deferred = field.attrs.deferred;
 
             quote! {
                 #toasty::core::schema::app::Field {

--- a/crates/toasty-macros/src/model/expand/update.rs
+++ b/crates/toasty-macros/src/model/expand/update.rs
@@ -339,10 +339,17 @@ impl Expand<'_> {
                 FieldTy::Primitive(ty) => {
                     quote!(#i => <#ty as #toasty::Load>::reload(&mut target.#field_ident, value)?,)
                 }
-                _ => {
-                    // Relation fields (BelongsTo, HasMany, HasOne) are unloaded on update.
-                    // Embedded fields are handled above via the Primitive arm.
-                    quote!(#i => target.#field_ident.unload(),)
+                FieldTy::BelongsTo(rel) => {
+                    let ty = &rel.ty;
+                    quote!(#i => <#ty as #toasty::BelongsToField>::reload(&mut target.#field_ident, value)?,)
+                }
+                FieldTy::HasMany(rel) => {
+                    let ty = &rel.ty;
+                    quote!(#i => <#ty as #toasty::HasManyField>::reload(&mut target.#field_ident, value)?,)
+                }
+                FieldTy::HasOne(rel) => {
+                    let ty = &rel.ty;
+                    quote!(#i => <#ty as #toasty::HasOneField>::reload(&mut target.#field_ident, value)?,)
                 }
             }
 

--- a/crates/toasty/src/engine.rs
+++ b/crates/toasty/src/engine.rs
@@ -76,13 +76,6 @@ impl Engine {
 
         self.verify(&stmt)?;
 
-        if let stmt::Statement::Insert(stmt) = &stmt {
-            assert!(matches!(
-                stmt.returning,
-                Some(stmt::Returning::Model { .. })
-            ));
-        }
-
         // Lower the statement to High-level intermediate representation
         let hir = self.lower_stmt(stmt)?;
 

--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -835,9 +835,10 @@ impl visit_mut::VisitMut for LowerStatement<'_, '_> {
             // the fields named by include paths (and for every deferred field
             // when this is an `INSERT ... RETURNING`).
             let mut returning = self.mapping_unwrap().default_returning.clone();
-            let include_paths = std::mem::take(include);
+            let mut include_paths = std::mem::take(include);
             let is_insert = self.cx.is_insert();
 
+            self.prepare_model_returning_for_context(&mut returning, &mut include_paths, is_insert);
             self.process_top_level_includes(&mut returning, &include_paths, is_insert);
 
             *i = stmt::Returning::Project(returning);

--- a/crates/toasty/src/engine/lower/include.rs
+++ b/crates/toasty/src/engine/lower/include.rs
@@ -268,8 +268,12 @@ impl LowerStatement<'_, '_> {
         field_index: usize,
         nested: &[stmt::Projection],
     ) {
-        returning[field_index] =
-            lazy_slot::loaded_expr(self.build_relation_subquery(field_index, nested));
+        let value = self.build_relation_subquery(field_index, nested);
+        returning[field_index] = if self.model_unwrap().fields[field_index].deferred {
+            lazy_slot::loaded_expr(value)
+        } else {
+            value
+        };
     }
 
     /// Build a subquery that loads the related model(s) for a

--- a/crates/toasty/src/engine/lower/insert.rs
+++ b/crates/toasty/src/engine/lower/insert.rs
@@ -230,7 +230,8 @@ impl LowerStatement<'_, '_> {
                 expr_arg: &stmt::ExprArg,
                 projection: &stmt::Projection,
             ) -> Option<stmt::Expr> {
-                todo!("self={self:#?}; expr_arg={expr_arg:#?}; projection={projection:#?}");
+                let _ = (expr_arg, projection);
+                None
             }
 
             fn resolve_ref(

--- a/crates/toasty/src/engine/lower/relation.rs
+++ b/crates/toasty/src/engine/lower/relation.rs
@@ -40,7 +40,7 @@ trait RelationSource: std::fmt::Debug {
     fn set_source_field(&mut self, field: FieldId, expr: stmt::Expr);
 
     /// Update a returning field expression
-    fn set_returning_field(&mut self, field: FieldId, expr: stmt::Expr);
+    fn set_returning_field(&mut self, field: &Field, expr: stmt::Expr);
 
     /// Whether the source might produce zero rows. When true, relation
     /// mutations must be wrapped in a conditional to avoid FK updates when
@@ -422,7 +422,7 @@ impl LowerStatement<'_, '_> {
         // Run the canonical pipeline on the synthesized child insert and
         // stitch it onto the parent as an `Expr::Arg`.
         let arg = self.lower_sub_stmt(stmt::Statement::Insert(stmt));
-        source.set_returning_field(_field.id, arg);
+        source.set_returning_field(_field, arg);
     }
 
     fn plan_mut_belongs_to(
@@ -809,7 +809,7 @@ impl RelationSource for &stmt::Delete {
         unimplemented!("delete statements do not need to update field values");
     }
 
-    fn set_returning_field(&mut self, _field: FieldId, _expr: stmt::Expr) {
+    fn set_returning_field(&mut self, _field: &Field, _expr: stmt::Expr) {
         unimplemented!("delete statements do not need to update field values");
     }
 
@@ -829,7 +829,7 @@ impl RelationSource for UpdateRelationSource<'_> {
         self.assignments.set(field, expr);
     }
 
-    fn set_returning_field(&mut self, field: FieldId, expr: stmt::Expr) {
+    fn set_returning_field(&mut self, field: &Field, expr: stmt::Expr) {
         debug_assert!(self.returning_changed, "TODO");
 
         let Some(stmt::Returning::Project(stmt::Expr::Cast(expr_cast))) = self.returning else {
@@ -842,14 +842,14 @@ impl RelationSource for UpdateRelationSource<'_> {
 
         let position = path_field_set
             .iter()
-            .position(|field_id| field_id == field.index)
+            .position(|field_id| field_id == field.id.index)
             .unwrap();
 
         let stmt::Expr::Record(record) = &mut *expr_cast.expr else {
             todo!()
         };
 
-        set_returning_slot(record, position, expr);
+        set_returning_slot(record, position, expr, field.deferred);
     }
 
     fn needs_existence_check(&self) -> bool {
@@ -881,7 +881,7 @@ impl RelationSource for InsertRelationSource<'_> {
         self.row.as_record_mut_unwrap()[field.index] = expr;
     }
 
-    fn set_returning_field(&mut self, field: FieldId, expr: stmt::Expr) {
+    fn set_returning_field(&mut self, field: &Field, expr: stmt::Expr) {
         let record = match self.returning {
             Some(stmt::Returning::Project(stmt::Expr::Record(record))) => record,
             Some(stmt::Returning::Expr(stmt::Expr::List(rows))) => {
@@ -891,7 +891,7 @@ impl RelationSource for InsertRelationSource<'_> {
             _ => todo!("InsertRelationSource={self:#?}"),
         };
 
-        set_returning_slot(record, field.index, expr);
+        set_returning_slot(record, field.id.index, expr, field.deferred);
     }
 
     fn needs_existence_check(&self) -> bool {
@@ -986,11 +986,15 @@ fn flatten_relation_batch(entries: &mut Vec<stmt::Assignment>) {
     }
 }
 
-fn set_returning_slot(record: &mut stmt::ExprRecord, index: usize, expr: stmt::Expr) {
-    assert!(
-        record.fields[index].is_value_null(),
-        "TODO: probably need to merge instead of overwrite; actual={:#?}",
-        record.fields[index]
-    );
-    record.fields[index] = lazy_slot::loaded_expr(expr);
+fn set_returning_slot(
+    record: &mut stmt::ExprRecord,
+    index: usize,
+    expr: stmt::Expr,
+    deferred: bool,
+) {
+    record.fields[index] = if deferred {
+        lazy_slot::loaded_expr(expr)
+    } else {
+        expr
+    };
 }

--- a/crates/toasty/src/engine/lower/returning.rs
+++ b/crates/toasty/src/engine/lower/returning.rs
@@ -1,5 +1,11 @@
 use indexmap::IndexMap;
-use toasty_core::{schema::db::ColumnId, stmt};
+use toasty_core::{
+    schema::{
+        app::{FieldTy, ModelId},
+        db::ColumnId,
+    },
+    stmt,
+};
 
 use crate::engine::lower::{LowerStatement, LoweringContext};
 
@@ -21,6 +27,49 @@ enum ConstantizeSource<'a> {
 }
 
 impl LowerStatement<'_, '_> {
+    /// Shape `Returning::Model` for the statement kind before include lowering.
+    ///
+    /// Plain relation fields are implicit includes, except local `has_many` /
+    /// `has_one` fields during insert returning. Those slots are filled from
+    /// nested relation inserts later in insert relation planning; building an
+    /// include subquery here would create a second, stale dependency for the
+    /// same returning slot.
+    pub(super) fn prepare_model_returning_for_context(
+        &self,
+        returning: &mut stmt::Expr,
+        include_paths: &mut Vec<stmt::Path>,
+        is_insert: bool,
+    ) {
+        let model = self.model_unwrap();
+        let stmt::Expr::Record(record) = returning else {
+            return;
+        };
+
+        if is_insert {
+            include_paths.retain(|path| {
+                !first_model_field(path, model.id)
+                    .is_some_and(|field| is_insert_local_eager_relation(&model.fields[field].ty))
+            });
+        }
+
+        for field in &model.fields {
+            if !field.ty.is_relation() || field.deferred {
+                continue;
+            }
+
+            if is_insert && is_insert_local_eager_relation(&field.ty) {
+                record[field.id.index] = match field.ty {
+                    FieldTy::HasMany(_) => stmt::Expr::list_from_vec(vec![]),
+                    FieldTy::HasOne(_) => stmt::Expr::null(),
+                    _ => unreachable!(),
+                };
+                continue;
+            }
+
+            include_paths.push(stmt::Path::field(model.id, field.id.index));
+        }
+    }
+
     /// Attempts to evaluate an INSERT statement's RETURNING clause at compile
     /// time.
     ///
@@ -318,6 +367,18 @@ impl LowerStatement<'_, '_> {
             *returning = stmt::Returning::Project(row.into());
         }
     }
+}
+
+fn is_insert_local_eager_relation(field_ty: &FieldTy) -> bool {
+    matches!(field_ty, FieldTy::HasMany(_) | FieldTy::HasOne(_))
+}
+
+fn first_model_field(path: &stmt::Path, model_id: ModelId) -> Option<usize> {
+    if path.root.as_model()? != model_id {
+        return None;
+    }
+
+    path.projection.as_slice().first().copied()
 }
 
 impl stmt::Input for ConstantizeReturning<'_> {

--- a/crates/toasty/src/lib.rs
+++ b/crates/toasty/src/lib.rs
@@ -25,8 +25,10 @@
 //! [`Auto`](schema::Auto), a wrapper for auto-generated values such as
 //! database-assigned IDs.
 //!
-//! Relation fields use [`Deferred`](schema::Deferred) and are populated through
-//! `.include(...)` or generated relation accessors.
+//! Relation fields can use [`Deferred`](schema::Deferred) for lazy loading or
+//! direct relation values for eager loading. Lazy relations are populated
+//! through `.include(...)` or generated relation accessors. Eager relations are
+//! loaded whenever the model is loaded.
 //!
 //! The module also re-exports from `toasty-core` for inspecting the
 //! app-level and db-level schema representations at runtime.

--- a/crates/toasty/src/schema/belongs_to.rs
+++ b/crates/toasty/src/schema/belongs_to.rs
@@ -1,4 +1,4 @@
-use super::{BelongsToField, Deferred, Register, Relation};
+use super::{BelongsToField, Deferred, Load, Register, Relation};
 
 use toasty_core::schema::app::{self, FieldTy, ForeignKey};
 use toasty_core::stmt;
@@ -8,6 +8,31 @@ impl<T: Relation> BelongsToField for Deferred<T> {
 
     fn nullable() -> bool {
         <T as Relation>::nullable()
+    }
+
+    const DEFERRED: bool = true;
+
+    fn reload(target: &mut Self, _value: stmt::Value) -> crate::Result<()> {
+        target.unload();
+        Ok(())
+    }
+
+    fn belongs_to_field_ty(foreign_key: ForeignKey) -> FieldTy {
+        belongs_to_field_ty::<T>(foreign_key)
+    }
+}
+
+impl<T: Relation> BelongsToField for T {
+    type Target = T;
+
+    fn nullable() -> bool {
+        <T as Relation>::nullable()
+    }
+
+    const DEFERRED: bool = false;
+
+    fn reload(target: &mut Self, value: stmt::Value) -> crate::Result<()> {
+        <Self as Load>::reload(target, value)
     }
 
     fn belongs_to_field_ty(foreign_key: ForeignKey) -> FieldTy {

--- a/crates/toasty/src/schema/has_many.rs
+++ b/crates/toasty/src/schema/has_many.rs
@@ -1,4 +1,4 @@
-use super::{Deferred, HasManyField, Register, Relation};
+use super::{Deferred, HasManyField, Load, Register, Relation};
 
 use toasty_core::schema::Name;
 use toasty_core::schema::app::{self, FieldId, FieldTy, ModelId};
@@ -9,6 +9,35 @@ impl<T: Relation> HasManyField for Deferred<Vec<T>> {
 
     fn nullable() -> bool {
         <T as Relation>::nullable()
+    }
+
+    const DEFERRED: bool = true;
+
+    fn reload(target: &mut Self, _value: stmt::Value) -> crate::Result<()> {
+        target.unload();
+        Ok(())
+    }
+
+    fn has_many_field_ty(
+        singular: Name,
+        pair: Option<FieldId>,
+        via: Option<stmt::Path>,
+    ) -> FieldTy {
+        has_many_field_ty::<T>(singular, pair, via)
+    }
+}
+
+impl<T: Relation> HasManyField for Vec<T> {
+    type Target = T;
+
+    fn nullable() -> bool {
+        <T as Relation>::nullable()
+    }
+
+    const DEFERRED: bool = false;
+
+    fn reload(target: &mut Self, value: stmt::Value) -> crate::Result<()> {
+        <Self as Load>::reload(target, value)
     }
 
     fn has_many_field_ty(

--- a/crates/toasty/src/schema/has_one.rs
+++ b/crates/toasty/src/schema/has_one.rs
@@ -1,5 +1,5 @@
 use super::has_many::has_kind;
-use super::{Deferred, HasOneField, Register, Relation};
+use super::{Deferred, HasOneField, Load, Register, Relation};
 
 use toasty_core::schema::app::{self, FieldId, FieldTy};
 use toasty_core::stmt;
@@ -9,6 +9,31 @@ impl<T: Relation> HasOneField for Deferred<T> {
 
     fn nullable() -> bool {
         <T as Relation>::nullable()
+    }
+
+    const DEFERRED: bool = true;
+
+    fn reload(target: &mut Self, _value: stmt::Value) -> crate::Result<()> {
+        target.unload();
+        Ok(())
+    }
+
+    fn has_one_field_ty(pair: Option<FieldId>, via: Option<stmt::Path>) -> FieldTy {
+        has_one_field_ty::<T>(pair, via)
+    }
+}
+
+impl<T: Relation> HasOneField for T {
+    type Target = T;
+
+    fn nullable() -> bool {
+        <T as Relation>::nullable()
+    }
+
+    const DEFERRED: bool = false;
+
+    fn reload(target: &mut Self, value: stmt::Value) -> crate::Result<()> {
+        <Self as Load>::reload(target, value)
     }
 
     fn has_one_field_ty(pair: Option<FieldId>, via: Option<stmt::Path>) -> FieldTy {

--- a/crates/toasty/src/schema/relation.rs
+++ b/crates/toasty/src/schema/relation.rs
@@ -77,6 +77,12 @@ pub trait HasManyField: Load<Output = Self> {
         <Self::Target as Relation>::nullable()
     }
 
+    /// Whether the field stores its value in a deferred load slot.
+    const DEFERRED: bool;
+
+    /// Reloads this relation field from a returned value.
+    fn reload(target: &mut Self, value: stmt::Value) -> crate::Result<()>;
+
     /// Build the [`FieldTy`] for a `HasMany` relation field, given the
     /// singular name derived from the field identifier and an optional
     /// paired `BelongsTo` field on the target model resolved from
@@ -101,6 +107,12 @@ pub trait HasOneField: Load<Output = Self> {
         <Self::Target as Relation>::nullable()
     }
 
+    /// Whether the field stores its value in a deferred load slot.
+    const DEFERRED: bool;
+
+    /// Reloads this relation field from a returned value.
+    fn reload(target: &mut Self, value: stmt::Value) -> crate::Result<()>;
+
     /// Build the [`FieldTy`] for a `HasOne` relation field, given an
     /// optional paired `BelongsTo` field on the target model resolved
     /// from `#[has_one(pair = <field>)]`. When `None`, the linker selects
@@ -122,6 +134,12 @@ pub trait BelongsToField: Load<Output = Self> {
     fn nullable() -> bool {
         <Self::Target as Relation>::nullable()
     }
+
+    /// Whether the field stores its value in a deferred load slot.
+    const DEFERRED: bool;
+
+    /// Reloads this relation field from a returned value.
+    fn reload(target: &mut Self, value: stmt::Value) -> crate::Result<()>;
 
     /// Build the [`FieldTy`] for a `BelongsTo` relation field, given the
     /// foreign key resolved from the field's `#[belongs_to(...)]` attribute.

--- a/crates/toasty/src/schema/relation.rs
+++ b/crates/toasty/src/schema/relation.rs
@@ -65,9 +65,10 @@ pub trait Relation: Load<Output = Self> {
 
 /// A Rust field type that represents a `#[has_many]` relation.
 ///
-/// This is implemented by [`Deferred<Vec<T>>`](super::Deferred). The target
-/// model/query-builder metadata stays on [`Relation`]; this trait only
-/// describes how the field itself contributes relation schema metadata.
+/// This is implemented by [`Deferred<Vec<T>>`](super::Deferred) for lazy
+/// relations and by `Vec<T>` for eager relations. The target model/query-builder
+/// metadata stays on [`Relation`]; this trait only describes how the field
+/// itself contributes relation schema metadata.
 pub trait HasManyField: Load<Output = Self> {
     /// The relation target type carried by this field.
     type Target: Relation;
@@ -98,6 +99,10 @@ pub trait HasManyField: Load<Output = Self> {
 }
 
 /// A Rust field type that represents a `#[has_one]` relation.
+///
+/// This is implemented by [`Deferred<T>`](super::Deferred) for lazy relations
+/// and by `T` for eager relations. `T` may be `Option<Model>` for nullable
+/// `has_one` fields.
 pub trait HasOneField: Load<Output = Self> {
     /// The relation target type carried by this field.
     type Target: Relation;
@@ -126,6 +131,10 @@ pub trait HasOneField: Load<Output = Self> {
 }
 
 /// A Rust field type that represents a `#[belongs_to]` relation.
+///
+/// This is implemented by [`Deferred<T>`](super::Deferred) for lazy relations
+/// and by `T` for eager relations. `T` may be `Option<Model>` for nullable
+/// `belongs_to` fields.
 pub trait BelongsToField: Load<Output = Self> {
     /// The relation target type carried by this field.
     type Target: Relation;

--- a/docs/dev/design/deferred-relations.md
+++ b/docs/dev/design/deferred-relations.md
@@ -2,10 +2,11 @@
 
 ## Summary
 
-Relations should use the same loaded/unloaded value model as deferred fields.
-Instead of declaring relation fields with dedicated wrapper types such as
-`HasMany<T>`, `HasOne<T>`, and `BelongsTo<T>`, users will declare relations
-with `Deferred<T>`:
+Relations use ordinary Rust field types to control loading behavior. A relation
+wrapped in `Deferred<T>` is lazy, and a direct relation value is eager. Instead
+of declaring relation fields with dedicated wrapper types such as `HasMany<T>`,
+`HasOne<T>`, and `BelongsTo<T>`, users declare lazy relations with
+`Deferred<T>`:
 
 ```rust
 #[has_many]
@@ -18,8 +19,22 @@ profile: toasty::Deferred<Option<Profile>>,
 user: toasty::Deferred<User>,
 ```
 
-This removes the public relation wrapper types and makes relation loading
-consistent with `#[deferred]` scalar and embedded fields.
+They declare eager relations with the relation value directly:
+
+```rust
+#[has_many]
+foos: Vec<Foo>,
+
+#[has_one]
+profile: Option<Profile>,
+
+#[belongs_to(key = user_id, references = id)]
+user: User,
+```
+
+This removes the public relation wrapper types and makes the field type describe
+whether Toasty loads the relation on demand or with every query that returns the
+model.
 
 ## Motivation
 
@@ -31,9 +46,10 @@ are separate:
 - `HasMany<T>`, `HasOne<T>`, and `BelongsTo<T>` are used for relations.
 
 The split leaks into the API. Users must learn separate wrapper names, separate
-loaded-state types, and separate rules for when `.include()` matters. Once
+loaded-state types, and separate rules for when `.include()` matters. Once lazy
 relations are modeled as `Deferred<RelationValue>`, relation fields use the
-same loaded-state API as other deferred fields.
+same loaded-state API as other deferred fields. Direct relation fields cover the
+other common case: a relation that every query for the model needs.
 
 ## User-facing API
 
@@ -82,6 +98,27 @@ for post in user.posts.get() {
 }
 ```
 
+Eager relations are declared by using the relation value directly. Toasty loads
+an eager relation with every query that returns the model, as if the query had
+included the relation path.
+
+```rust
+#[derive(Debug, toasty::Model)]
+struct User {
+    #[key]
+    id: toasty::Id<Self>,
+
+    #[has_many]
+    posts: Vec<Post>,
+}
+
+let user = User::filter_by_id(id).get(&mut db).await?;
+
+for post in &user.posts {
+    println!("{}", post.title);
+}
+```
+
 Before:
 
 ```rust
@@ -102,6 +139,16 @@ posts: toasty::Deferred<Vec<Post>>,
 user: toasty::Deferred<User>,
 ```
 
+Or, when the relation should load with every model query:
+
+```rust
+#[has_many]
+posts: Vec<Post>,
+
+#[belongs_to(key = user_id, references = id)]
+user: User,
+```
+
 ## Behavior
 
 Lazy relation fields behave like other `Deferred<T>` fields. The field is
@@ -113,15 +160,22 @@ exist. `#[has_one] Deferred<Option<T>>` and
 `#[belongs_to] Deferred<Option<T>>` load as `None` when the relation was loaded
 and no related row exists.
 
-Direct relation fields are not supported until the engine has eager relation
-loading. Every relation field must use `Deferred<_>`.
+Direct relation fields are eager. `#[has_many] Vec<T>` loads as an empty
+`Vec<T>` when no related rows exist. `#[has_one] Option<T>` and
+`#[belongs_to] Option<T>` load as `None` when the relation is optional and no
+related row exists. Required direct single relations use `T`.
+
+Toasty rejects schemas with eager-load cycles. A schema such as
+`User { posts: Vec<Post> }` and `Post { user: User }` would recurse forever, so
+one side must use `Deferred<_>`.
 
 Relation accessors remain available. A `user.posts()` method still returns a
 relation query builder for querying, filtering, inserting into, or removing
 from the association. The field value and relation query accessor continue to
 serve different purposes:
 
-- `user.posts` is the loaded model field.
+- `user.posts` is the loaded model field for eager relations, or the
+  loaded/unloaded slot for lazy relations.
 - `user.posts()` builds a statement for the association.
 
 ## Edge cases
@@ -135,14 +189,13 @@ use one lazy-slot convention for deferred fields and relations:
 This lets `Deferred<Option<T>>` and `Deferred<Option<Model>>` represent loaded
 `None` as `Record([Null])` without a relation-specific special value.
 
-Eager relation fields remain out of scope for this phase. When eager relations
-are added, cycles such as `User { posts: Vec<Post> }` and `Post { user: User }`
-must be rejected or bounded.
+Eager relation cycles are schema errors. Cycles are checked across eager
+relation fields only. A cycle that contains a `Deferred<_>` edge is allowed
+because the lazy edge does not load by default.
 
-Multi-step `via` relations should remain lazy-only until include/select support
-for `via` relations exists. The current relation include path already rejects
-multi-step relation projection, so eager `via` would expose an unsupported
-default-load path.
+Multi-step `via` relations may be eager once include/select support for `via`
+relations exists. The eager-cycle check must treat an eager `via` relation like
+the relation path it follows.
 
 ## Driver integration
 
@@ -176,17 +229,16 @@ the public relation syntax changes.
    `Deferred<Option<T>>` where applicable.
 
 6. Done: change macro parsing and expansion to use field-level relation traits.
-   Relation attributes accept `Deferred<_>`. Old wrapper types and direct value
-   types are rejected as relation fields.
+   Relation attributes accept `Deferred<_>` for lazy relations and direct value
+   types for eager relations. Old wrapper types are rejected as relation fields.
 
-7. Future: teach default returning lowering to include non-deferred relation
+7. Done: teach default returning lowering to include non-deferred relation
    fields. `Deferred<_>` relation fields stay unloaded by default; direct
-   relation fields are included automatically once eager loading exists.
+   relation fields are included automatically.
 
-8. Add schema verification for eager relation cycles and unsupported eager
-   `via` relations.
+8. Done: add schema verification for eager relation cycles.
 
-9. Update tests and docs for the new syntax.
+9. Done: update tests and docs for the new syntax.
 
 10. Done: remove `HasMany<T>`, `HasOne<T>`, and `BelongsTo<T>` from the public
     API.
@@ -221,21 +273,17 @@ without overloading `Option`.
 
 ## Open questions
 
-- Blocking implementation: should eager `belongs_to` be allowed for required
-  relations only, or also for nullable `Option<T>`?
-- Blocking implementation: should eager relation cycle detection reject every
-  cycle, or allow explicitly bounded cycles in the future?
 - Deferrable: should there be a batch loader for already-loaded
   `Vec<Model>` values with lazy relation fields?
 - Deferrable: when old relation wrappers are deprecated, should they become
   type aliases, compatibility structs, or disappear in one major release step?
+- Deferrable: should eager relation cycle detection ever allow explicitly
+  bounded cycles?
 
 ## Out of scope
 
 - Per-query relation projection beyond existing `.include(...)` and
   `.select(...)`; this design only changes relation field representation and
   default loading.
-- Eager loading through multi-step `via` relations; this should wait for
-  include/select support for `via`.
 - Driver-specific join optimization; relation loading can continue to use the
   existing nested-query and nested-merge path.

--- a/docs/guide/src/belongs-to.md
+++ b/docs/guide/src/belongs-to.md
@@ -6,9 +6,9 @@ foreign key. The child stores the parent's ID in one of its own fields.
 ## Defining a BelongsTo relationship
 
 A BelongsTo relationship requires two things on the child model: a foreign key
-field and a `Deferred<T>` relation field. The `#[belongs_to]` attribute tells
-Toasty which field holds the foreign key and which field on the parent it
-references.
+field and a relation field. Wrap the relation in `Deferred<T>` for lazy loading,
+or use `T` directly for eager loading. The `#[belongs_to]` attribute tells Toasty
+which field holds the foreign key and which field on the parent it references.
 
 ```rust
 # use toasty::Model;
@@ -59,6 +59,16 @@ CREATE INDEX idx_posts_user_id ON posts (user_id);
 The parent model (`User`) typically declares a `#[has_many]` field pointing back
 at the child. See [HasMany](./has-many.md) for details.
 
+Use a plain relation field when every loaded child should also load its parent:
+
+```rust,ignore
+#[belongs_to(key = user_id, references = id)]
+user: User,
+```
+
+This behaves like an implicit `.include(Post::fields().user())` on every query
+that returns `Post`.
+
 ## Optional BelongsTo
 
 If a child does not always have a parent, make the foreign key `Option<T>` and
@@ -90,6 +100,13 @@ struct Post {
 ```
 
 The `user_id` column is now nullable. A post can exist without a user.
+
+For eager loading, omit `Deferred` and keep the `Option`:
+
+```rust,ignore
+#[belongs_to(key = user_id, references = id)]
+user: Option<User>,
+```
 
 ## Accessing the related record
 

--- a/docs/guide/src/database-setup.md
+++ b/docs/guide/src/database-setup.md
@@ -35,8 +35,9 @@ one crate.
 You don't need to list every model. Registering a model also registers any
 models reachable through its fields — `BelongsTo`, `HasMany`, `HasOne`, and
 embedded types are all discovered by traversing the model's fields. For
-example, if `User` has a `Deferred<Vec<Post>>` field and `Post` has a `Deferred<User>`
-field, `toasty::models!(User)` registers both `User` and `Post`.
+example, if `User` has a `Vec<Post>` or `Deferred<Vec<Post>>` field and `Post`
+has a `User` or `Deferred<User>` field, `toasty::models!(User)` registers both
+`User` and `Post`.
 
 ## Connection URLs
 

--- a/docs/guide/src/deferred-fields.md
+++ b/docs/guide/src/deferred-fields.md
@@ -10,8 +10,8 @@ read: a `Document` body, a binary blob, an audit-event JSON payload.
 Without the deferred annotation, every list query reads every column
 whether the caller needs it or not.
 
-The API mirrors deferred relation fields: a synchronous `.get()` reads an
-already-loaded value, an async per-field accessor loads on demand, and
+The API mirrors relation fields wrapped in `Deferred<_>`: a synchronous `.get()`
+reads an already-loaded value, an async per-field accessor loads on demand, and
 `.include()` preloads as part of the parent query.
 
 ## Marking a field as deferred
@@ -97,8 +97,8 @@ let body: &String = doc.body.get();   // synchronous, no query
 
 `#[deferred]` is supported on primitive fields and on embedded types
 (`#[derive(Embed)]` structs and enums). It does not compose with
-`#[belongs_to]`, `#[has_many]`, or `#[has_one]` — relations are already
-lazy.
+`#[belongs_to]`, `#[has_many]`, or `#[has_one]`. Relation fields use
+`Deferred<_>` in the field type itself when they should be lazy.
 
 A deferred embed value omits all of the embed's columns from the default
 projection. Loading is the same as for a primitive: call the per-field

--- a/docs/guide/src/has-many.md
+++ b/docs/guide/src/has-many.md
@@ -1,13 +1,15 @@
 # HasMany
 
 A `HasMany` relationship connects a parent model to multiple child records. The
-parent declares a `Deferred<Vec<T>>` field, and the child stores a foreign key
-pointing back to the parent via [BelongsTo](./belongs-to.md).
+parent declares a `Vec<T>` relation field, usually wrapped in `Deferred<_>` for
+lazy loading. The child stores a foreign key pointing back to the parent via
+[BelongsTo](./belongs-to.md).
 
 ## Defining a HasMany relationship
 
-Add a `#[has_many]` field of type `Deferred<Vec<T>>` on the parent model. The child
-model must have a corresponding `#[belongs_to]` field.
+Add a `#[has_many]` field on the parent model. Use `Deferred<Vec<T>>` for lazy
+loading, or `Vec<T>` for eager loading. The child model must have a
+corresponding `#[belongs_to]` field.
 
 ```rust
 # use toasty::Model;
@@ -41,6 +43,16 @@ struct Post {
 
 The `#[has_many]` attribute does not add any columns to the parent's table. The
 relationship is stored entirely in the child's foreign key column (`user_id`).
+
+With an eager field, Toasty loads the children whenever it loads the parent:
+
+```rust,ignore
+#[has_many]
+posts: Vec<Post>,
+```
+
+This behaves like an implicit `.include(User::fields().posts())` on every query
+that returns `User`.
 
 ## Querying children
 

--- a/docs/guide/src/has-one.md
+++ b/docs/guide/src/has-one.md
@@ -6,9 +6,10 @@ A `HasOne` relationship connects a parent model to a single child record. Like
 
 ## Defining a HasOne relationship
 
-Add a `#[has_one]` field of type `Deferred<T>` on the parent model. The child
-model must have a corresponding `#[belongs_to]` field with a `#[unique]` foreign
-key (since each parent maps to at most one child):
+Add a `#[has_one]` field on the parent model. Use `Deferred<T>` or
+`Deferred<Option<T>>` for lazy loading, or `T` / `Option<T>` for eager loading.
+The child model must have a corresponding `#[belongs_to]` field with a
+`#[unique]` foreign key (since each parent maps to at most one child):
 
 ```rust
 # use toasty::Model;
@@ -52,11 +53,21 @@ CREATE TABLE profiles (
 CREATE UNIQUE INDEX idx_profiles_user_id ON profiles (user_id);
 ```
 
+With an eager field, Toasty loads the child whenever it loads the parent:
+
+```rust,ignore
+#[has_one]
+profile: Option<Profile>,
+```
+
+This behaves like an implicit `.include(User::fields().profile())` on every
+query that returns `User`.
+
 ## Optional vs required HasOne
 
 The type parameter on `HasOne` controls whether the parent must have a child.
 
-### Optional: `Deferred<Option<Profile>>`
+### Optional: `Deferred<Option<Profile>>` or `Option<Profile>`
 
 The parent may or may not have a child. Creating a parent without a child is
 allowed:
@@ -92,7 +103,7 @@ assert!(user.profile().exec(&mut db).await?.is_none());
 # }
 ```
 
-### Required: `Deferred<Profile>`
+### Required: `Deferred<Profile>` or `Profile`
 
 The parent must have a child. Creating a parent requires providing a child:
 

--- a/docs/guide/src/preloading-associations.md
+++ b/docs/guide/src/preloading-associations.md
@@ -6,16 +6,16 @@ query, avoiding extra database round-trips when you access associations.
 ## Async means a query
 
 Toasty's API follows one rule for associations: **if you `.await` it, it hits
-the database.** The two ways to access
-an association make this visible in the code:
+the database.** Lazy relation fields make this visible in the code:
 
 - `user.posts().exec(&mut db).await?` — async, executes a query.
 - `user.posts.get()` — not async, reads already-loaded data in memory.
 
 Because `.get()` is a plain (non-async) method, the compiler won't let you
-confuse the two. You can scan any code path for `.await` to know exactly where
-database round-trips happen. This makes N+1 problems easy to spot and impossible
-to introduce by accident.
+confuse the two. Plain eager relation fields are already-loaded values, so
+accessing `user.posts` also does not issue a query. You can scan any code path
+for `.await` to know exactly where database round-trips happen. This makes N+1
+problems easy to spot and impossible to introduce by accident.
 
 ## The N+1 problem
 
@@ -40,8 +40,8 @@ how many records you load.
 
 ## Using `.include()`
 
-Add `.include()` to a query to preload a relation. Pass the field path from the
-model's `fields()` accessor:
+Add `.include()` to a query to preload a `Deferred<_>` relation. Pass the field
+path from the model's `fields()` accessor:
 
 ```rust
 # use toasty::Model;
@@ -88,14 +88,46 @@ with `user.posts().exec(&mut db).await?`, which is async and always runs a
 query. The presence or absence of `.await` tells you whether code touches the
 database.
 
+## Eager relation fields
+
+A relation field that is not wrapped in `Deferred<_>` is loaded by every query
+that returns the model. This is equivalent to an implicit `.include(...)`.
+
+```rust,ignore
+#[derive(Debug, toasty::Model)]
+struct User {
+    #[key]
+    #[auto]
+    id: u64,
+
+    #[has_many]
+    posts: Vec<Post>,
+}
+
+let user = User::filter_by_id(user_id).get(&mut db).await?;
+
+// Already loaded — no .include() and no .get() wrapper.
+let post_count = user.posts.len();
+```
+
+Use eager relation fields when most queries for the model need the relation. Use
+`Deferred<_>` when callers should choose between lazy access and explicit
+`.include(...)`.
+
+Eager relations cannot form cycles. Toasty rejects a schema where eager loading
+would recurse forever, such as `User.posts: Vec<Post>` paired with
+`Post.user: User`. Make one side `Deferred<_>` when two models point at each
+other.
+
 ## Preloaded vs unloaded access
 
-There are two ways to access a relation, depending on whether it was preloaded:
+There are three access patterns for relations:
 
 | Access pattern | Async | When to use | Queries |
 |---|---|---|---|
-| `user.posts().exec(&mut db).await?` | Yes | Relation was not preloaded | Executes a query |
-| `user.posts.get()` | No | Relation was preloaded with `.include()` | No query |
+| `user.posts().exec(&mut db).await?` | Yes | Lazy relation was not preloaded | Executes a query |
+| `user.posts.get()` | No | `Deferred<_>` relation was preloaded with `.include()` | No query |
+| `user.posts` | No | Relation field is not wrapped in `Deferred<_>` | No query |
 
 Calling `.get()` on an unloaded relation panics. Only use `.get()` when you know
 the relation was preloaded.
@@ -331,9 +363,8 @@ for user in &users {
 
 | Syntax | Description |
 |---|---|
-| `.include(Model::fields().relation())` | Preload a relation in the query |
-| `model.relation.get()` | Access preloaded HasMany data (returns `&[T]`) |
-| `model.relation.get()` | Access preloaded BelongsTo data (returns `&T`) |
-| `model.relation.get()` | Access preloaded HasOne data (returns `&T` or `&Option<T>`) |
+| `.include(Model::fields().relation())` | Preload a `Deferred<_>` relation in the query |
+| `model.relation.get()` | Access preloaded `Deferred<Vec<T>>`, `Deferred<T>`, or `Deferred<Option<T>>` data |
+| `model.relation` | Access an eager `Vec<T>`, `T`, or `Option<T>` relation field |
 | `model.relation.try_get()` | Non-panicking access; returns `None` if not preloaded |
-| `model.relation.is_unloaded()` | Check if a relation was preloaded |
+| `model.relation.is_unloaded()` | Check whether a `Deferred<_>` relation was preloaded |

--- a/docs/guide/src/relationships.md
+++ b/docs/guide/src/relationships.md
@@ -103,6 +103,45 @@ is not allowed — a `#[has_many]` or `#[has_one]` field always requires a
 matching `#[belongs_to]` on the target model, because Toasty needs the foreign
 key definition to know how the models connect.
 
+### Lazy and eager relation fields
+
+The relation field type controls when Toasty loads the related records.
+
+Use `Deferred<_>` for a lazy relation. A normal query leaves the field unloaded.
+Load it by calling the generated relation accessor, or preload it with
+`.include(...)`:
+
+```rust,ignore
+#[has_many]
+posts: toasty::Deferred<Vec<Post>>,
+
+let posts = user.posts().exec(&mut db).await?;
+```
+
+Use the relation value directly for an eager relation. Toasty loads the relation
+with every query that returns the model, as if the query had an implicit
+`.include(...)`:
+
+```rust,ignore
+#[has_many]
+posts: Vec<Post>,
+
+let user = User::filter_by_id(user_id).get(&mut db).await?;
+let post_count = user.posts.len();
+```
+
+The accepted eager field types are:
+
+| Attribute | Lazy field type | Eager field type |
+|---|---|---|
+| `#[has_many]` | `Deferred<Vec<T>>` | `Vec<T>` |
+| `#[has_one]` | `Deferred<T>` or `Deferred<Option<T>>` | `T` or `Option<T>` |
+| `#[belongs_to]` | `Deferred<T>` or `Deferred<Option<T>>` | `T` or `Option<T>` |
+
+Eager relations can load other eager relations. Toasty rejects schemas with an
+eager-load cycle, such as `User.posts: Vec<Post>` and `Post.user: User`. Wrap at
+least one relation in `Deferred<_>` to break the cycle.
+
 ## Required vs optional relationships
 
 The nullability of the foreign key field controls whether the relationship is
@@ -203,9 +242,9 @@ generates the appropriate cascade deletes or null-setting updates automatically.
 
 | You want to express… | Use | FK goes on |
 |---|---|---|
-| A post has one author | `Post` → `Deferred<User>` + `User` → `Deferred<Vec<Post>>` | `posts.user_id` |
-| A user has one profile | `User` → `Deferred<Profile>` + `Profile` → `Deferred<User>` | `profiles.user_id` |
-| A comment belongs to a post | `Comment` → `Deferred<Post>` + `Post` → `Deferred<Vec<Comment>>` | `comments.post_id` |
+| A post has one author | `Post` → `Deferred<User>` or `User` + `User` → `Deferred<Vec<Post>>` or `Vec<Post>` | `posts.user_id` |
+| A user has one profile | `User` → `Deferred<Profile>` or `Profile` + `Profile` → `Deferred<User>` or `User` | `profiles.user_id` |
+| A comment belongs to a post | `Comment` → `Deferred<Post>` or `Post` + `Post` → `Deferred<Vec<Comment>>` or `Vec<Comment>` | `comments.post_id` |
 
 When deciding between `HasOne` and `HasMany`, ask: "Can the parent have more
 than one?" If yes, use `HasMany`. If exactly one (or zero), use `HasOne`. The


### PR DESCRIPTION
## Summary

- Add eager relation fields for `#[has_many]`, `#[has_one]`, and `#[belongs_to]` when the field is not wrapped in `Deferred<_>`.
- Keep `Deferred<_>` relation fields lazy, convert relation field traits to expose `DEFERRED` as a const, and make default returning lowering populate eager relation fields.
- Reject eager-load cycles during schema verification so implicit includes cannot recurse forever.
- Add integration coverage for eager relation loading, insert returning behavior, create macro interaction, and eager-load cycle errors.
- Update the macro API docs, user guide, and deferred-relations design doc.

## Type of change

- [x] Other: implements eager relation fields and updates the accepted deferred-relations design.

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API -> a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior -> the design doc covers it

## Notes for reviewers

Focus on eager-load cycle validation and the insert returning path for eager `has_many`, `has_one`, and `belongs_to` fields.