### PR TITLE
fix(engine): handle ExprOr in eval verify_expr

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/crud_query_macro.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/crud_query_macro.rs
@@ -136,11 +136,7 @@ pub async fn query_macro_filter_not(test: &mut Test) -> Result<()> {
     Ok(())
 }
 
-// Gated on `requires(sql)` until [#857] is fixed — `OR` of comparison ops
-// nested inside an `AND` panics in eval on the DynamoDB scan path.
-//
-// [#857]: https://github.com/tokio-rs/toasty/issues/857
-#[driver_test(id(ID), scenario(crate::scenarios::user_with_age), requires(sql))]
+#[driver_test(id(ID), scenario(crate::scenarios::user_with_age), requires(scan))]
 pub async fn query_macro_filter_parens(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 

--- a/crates/toasty/src/engine/eval.rs
+++ b/crates/toasty/src/engine/eval.rs
@@ -76,6 +76,7 @@ fn verify_expr(expr: &stmt::Expr) -> bool {
     match expr {
         Arg(_) => true,
         And(expr_and) => expr_and.operands.iter().all(verify_expr),
+        Or(expr_or) => expr_or.operands.iter().all(verify_expr),
         BinaryOp(expr) => verify_expr(&expr.lhs) && verify_expr(&expr.rhs),
         Cast(expr) => verify_expr(&expr.expr),
         IsNull(expr) => verify_expr(&expr.expr),


### PR DESCRIPTION
## Summary

Fixes #857.

`verify_expr` in `engine/eval.rs` had an arm for `And` but not `Or`. Filters of the form `field == X AND (field > Y OR field < Z)` would recurse into the `And`, encounter the inner `ExprOr`, and hit the `todo!()` catch-all — panicking at runtime across all drivers.

`OR` of equalities was unaffected because the simplifier rewrites them to `IN` before eval. `OR` of comparison operators has no such rewrite and exposed the gap.

Fix: one line — `Or` mirrors `And` exactly, since both hold a flat list of operand expressions.

Also removes the `requires(sql)` gate from `query_macro_filter_parens`, which was added as a workaround for this bug.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

`verify_expr` gates whether an expression is safe to evaluate in-process as a post-fetch filter. The fix belongs here rather than in the simplifier because `OR` of comparison ops has no canonical rewrite — there's nothing to normalize it to, so the evaluator needs to handle it directly. The `query_macro_filter_parens` test exercises the exact panic path (`AND` containing a nested `OR` of `>` / `<` ops) and now runs on all drivers.