### PR TITLE
ci: publish release-plz only from release PRs

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,7 +2,7 @@
 git_release_draft = true
 pr_draft = true
 pr_labels = ["release"]
-release_always = true
+release_always = false
 
 [changelog]
 # Pipe each rendered release section through Claude to filter for


### PR DESCRIPTION
## Summary

`release-plz release` publishes package versions that already exist on `main`. With `release_always = true`, adding `toasty-driver-turso` to the release-plz package list made the `main` release job try to publish `toasty-driver-turso 0.6.1` before a release PR could bump the workspace versions and dependency versions.

Set `release_always = false` so release-plz publishes only after a release PR merge. That keeps publishing tied to the prepared release state, where the workspace crates and their local dependency versions have already been updated together.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` is clean

## Notes for reviewers

This keeps cargo publish verification enabled and avoids changing Turso source code to compile against older published workspace crates.