### PR TITLE
feat: add raw SQL execution API

### DIFF
--- a/crates/toasty-core/src/driver.rs
+++ b/crates/toasty-core/src/driver.rs
@@ -6,13 +6,15 @@
 //! operations against a live database session).
 //!
 //! The query planner inspects [`Capability`] to decide which [`Operation`]
-//! variants to emit. SQL-based drivers receive [`Operation::QuerySql`] and
-//! [`Operation::Insert`], while key-value drivers (e.g., DynamoDB) receive
-//! [`Operation::GetByKey`], [`Operation::QueryPk`], etc. The
+//! variants to emit. SQL-based drivers receive [`Operation::QuerySql`],
+//! [`Operation::RawSql`], and [`Operation::Insert`], while key-value drivers
+//! (e.g., DynamoDB) receive [`Operation::GetByKey`], [`Operation::QueryPk`], etc. The
 //! [`SchemaMutations`] sub-struct (`Capability::schema_mutations`) describes
 //! what the database can do to its own schema — for example, whether
 //! `ALTER COLUMN` can change a column's type — and the migration generator
 //! consults it to decide between an in-place alter and a table rebuild.
+//! [`SqlPlaceholder`] describes the bind placeholder syntax used by SQL
+//! operations and raw SQL.
 //!
 //! # Architecture
 //!
@@ -51,7 +53,7 @@
 //! [`crate::Error::driver_operation_failed`].
 
 mod capability;
-pub use capability::{Capability, SchemaMutations, StorageTypes};
+pub use capability::{Capability, SchemaMutations, SqlPlaceholder, StorageTypes};
 
 mod response;
 pub use response::{ExecResponse, Rows};

--- a/crates/toasty-core/src/driver/capability.rs
+++ b/crates/toasty-core/src/driver/capability.rs
@@ -27,6 +27,11 @@ pub struct Capability {
     /// planner will emit [`QuerySql`](super::operation::QuerySql) operations.
     pub sql: bool,
 
+    /// Placeholder syntax accepted by the driver's SQL bind layer.
+    ///
+    /// SQL drivers set this to `Some`. Non-SQL drivers set this to `None`.
+    pub sql_placeholder: Option<SqlPlaceholder>,
+
     /// Column storage types supported by the database.
     pub storage_types: StorageTypes,
 
@@ -361,6 +366,24 @@ pub struct SchemaMutations {
     pub alter_column_properties_atomic: bool,
 }
 
+/// SQL bind-parameter placeholder syntax accepted by a driver.
+///
+/// This describes the SQL text users must write when sending raw SQL through
+/// [`RawSql`](super::operation::RawSql). The SQL serializer uses the same
+/// value when rendering Toasty-generated SQL.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SqlPlaceholder {
+    /// Positional `?` placeholders, where parameter order is the occurrence
+    /// order in the SQL string.
+    QuestionMark,
+
+    /// Numbered `?1`, `?2`, ... placeholders.
+    NumberedQuestionMark,
+
+    /// Numbered `$1`, `$2`, ... placeholders.
+    DollarNumber,
+}
+
 impl Capability {
     /// Validates the consistency of the capability configuration.
     ///
@@ -388,6 +411,18 @@ impl Capability {
         if self.native_ilike && !self.native_like {
             return Err(crate::Error::invalid_driver_configuration(
                 "native_ilike is true but native_like is false",
+            ));
+        }
+
+        if self.sql && self.sql_placeholder.is_none() {
+            return Err(crate::Error::invalid_driver_configuration(
+                "sql is true but sql_placeholder is None",
+            ));
+        }
+
+        if !self.sql && self.sql_placeholder.is_some() {
+            return Err(crate::Error::invalid_driver_configuration(
+                "sql is false but sql_placeholder is Some",
             ));
         }
 
@@ -433,6 +468,7 @@ impl Capability {
     /// SQLite capabilities.
     pub const SQLITE: Self = Self {
         sql: true,
+        sql_placeholder: Some(SqlPlaceholder::NumberedQuestionMark),
         storage_types: StorageTypes::SQLITE,
         schema_mutations: SchemaMutations::SQLITE,
         cte_with_update: false,
@@ -510,6 +546,7 @@ impl Capability {
     /// PostgreSQL capabilities
     pub const POSTGRESQL: Self = Self {
         cte_with_update: true,
+        sql_placeholder: Some(SqlPlaceholder::DollarNumber),
         storage_types: StorageTypes::POSTGRESQL,
         schema_mutations: SchemaMutations::POSTGRESQL,
         select_for_update: true,
@@ -563,6 +600,7 @@ impl Capability {
     /// MySQL capabilities
     pub const MYSQL: Self = Self {
         cte_with_update: false,
+        sql_placeholder: Some(SqlPlaceholder::QuestionMark),
         storage_types: StorageTypes::MYSQL,
         schema_mutations: SchemaMutations::MYSQL,
         select_for_update: true,
@@ -624,6 +662,7 @@ impl Capability {
     /// DynamoDB capabilities
     pub const DYNAMODB: Self = Self {
         sql: false,
+        sql_placeholder: None,
         storage_types: StorageTypes::DYNAMODB,
         schema_mutations: SchemaMutations::DYNAMODB,
         cte_with_update: false,
@@ -876,6 +915,40 @@ mod tests {
     fn test_validate_dynamodb_capability() {
         // DynamoDB has native_varchar=false and varchar=None, should pass
         assert!(Capability::DYNAMODB.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_fails_when_sql_has_no_placeholder() {
+        let invalid = Capability {
+            sql_placeholder: None,
+            ..Capability::SQLITE
+        };
+
+        let result = invalid.validate();
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("sql is true but sql_placeholder is None")
+        );
+    }
+
+    #[test]
+    fn test_validate_fails_when_non_sql_has_placeholder() {
+        let invalid = Capability {
+            sql_placeholder: Some(SqlPlaceholder::QuestionMark),
+            ..Capability::DYNAMODB
+        };
+
+        let result = invalid.validate();
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("sql is false but sql_placeholder is Some")
+        );
     }
 
     #[test]

--- a/crates/toasty-core/src/driver/operation.rs
+++ b/crates/toasty-core/src/driver/operation.rs
@@ -2,10 +2,11 @@
 //!
 //! An [`Operation`] is the unit of work sent to [`Connection::exec`](super::Connection::exec).
 //! The query engine compiles user queries into one or more `Operation` values.
-//! SQL drivers handle [`QuerySql`] and [`Insert`]; key-value drivers handle
-//! [`GetByKey`], [`QueryPk`], [`DeleteByKey`], [`FindPkByIndex`], [`UpdateByKey`],
-//! and (when [`Capability::scan`](super::Capability::scan) is `true`) [`Scan`].
-//! Both driver types handle [`Transaction`] operations.
+//! SQL drivers handle [`QuerySql`], [`RawSql`], and [`Insert`]; key-value
+//! drivers handle [`GetByKey`], [`QueryPk`], [`DeleteByKey`],
+//! [`FindPkByIndex`], [`UpdateByKey`], and (when
+//! [`Capability::scan`](super::Capability::scan) is `true`) [`Scan`]. Both
+//! driver types handle [`Transaction`] operations.
 
 mod delete_by_key;
 pub use delete_by_key::DeleteByKey;
@@ -27,6 +28,9 @@ pub use query_pk::QueryPk;
 
 mod query_sql;
 pub use query_sql::QuerySql;
+
+mod raw_sql;
+pub use raw_sql::{RawSql, RawSqlRet};
 
 mod scan;
 pub use scan::Scan;
@@ -77,8 +81,12 @@ pub enum Operation {
     /// ordering, and pagination.
     QueryPk(QueryPk),
 
-    /// Execute a raw SQL statement. Only sent to SQL-capable drivers.
+    /// Execute SQL generated from a lowered Toasty statement AST. Only sent to
+    /// SQL-capable drivers.
     QuerySql(QuerySql),
+
+    /// Execute user-authored SQL text. Only sent to SQL-capable drivers.
+    RawSql(RawSql),
 
     /// A transaction lifecycle operation (begin, commit, rollback, savepoint).
     Transaction(Transaction),
@@ -102,6 +110,7 @@ impl Operation {
             Operation::GetByKey(_) => "get_by_key",
             Operation::QueryPk(_) => "query_pk",
             Operation::QuerySql(_) => "query_sql",
+            Operation::RawSql(_) => "raw_sql",
             Operation::Transaction(_) => "transaction",
             Operation::UpdateByKey(_) => "update_by_key",
             Operation::Scan(_) => "scan",

--- a/crates/toasty-core/src/driver/operation/raw_sql.rs
+++ b/crates/toasty-core/src/driver/operation/raw_sql.rs
@@ -1,0 +1,59 @@
+use super::{Operation, TypedValue};
+
+use crate::stmt;
+
+/// Executes user-authored SQL against a SQL-capable driver.
+///
+/// Unlike [`QuerySql`](super::QuerySql), this operation carries backend SQL
+/// text directly. The driver does not serialize a Toasty statement AST before
+/// executing it.
+///
+/// The SQL text uses the placeholder syntax reported by
+/// [`Capability::sql_placeholder`](super::super::Capability::sql_placeholder).
+/// Parameters carry database storage types. The public raw SQL builders infer
+/// these from bound values and driver capabilities unless the caller supplies
+/// an explicit type.
+#[derive(Debug, Clone)]
+pub struct RawSql {
+    /// Backend SQL text to execute.
+    pub sql: String,
+
+    /// Typed bind parameters in placeholder order.
+    pub params: Vec<TypedValue>,
+
+    /// How the driver should execute and decode the SQL.
+    pub ret: RawSqlRet,
+}
+
+/// Return mode for a [`RawSql`] operation.
+#[derive(Debug, Clone)]
+pub enum RawSqlRet {
+    /// Execute as a statement and return an affected-row count.
+    None,
+
+    /// Execute as a query and infer result value types from driver metadata.
+    ///
+    /// Drivers should map backend-native result metadata to the closest
+    /// [`stmt::Value`](crate::stmt::Value) variant. Ambiguous backend values
+    /// may decode to their storage representation.
+    Infer,
+
+    /// Execute as a query using explicit result column type hints.
+    ///
+    /// Type hints affect decoding only; drivers must execute the SQL text
+    /// unchanged.
+    Types(Vec<stmt::Type>),
+}
+
+impl Operation {
+    /// Returns `true` if this is a [`RawSql`](Operation::RawSql) operation.
+    pub fn is_raw_sql(&self) -> bool {
+        matches!(self, Operation::RawSql(_))
+    }
+}
+
+impl From<RawSql> for Operation {
+    fn from(value: RawSql) -> Self {
+        Self::RawSql(value)
+    }
+}

--- a/crates/toasty-driver-dynamodb/src/lib.rs
+++ b/crates/toasty-driver-dynamodb/src/lib.rs
@@ -198,6 +198,9 @@ impl Connection {
                 }
             }
             Operation::Scan(op) => self.exec_scan(schema, op).await,
+            Operation::RawSql(_) => Err(Error::unsupported_feature(
+                "raw SQL is only supported by SQL drivers",
+            )),
             Operation::Transaction(_) => Err(Error::unsupported_feature(
                 "transactions are not supported by the DynamoDB driver",
             )),

--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -56,6 +56,7 @@ pub mod lift_belongs_to_complex_filter;
 pub mod query_count;
 pub mod query_in_list;
 pub mod raw_identifier_fields;
+pub mod raw_sql;
 pub mod record_not_found;
 pub mod relation_belongs_to_configured;
 pub mod relation_belongs_to_embed_key;

--- a/crates/toasty-driver-integration-suite/src/tests/raw_sql.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/raw_sql.rs
@@ -1,0 +1,160 @@
+use crate::prelude::*;
+
+#[driver_test(requires(sql))]
+pub async fn statement_and_query_on_db(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: u64,
+        #[index]
+        name: String,
+    }
+
+    let mut db = t.setup_db(models!(User)).await;
+    let table = table_name(&db, "users");
+
+    toasty::create!(User { name: "Alice" })
+        .exec(&mut db)
+        .await?;
+
+    let count = toasty::sql::statement(format!(
+        "UPDATE {table} SET name = {} WHERE name = {}",
+        placeholder(&db, 1),
+        placeholder(&db, 2),
+    ))
+    .bind("Bob")
+    .bind("Alice")
+    .exec(&mut db)
+    .await?;
+    assert_eq!(count, 1);
+
+    let rows = toasty::sql::query(format!("SELECT name FROM {table}"))
+        .exec(&mut db)
+        .await?;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(field(&rows[0], 0), &toasty::stmt::Value::from("Bob"));
+
+    Ok(())
+}
+
+#[driver_test(requires(sql))]
+pub async fn query_on_connection(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: u64,
+        #[index]
+        name: String,
+    }
+
+    let mut db = t.setup_db(models!(User)).await;
+    let table = table_name(&db, "users");
+
+    toasty::create!(User { name: "Alice" })
+        .exec(&mut db)
+        .await?;
+
+    let mut conn = db.connection().await?;
+    let rows = toasty::sql::query(format!(
+        "SELECT name FROM {table} WHERE name = {}",
+        placeholder(&db, 1),
+    ))
+    .bind("Alice")
+    .exec(&mut conn)
+    .await?;
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(field(&rows[0], 0), &toasty::stmt::Value::from("Alice"));
+
+    Ok(())
+}
+
+#[driver_test(requires(sql))]
+pub async fn statement_inside_transaction_rolls_back(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: u64,
+        #[index]
+        name: String,
+    }
+
+    let mut db = t.setup_db(models!(User)).await;
+    let table = table_name(&db, "users");
+
+    toasty::create!(User { name: "Alice" })
+        .exec(&mut db)
+        .await?;
+
+    let mut tx = db.transaction().await?;
+    toasty::sql::statement(format!("UPDATE {table} SET name = 'Bob'"))
+        .exec(&mut tx)
+        .await?;
+    tx.rollback().await?;
+
+    let user = User::filter_by_name("Alice").get(&mut db).await?;
+    assert_eq!(user.name, "Alice");
+
+    Ok(())
+}
+
+#[driver_test(requires(not(sql)))]
+pub async fn raw_sql_rejects_non_sql_drivers(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        id: uuid::Uuid,
+        name: String,
+    }
+
+    let mut db = t.setup_db(models!(Item)).await;
+    let err = toasty::sql::statement("SELECT 1")
+        .exec(&mut db)
+        .await
+        .unwrap_err();
+
+    assert!(
+        err.is_unsupported_feature(),
+        "expected UnsupportedFeature, got: {err}"
+    );
+
+    Ok(())
+}
+
+fn table_name(db: &toasty::Db, suffix: &str) -> String {
+    db.schema()
+        .db
+        .tables
+        .iter()
+        .find(|table| table.name.ends_with(suffix))
+        .map(|table| table.name.clone())
+        .unwrap_or_else(|| panic!("table {suffix} not found"))
+}
+
+fn placeholder(db: &toasty::Db, index: usize) -> String {
+    render_placeholder(
+        db.capability()
+            .sql_placeholder
+            .expect("SQL driver has placeholders"),
+        index,
+    )
+}
+
+fn render_placeholder(placeholder: toasty::SqlPlaceholder, index: usize) -> String {
+    match placeholder {
+        toasty::SqlPlaceholder::QuestionMark => "?".to_string(),
+        toasty::SqlPlaceholder::NumberedQuestionMark => format!("?{index}"),
+        toasty::SqlPlaceholder::DollarNumber => format!("${index}"),
+    }
+}
+
+fn field(value: &toasty::stmt::Value, index: usize) -> &toasty::stmt::Value {
+    let toasty::stmt::Value::Record(record) = value else {
+        panic!("expected record, got {value:?}");
+    };
+
+    &record[index]
+}

--- a/crates/toasty-driver-integration-suite/src/tests/raw_sql.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/raw_sql.rs
@@ -1,5 +1,11 @@
 use crate::prelude::*;
 
+use toasty::stmt::{self, Value};
+use toasty_core::{
+    driver::{Operation, operation::RawSqlRet},
+    schema::db,
+};
+
 #[driver_test(requires(sql))]
 pub async fn statement_and_query_on_db(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
@@ -101,6 +107,399 @@ pub async fn statement_inside_transaction_rolls_back(t: &mut Test) -> Result<()>
     Ok(())
 }
 
+#[driver_test(requires(sql))]
+pub async fn query_is_sent_as_raw_sql_driver_operation(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: u64,
+    }
+
+    let mut db = t.setup_db(models!(Item)).await;
+    let sql = format!("SELECT {}", placeholder(&db, 1));
+
+    t.log().clear();
+    let rows = toasty::sql::query(sql.clone())
+        .bind_typed(Value::I64(123), db::Type::Integer(8))
+        .column_types([stmt::Type::I64])
+        .exec(&mut db)
+        .await?;
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(field(&rows[0], 0), &Value::I64(123));
+
+    let (op, _) = t.log().pop();
+    let Operation::RawSql(op) = op else {
+        panic!("expected RawSql operation, got {op:?}");
+    };
+
+    assert_eq!(op.sql, sql);
+    assert_eq!(op.params.len(), 1);
+    assert_eq!(op.params[0].value, Value::I64(123));
+    assert_eq!(op.params[0].ty, db::Type::Integer(8));
+    assert!(matches!(op.ret, RawSqlRet::Types(types) if types == vec![stmt::Type::I64]));
+    assert!(t.log().is_empty());
+
+    Ok(())
+}
+
+#[driver_test(requires(sql))]
+pub async fn query_infers_storage_values(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: u64,
+        bool_v: bool,
+        int_v: i64,
+        float_v: f64,
+        string_v: String,
+        bytes_v: Vec<u8>,
+        uuid_v: uuid::Uuid,
+    }
+
+    let mut db = t.setup_db(models!(Item)).await;
+    let table = table_name(&db, "items");
+    let uuid = uuid::Uuid::from_u128(0x0123456789abcdef0123456789abcdef);
+
+    let item = toasty::create!(Item {
+        bool_v: true,
+        int_v: -42,
+        float_v: 10.25,
+        string_v: "hello".to_string(),
+        bytes_v: vec![0, 1, 2, 255],
+        uuid_v: uuid,
+    })
+    .exec(&mut db)
+    .await?;
+
+    let rows = toasty::sql::query(format!(
+        "SELECT bool_v, int_v, float_v, string_v, bytes_v, uuid_v FROM {table} WHERE id = {}",
+        placeholder(&db, 1),
+    ))
+    .bind(item.id)
+    .exec(&mut db)
+    .await?;
+
+    assert_eq!(rows.len(), 1);
+
+    let expected_bool = if is_postgresql(&db) {
+        Value::Bool(true)
+    } else {
+        Value::I64(1)
+    };
+    let expected_uuid = match db.capability().sql_placeholder.unwrap() {
+        toasty::SqlPlaceholder::DollarNumber => Value::Uuid(uuid),
+        toasty::SqlPlaceholder::QuestionMark => Value::String(uuid.to_string()),
+        toasty::SqlPlaceholder::NumberedQuestionMark => Value::Bytes(uuid.as_bytes().to_vec()),
+    };
+    let expected = vec![
+        expected_bool,
+        Value::I64(-42),
+        Value::F64(10.25),
+        Value::String("hello".to_string()),
+        Value::Bytes(vec![0, 1, 2, 255]),
+        expected_uuid,
+    ];
+
+    assert_eq!(fields(&rows[0]), expected.as_slice());
+
+    Ok(())
+}
+
+#[driver_test(requires(sql))]
+pub async fn query_column_types_decode_scalars(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: u64,
+        bool_v: bool,
+        i8_v: i8,
+        i16_v: i16,
+        i32_v: i32,
+        i64_v: i64,
+        u8_v: u8,
+        u16_v: u16,
+        u32_v: u32,
+        u64_v: u64,
+        f32_v: f32,
+        f64_v: f64,
+        string_v: String,
+        bytes_v: Vec<u8>,
+        #[column(type = text)]
+        uuid_v: uuid::Uuid,
+    }
+
+    let mut db = t.setup_db(models!(Item)).await;
+    let table = table_name(&db, "items");
+    let uuid = uuid::Uuid::from_u128(0xfedcba9876543210fedcba9876543210);
+
+    let item = toasty::create!(Item {
+        bool_v: true,
+        i8_v: -8,
+        i16_v: -16,
+        i32_v: -32,
+        i64_v: -64,
+        u8_v: 8,
+        u16_v: 16,
+        u32_v: 32,
+        u64_v: 64,
+        f32_v: 1.25,
+        f64_v: 2.5,
+        string_v: "hello".to_string(),
+        bytes_v: vec![3, 4, 5, 255],
+        uuid_v: uuid,
+    })
+    .exec(&mut db)
+    .await?;
+
+    let rows = toasty::sql::query(format!(
+        "SELECT bool_v, i8_v, i16_v, i32_v, i64_v, u8_v, u16_v, u32_v, u64_v, \
+         f32_v, f64_v, string_v, bytes_v, uuid_v FROM {table} WHERE id = {}",
+        placeholder(&db, 1),
+    ))
+    .bind(item.id)
+    .column_types([
+        stmt::Type::Bool,
+        stmt::Type::I8,
+        stmt::Type::I16,
+        stmt::Type::I32,
+        stmt::Type::I64,
+        stmt::Type::U8,
+        stmt::Type::U16,
+        stmt::Type::U32,
+        stmt::Type::U64,
+        stmt::Type::F32,
+        stmt::Type::F64,
+        stmt::Type::String,
+        stmt::Type::Bytes,
+        stmt::Type::Uuid,
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let expected = vec![
+        Value::Bool(true),
+        Value::I8(-8),
+        Value::I16(-16),
+        Value::I32(-32),
+        Value::I64(-64),
+        Value::U8(8),
+        Value::U16(16),
+        Value::U32(32),
+        Value::U64(64),
+        Value::F32(1.25),
+        Value::F64(2.5),
+        Value::String("hello".to_string()),
+        Value::Bytes(vec![3, 4, 5, 255]),
+        Value::Uuid(uuid),
+    ];
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(fields(&rows[0]), expected.as_slice());
+
+    Ok(())
+}
+
+#[driver_test(requires(sql))]
+pub async fn statement_binds_typed_null(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: u64,
+        name: Option<String>,
+    }
+
+    let mut db = t.setup_db(models!(Item)).await;
+    let table = table_name(&db, "items");
+
+    let count = toasty::sql::statement(format!(
+        "INSERT INTO {table} (name) VALUES ({})",
+        placeholder(&db, 1),
+    ))
+    .bind_typed(Value::Null, toasty::schema::db::Type::Text)
+    .exec(&mut db)
+    .await?;
+    assert_eq!(count, 1);
+
+    let rows = toasty::sql::query(format!("SELECT name FROM {table}"))
+        .exec(&mut db)
+        .await?;
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(field(&rows[0], 0), &Value::Null);
+
+    Ok(())
+}
+
+#[driver_test(requires(and(sql, vec_scalar)))]
+pub async fn query_column_types_decode_list(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: u64,
+        tags: Vec<String>,
+    }
+
+    let mut db = t.setup_db(models!(Item)).await;
+    let table = table_name(&db, "items");
+    let tags = vec!["rust".to_string(), "toasty".to_string()];
+
+    let item = toasty::create!(Item { tags: tags.clone() })
+        .exec(&mut db)
+        .await?;
+
+    let rows = toasty::sql::query(format!(
+        "SELECT tags FROM {table} WHERE id = {}",
+        placeholder(&db, 1),
+    ))
+    .bind(item.id)
+    .column_types([stmt::Type::list(stmt::Type::String)])
+    .exec(&mut db)
+    .await?;
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        field(&rows[0], 0),
+        &Value::List(tags.into_iter().map(Value::String).collect())
+    );
+
+    Ok(())
+}
+
+#[driver_test(requires(and(sql, native_datetime)))]
+pub async fn query_column_types_decode_temporal(t: &mut Test) -> Result<(), BoxError> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: u64,
+        timestamp_v: jiff::Timestamp,
+        date_v: jiff::civil::Date,
+        time_v: jiff::civil::Time,
+        datetime_v: jiff::civil::DateTime,
+    }
+
+    let mut db = t.setup_db(models!(Item)).await;
+    let table = table_name(&db, "items");
+    let timestamp = jiff::Timestamp::from_second(1_700_000_000)?
+        .checked_add(jiff::Span::new().nanoseconds(123_456_000))?;
+    let date = jiff::civil::date(2025, 6, 15);
+    let time = jiff::civil::time(9, 30, 45, 123_456_000);
+    let datetime = jiff::civil::datetime(2025, 6, 15, 9, 30, 45, 123_456_000);
+
+    let item = toasty::create!(Item {
+        timestamp_v: timestamp,
+        date_v: date,
+        time_v: time,
+        datetime_v: datetime,
+    })
+    .exec(&mut db)
+    .await?;
+
+    let rows = toasty::sql::query(format!(
+        "SELECT timestamp_v, date_v, time_v, datetime_v FROM {table} WHERE id = {}",
+        placeholder(&db, 1),
+    ))
+    .bind(item.id)
+    .column_types([
+        stmt::Type::Timestamp,
+        stmt::Type::Date,
+        stmt::Type::Time,
+        stmt::Type::DateTime,
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let expected = vec![
+        Value::Timestamp(timestamp),
+        Value::Date(date),
+        Value::Time(time),
+        Value::DateTime(datetime),
+    ];
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(fields(&rows[0]), expected.as_slice());
+
+    Ok(())
+}
+
+#[driver_test(requires(and(sql, native_decimal)))]
+pub async fn query_column_types_decode_decimal(t: &mut Test) -> Result<(), BoxError> {
+    use rust_decimal::Decimal;
+    use std::str::FromStr;
+
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: u64,
+        #[column(type = numeric(28, 10))]
+        val: Decimal,
+    }
+
+    let mut db = t.setup_db(models!(Item)).await;
+    let table = table_name(&db, "items");
+    let val = Decimal::from_str("123456789012345678.1234567890")?;
+
+    let item = toasty::create!(Item { val }).exec(&mut db).await?;
+
+    let rows = toasty::sql::query(format!(
+        "SELECT val FROM {table} WHERE id = {}",
+        placeholder(&db, 1),
+    ))
+    .bind(item.id)
+    .column_types([stmt::Type::Decimal])
+    .exec(&mut db)
+    .await?;
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(field(&rows[0], 0), &Value::Decimal(val));
+
+    Ok(())
+}
+
+#[driver_test(requires(and(sql, native_decimal, bigdecimal_implemented)))]
+pub async fn query_column_types_decode_bigdecimal(t: &mut Test) -> Result<(), BoxError> {
+    use bigdecimal::BigDecimal;
+    use std::str::FromStr;
+
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: u64,
+        #[column(type = numeric(38, 20))]
+        val: BigDecimal,
+    }
+
+    let mut db = t.setup_db(models!(Item)).await;
+    let table = table_name(&db, "items");
+    let val = BigDecimal::from_str("123456789012345678.12345678901234567890")?;
+
+    let item = toasty::create!(Item { val: val.clone() })
+        .exec(&mut db)
+        .await?;
+
+    let rows = toasty::sql::query(format!(
+        "SELECT val FROM {table} WHERE id = {}",
+        placeholder(&db, 1),
+    ))
+    .bind(item.id)
+    .column_types([stmt::Type::BigDecimal])
+    .exec(&mut db)
+    .await?;
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(field(&rows[0], 0), &Value::BigDecimal(val));
+
+    Ok(())
+}
+
 #[driver_test(requires(not(sql)))]
 pub async fn raw_sql_rejects_non_sql_drivers(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
@@ -151,10 +550,21 @@ fn render_placeholder(placeholder: toasty::SqlPlaceholder, index: usize) -> Stri
     }
 }
 
-fn field(value: &toasty::stmt::Value, index: usize) -> &toasty::stmt::Value {
-    let toasty::stmt::Value::Record(record) = value else {
+fn is_postgresql(db: &toasty::Db) -> bool {
+    matches!(
+        db.capability().sql_placeholder,
+        Some(toasty::SqlPlaceholder::DollarNumber)
+    )
+}
+
+fn fields(value: &Value) -> &[Value] {
+    let Value::Record(record) = value else {
         panic!("expected record, got {value:?}");
     };
 
-    &record[index]
+    record
+}
+
+fn field(value: &toasty::stmt::Value, index: usize) -> &toasty::stmt::Value {
+    &fields(value)[index]
 }

--- a/crates/toasty-driver-mysql/src/lib.rs
+++ b/crates/toasty-driver-mysql/src/lib.rs
@@ -25,7 +25,7 @@ use toasty_core::{
     Result, Schema,
     driver::{
         Capability, Driver, ExecResponse, Operation,
-        operation::{Transaction, TransactionMode},
+        operation::{RawSqlRet, Transaction, TransactionMode},
     },
     schema::{
         db::{self, Migration, Table},
@@ -35,6 +35,15 @@ use toasty_core::{
 };
 use toasty_sql::{self as sql};
 use url::Url;
+
+enum SqlReturn {
+    Count {
+        last_insert_id_hack: Option<u64>,
+        sql_is_insert: bool,
+    },
+    Infer,
+    Types(Vec<stmt::Type>),
+}
 
 /// Classifies a `mysql_async::Error` into a Toasty error.
 ///
@@ -198,6 +207,103 @@ impl Connection {
         }
     }
 
+    async fn exec_sql(
+        &mut self,
+        sql_as_str: &str,
+        args: Vec<mysql_async::Value>,
+        ret: SqlReturn,
+    ) -> Result<ExecResponse> {
+        tracing::debug!(db.system = "mysql", db.statement = %sql_as_str, params = args.len(), "executing SQL");
+
+        let statement = self
+            .conn
+            .prep(sql_as_str)
+            .await
+            .map_err(|e| record_mysql_err(&self.valid, e))?;
+
+        if let SqlReturn::Count {
+            last_insert_id_hack,
+            sql_is_insert,
+        } = ret
+        {
+            let count = self
+                .conn
+                .exec_iter(&statement, mysql_async::Params::Positional(args))
+                .await
+                .map_err(|e| record_mysql_err(&self.valid, e))?
+                .affected_rows();
+
+            if let Some(num_rows) = last_insert_id_hack {
+                assert!(
+                    sql_is_insert,
+                    "last_insert_id_hack should only be used with INSERT statements"
+                );
+
+                let first_id: u64 = self
+                    .conn
+                    .query_first("SELECT LAST_INSERT_ID()")
+                    .await
+                    .map_err(|e| record_mysql_err(&self.valid, e))?
+                    .ok_or_else(|| {
+                        toasty_core::Error::driver_operation_failed(std::io::Error::other(
+                            "LAST_INSERT_ID() returned no rows",
+                        ))
+                    })?;
+
+                let results = (0..num_rows).map(move |offset| {
+                    let id = first_id + offset;
+                    Ok(ValueRecord::from_vec(vec![stmt::Value::U64(id)]))
+                });
+
+                return Ok(ExecResponse::value_stream(stmt::ValueStream::from_iter(
+                    results,
+                )));
+            }
+
+            return Ok(ExecResponse::count(count));
+        }
+
+        let rows: Vec<mysql_async::Row> = self
+            .conn
+            .exec(&statement, &args)
+            .await
+            .map_err(|e| record_mysql_err(&self.valid, e))?;
+
+        let results = rows.into_iter().map(move |mut row| {
+            let mut results = Vec::new();
+
+            match &ret {
+                SqlReturn::Count { .. } => unreachable!(),
+                SqlReturn::Infer => {
+                    for i in 0..row.len() {
+                        let column = row.columns()[i].clone();
+                        results.push(Value::from_sql_infer(i, &mut row, &column).into_inner());
+                    }
+                }
+                SqlReturn::Types(returning) => {
+                    assert_eq!(
+                        row.len(),
+                        returning.len(),
+                        "row={row:#?}; returning={returning:#?}"
+                    );
+
+                    for i in 0..row.len() {
+                        let column = row.columns()[i].clone();
+                        results.push(
+                            Value::from_sql(i, &mut row, &column, &returning[i]).into_inner(),
+                        );
+                    }
+                }
+            }
+
+            Ok(ValueRecord::from_vec(results))
+        });
+
+        Ok(ExecResponse::value_stream(stmt::ValueStream::from_iter(
+            results,
+        )))
+    }
+
     /// Create a table and its indices from a schema definition.
     pub async fn create_table(&mut self, schema: &db::Schema, table: &Table) -> Result<()> {
         let serializer = sql::Serializer::mysql(schema);
@@ -244,6 +350,22 @@ impl toasty_core::driver::Connection for Connection {
                 op.ret,
                 op.last_insert_id_hack,
             ),
+            Operation::RawSql(op) => {
+                let args = op
+                    .params
+                    .into_iter()
+                    .map(|tv| Value::from(tv.value).to_value())
+                    .collect();
+                let ret = match op.ret {
+                    RawSqlRet::None => SqlReturn::Count {
+                        last_insert_id_hack: None,
+                        sql_is_insert: false,
+                    },
+                    RawSqlRet::Infer => SqlReturn::Infer,
+                    RawSqlRet::Types(types) => SqlReturn::Types(types),
+                };
+                return self.exec_sql(&op.sql, args, ret).await;
+            }
             Operation::Transaction(op) => {
                 // MySQL has no `BEGIN IMMEDIATE` / `BEGIN EXCLUSIVE`
                 // analogue; reject non-Default modes loudly rather than
@@ -270,8 +392,6 @@ impl toasty_core::driver::Connection for Connection {
         let (sql_as_str, arg_order) =
             sql::Serializer::mysql(&schema.db).serialize_with_arg_order(&sql);
 
-        tracing::debug!(db.system = "mysql", db.statement = %sql_as_str, params = typed_params.len(), "executing SQL");
-
         // MySQL uses positional `?` without indices, so params must be reordered
         // to match the order `Expr::Arg(n)` placeholders appear in the SQL.
         let params: Vec<_> = arg_order
@@ -283,94 +403,15 @@ impl toasty_core::driver::Connection for Connection {
             .map(|param| param.to_value())
             .collect::<Vec<_>>();
 
-        let statement = self
-            .conn
-            .prep(&sql_as_str)
-            .await
-            .map_err(|e| record_mysql_err(&self.valid, e))?;
+        let ret = match ret {
+            Some(types) => SqlReturn::Types(types),
+            None => SqlReturn::Count {
+                last_insert_id_hack,
+                sql_is_insert: matches!(sql, sql::Statement::Insert(_)),
+            },
+        };
 
-        if ret.is_none() {
-            let count = self
-                .conn
-                .exec_iter(&statement, mysql_async::Params::Positional(args))
-                .await
-                .map_err(|e| record_mysql_err(&self.valid, e))?
-                .affected_rows();
-
-            // Handle the last_insert_id_hack for MySQL INSERT with RETURNING
-            if let Some(num_rows) = last_insert_id_hack {
-                // Assert the previous statement was an INSERT
-                assert!(
-                    matches!(sql, sql::Statement::Insert(_)),
-                    "last_insert_id_hack should only be used with INSERT statements"
-                );
-
-                // Execute SELECT LAST_INSERT_ID() on the same connection
-                let first_id: u64 = self
-                    .conn
-                    .query_first("SELECT LAST_INSERT_ID()")
-                    .await
-                    .map_err(|e| record_mysql_err(&self.valid, e))?
-                    .ok_or_else(|| {
-                        toasty_core::Error::driver_operation_failed(std::io::Error::other(
-                            "LAST_INSERT_ID() returned no rows",
-                        ))
-                    })?;
-
-                // Generate rows with sequential IDs
-                let results = (0..num_rows).map(move |offset| {
-                    let id = first_id + offset;
-                    // Return a record with a single field containing the ID
-                    Ok(ValueRecord::from_vec(vec![stmt::Value::U64(id)]))
-                });
-
-                return Ok(ExecResponse::value_stream(stmt::ValueStream::from_iter(
-                    results,
-                )));
-            }
-
-            return Ok(ExecResponse::count(count));
-        }
-
-        let rows: Vec<mysql_async::Row> = self
-            .conn
-            .exec(&statement, &args)
-            .await
-            .map_err(|e| record_mysql_err(&self.valid, e))?;
-
-        if let Some(returning) = ret {
-            let results = rows.into_iter().map(move |mut row| {
-                assert_eq!(
-                    row.len(),
-                    returning.len(),
-                    "row={row:#?}; returning={returning:#?}"
-                );
-
-                let mut results = Vec::new();
-                for i in 0..row.len() {
-                    let column = &row.columns()[i];
-                    results.push(Value::from_sql(i, &mut row, column, &returning[i]).into_inner());
-                }
-
-                Ok(ValueRecord::from_vec(results))
-            });
-
-            Ok(ExecResponse::value_stream(stmt::ValueStream::from_iter(
-                results,
-            )))
-        } else {
-            let [row] = &rows[..] else { todo!() };
-            let total = row.get::<i64, usize>(0).unwrap();
-            let condition_matched = row.get::<i64, usize>(1).unwrap();
-
-            if total == condition_matched {
-                Ok(ExecResponse::count(total as _))
-            } else {
-                Err(toasty_core::Error::condition_failed(
-                    "update condition did not match",
-                ))
-            }
-        }
+        self.exec_sql(&sql_as_str, args, ret).await
     }
 
     async fn push_schema(&mut self, schema: &Schema) -> Result<()> {

--- a/crates/toasty-driver-mysql/src/value.rs
+++ b/crates/toasty-driver-mysql/src/value.rs
@@ -1,4 +1,5 @@
 use mysql_async::{Column, Row, prelude::ToValue};
+use std::fmt;
 use toasty_core::stmt::{self, Value as CoreValue};
 
 #[derive(Debug)]
@@ -113,9 +114,9 @@ fn typed_mysql_value_to_core(
         | CT::MYSQL_TYPE_BLOB
         | CT::MYSQL_TYPE_ENUM
         | CT::MYSQL_TYPE_SET => match ty {
-            stmt::Type::String => convert_or_null(value, stmt::Value::String),
-            stmt::Type::Uuid => convert_or_null(value, stmt::Value::Uuid),
-            stmt::Type::Bytes => convert_or_null(value, stmt::Value::Bytes),
+            stmt::Type::String => bytes_to_string_value(value),
+            stmt::Type::Uuid => bytes_to_uuid_value(value),
+            stmt::Type::Bytes => bytes_to_bytes_value(value),
             _ => todo!("ty={ty:#?}"),
         },
 
@@ -124,15 +125,15 @@ fn typed_mysql_value_to_core(
         | CT::MYSQL_TYPE_INT24
         | CT::MYSQL_TYPE_LONG
         | CT::MYSQL_TYPE_LONGLONG => match ty {
-            stmt::Type::Bool => convert_or_null(value, stmt::Value::Bool),
-            stmt::Type::I8 => convert_or_null(value, stmt::Value::I8),
-            stmt::Type::I16 => convert_or_null(value, stmt::Value::I16),
-            stmt::Type::I32 => convert_or_null(value, stmt::Value::I32),
-            stmt::Type::I64 => convert_or_null(value, stmt::Value::I64),
-            stmt::Type::U8 => convert_or_null(value, stmt::Value::U8),
-            stmt::Type::U16 => convert_or_null(value, stmt::Value::U16),
-            stmt::Type::U32 => convert_or_null(value, stmt::Value::U32),
-            stmt::Type::U64 => convert_or_null(value, stmt::Value::U64),
+            stmt::Type::Bool => integer_to_bool_value(value),
+            stmt::Type::I8 => integer_to_signed_value(value, stmt::Value::I8, "i8"),
+            stmt::Type::I16 => integer_to_signed_value(value, stmt::Value::I16, "i16"),
+            stmt::Type::I32 => integer_to_signed_value(value, stmt::Value::I32, "i32"),
+            stmt::Type::I64 => integer_to_signed_value(value, stmt::Value::I64, "i64"),
+            stmt::Type::U8 => integer_to_unsigned_value(value, stmt::Value::U8, "u8"),
+            stmt::Type::U16 => integer_to_unsigned_value(value, stmt::Value::U16, "u16"),
+            stmt::Type::U32 => integer_to_unsigned_value(value, stmt::Value::U32, "u32"),
+            stmt::Type::U64 => integer_to_unsigned_value(value, stmt::Value::U64, "u64"),
             _ => todo!("ty={ty:#?}"),
         },
 
@@ -248,6 +249,102 @@ fn typed_mysql_value_to_core(
             value,
             ty
         ),
+    }
+}
+
+fn bytes_to_string_value(value: mysql_async::Value) -> stmt::Value {
+    match value {
+        mysql_async::Value::Bytes(bytes) => stmt::Value::String(
+            String::from_utf8(bytes).expect("invalid UTF-8 in MySQL string value"),
+        ),
+        mysql_async::Value::NULL => stmt::Value::Null,
+        value => panic!("unexpected MySQL value for string: {value:#?}"),
+    }
+}
+
+fn bytes_to_uuid_value(value: mysql_async::Value) -> stmt::Value {
+    match value {
+        mysql_async::Value::Bytes(bytes) => {
+            let uuid = uuid::Uuid::from_slice(&bytes).or_else(|_| {
+                let s = std::str::from_utf8(&bytes).expect("invalid UTF-8 in MySQL UUID value");
+                uuid::Uuid::parse_str(s)
+            });
+
+            stmt::Value::Uuid(uuid.expect("failed to parse UUID from MySQL value"))
+        }
+        mysql_async::Value::NULL => stmt::Value::Null,
+        value => panic!("unexpected MySQL value for UUID: {value:#?}"),
+    }
+}
+
+fn bytes_to_bytes_value(value: mysql_async::Value) -> stmt::Value {
+    match value {
+        mysql_async::Value::Bytes(bytes) => stmt::Value::Bytes(bytes),
+        mysql_async::Value::NULL => stmt::Value::Null,
+        value => panic!("unexpected MySQL value for bytes: {value:#?}"),
+    }
+}
+
+fn integer_to_bool_value(value: mysql_async::Value) -> stmt::Value {
+    match integer_to_u128(value) {
+        Some(value) => stmt::Value::Bool(value != 0),
+        None => stmt::Value::Null,
+    }
+}
+
+fn integer_to_signed_value<T>(
+    value: mysql_async::Value,
+    constructor: impl FnOnce(T) -> stmt::Value,
+    ty: &str,
+) -> stmt::Value
+where
+    T: TryFrom<i128>,
+    T::Error: fmt::Debug,
+{
+    match integer_to_i128(value) {
+        Some(value) => constructor(
+            value
+                .try_into()
+                .unwrap_or_else(|_| panic!("MySQL {ty} value out of range")),
+        ),
+        None => stmt::Value::Null,
+    }
+}
+
+fn integer_to_unsigned_value<T>(
+    value: mysql_async::Value,
+    constructor: impl FnOnce(T) -> stmt::Value,
+    ty: &str,
+) -> stmt::Value
+where
+    T: TryFrom<u128>,
+    T::Error: fmt::Debug,
+{
+    match integer_to_u128(value) {
+        Some(value) => constructor(
+            value
+                .try_into()
+                .unwrap_or_else(|_| panic!("MySQL {ty} value out of range")),
+        ),
+        None => stmt::Value::Null,
+    }
+}
+
+fn integer_to_i128(value: mysql_async::Value) -> Option<i128> {
+    match value {
+        mysql_async::Value::Int(value) => Some(value as i128),
+        mysql_async::Value::UInt(value) => Some(value as i128),
+        mysql_async::Value::NULL => None,
+        value => panic!("unexpected MySQL integer value: {value:#?}"),
+    }
+}
+
+fn integer_to_u128(value: mysql_async::Value) -> Option<u128> {
+    match value {
+        mysql_async::Value::Int(value) => Some(value.try_into().expect("negative MySQL integer")),
+        mysql_async::Value::UInt(value) => Some(value as u128),
+        mysql_async::Value::NULL => None,
+        value => panic!("unexpected MySQL integer value: {value:#?}"),
     }
 }
 

--- a/crates/toasty-driver-mysql/src/value.rs
+++ b/crates/toasty-driver-mysql/src/value.rs
@@ -184,6 +184,65 @@ impl Value {
 
         Value(core_value)
     }
+
+    /// Converts a MySQL value within a row using the value metadata available
+    /// from the driver.
+    pub fn from_sql_infer(i: usize, row: &mut Row, _column: &Column) -> Self {
+        let value = match row.take_opt(i).expect("value missing") {
+            Ok(value) => value,
+            Err(err) => err.0,
+        };
+
+        let core_value = match value {
+            mysql_async::Value::NULL => stmt::Value::Null,
+            mysql_async::Value::Bytes(bytes) => String::from_utf8(bytes)
+                .map(stmt::Value::String)
+                .unwrap_or_else(|err| stmt::Value::Bytes(err.into_bytes())),
+            mysql_async::Value::Int(value) => stmt::Value::I64(value),
+            mysql_async::Value::UInt(value) => stmt::Value::U64(value),
+            mysql_async::Value::Float(value) => stmt::Value::F32(value),
+            mysql_async::Value::Double(value) => stmt::Value::F64(value),
+            #[cfg(feature = "jiff")]
+            mysql_async::Value::Date(year, month, day, 0, 0, 0, 0) => stmt::Value::Date(
+                jiff::civil::Date::constant(year as i16, month as i8, day as i8),
+            ),
+            #[cfg(feature = "jiff")]
+            mysql_async::Value::Date(year, month, day, hour, minute, second, microsecond) => {
+                stmt::Value::DateTime(jiff::civil::DateTime::constant(
+                    year as i16,
+                    month as i8,
+                    day as i8,
+                    hour as i8,
+                    minute as i8,
+                    second as i8,
+                    (microsecond * 1000) as i32,
+                ))
+            }
+            #[cfg(not(feature = "jiff"))]
+            mysql_async::Value::Date(year, month, day, hour, minute, second, microsecond) => {
+                stmt::Value::String(format!(
+                    "{year:04}-{month:02}-{day:02} {hour:02}:{minute:02}:{second:02}.{microsecond:06}"
+                ))
+            }
+            #[cfg(feature = "jiff")]
+            mysql_async::Value::Time(_, _, hour, minute, second, microsecond) => {
+                stmt::Value::Time(jiff::civil::Time::constant(
+                    hour as i8,
+                    minute as i8,
+                    second as i8,
+                    (microsecond * 1000) as i32,
+                ))
+            }
+            #[cfg(not(feature = "jiff"))]
+            mysql_async::Value::Time(_, days, hour, minute, second, microsecond) => {
+                stmt::Value::String(format!(
+                    "{days} {hour:02}:{minute:02}:{second:02}.{microsecond:06}"
+                ))
+            }
+        };
+
+        Value(core_value)
+    }
 }
 
 impl ToValue for Value {

--- a/crates/toasty-driver-mysql/src/value.rs
+++ b/crates/toasty-driver-mysql/src/value.rs
@@ -2,7 +2,7 @@ use mysql_async::{Column, Row, prelude::ToValue};
 use toasty_core::stmt::{self, Value as CoreValue};
 
 #[derive(Debug)]
-pub struct Value(CoreValue);
+pub(crate) struct Value(CoreValue);
 
 impl From<CoreValue> for Value {
     fn from(value: CoreValue) -> Self {
@@ -12,236 +12,256 @@ impl From<CoreValue> for Value {
 
 impl Value {
     /// Converts this MySQL driver value into the core Toasty value.
-    pub fn into_inner(self) -> CoreValue {
+    pub(crate) fn into_inner(self) -> CoreValue {
         self.0
     }
 
     /// Converts a MySQL value within a row to a Toasty value.
-    pub fn from_sql(i: usize, row: &mut Row, column: &Column, ty: &stmt::Type) -> Self {
-        use mysql_async::consts::ColumnType as CT;
+    pub(crate) fn from_sql(i: usize, row: &mut Row, column: &Column, ty: &stmt::Type) -> Self {
+        let value = take_mysql_value(row, i);
 
-        /// Helper function to extract a value from a MySQL row or return Null if the value is NULL
-        fn extract_or_null<T>(
-            row: &mut Row,
-            i: usize,
-            constructor: fn(T) -> stmt::Value,
-        ) -> stmt::Value
-        where
-            T: mysql_async::prelude::FromValue,
-        {
-            match row.take_opt(i).expect("value missing") {
-                Ok(v) => constructor(v),
-                Err(e) => {
-                    assert!(matches!(e.0, mysql_async::Value::NULL));
-                    stmt::Value::Null
-                }
-            }
-        }
-
-        let core_value = match column.column_type() {
-            CT::MYSQL_TYPE_NULL => stmt::Value::Null,
-
-            CT::MYSQL_TYPE_VARCHAR
-            | CT::MYSQL_TYPE_VAR_STRING
-            | CT::MYSQL_TYPE_STRING
-            | CT::MYSQL_TYPE_BLOB => match ty {
-                stmt::Type::String => extract_or_null(row, i, stmt::Value::String),
-                stmt::Type::Uuid => extract_or_null(row, i, stmt::Value::Uuid),
-                stmt::Type::Bytes => extract_or_null(row, i, stmt::Value::Bytes),
-                _ => todo!("ty={ty:#?}"),
-            },
-
-            CT::MYSQL_TYPE_TINY
-            | CT::MYSQL_TYPE_SHORT
-            | CT::MYSQL_TYPE_INT24
-            | CT::MYSQL_TYPE_LONG
-            | CT::MYSQL_TYPE_LONGLONG => match ty {
-                stmt::Type::Bool => extract_or_null(row, i, stmt::Value::Bool),
-                stmt::Type::I8 => extract_or_null(row, i, stmt::Value::I8),
-                stmt::Type::I16 => extract_or_null(row, i, stmt::Value::I16),
-                stmt::Type::I32 => extract_or_null(row, i, stmt::Value::I32),
-                stmt::Type::I64 => extract_or_null(row, i, stmt::Value::I64),
-                stmt::Type::U8 => extract_or_null(row, i, stmt::Value::U8),
-                stmt::Type::U16 => extract_or_null(row, i, stmt::Value::U16),
-                stmt::Type::U32 => extract_or_null(row, i, stmt::Value::U32),
-                stmt::Type::U64 => extract_or_null(row, i, stmt::Value::U64),
-                _ => todo!("ty={ty:#?}"),
-            },
-
-            #[cfg(feature = "jiff")]
-            CT::MYSQL_TYPE_TIMESTAMP | CT::MYSQL_TYPE_DATETIME => {
-                match row.take_opt(i).expect("value missing") {
-                    Ok(mysql_async::Value::Date(
-                        year,
-                        month,
-                        day,
-                        hour,
-                        minute,
-                        second,
-                        microsecond,
-                    )) => {
-                        let dt = jiff::civil::DateTime::constant(
-                            year as i16,
-                            month as i8,
-                            day as i8,
-                            hour as i8,
-                            minute as i8,
-                            second as i8,
-                            (microsecond * 1000) as i32, // Convert microseconds to nanoseconds
-                        );
-                        match ty {
-                            stmt::Type::DateTime => stmt::Value::DateTime(dt),
-                            stmt::Type::Timestamp => stmt::Value::Timestamp(
-                                dt.to_zoned(jiff::tz::TimeZone::UTC).unwrap().into(),
-                            ),
-                            _ => todo!("unexpected type for DATETIME: {ty:#?}"),
-                        }
-                    }
-                    Ok(mysql_async::Value::NULL) | Err(_) => stmt::Value::Null,
-                    Ok(v) => panic!("unexpected MySQL value for TIMESTAMP/DATETIME: {v:#?}"),
-                }
-            }
-
-            #[cfg(feature = "jiff")]
-            CT::MYSQL_TYPE_DATE => match row.take_opt(i).expect("value missing") {
-                Ok(mysql_async::Value::Date(year, month, day, _, _, _, _)) => stmt::Value::Date(
-                    jiff::civil::Date::constant(year as i16, month as i8, day as i8),
-                ),
-                Ok(mysql_async::Value::NULL) | Err(_) => stmt::Value::Null,
-                Ok(v) => panic!("unexpected MySQL value for DATE: {v:#?}"),
-            },
-
-            #[cfg(feature = "jiff")]
-            CT::MYSQL_TYPE_TIME => {
-                match row.take_opt(i).expect("value missing") {
-                    Ok(mysql_async::Value::Time(
-                        _is_negative,
-                        _days,
-                        hour,
-                        minute,
-                        second,
-                        microsecond,
-                    )) => {
-                        stmt::Value::Time(jiff::civil::Time::constant(
-                            hour as i8,
-                            minute as i8,
-                            second as i8,
-                            (microsecond * 1000) as i32, // Convert microseconds to nanoseconds
-                        ))
-                    }
-                    Ok(mysql_async::Value::NULL) | Err(_) => stmt::Value::Null,
-                    Ok(v) => panic!("unexpected MySQL value for TIME: {v:#?}"),
-                }
-            }
-
-            CT::MYSQL_TYPE_FLOAT => match ty {
-                stmt::Type::F32 => extract_or_null(row, i, stmt::Value::F32),
-                stmt::Type::F64 => extract_or_null(row, i, |v: f32| stmt::Value::F64(v as f64)),
-                _ => todo!("ty={ty:#?}"),
-            },
-
-            CT::MYSQL_TYPE_DOUBLE => match ty {
-                stmt::Type::F64 => extract_or_null(row, i, stmt::Value::F64),
-                stmt::Type::F32 => extract_or_null(row, i, |v: f64| stmt::Value::F32(v as f32)),
-                _ => todo!("ty={ty:#?}"),
-            },
-
-            CT::MYSQL_TYPE_JSON => match ty {
-                stmt::Type::List(elem) => {
-                    let bytes: Vec<u8> = match row.take_opt(i).expect("value missing") {
-                        Ok(v) => v,
-                        Err(e) => {
-                            assert!(matches!(e.0, mysql_async::Value::NULL));
-                            return Value(stmt::Value::Null);
-                        }
-                    };
-                    json_bytes_to_value_list(&bytes, elem)
-                }
-                _ => todo!("MySQL JSON column with stmt::Type {ty:#?}"),
-            },
-
-            CT::MYSQL_TYPE_NEWDECIMAL | CT::MYSQL_TYPE_DECIMAL => match ty {
-                #[cfg(feature = "rust_decimal")]
-                stmt::Type::Decimal => extract_or_null(row, i, |s: String| {
-                    stmt::Value::Decimal(s.parse().expect("failed to parse Decimal from MySQL"))
-                }),
-                #[cfg(feature = "bigdecimal")]
-                stmt::Type::BigDecimal => extract_or_null(row, i, |s: String| {
-                    stmt::Value::BigDecimal(
-                        s.parse().expect("failed to parse BigDecimal from MySQL"),
-                    )
-                }),
-                _ => todo!("unexpected type for DECIMAL: {ty:#?}"),
-            },
-
-            _ => todo!(
-                "implement MySQL to toasty conversion for `{:#?}`; {:#?}; ty={:#?}",
-                column.column_type(),
-                row.get::<mysql_async::Value, _>(i),
-                ty
-            ),
-        };
-
-        Value(core_value)
+        Value(typed_mysql_value_to_core(value, column, ty))
     }
 
     /// Converts a MySQL value within a row using the value metadata available
     /// from the driver.
-    pub fn from_sql_infer(i: usize, row: &mut Row, _column: &Column) -> Self {
-        let value = match row.take_opt(i).expect("value missing") {
-            Ok(value) => value,
-            Err(err) => err.0,
-        };
+    pub(crate) fn from_sql_infer(i: usize, row: &mut Row, column: &Column) -> Self {
+        let value = take_mysql_value(row, i);
+        let ty = infer_mysql_type(column, &value);
 
-        let core_value = match value {
-            mysql_async::Value::NULL => stmt::Value::Null,
-            mysql_async::Value::Bytes(bytes) => String::from_utf8(bytes)
-                .map(stmt::Value::String)
-                .unwrap_or_else(|err| stmt::Value::Bytes(err.into_bytes())),
-            mysql_async::Value::Int(value) => stmt::Value::I64(value),
-            mysql_async::Value::UInt(value) => stmt::Value::U64(value),
-            mysql_async::Value::Float(value) => stmt::Value::F32(value),
-            mysql_async::Value::Double(value) => stmt::Value::F64(value),
+        Value(typed_mysql_value_to_core(value, column, &ty))
+    }
+}
+
+fn take_mysql_value(row: &mut Row, i: usize) -> mysql_async::Value {
+    match row.take_opt(i).expect("value missing") {
+        Ok(value) => value,
+        Err(err) => err.0,
+    }
+}
+
+fn infer_mysql_type(column: &Column, value: &mysql_async::Value) -> stmt::Type {
+    use mysql_async::consts::ColumnFlags as CF;
+
+    match value {
+        mysql_async::Value::NULL => stmt::Type::Null,
+        mysql_async::Value::Bytes(bytes) => {
+            if std::str::from_utf8(bytes).is_ok() {
+                stmt::Type::String
+            } else {
+                stmt::Type::Bytes
+            }
+        }
+        mysql_async::Value::Int(_) if column.flags().contains(CF::UNSIGNED_FLAG) => stmt::Type::U64,
+        mysql_async::Value::Int(_) => stmt::Type::I64,
+        mysql_async::Value::UInt(_) => stmt::Type::U64,
+        mysql_async::Value::Float(_) => stmt::Type::F32,
+        mysql_async::Value::Double(_) => stmt::Type::F64,
+        mysql_async::Value::Date(_, _, _, 0, 0, 0, 0) => {
             #[cfg(feature = "jiff")]
-            mysql_async::Value::Date(year, month, day, 0, 0, 0, 0) => stmt::Value::Date(
-                jiff::civil::Date::constant(year as i16, month as i8, day as i8),
-            ),
+            {
+                stmt::Type::Date
+            }
+            #[cfg(not(feature = "jiff"))]
+            {
+                stmt::Type::String
+            }
+        }
+        mysql_async::Value::Date(..) => {
             #[cfg(feature = "jiff")]
+            {
+                stmt::Type::DateTime
+            }
+            #[cfg(not(feature = "jiff"))]
+            {
+                stmt::Type::String
+            }
+        }
+        mysql_async::Value::Time(..) => {
+            #[cfg(feature = "jiff")]
+            {
+                stmt::Type::Time
+            }
+            #[cfg(not(feature = "jiff"))]
+            {
+                stmt::Type::String
+            }
+        }
+    }
+}
+
+fn typed_mysql_value_to_core(
+    value: mysql_async::Value,
+    column: &Column,
+    ty: &stmt::Type,
+) -> CoreValue {
+    use mysql_async::consts::ColumnType as CT;
+
+    if matches!(value, mysql_async::Value::NULL) {
+        return stmt::Value::Null;
+    }
+
+    match column.column_type() {
+        CT::MYSQL_TYPE_NULL => stmt::Value::Null,
+
+        CT::MYSQL_TYPE_VARCHAR
+        | CT::MYSQL_TYPE_VAR_STRING
+        | CT::MYSQL_TYPE_STRING
+        | CT::MYSQL_TYPE_TINY_BLOB
+        | CT::MYSQL_TYPE_MEDIUM_BLOB
+        | CT::MYSQL_TYPE_LONG_BLOB
+        | CT::MYSQL_TYPE_BLOB
+        | CT::MYSQL_TYPE_ENUM
+        | CT::MYSQL_TYPE_SET => match ty {
+            stmt::Type::String => convert_or_null(value, stmt::Value::String),
+            stmt::Type::Uuid => convert_or_null(value, stmt::Value::Uuid),
+            stmt::Type::Bytes => convert_or_null(value, stmt::Value::Bytes),
+            _ => todo!("ty={ty:#?}"),
+        },
+
+        CT::MYSQL_TYPE_TINY
+        | CT::MYSQL_TYPE_SHORT
+        | CT::MYSQL_TYPE_INT24
+        | CT::MYSQL_TYPE_LONG
+        | CT::MYSQL_TYPE_LONGLONG => match ty {
+            stmt::Type::Bool => convert_or_null(value, stmt::Value::Bool),
+            stmt::Type::I8 => convert_or_null(value, stmt::Value::I8),
+            stmt::Type::I16 => convert_or_null(value, stmt::Value::I16),
+            stmt::Type::I32 => convert_or_null(value, stmt::Value::I32),
+            stmt::Type::I64 => convert_or_null(value, stmt::Value::I64),
+            stmt::Type::U8 => convert_or_null(value, stmt::Value::U8),
+            stmt::Type::U16 => convert_or_null(value, stmt::Value::U16),
+            stmt::Type::U32 => convert_or_null(value, stmt::Value::U32),
+            stmt::Type::U64 => convert_or_null(value, stmt::Value::U64),
+            _ => todo!("ty={ty:#?}"),
+        },
+
+        #[cfg(feature = "jiff")]
+        CT::MYSQL_TYPE_TIMESTAMP | CT::MYSQL_TYPE_DATETIME => match value {
             mysql_async::Value::Date(year, month, day, hour, minute, second, microsecond) => {
-                stmt::Value::DateTime(jiff::civil::DateTime::constant(
+                let dt = jiff::civil::DateTime::constant(
                     year as i16,
                     month as i8,
                     day as i8,
                     hour as i8,
                     minute as i8,
                     second as i8,
-                    (microsecond * 1000) as i32,
-                ))
+                    (microsecond * 1000) as i32, // Convert microseconds to nanoseconds
+                );
+                match ty {
+                    stmt::Type::DateTime => stmt::Value::DateTime(dt),
+                    stmt::Type::Timestamp => {
+                        stmt::Value::Timestamp(dt.to_zoned(jiff::tz::TimeZone::UTC).unwrap().into())
+                    }
+                    _ => todo!("unexpected type for DATETIME: {ty:#?}"),
+                }
             }
-            #[cfg(not(feature = "jiff"))]
-            mysql_async::Value::Date(year, month, day, hour, minute, second, microsecond) => {
-                stmt::Value::String(format!(
-                    "{year:04}-{month:02}-{day:02} {hour:02}:{minute:02}:{second:02}.{microsecond:06}"
-                ))
-            }
-            #[cfg(feature = "jiff")]
-            mysql_async::Value::Time(_, _, hour, minute, second, microsecond) => {
+            mysql_async::Value::NULL => stmt::Value::Null,
+            v => panic!("unexpected MySQL value for TIMESTAMP/DATETIME: {v:#?}"),
+        },
+
+        #[cfg(feature = "jiff")]
+        CT::MYSQL_TYPE_DATE => match value {
+            mysql_async::Value::Date(year, month, day, _, _, _, _) => stmt::Value::Date(
+                jiff::civil::Date::constant(year as i16, month as i8, day as i8),
+            ),
+            mysql_async::Value::NULL => stmt::Value::Null,
+            v => panic!("unexpected MySQL value for DATE: {v:#?}"),
+        },
+
+        #[cfg(feature = "jiff")]
+        CT::MYSQL_TYPE_TIME => match value {
+            mysql_async::Value::Time(_is_negative, _days, hour, minute, second, microsecond) => {
                 stmt::Value::Time(jiff::civil::Time::constant(
                     hour as i8,
                     minute as i8,
                     second as i8,
-                    (microsecond * 1000) as i32,
+                    (microsecond * 1000) as i32, // Convert microseconds to nanoseconds
                 ))
             }
-            #[cfg(not(feature = "jiff"))]
-            mysql_async::Value::Time(_, days, hour, minute, second, microsecond) => {
-                stmt::Value::String(format!(
-                    "{days} {hour:02}:{minute:02}:{second:02}.{microsecond:06}"
-                ))
-            }
-        };
+            mysql_async::Value::NULL => stmt::Value::Null,
+            v => panic!("unexpected MySQL value for TIME: {v:#?}"),
+        },
 
-        Value(core_value)
+        #[cfg(not(feature = "jiff"))]
+        CT::MYSQL_TYPE_TIMESTAMP | CT::MYSQL_TYPE_DATETIME | CT::MYSQL_TYPE_DATE => match ty {
+            stmt::Type::String => match value {
+                mysql_async::Value::Date(year, month, day, hour, minute, second, microsecond) => {
+                    stmt::Value::String(format!(
+                        "{year:04}-{month:02}-{day:02} {hour:02}:{minute:02}:{second:02}.{microsecond:06}"
+                    ))
+                }
+                v => panic!("unexpected MySQL value for TIMESTAMP/DATETIME/DATE: {v:#?}"),
+            },
+            _ => todo!("unexpected type for DATETIME: {ty:#?}"),
+        },
+
+        #[cfg(not(feature = "jiff"))]
+        CT::MYSQL_TYPE_TIME => match ty {
+            stmt::Type::String => match value {
+                mysql_async::Value::Time(_, days, hour, minute, second, microsecond) => {
+                    stmt::Value::String(format!(
+                        "{days} {hour:02}:{minute:02}:{second:02}.{microsecond:06}"
+                    ))
+                }
+                v => panic!("unexpected MySQL value for TIME: {v:#?}"),
+            },
+            _ => todo!("unexpected type for TIME: {ty:#?}"),
+        },
+
+        CT::MYSQL_TYPE_FLOAT => match ty {
+            stmt::Type::F32 => convert_or_null(value, stmt::Value::F32),
+            stmt::Type::F64 => convert_or_null(value, |v: f32| stmt::Value::F64(v as f64)),
+            _ => todo!("ty={ty:#?}"),
+        },
+
+        CT::MYSQL_TYPE_DOUBLE => match ty {
+            stmt::Type::F64 => convert_or_null(value, stmt::Value::F64),
+            stmt::Type::F32 => convert_or_null(value, |v: f64| stmt::Value::F32(v as f32)),
+            _ => todo!("ty={ty:#?}"),
+        },
+
+        CT::MYSQL_TYPE_JSON => match ty {
+            stmt::Type::String => convert_or_null(value, stmt::Value::String),
+            stmt::Type::List(elem) => convert_or_null(value, |bytes: Vec<u8>| {
+                json_bytes_to_value_list(&bytes, elem)
+            }),
+            _ => todo!("MySQL JSON column with stmt::Type {ty:#?}"),
+        },
+
+        CT::MYSQL_TYPE_NEWDECIMAL | CT::MYSQL_TYPE_DECIMAL => match ty {
+            stmt::Type::String => convert_or_null(value, stmt::Value::String),
+            #[cfg(feature = "rust_decimal")]
+            stmt::Type::Decimal => convert_or_null(value, |s: String| {
+                stmt::Value::Decimal(s.parse().expect("failed to parse Decimal from MySQL"))
+            }),
+            #[cfg(feature = "bigdecimal")]
+            stmt::Type::BigDecimal => convert_or_null(value, |s: String| {
+                stmt::Value::BigDecimal(s.parse().expect("failed to parse BigDecimal from MySQL"))
+            }),
+            _ => todo!("unexpected type for DECIMAL: {ty:#?}"),
+        },
+
+        _ => todo!(
+            "implement MySQL to toasty conversion for `{:#?}`; {:#?}; ty={:#?}",
+            column.column_type(),
+            value,
+            ty
+        ),
+    }
+}
+
+fn convert_or_null<T, F>(value: mysql_async::Value, constructor: F) -> stmt::Value
+where
+    T: mysql_async::prelude::FromValue,
+    F: FnOnce(T) -> stmt::Value,
+{
+    match mysql_async::from_value_opt::<T>(value) {
+        Ok(v) => constructor(v),
+        Err(e) => {
+            assert!(matches!(e.0, mysql_async::Value::NULL));
+            stmt::Value::Null
+        }
     }
 }
 

--- a/crates/toasty-driver-postgresql/src/lib.rs
+++ b/crates/toasty-driver-postgresql/src/lib.rs
@@ -27,7 +27,7 @@ use toasty_core::{
     Result, Schema,
     driver::{
         Capability, Driver, ExecResponse, Operation,
-        operation::{Transaction, TransactionMode},
+        operation::{RawSqlRet, Transaction, TransactionMode, TypedValue},
     },
     schema::{
         db::{self, Migration, Table},
@@ -39,6 +39,12 @@ use toasty_core::{
 use toasty_sql::{self as sql};
 use tokio_postgres::{Client, Config, Socket, tls::MakeTlsConnect, types::ToSql};
 use url::Url;
+
+enum SqlReturn {
+    Count,
+    Infer,
+    Types(Vec<stmt::Type>),
+}
 
 use crate::{oid_cache::OidCache, statement_cache::StatementCache};
 
@@ -312,6 +318,77 @@ impl Connection {
         Ok(Self::new(client))
     }
 
+    async fn exec_sql(
+        &mut self,
+        sql_as_str: &str,
+        typed_params: Vec<TypedValue>,
+        ret: SqlReturn,
+    ) -> Result<ExecResponse> {
+        tracing::debug!(db.system = "postgresql", db.statement = %sql_as_str, params = typed_params.len(), "executing SQL");
+
+        self.oid_cache
+            .preload(&self.client, typed_params.iter().map(|tv| &tv.ty))
+            .await?;
+        let param_types: Vec<_> = typed_params
+            .iter()
+            .map(|tv| self.oid_cache.get(&tv.ty).clone())
+            .collect();
+
+        let values: Vec<_> = typed_params
+            .into_iter()
+            .map(|tv| Value::from(tv.value))
+            .collect();
+        let params = values
+            .iter()
+            .map(|param| param as &(dyn ToSql + Sync))
+            .collect::<Vec<_>>();
+
+        let statement = self
+            .statement_cache
+            .prepare_typed(&mut self.client, sql_as_str, &param_types)
+            .await
+            .map_err(classify_pg_error)?;
+
+        if matches!(ret, SqlReturn::Count) {
+            let count = self
+                .client
+                .execute(&statement, &params)
+                .await
+                .map_err(classify_pg_error)?;
+            return Ok(ExecResponse::count(count));
+        }
+
+        let rows = self
+            .client
+            .query(&statement, &params)
+            .await
+            .map_err(classify_pg_error)?;
+
+        let results = rows.into_iter().map(move |row| {
+            let mut results = Vec::new();
+
+            match &ret {
+                SqlReturn::Count => unreachable!(),
+                SqlReturn::Infer => {
+                    for (i, column) in row.columns().iter().enumerate() {
+                        results.push(Value::from_sql_infer(i, &row, column).into_inner());
+                    }
+                }
+                SqlReturn::Types(ret_tys) => {
+                    for (i, column) in row.columns().iter().enumerate() {
+                        results.push(Value::from_sql(i, &row, column, &ret_tys[i]).into_inner());
+                    }
+                }
+            }
+
+            Ok(ValueRecord::from_vec(results))
+        });
+
+        Ok(ExecResponse::value_stream(stmt::ValueStream::from_iter(
+            results,
+        )))
+    }
+
     /// Creates a table.
     pub async fn create_table(&mut self, schema: &db::Schema, table: &Table) -> Result<()> {
         let serializer = sql::Serializer::postgresql(schema);
@@ -384,80 +461,26 @@ impl toasty_core::driver::Connection for Connection {
                 );
                 (sql::Statement::from(query.stmt), query.params, query.ret)
             }
+            Operation::RawSql(op) => {
+                let ret = match op.ret {
+                    RawSqlRet::None => SqlReturn::Count,
+                    RawSqlRet::Infer => SqlReturn::Infer,
+                    RawSqlRet::Types(types) => SqlReturn::Types(types),
+                };
+                return self.exec_sql(&op.sql, op.params, ret).await;
+            }
             op => todo!("op={:#?}", op),
         };
 
-        let width = sql.returning_len();
-
         let sql_as_str = sql::Serializer::postgresql(&schema.db).serialize(&sql);
 
-        tracing::debug!(db.system = "postgresql", db.statement = %sql_as_str, params = typed_params.len(), "executing SQL");
-
-        self.oid_cache
-            .preload(&self.client, typed_params.iter().map(|tv| &tv.ty))
-            .await?;
-        let param_types: Vec<_> = typed_params
-            .iter()
-            .map(|tv| self.oid_cache.get(&tv.ty).clone())
-            .collect();
-
-        let values: Vec<_> = typed_params
-            .into_iter()
-            .map(|tv| Value::from(tv.value))
-            .collect();
-        let params = values
-            .iter()
-            .map(|param| param as &(dyn ToSql + Sync))
-            .collect::<Vec<_>>();
-
-        let statement = self
-            .statement_cache
-            .prepare_typed(&mut self.client, &sql_as_str, &param_types)
-            .await
-            .map_err(classify_pg_error)?;
-
-        if width.is_none() {
-            let count = self
-                .client
-                .execute(&statement, &params)
-                .await
-                .map_err(classify_pg_error)?;
-            return Ok(ExecResponse::count(count));
-        }
-
-        let rows = self
-            .client
-            .query(&statement, &params)
-            .await
-            .map_err(classify_pg_error)?;
-
-        if width.is_none() {
-            let [row] = &rows[..] else { todo!() };
-            let total = row.get::<usize, i64>(0);
-            let condition_matched = row.get::<usize, i64>(1);
-
-            if total == condition_matched {
-                Ok(ExecResponse::count(total as _))
-            } else {
-                Err(toasty_core::Error::condition_failed(
-                    "update condition did not match",
-                ))
-            }
+        let ret = if sql.returning_len().is_some() {
+            SqlReturn::Types(ret_tys.unwrap())
         } else {
-            let ret_tys = ret_tys.as_ref().unwrap().clone();
-            let results = rows.into_iter().map(move |row| {
-                let mut results = Vec::new();
-                for (i, column) in row.columns().iter().enumerate() {
-                    results.push(Value::from_sql(i, &row, column, &ret_tys[i]).into_inner());
-                }
+            SqlReturn::Count
+        };
 
-                Ok(ValueRecord::from_vec(results))
-            });
-
-            Ok(ExecResponse::value_stream(stmt::ValueStream::from_iter(
-                results,
-            )))
-        }
+        self.exec_sql(&sql_as_str, typed_params, ret).await
     }
 
     async fn push_schema(&mut self, schema: &Schema) -> Result<()> {

--- a/crates/toasty-driver-postgresql/src/value.rs
+++ b/crates/toasty-driver-postgresql/src/value.rs
@@ -186,6 +186,96 @@ impl Value {
 
         Value(core_value)
     }
+
+    /// Converts a PostgreSQL value within a row using PostgreSQL column
+    /// metadata as the Toasty value type.
+    pub fn from_sql_infer(index: usize, row: &Row, column: &Column) -> Self {
+        macro_rules! get_or_return_null {
+            ($ty:ty) => {{
+                match row.get::<usize, Option<$ty>>(index) {
+                    Some(inner) => inner,
+                    None => return Self(stmt::Value::Null),
+                }
+            }};
+        }
+
+        let core_value = if column.type_() == &Type::TEXT || column.type_() == &Type::VARCHAR {
+            stmt::Value::String(get_or_return_null!(String))
+        } else if column.type_() == &Type::BOOL {
+            stmt::Value::Bool(get_or_return_null!(bool))
+        } else if column.type_() == &Type::INT2 {
+            stmt::Value::I16(get_or_return_null!(i16))
+        } else if column.type_() == &Type::INT4 {
+            stmt::Value::I32(get_or_return_null!(i32))
+        } else if column.type_() == &Type::INT8 {
+            stmt::Value::I64(get_or_return_null!(i64))
+        } else if column.type_() == &Type::UUID {
+            stmt::Value::Uuid(get_or_return_null!(uuid::Uuid))
+        } else if column.type_() == &Type::BYTEA {
+            stmt::Value::Bytes(get_or_return_null!(Vec<u8>))
+        } else if column.type_() == &Type::TIMESTAMPTZ {
+            #[cfg(feature = "jiff")]
+            {
+                stmt::Value::Timestamp(get_or_return_null!(jiff::Timestamp))
+            }
+            #[cfg(not(feature = "jiff"))]
+            {
+                panic!("TIMESTAMPTZ requires jiff feature to be enabled")
+            }
+        } else if column.type_() == &Type::TIMESTAMP {
+            #[cfg(feature = "jiff")]
+            {
+                stmt::Value::DateTime(get_or_return_null!(jiff::civil::DateTime))
+            }
+            #[cfg(not(feature = "jiff"))]
+            {
+                panic!("TIMESTAMP requires jiff feature to be enabled")
+            }
+        } else if column.type_() == &Type::DATE {
+            #[cfg(feature = "jiff")]
+            {
+                stmt::Value::Date(get_or_return_null!(jiff::civil::Date))
+            }
+            #[cfg(not(feature = "jiff"))]
+            {
+                panic!("DATE requires jiff feature to be enabled")
+            }
+        } else if column.type_() == &Type::TIME {
+            #[cfg(feature = "jiff")]
+            {
+                stmt::Value::Time(get_or_return_null!(jiff::civil::Time))
+            }
+            #[cfg(not(feature = "jiff"))]
+            {
+                panic!("TIME requires jiff feature to be enabled")
+            }
+        } else if column.type_() == &Type::FLOAT4 {
+            stmt::Value::F32(get_or_return_null!(f32))
+        } else if column.type_() == &Type::FLOAT8 {
+            stmt::Value::F64(get_or_return_null!(f64))
+        } else if column.type_() == &Type::NUMERIC {
+            #[cfg(feature = "rust_decimal")]
+            {
+                stmt::Value::Decimal(get_or_return_null!(rust_decimal::Decimal))
+            }
+            #[cfg(not(feature = "rust_decimal"))]
+            {
+                panic!("NUMERIC requires rust_decimal feature to be enabled")
+            }
+        } else if matches!(column.type_().kind(), Kind::Enum(_)) {
+            match row.get::<usize, Option<EnumString>>(index) {
+                Some(EnumString(v)) => stmt::Value::String(v),
+                None => return Self(stmt::Value::Null),
+            }
+        } else {
+            todo!(
+                "implement PostgreSQL raw SQL inference for `{:#?}`",
+                column.type_()
+            );
+        };
+
+        Value(core_value)
+    }
 }
 
 // ============================================================================

--- a/crates/toasty-driver-postgresql/src/value.rs
+++ b/crates/toasty-driver-postgresql/src/value.rs
@@ -49,7 +49,7 @@ impl<'a> postgres_types::FromSql<'a> for RawBytes<'a> {
 }
 
 #[derive(Debug)]
-pub struct Value(pub(crate) CoreValue);
+pub(crate) struct Value(CoreValue);
 
 impl From<CoreValue> for Value {
     fn from(value: CoreValue) -> Self {
@@ -59,12 +59,17 @@ impl From<CoreValue> for Value {
 
 impl Value {
     /// Converts this PostgreSQL driver value into the core Toasty value.
-    pub fn into_inner(self) -> CoreValue {
+    pub(crate) fn into_inner(self) -> CoreValue {
         self.0
     }
 
     /// Converts a PostgreSQL value within a row to a Toasty value.
-    pub fn from_sql(index: usize, row: &Row, column: &Column, expected_ty: &stmt::Type) -> Self {
+    pub(crate) fn from_sql(
+        index: usize,
+        row: &Row,
+        column: &Column,
+        expected_ty: &stmt::Type,
+    ) -> Self {
         // Gets the value from the row as Option<T> and return stmt::Value::Null if the Option is
         // None.
         macro_rules! get_or_return_null {
@@ -189,7 +194,7 @@ impl Value {
 
     /// Converts a PostgreSQL value within a row using PostgreSQL column
     /// metadata as the Toasty value type.
-    pub fn from_sql_infer(index: usize, row: &Row, column: &Column) -> Self {
+    pub(crate) fn from_sql_infer(index: usize, row: &Row, column: &Column) -> Self {
         macro_rules! get_or_return_null {
             ($ty:ty) => {{
                 match row.get::<usize, Option<$ty>>(index) {

--- a/crates/toasty-driver-sqlite/src/lib.rs
+++ b/crates/toasty-driver-sqlite/src/lib.rs
@@ -31,7 +31,7 @@ use toasty_core::{
     Result, Schema,
     driver::{
         Capability, Driver, ExecResponse,
-        operation::{IsolationLevel, Operation, Transaction},
+        operation::{IsolationLevel, Operation, RawSqlRet, Transaction, TypedValue},
     },
     schema::{
         db::{self, Migration, Table},
@@ -41,6 +41,12 @@ use toasty_core::{
 };
 use toasty_sql::{self as sql};
 use url::Url;
+
+enum SqlReturn {
+    Count,
+    Infer,
+    Types(Vec<stmt::Type>),
+}
 
 /// A SQLite [`Driver`] that opens connections to a file or in-memory database.
 ///
@@ -165,6 +171,65 @@ impl Connection {
         let sqlite = Self { connection };
         Ok(sqlite)
     }
+
+    fn exec_sql(
+        &mut self,
+        sql_str: &str,
+        typed_params: Vec<TypedValue>,
+        ret: SqlReturn,
+    ) -> Result<ExecResponse> {
+        tracing::debug!(db.system = "sqlite", db.statement = %sql_str, params = typed_params.len(), "executing SQL");
+
+        let mut stmt = self.connection.prepare_cached(sql_str).unwrap();
+
+        let params = typed_params
+            .into_iter()
+            .map(|tv| Value::from(tv.value))
+            .collect::<Vec<_>>();
+
+        if matches!(ret, SqlReturn::Count) {
+            let count = stmt
+                .execute(rusqlite::params_from_iter(params.iter()))
+                .map_err(toasty_core::Error::driver_operation_failed)?;
+
+            return Ok(ExecResponse::count(count as _));
+        }
+
+        let mut rows = stmt
+            .query(rusqlite::params_from_iter(params.iter()))
+            .unwrap();
+
+        let mut values = vec![];
+        let column_count = rows.as_ref().map(|stmt| stmt.column_count()).unwrap_or(0);
+
+        loop {
+            match rows.next() {
+                Ok(Some(row)) => {
+                    let items = match &ret {
+                        SqlReturn::Count => unreachable!(),
+                        SqlReturn::Infer => (0..column_count)
+                            .map(|index| Value::from_sql_infer(row, index).into_inner())
+                            .collect(),
+                        SqlReturn::Types(ret_tys) => ret_tys
+                            .iter()
+                            .enumerate()
+                            .map(|(index, ret_ty)| Value::from_sql(row, index, ret_ty).into_inner())
+                            .collect(),
+                    };
+
+                    values.push(stmt::ValueRecord::from_vec(items).into());
+                }
+                Ok(None) => break,
+                Err(err) => {
+                    return Err(toasty_core::Error::driver_operation_failed(err));
+                }
+            }
+        }
+
+        Ok(ExecResponse::value_stream(stmt::ValueStream::from_vec(
+            values,
+        )))
+    }
 }
 
 #[async_trait]
@@ -179,6 +244,14 @@ impl toasty_core::driver::Connection for Connection {
                     "last_insert_id_hack is MySQL-specific and should not be set for SQLite"
                 );
                 (sql::Statement::from(op.stmt), op.params, op.ret)
+            }
+            Operation::RawSql(op) => {
+                let ret = match op.ret {
+                    RawSqlRet::None => SqlReturn::Count,
+                    RawSqlRet::Infer => SqlReturn::Infer,
+                    RawSqlRet::Types(types) => SqlReturn::Types(types),
+                };
+                return self.exec_sql(&op.sql, op.params, ret);
             }
             // Operation::Insert(op) => op.stmt.into(),
             Operation::Transaction(mut op) => {
@@ -199,78 +272,33 @@ impl toasty_core::driver::Connection for Connection {
             _ => todo!("op={:#?}", op),
         };
 
-        let sql_str = sql::Serializer::sqlite(&schema.db).serialize(&sql);
-
-        tracing::debug!(db.system = "sqlite", db.statement = %sql_str, params = typed_params.len(), "executing SQL");
-
-        let mut stmt = self.connection.prepare_cached(&sql_str).unwrap();
-
-        let width = match &sql {
+        let ret = match &sql {
             sql::Statement::Query(stmt) => match &stmt.body {
-                stmt::ExprSet::Select(stmt) => {
-                    Some(stmt.returning.as_project_unwrap().as_record_unwrap().len())
-                }
+                stmt::ExprSet::Select(_) => SqlReturn::Types(ret_tys.unwrap()),
                 _ => todo!(),
             },
             sql::Statement::Insert(stmt) => stmt
                 .returning
                 .as_ref()
-                .map(|returning| returning.as_project_unwrap().as_record_unwrap().len()),
+                .map(|_| SqlReturn::Types(ret_tys.unwrap()))
+                .unwrap_or(SqlReturn::Count),
             sql::Statement::Delete(stmt) => stmt
                 .returning
                 .as_ref()
-                .map(|returning| returning.as_project_unwrap().as_record_unwrap().len()),
+                .map(|_| SqlReturn::Types(ret_tys.unwrap()))
+                .unwrap_or(SqlReturn::Count),
             sql::Statement::Update(stmt) => {
                 assert!(stmt.condition.is_none(), "stmt={stmt:#?}");
                 stmt.returning
                     .as_ref()
-                    .map(|returning| returning.as_project_unwrap().as_record_unwrap().len())
+                    .map(|_| SqlReturn::Types(ret_tys.unwrap()))
+                    .unwrap_or(SqlReturn::Count)
             }
-            _ => None,
+            _ => SqlReturn::Count,
         };
 
-        let params = typed_params
-            .into_iter()
-            .map(|tv| Value::from(tv.value))
-            .collect::<Vec<_>>();
-
-        if width.is_none() {
-            let count = stmt
-                .execute(rusqlite::params_from_iter(params.iter()))
-                .map_err(toasty_core::Error::driver_operation_failed)?;
-
-            return Ok(ExecResponse::count(count as _));
-        }
-
-        let mut rows = stmt
-            .query(rusqlite::params_from_iter(params.iter()))
-            .unwrap();
-
-        let mut ret = vec![];
-
-        let ret_tys = &ret_tys.as_ref().unwrap();
-
-        loop {
-            match rows.next() {
-                Ok(Some(row)) => {
-                    let mut items = vec![];
-
-                    let width = width.unwrap();
-
-                    for index in 0..width {
-                        items.push(Value::from_sql(row, index, &ret_tys[index]).into_inner());
-                    }
-
-                    ret.push(stmt::ValueRecord::from_vec(items).into());
-                }
-                Ok(None) => break,
-                Err(err) => {
-                    return Err(toasty_core::Error::driver_operation_failed(err));
-                }
-            }
-        }
-
-        Ok(ExecResponse::value_stream(stmt::ValueStream::from_vec(ret)))
+        let sql_str = sql::Serializer::sqlite(&schema.db).serialize(&sql);
+        self.exec_sql(&sql_str, typed_params, ret)
     }
 
     async fn push_schema(&mut self, schema: &Schema) -> Result<()> {

--- a/crates/toasty-driver-sqlite/src/value.rs
+++ b/crates/toasty-driver-sqlite/src/value.rs
@@ -5,7 +5,7 @@ use rusqlite::{
 use toasty_core::stmt::{self, Value as CoreValue};
 
 #[derive(Debug)]
-pub struct Value(CoreValue);
+pub(crate) struct Value(CoreValue);
 
 impl From<CoreValue> for Value {
     fn from(value: CoreValue) -> Self {
@@ -15,16 +15,16 @@ impl From<CoreValue> for Value {
 
 impl Value {
     /// Converts this SQLite driver value into the core Toasty value.
-    pub fn into_inner(self) -> CoreValue {
+    pub(crate) fn into_inner(self) -> CoreValue {
         self.0
     }
 
     /// Converts a SQLite value within a row to a Toasty value.
-    pub fn from_sql(row: &Row, index: usize, ty: &stmt::Type) -> Self {
+    pub(crate) fn from_sql(row: &Row, index: usize, ty: &stmt::Type) -> Self {
         let value: Option<SqlValue> = row.get(index).unwrap();
 
         let core_value = match value {
-            Some(SqlValue::Null) => stmt::Value::Null,
+            Some(SqlValue::Null) | None => stmt::Value::Null,
             Some(SqlValue::Integer(value)) => match ty {
                 stmt::Type::Bool => stmt::Value::Bool(value != 0),
                 stmt::Type::I8 => stmt::Value::I8(value as i8),
@@ -51,14 +51,13 @@ impl Value {
                 stmt::Type::Bytes => stmt::Value::Bytes(value),
                 _ => todo!("value={value:#?}"),
             },
-            None => stmt::Value::Null,
         };
 
         Value(core_value)
     }
 
     /// Converts a SQLite value within a row using SQLite's runtime storage class.
-    pub fn from_sql_infer(row: &Row, index: usize) -> Self {
+    pub(crate) fn from_sql_infer(row: &Row, index: usize) -> Self {
         let value: Option<SqlValue> = row.get(index).unwrap();
 
         let core_value = match value {

--- a/crates/toasty-driver-sqlite/src/value.rs
+++ b/crates/toasty-driver-sqlite/src/value.rs
@@ -56,6 +56,21 @@ impl Value {
 
         Value(core_value)
     }
+
+    /// Converts a SQLite value within a row using SQLite's runtime storage class.
+    pub fn from_sql_infer(row: &Row, index: usize) -> Self {
+        let value: Option<SqlValue> = row.get(index).unwrap();
+
+        let core_value = match value {
+            Some(SqlValue::Null) | None => stmt::Value::Null,
+            Some(SqlValue::Integer(value)) => stmt::Value::I64(value),
+            Some(SqlValue::Real(value)) => stmt::Value::F64(value),
+            Some(SqlValue::Text(value)) => stmt::Value::String(value),
+            Some(SqlValue::Blob(value)) => stmt::Value::Bytes(value),
+        };
+
+        Value(core_value)
+    }
 }
 
 impl ToSql for Value {

--- a/crates/toasty-driver-turso/src/lib.rs
+++ b/crates/toasty-driver-turso/src/lib.rs
@@ -47,7 +47,7 @@ use toasty_core::{
     Result, Schema,
     driver::{
         Capability, Driver, ExecResponse,
-        operation::{IsolationLevel, Operation, Transaction},
+        operation::{IsolationLevel, Operation, RawSqlRet, Transaction, TypedValue},
     },
     schema::{
         db::{self, Migration, Table},
@@ -59,6 +59,12 @@ use toasty_sql::{self as sql};
 use tokio::sync::Mutex;
 use turso::{Builder, Connection as TursoConn, Database, Statement, Value as TursoValue};
 use url::Url;
+
+enum SqlReturn {
+    Count,
+    Infer,
+    Types(Vec<stmt::Type>),
+}
 
 const CREATE_MIGRATIONS_TABLE: &str = "\
 CREATE TABLE IF NOT EXISTS __toasty_migrations (
@@ -425,6 +431,74 @@ impl fmt::Debug for Connection {
     }
 }
 
+impl Connection {
+    async fn exec_sql(
+        &mut self,
+        sql_str: &str,
+        typed_params: Vec<TypedValue>,
+        ret: SqlReturn,
+    ) -> Result<ExecResponse> {
+        tracing::debug!(db.system = "turso", db.statement = %sql_str, params = typed_params.len(), "executing SQL");
+
+        let params: Vec<TursoValue> = typed_params
+            .iter()
+            .map(|tv| value::to_turso(&tv.value))
+            .collect();
+
+        let mut stmt: Statement = self
+            .conn
+            .prepare_cached(sql_str)
+            .await
+            .map_err(classify_turso_error)?;
+
+        if matches!(ret, SqlReturn::Count) {
+            let count = stmt.execute(params).await.map_err(classify_turso_error)?;
+
+            return Ok(ExecResponse::count(count as _));
+        }
+
+        let mut rows = stmt.query(params).await.map_err(classify_turso_error)?;
+
+        let mut values = vec![];
+
+        loop {
+            match rows.next().await {
+                Ok(Some(row)) => {
+                    let items = match &ret {
+                        SqlReturn::Count => unreachable!(),
+                        SqlReturn::Infer => {
+                            let mut items = vec![];
+                            for index in 0..row.column_count() {
+                                let turso_val =
+                                    row.get_value(index).map_err(classify_turso_error)?;
+                                items.push(value::from_turso_infer(turso_val));
+                            }
+                            items
+                        }
+                        SqlReturn::Types(ret_tys) => {
+                            let mut items = Vec::with_capacity(ret_tys.len());
+                            for (index, ret_ty) in ret_tys.iter().enumerate() {
+                                let turso_val =
+                                    row.get_value(index).map_err(classify_turso_error)?;
+                                items.push(value::from_turso(turso_val, ret_ty));
+                            }
+                            items
+                        }
+                    };
+
+                    values.push(stmt::ValueRecord::from_vec(items).into());
+                }
+                Ok(None) => break,
+                Err(err) => return Err(classify_turso_error(err)),
+            }
+        }
+
+        Ok(ExecResponse::value_stream(stmt::ValueStream::from_vec(
+            values,
+        )))
+    }
+}
+
 #[async_trait]
 impl toasty_core::driver::Connection for Connection {
     async fn exec(&mut self, schema: &Arc<Schema>, op: Operation) -> Result<ExecResponse> {
@@ -437,6 +511,14 @@ impl toasty_core::driver::Connection for Connection {
                     "last_insert_id_hack is MySQL-specific and should not be set for Turso"
                 );
                 (sql::Statement::from(op.stmt), op.params, op.ret)
+            }
+            Operation::RawSql(op) => {
+                let ret = match op.ret {
+                    RawSqlRet::None => SqlReturn::Count,
+                    RawSqlRet::Infer => SqlReturn::Infer,
+                    RawSqlRet::Types(types) => SqlReturn::Types(types),
+                };
+                return self.exec_sql(&op.sql, op.params, ret).await;
             }
             Operation::Transaction(op) => {
                 if let Transaction::Start { isolation, .. } = &op
@@ -462,50 +544,14 @@ impl toasty_core::driver::Connection for Connection {
             _ => todo!("op={:#?}", op),
         };
 
+        let ret = if sql.returning_len().is_some() {
+            SqlReturn::Types(ret_tys.unwrap())
+        } else {
+            SqlReturn::Count
+        };
+
         let sql_str = sql::Serializer::sqlite(&schema.db).serialize(&sql);
-
-        tracing::debug!(db.system = "turso", db.statement = %sql_str, params = typed_params.len(), "executing SQL");
-
-        let width = sql.returning_len();
-
-        let params: Vec<TursoValue> = typed_params
-            .iter()
-            .map(|tv| value::to_turso(&tv.value))
-            .collect();
-
-        let mut stmt: Statement = self
-            .conn
-            .prepare_cached(&sql_str)
-            .await
-            .map_err(classify_turso_error)?;
-
-        if width.is_none() {
-            let count = stmt.execute(params).await.map_err(classify_turso_error)?;
-
-            return Ok(ExecResponse::count(count as _));
-        }
-
-        let mut rows = stmt.query(params).await.map_err(classify_turso_error)?;
-
-        let mut ret = vec![];
-        let ret_tys = ret_tys.as_ref().unwrap();
-
-        loop {
-            match rows.next().await {
-                Ok(Some(row)) => {
-                    let mut items = Vec::with_capacity(ret_tys.len());
-                    for (index, ret_ty) in ret_tys.iter().enumerate() {
-                        let turso_val = row.get_value(index).map_err(classify_turso_error)?;
-                        items.push(value::from_turso(turso_val, ret_ty));
-                    }
-                    ret.push(stmt::ValueRecord::from_vec(items).into());
-                }
-                Ok(None) => break,
-                Err(err) => return Err(classify_turso_error(err)),
-            }
-        }
-
-        Ok(ExecResponse::value_stream(stmt::ValueStream::from_vec(ret)))
+        self.exec_sql(&sql_str, typed_params, ret).await
     }
 
     async fn push_schema(&mut self, schema: &Schema) -> Result<()> {

--- a/crates/toasty-driver-turso/src/value.rs
+++ b/crates/toasty-driver-turso/src/value.rs
@@ -69,6 +69,18 @@ pub(crate) fn from_turso(value: TursoValue, ty: &stmt::Type) -> CoreValue {
     }
 }
 
+/// Converts a [`turso::Value`] back to a [`toasty_core::stmt::Value`] using
+/// SQLite's runtime storage class.
+pub(crate) fn from_turso_infer(value: TursoValue) -> CoreValue {
+    match value {
+        TursoValue::Null => CoreValue::Null,
+        TursoValue::Integer(v) => CoreValue::I64(v),
+        TursoValue::Real(v) => CoreValue::F64(v),
+        TursoValue::Text(v) => CoreValue::String(v),
+        TursoValue::Blob(v) => CoreValue::Bytes(v),
+    }
+}
+
 fn value_list_to_json_text(value: &CoreValue) -> String {
     let json = toasty_sql::value_json::value_list_to_json(value);
     serde_json::to_string(&json).expect("serialize Vec<scalar> to JSON")

--- a/crates/toasty-sql/src/serializer/flavor.rs
+++ b/crates/toasty-sql/src/serializer/flavor.rs
@@ -1,6 +1,6 @@
 use super::Serializer;
 
-use toasty_core::schema::db;
+use toasty_core::{driver::SqlPlaceholder, schema::db};
 
 #[derive(Debug)]
 pub(super) enum Flavor {
@@ -56,5 +56,15 @@ impl<'a> Serializer<'a> {
 
     pub(super) fn is_mysql(&self) -> bool {
         matches!(self.flavor, Flavor::Mysql)
+    }
+}
+
+impl Flavor {
+    pub(super) fn sql_placeholder(&self) -> SqlPlaceholder {
+        match self {
+            Flavor::Postgresql => SqlPlaceholder::DollarNumber,
+            Flavor::Sqlite => SqlPlaceholder::NumberedQuestionMark,
+            Flavor::Mysql => SqlPlaceholder::QuestionMark,
+        }
     }
 }

--- a/crates/toasty-sql/src/serializer/params.rs
+++ b/crates/toasty-sql/src/serializer/params.rs
@@ -1,5 +1,8 @@
 use super::{Formatter, ToSql};
 
+use std::fmt;
+use toasty_core::driver::SqlPlaceholder;
+
 /// A positional bind-parameter placeholder.
 ///
 /// The inner `usize` is the 1-based parameter index. The serializer renders
@@ -17,12 +20,18 @@ pub struct Placeholder(pub usize);
 
 impl ToSql for Placeholder {
     fn to_sql(self, f: &mut Formatter<'_>) {
-        use std::fmt::Write;
+        write_sql_placeholder(&mut f.dst, f.serializer.flavor.sql_placeholder(), self.0).unwrap();
+    }
+}
 
-        match f.serializer.flavor {
-            super::Flavor::Mysql => write!(&mut f.dst, "?").unwrap(),
-            super::Flavor::Postgresql => write!(&mut f.dst, "${}", self.0).unwrap(),
-            super::Flavor::Sqlite => write!(&mut f.dst, "?{}", self.0).unwrap(),
-        }
+fn write_sql_placeholder(
+    dst: &mut impl fmt::Write,
+    placeholder: SqlPlaceholder,
+    index: usize,
+) -> fmt::Result {
+    match placeholder {
+        SqlPlaceholder::QuestionMark => dst.write_str("?"),
+        SqlPlaceholder::NumberedQuestionMark => write!(dst, "?{index}"),
+        SqlPlaceholder::DollarNumber => write!(dst, "${index}"),
     }
 }

--- a/crates/toasty/src/db.rs
+++ b/crates/toasty/src/db.rs
@@ -11,7 +11,7 @@ pub use connect::Connect;
 pub use connection::Connection;
 pub use executor::Executor;
 pub use pool::{Pool, PoolStatus};
-pub use toasty_core::driver::{Capability, Driver};
+pub use toasty_core::driver::{Capability, Driver, SqlPlaceholder};
 pub use tx::{Transaction, TransactionBuilder};
 
 /// Response from executing a statement, including pagination metadata.
@@ -23,7 +23,7 @@ pub(crate) use tx::ConnRef;
 use crate::{Result, engine::Engine};
 
 use async_trait::async_trait;
-use toasty_core::{Schema, stmt};
+use toasty_core::{Schema, driver::operation::RawSql, stmt};
 
 use std::sync::Arc;
 
@@ -175,6 +175,15 @@ impl Executor for Db {
 
     async fn exec_untyped(&mut self, stmt: stmt::Statement) -> Result<ExecResponse> {
         self.exec_stmt(stmt, false).await
+    }
+
+    async fn exec_raw_sql(&mut self, raw: RawSql) -> Result<ExecResponse> {
+        let conn = self.connection().await?;
+        conn.exec_raw_sql(raw).await
+    }
+
+    fn capability(&mut self) -> &Capability {
+        Db::capability(self)
     }
 
     fn schema(&mut self) -> &Arc<Schema> {

--- a/crates/toasty/src/db/connection.rs
+++ b/crates/toasty/src/db/connection.rs
@@ -7,7 +7,10 @@ use async_trait::async_trait;
 use std::sync::Arc;
 use toasty_core::{
     Schema,
-    driver::{ExecResponse, operation::Operation},
+    driver::{
+        Capability, ExecResponse,
+        operation::{Operation, RawSql},
+    },
     stmt,
 };
 use tokio::sync::oneshot;
@@ -68,6 +71,20 @@ impl Connection {
         rx.await.unwrap()
     }
 
+    pub(crate) async fn exec_raw_sql(&self, raw: RawSql) -> crate::Result<ExecResponse> {
+        let (tx, rx) = oneshot::channel();
+
+        self.handle()
+            .in_tx
+            .send(ConnectionOperation::ExecRawSql {
+                raw: Box::new(raw),
+                tx,
+            })
+            .unwrap();
+
+        rx.await.unwrap()
+    }
+
     /// Begin a transaction on this connection.
     ///
     /// Takes `&mut self` so the `Connection` is exclusively borrowed while
@@ -110,6 +127,14 @@ impl super::Executor for Connection {
         stmt: toasty_core::stmt::Statement,
     ) -> crate::Result<ExecResponse> {
         self.exec_stmt(stmt, false).await
+    }
+
+    async fn exec_raw_sql(&mut self, raw: RawSql) -> crate::Result<ExecResponse> {
+        Connection::exec_raw_sql(self, raw).await
+    }
+
+    fn capability(&mut self) -> &Capability {
+        self.shared.engine.capability()
     }
 
     fn schema(&mut self) -> &Arc<Schema> {

--- a/crates/toasty/src/db/connection_task.rs
+++ b/crates/toasty/src/db/connection_task.rs
@@ -10,6 +10,7 @@
 
 use std::sync::Arc;
 
+use toasty_core::driver::operation::RawSql;
 use toasty_core::driver::{Connection, Rows};
 use toasty_core::stmt::Value;
 use tokio::{
@@ -30,6 +31,11 @@ pub(crate) enum ConnectionOperation {
     },
     ExecOperation {
         operation: Box<toasty_core::driver::operation::Operation>,
+        tx: oneshot::Sender<crate::Result<toasty_core::driver::ExecResponse>>,
+    },
+    /// Execute user-authored SQL through the engine's SQL capability guard.
+    ExecRawSql {
+        raw: Box<RawSql>,
         tx: oneshot::Sender<crate::Result<toasty_core::driver::ExecResponse>>,
     },
     /// Push schema to the database.
@@ -125,6 +131,10 @@ impl ConnectionTask {
             }
             ConnectionOperation::ExecOperation { operation, tx } => {
                 let result = self.connection.exec(&self.engine.schema, *operation).await;
+                self.respond(tx, result)
+            }
+            ConnectionOperation::ExecRawSql { raw, tx } => {
+                let result = self.engine.exec_raw_sql(&mut *self.connection, *raw).await;
                 self.respond(tx, result)
             }
             ConnectionOperation::PushSchema { tx } => {

--- a/crates/toasty/src/db/executor.rs
+++ b/crates/toasty/src/db/executor.rs
@@ -2,10 +2,13 @@ use crate::{Result, Statement, db::Transaction, schema::Load};
 
 use async_trait::async_trait;
 use std::sync::Arc;
-use toasty_core::{Schema, driver::ExecResponse};
+use toasty_core::{
+    Schema,
+    driver::{Capability, ExecResponse, operation::RawSql},
+};
 
-/// Anything that can execute queries — [`Db`](crate::Db) or
-/// [`Transaction`](crate::db::Transaction).
+/// Anything that can execute queries — [`Db`](crate::Db),
+/// [`Connection`](crate::Connection), or [`Transaction`](crate::Transaction).
 ///
 /// This trait is dyn-compatible. The generic [`exec`](dyn Executor::exec)
 /// method lives on `dyn Executor` and accepts any typed
@@ -23,6 +26,14 @@ pub trait Executor: Send + Sync {
     /// Execute an untyped statement, returning the full execution response.
     #[doc(hidden)]
     async fn exec_untyped(&mut self, stmt: toasty_core::stmt::Statement) -> Result<ExecResponse>;
+
+    /// Execute user-authored SQL, returning the full execution response.
+    #[doc(hidden)]
+    async fn exec_raw_sql(&mut self, raw: RawSql) -> Result<ExecResponse>;
+
+    /// Returns the capabilities associated with this executor.
+    #[doc(hidden)]
+    fn capability(&mut self) -> &Capability;
 
     /// Returns the schema associated with this executor.
     #[doc(hidden)]

--- a/crates/toasty/src/db/tx.rs
+++ b/crates/toasty/src/db/tx.rs
@@ -7,7 +7,10 @@ use crate::{Result, db::ConnectionOperation, db::Executor};
 use async_trait::async_trait;
 use toasty_core::{
     Schema,
-    driver::operation::{self, IsolationLevel, TransactionMode},
+    driver::{
+        Capability,
+        operation::{self, IsolationLevel, RawSql, TransactionMode},
+    },
 };
 use tokio::sync::oneshot;
 
@@ -269,6 +272,14 @@ impl<'a> Executor for Transaction<'a> {
         stmt: toasty_core::stmt::Statement,
     ) -> Result<toasty_core::driver::ExecResponse> {
         self.conn.exec_stmt(stmt, true).await
+    }
+
+    async fn exec_raw_sql(&mut self, raw: RawSql) -> Result<toasty_core::driver::ExecResponse> {
+        self.conn.exec_raw_sql(raw).await
+    }
+
+    fn capability(&mut self) -> &Capability {
+        self.conn.shared.engine.capability()
     }
 
     fn schema(&mut self) -> &Arc<Schema> {

--- a/crates/toasty/src/engine.rs
+++ b/crates/toasty/src/engine.rs
@@ -23,7 +23,7 @@ use crate::Result;
 use std::sync::Arc;
 use toasty_core::{
     Connection, Schema,
-    driver::Capability,
+    driver::{Capability, operation::RawSql},
     stmt::{self, Statement},
 };
 
@@ -98,6 +98,23 @@ impl Engine {
         // The plan is called once (single entry record stream) with no arguments
         // (empty record).
         self.exec_plan(connection, plan, in_transaction).await
+    }
+
+    /// Executes user-authored SQL through the driver SQL path.
+    pub(crate) async fn exec_raw_sql(
+        &self,
+        connection: &mut dyn Connection,
+        raw: RawSql,
+    ) -> Result<toasty_core::driver::ExecResponse> {
+        if !self.capability.sql {
+            return Err(toasty_core::Error::unsupported_feature(
+                "raw SQL is only supported by SQL drivers",
+            ));
+        }
+
+        tracing::debug!("executing raw SQL");
+
+        connection.exec(&self.schema, raw.into()).await
     }
 
     /// Returns a new [`ExprContext`](stmt::ExprContext) for a specific target.

--- a/crates/toasty/src/lib.rs
+++ b/crates/toasty/src/lib.rs
@@ -41,6 +41,11 @@
 //! Generated query builders (e.g. `find_by_*`, `filter_by_*`) produce these
 //! types.
 //!
+//! ## [`sql`] — raw SQL execution helpers
+//!
+//! Contains [`sql::statement`] and [`sql::query`] for running backend SQL
+//! through [`Db`], [`Connection`], or [`Transaction`] handles.
+//!
 //! # Key traits
 //!
 //! - [`Model`](schema::Model) — a root model backed by a database table.
@@ -61,6 +66,8 @@
 //! - [`Page`](stmt::Page) — a page of results from a paginated query, with cursor-based
 //!   navigation.
 //! - [`Batch`](stmt::Batch) — groups multiple queries into a single round-trip.
+//! - [`Capability`] / [`SqlPlaceholder`] — driver metadata, including SQL
+//!   placeholder syntax for raw SQL.
 //! - [`Error`] / [`Result`] — re-exported from `toasty-core`.
 //!
 //! # Derive macros
@@ -109,7 +116,9 @@ pub use stmt::{Batch, batch};
 
 /// Database handle, connection pool, executor trait, and transaction support.
 pub mod db;
-pub use db::{Connection, Db, Executor, Transaction, TransactionBuilder};
+pub use db::{
+    Capability, Connection, Db, Executor, SqlPlaceholder, Transaction, TransactionBuilder,
+};
 
 mod engine;
 
@@ -128,6 +137,9 @@ pub mod stmt;
 #[cfg(feature = "serde")]
 pub use stmt::Json;
 pub use stmt::Statement;
+
+/// Raw SQL execution helpers.
+pub mod sql;
 
 pub use toasty_macros::{Embed, Model, create, query};
 

--- a/crates/toasty/src/sql.rs
+++ b/crates/toasty/src/sql.rs
@@ -1,0 +1,286 @@
+//! Raw SQL execution helpers for SQL backends.
+//!
+//! Use [`statement`] for SQL that returns an affected-row count and [`query`]
+//! for SQL that returns rows. Both builders execute through
+//! [`Executor`](crate::Executor), so they work with [`Db`](crate::Db),
+//! [`Connection`](crate::Connection), and [`Transaction`](crate::Transaction).
+//!
+//! Raw SQL is backend SQL. Toasty does not rewrite placeholders, quote
+//! identifiers, or hydrate models from raw query results. Use the placeholder
+//! syntax of the active driver. The syntax is exposed at runtime through
+//! [`Capability::sql_placeholder`](crate::Capability::sql_placeholder):
+//!
+//! | Backend | [`SqlPlaceholder`](crate::SqlPlaceholder) |
+//! |---|---|
+//! | SQLite | `NumberedQuestionMark` (`?1`, `?2`, ...) |
+//! | Turso | `NumberedQuestionMark` (`?1`, `?2`, ...) |
+//! | PostgreSQL | `DollarNumber` (`$1`, `$2`, ...) |
+//! | MySQL | `QuestionMark` (`?`, `?`, ...) |
+//!
+//! # Statements
+//!
+//! ```ignore
+//! let updated = toasty::sql::statement(
+//!     "UPDATE users SET name = ?1 WHERE id = ?2",
+//! )
+//! .bind("Alice")
+//! .bind(1_i64)
+//! .exec(&mut db)
+//! .await?;
+//!
+//! assert_eq!(updated, 1);
+//! ```
+//!
+//! # Queries
+//!
+//! Queries return dynamic [`Value`] rows. Each row is a [`Value::Record`] with
+//! fields in selected-column order.
+//!
+//! ```ignore
+//! let rows = toasty::sql::query(
+//!     "SELECT id, name FROM users WHERE active = ?1",
+//! )
+//! .bind(true)
+//! .exec(&mut db)
+//! .await?;
+//! ```
+//!
+//! The driver infers result value types from database metadata by default. Use
+//! [`Query::column_types`] when a result column is ambiguous, such as a SQLite
+//! boolean stored as an integer or a UUID stored as bytes.
+
+use crate::{Executor, Result};
+use toasty_core::{
+    Error,
+    driver::{
+        Capability,
+        operation::{RawSql, RawSqlRet, TypedValue},
+    },
+    schema::db,
+    stmt::{self, Value},
+};
+
+/// A raw SQL statement that returns an affected-row count.
+///
+/// Create one with [`statement`].
+pub struct Statement {
+    sql: String,
+    params: Vec<Param>,
+}
+
+/// A raw SQL query that returns dynamic rows.
+///
+/// Create one with [`query`].
+pub struct Query {
+    sql: String,
+    params: Vec<Param>,
+    ret: RawSqlRet,
+}
+
+#[derive(Debug, Clone)]
+enum Param {
+    Infer(Value),
+    Typed(TypedValue),
+}
+
+/// Create a raw SQL statement.
+///
+/// Statements are executed for their affected-row count. Use
+/// [`query`] for SQL that returns rows.
+///
+/// The SQL string must use the placeholder syntax reported by
+/// [`Capability::sql_placeholder`](crate::Capability::sql_placeholder).
+///
+/// ```ignore
+/// let count = toasty::sql::statement(
+///     "DELETE FROM users WHERE archived = ?1",
+/// )
+/// .bind(true)
+/// .exec(&mut db)
+/// .await?;
+/// ```
+pub fn statement(sql: impl Into<String>) -> Statement {
+    Statement {
+        sql: sql.into(),
+        params: vec![],
+    }
+}
+
+/// Create a raw SQL query.
+///
+/// Query rows are returned as dynamic [`Value`] records.
+///
+/// ```ignore
+/// let rows = toasty::sql::query(
+///     "SELECT id, name FROM users WHERE active = ?1",
+/// )
+/// .bind(true)
+/// .exec(&mut db)
+/// .await?;
+/// ```
+pub fn query(sql: impl Into<String>) -> Query {
+    Query {
+        sql: sql.into(),
+        params: vec![],
+        ret: RawSqlRet::Infer,
+    }
+}
+
+impl Statement {
+    /// Bind a value using the executor driver's default database type for
+    /// that value.
+    ///
+    /// Values are bound in the order this method is called. Use
+    /// [`bind_typed`](Self::bind_typed) for `NULL`, empty lists, or values
+    /// whose database type cannot be inferred from the value alone.
+    pub fn bind(mut self, value: impl Into<Value>) -> Self {
+        self.params.push(Param::Infer(value.into()));
+        self
+    }
+
+    /// Bind a value with an explicit database type.
+    ///
+    /// This is useful for `NULL`, empty lists, or backend-specific column
+    /// types.
+    ///
+    /// ```ignore
+    /// use toasty::schema::db;
+    ///
+    /// toasty::sql::statement(
+    ///     "UPDATE users SET archived_at = ?1 WHERE id = ?2",
+    /// )
+    /// .bind_typed(toasty::stmt::Value::Null, db::Type::Timestamp(6))
+    /// .bind(1_i64)
+    /// .exec(&mut db)
+    /// .await?;
+    /// ```
+    pub fn bind_typed(mut self, value: impl Into<Value>, ty: db::Type) -> Self {
+        self.params.push(Param::Typed(TypedValue {
+            value: value.into(),
+            ty,
+        }));
+        self
+    }
+
+    /// Execute the statement and return the affected-row count.
+    ///
+    /// The executor may be a [`Db`](crate::Db), [`Connection`](crate::Connection),
+    /// or [`Transaction`](crate::Transaction).
+    pub async fn exec(self, executor: &mut dyn Executor) -> Result<u64> {
+        let raw = into_raw_sql(
+            self.sql,
+            self.params,
+            RawSqlRet::None,
+            executor.capability(),
+        )?;
+        let response = executor.exec_raw_sql(raw).await?;
+
+        Ok(response.values.into_count())
+    }
+}
+
+impl Query {
+    /// Bind a value using the executor driver's default database type for
+    /// that value.
+    ///
+    /// Values are bound in the order this method is called. Use
+    /// [`bind_typed`](Self::bind_typed) for `NULL`, empty lists, or values
+    /// whose database type cannot be inferred from the value alone.
+    pub fn bind(mut self, value: impl Into<Value>) -> Self {
+        self.params.push(Param::Infer(value.into()));
+        self
+    }
+
+    /// Bind a value with an explicit database type.
+    ///
+    /// This is useful for `NULL`, empty lists, or backend-specific column
+    /// types.
+    pub fn bind_typed(mut self, value: impl Into<Value>, ty: db::Type) -> Self {
+        self.params.push(Param::Typed(TypedValue {
+            value: value.into(),
+            ty,
+        }));
+        self
+    }
+
+    /// Provide result column type hints for ambiguous backend values.
+    ///
+    /// Hints affect result decoding only. They do not change the SQL sent to
+    /// the database. Use this when backend metadata is not enough to choose the
+    /// desired Toasty value type.
+    ///
+    /// ```ignore
+    /// use toasty::stmt;
+    ///
+    /// let rows = toasty::sql::query(
+    ///     "SELECT id, enabled FROM users WHERE id = ?1",
+    /// )
+    /// .bind(1_i64)
+    /// .column_types([stmt::Type::I64, stmt::Type::Bool])
+    /// .exec(&mut db)
+    /// .await?;
+    /// ```
+    pub fn column_types(mut self, types: impl IntoIterator<Item = stmt::Type>) -> Self {
+        self.ret = RawSqlRet::Types(types.into_iter().collect());
+        self
+    }
+
+    /// Execute the query and return dynamic rows.
+    ///
+    /// Each row is a [`Value::Record`] with fields in selected-column order.
+    /// The executor may be a [`Db`](crate::Db), [`Connection`](crate::Connection),
+    /// or [`Transaction`](crate::Transaction).
+    pub async fn exec(self, executor: &mut dyn Executor) -> Result<Vec<Value>> {
+        let raw = into_raw_sql(self.sql, self.params, self.ret, executor.capability())?;
+        let response = executor.exec_raw_sql(raw).await?;
+
+        match response.values.collect_as_value().await? {
+            Value::List(items) => Ok(items),
+            value => Err(toasty_core::Error::invalid_result(format!(
+                "raw SQL query expected a list of rows, got {value:?}"
+            ))),
+        }
+    }
+}
+
+fn into_raw_sql(
+    sql: String,
+    params: Vec<Param>,
+    ret: RawSqlRet,
+    capability: &Capability,
+) -> Result<RawSql> {
+    if !capability.sql {
+        return Err(Error::unsupported_feature(
+            "raw SQL is only supported by SQL drivers",
+        ));
+    }
+
+    Ok(RawSql {
+        sql,
+        params: params
+            .into_iter()
+            .map(|param| param.into_typed(capability))
+            .collect::<Result<_>>()?,
+        ret,
+    })
+}
+
+impl Param {
+    fn into_typed(self, capability: &Capability) -> Result<TypedValue> {
+        match self {
+            Param::Infer(value) => infer_typed_value(value, capability),
+            Param::Typed(value) => Ok(value),
+        }
+    }
+}
+
+fn infer_typed_value(value: Value, capability: &Capability) -> Result<TypedValue> {
+    let ty = value.infer_ty();
+    let ty = db::Type::from_app(&ty, None, &capability.storage_types).map_err(|err| {
+        err.context(Error::invalid_statement(format!(
+            "cannot infer raw SQL bind type for {value:?}; use bind_typed"
+        )))
+    })?;
+
+    Ok(TypedValue { value, ty })
+}

--- a/crates/toasty/src/stmt.rs
+++ b/crates/toasty/src/stmt.rs
@@ -59,7 +59,7 @@ pub use scope::IntoScope;
 mod update;
 pub use update::Update;
 
-pub use toasty_core::stmt::{OrderBy, Projection, Value};
+pub use toasty_core::stmt::{OrderBy, Projection, Type, Value};
 
 use toasty_core::stmt;
 

--- a/docs/dev/roadmap.md
+++ b/docs/dev/roadmap.md
@@ -120,7 +120,6 @@ the entry lands here.
 ## Drivers
 
 - DynamoDB Scan support ([design](design/ddb-scan.md), [#741])
-- Raw SQL escape hatch ([#93])
 - Connection pooling improvements ([#384])
 - New driver backends
   - MongoDB — `toasty-mongodb` ([#48])

--- a/docs/guide/src/SUMMARY.md
+++ b/docs/guide/src/SUMMARY.md
@@ -39,6 +39,7 @@
 - [Deferred Fields](./deferred-fields.md)
 - [Batch Operations](./batch-operations.md)
 - [Transactions](./transactions.md)
+- [Raw SQL](./raw-sql.md)
 - [Concurrency Control](./concurrency-control.md)
 - [Database Setup](./database-setup.md)
 - [Migrations and Schema Management](./schema-management.md)

--- a/docs/guide/src/raw-sql.md
+++ b/docs/guide/src/raw-sql.md
@@ -1,0 +1,164 @@
+# Raw SQL
+
+Raw SQL runs backend SQL through Toasty's database handles. Use it when you need
+a database feature that Toasty's query builders do not expose.
+
+Raw SQL is available on SQL backends: SQLite, Turso, PostgreSQL, and MySQL.
+DynamoDB returns an `unsupported_feature` error.
+
+## Statements
+
+Use `toasty::sql::statement` for SQL that does not return rows. It returns the
+number of affected rows.
+
+```rust,ignore
+let updated = toasty::sql::statement(
+    "UPDATE users SET name = ?1 WHERE id = ?2",
+)
+.bind("Alice")
+.bind(1_i64)
+.exec(&mut db)
+.await?;
+
+assert_eq!(updated, 1);
+```
+
+## Queries
+
+Use `toasty::sql::query` for SQL that returns rows. It returns `Vec<Value>`.
+Each row is a `Value::Record` with fields in selected-column order.
+
+```rust,ignore
+let rows = toasty::sql::query(
+    "SELECT id, name FROM users WHERE active = ?1",
+)
+.bind(true)
+.exec(&mut db)
+.await?;
+
+for row in rows {
+    let toasty::stmt::Value::Record(row) = row else {
+        unreachable!("raw SQL queries return record rows");
+    };
+
+    println!("id={:?} name={:?}", row[0], row[1]);
+}
+```
+
+Raw SQL queries do not hydrate models. They return dynamic values so the SQL can
+select any expression, function call, join result, or database-specific value.
+
+## Placeholders
+
+Toasty does not rewrite placeholders in raw SQL. Use the placeholder syntax
+reported by `db.capability().sql_placeholder` for the active backend:
+
+| Backend | `SqlPlaceholder` | Placeholder syntax |
+|---|---|---|
+| SQLite | `NumberedQuestionMark` | `?1`, `?2`, ... |
+| Turso | `NumberedQuestionMark` | `?1`, `?2`, ... |
+| PostgreSQL | `DollarNumber` | `$1`, `$2`, ... |
+| MySQL | `QuestionMark` | `?`, `?`, ... |
+
+Values are bound in the order you call `.bind(...)`.
+
+```rust,ignore
+// PostgreSQL
+toasty::sql::query("SELECT name FROM users WHERE id = $1")
+    .bind(1_i64)
+    .exec(&mut db)
+    .await?;
+
+// MySQL
+toasty::sql::query("SELECT name FROM users WHERE id = ?")
+    .bind(1_i64)
+    .exec(&mut db)
+    .await?;
+```
+
+## Binding values
+
+`.bind(value)` infers a database type from common Toasty values: booleans,
+integers, floats, strings, bytes, UUIDs, decimals, date/time values, and
+non-empty lists.
+
+Use `.bind_typed(value, db_type)` when the type is ambiguous, such as `NULL` or
+an empty list:
+
+```rust,ignore
+use toasty::schema::db;
+
+toasty::sql::statement(
+    "UPDATE users SET archived_at = ?1 WHERE id = ?2",
+)
+.bind_typed(toasty::stmt::Value::Null, db::Type::Timestamp(6))
+.bind(1_i64)
+.exec(&mut db)
+.await?;
+```
+
+## Decoding query results
+
+By default, `query(...).exec(...)` asks the driver to infer result value types
+from database metadata.
+
+Inference is exact for many values, but some database values are ambiguous. For
+example, SQLite stores booleans as integers and UUIDs as blobs, so a raw query
+without type hints decodes them as `I64` and `Bytes`.
+
+Use `.column_types(...)` to provide Toasty result types for selected columns:
+
+```rust,ignore
+use toasty::stmt;
+
+let rows = toasty::sql::query(
+    "SELECT id, enabled FROM users WHERE id = ?1",
+)
+.bind(1_i64)
+.column_types([stmt::Type::I64, stmt::Type::Bool])
+.exec(&mut db)
+.await?;
+```
+
+Column type hints affect result decoding only. They do not change which SQL
+statement is sent to the database.
+
+## Connections and transactions
+
+Raw SQL uses the same executor interface as Toasty query builders. Pass any
+`Db`, `Connection`, or `Transaction` handle to `.exec(...)`.
+
+Use a dedicated connection when multiple raw statements need the same physical
+database session, such as temporary tables or session variables:
+
+```rust,ignore
+let mut conn = db.connection().await?;
+
+toasty::sql::statement("CREATE TEMP TABLE temp_ids (id INTEGER)")
+    .exec(&mut conn)
+    .await?;
+
+let rows = toasty::sql::query("SELECT id FROM temp_ids")
+    .exec(&mut conn)
+    .await?;
+```
+
+Use a transaction when raw SQL must commit or roll back with other Toasty
+operations:
+
+```rust,ignore
+let mut tx = db.transaction().await?;
+
+toasty::sql::statement("UPDATE users SET name = ?1 WHERE id = ?2")
+    .bind("Alice")
+    .bind(1_i64)
+    .exec(&mut tx)
+    .await?;
+
+User::filter_by_id(1).delete().exec(&mut tx).await?;
+
+tx.commit().await?;
+```
+
+Nested transactions work the same way as they do for query builders: raw SQL
+executed through the nested transaction is part of that savepoint.


### PR DESCRIPTION
## Summary

Closes #93.

- Add `toasty::sql::statement` for raw SQL statements that return affected-row counts.
- Add `toasty::sql::query` for raw SQL queries that return dynamic `Value` records, with inferred decoding and optional column type hints.
- Route raw SQL through a separate driver operation and implement it for SQLite, Turso, PostgreSQL, and MySQL; DynamoDB returns `unsupported_feature`.
- Expose SQL placeholder syntax through `Capability::sql_placeholder` and use `SqlPlaceholder` for driver metadata, Toasty SQL serialization, and raw SQL docs.
- Document raw SQL in the user guide and API docs.

## Type of change

- [x] Other (please explain): Adds a public raw SQL API and driver operation for the roadmap item.

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [ ] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [ ] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers

No design doc is included. The public and driver behavior is covered in the user guide and rustdoc.