### PR TITLE
refactor(core): split via relations into field variant

### DIFF
--- a/crates/toasty-core/src/schema/app.rs
+++ b/crates/toasty-core/src/schema/app.rs
@@ -57,7 +57,7 @@ mod pk;
 pub use pk::PrimaryKey;
 
 mod relation;
-pub use relation::{BelongsTo, Has, HasCardinality, HasKind, Via};
+pub use relation::{BelongsTo, Cardinality, Has, Via};
 
 mod schema;
 pub use schema::{Resolved, Schema};

--- a/crates/toasty-core/src/schema/app/field.rs
+++ b/crates/toasty-core/src/schema/app/field.rs
@@ -2,7 +2,7 @@ mod primitive;
 pub use primitive::{FieldPrimitive, SerializeFormat};
 
 use super::{
-    AutoStrategy, BelongsTo, Constraint, Embedded, Has, Model, ModelId, Schema, VariantId,
+    AutoStrategy, BelongsTo, Constraint, Embedded, Has, Model, ModelId, Schema, VariantId, Via,
 };
 use crate::{Result, driver, stmt};
 use std::fmt;
@@ -200,6 +200,8 @@ pub enum FieldTy {
     BelongsTo(BelongsTo),
     /// The inverse side of a relationship.
     Has(Has),
+    /// A relation reached by following a path of existing relations.
+    Via(Via),
 }
 
 impl Field {
@@ -243,7 +245,8 @@ impl Field {
         self.versionable
     }
 
-    /// Returns `true` if this field is a relation (`BelongsTo` or `Has`).
+    /// Returns `true` if this field is a relation (`BelongsTo`, `Has`, or
+    /// `Via`).
     pub fn is_relation(&self) -> bool {
         self.ty.is_relation()
     }
@@ -261,6 +264,7 @@ impl Field {
         match &self.ty {
             FieldTy::BelongsTo(belongs_to) => Some(belongs_to.target),
             FieldTy::Has(has) => Some(has.target),
+            FieldTy::Via(via) => Some(via.target),
             _ => None,
         }
     }
@@ -280,6 +284,7 @@ impl Field {
             FieldTy::Embedded(embedded) => &embedded.expr_ty,
             FieldTy::BelongsTo(belongs_to) => &belongs_to.expr_ty,
             FieldTy::Has(has) => &has.expr_ty,
+            FieldTy::Via(via) => &via.expr_ty,
         }
     }
 
@@ -294,7 +299,8 @@ impl Field {
             FieldTy::Primitive(_) => None,
             FieldTy::Embedded(_) => None,
             FieldTy::BelongsTo(belongs_to) => belongs_to.pair,
-            FieldTy::Has(has) => has.kind.pair_id(),
+            FieldTy::Has(has) => Some(has.pair_id),
+            FieldTy::Via(_) => None,
         }
     }
 
@@ -392,9 +398,10 @@ impl FieldTy {
         }
     }
 
-    /// Returns `true` if this is a relation type (`BelongsTo` or `Has`).
+    /// Returns `true` if this is a relation type (`BelongsTo`, `Has`, or
+    /// `Via`).
     pub fn is_relation(&self) -> bool {
-        matches!(self, Self::BelongsTo(..) | Self::Has(..))
+        matches!(self, Self::BelongsTo(..) | Self::Has(..) | Self::Via(..))
     }
 
     /// Returns `true` if this is a [`FieldTy::Has`] relation.
@@ -570,6 +577,7 @@ impl fmt::Debug for FieldTy {
             Self::Embedded(ty) => ty.fmt(fmt),
             Self::BelongsTo(ty) => ty.fmt(fmt),
             Self::Has(ty) => ty.fmt(fmt),
+            Self::Via(ty) => ty.fmt(fmt),
         }
     }
 }

--- a/crates/toasty-core/src/schema/app/model.rs
+++ b/crates/toasty-core/src/schema/app/model.rs
@@ -1,4 +1,4 @@
-use super::{Field, FieldId, FieldPrimitive, FieldTy, HasKind, Index, Name, PrimaryKey};
+use super::{Field, FieldId, FieldPrimitive, FieldTy, Index, Name, PrimaryKey};
 use crate::{Result, driver, stmt};
 use indexmap::IndexMap;
 use std::fmt;
@@ -227,9 +227,7 @@ impl ModelRoot {
             // Only SQL drivers can evaluate them today; key-value drivers
             // would need a separate per-step batched fetch strategy that
             // is not yet implemented.
-            let is_via =
-                matches!(&field.ty, FieldTy::Has(rel) if matches!(rel.kind, HasKind::Via(_)));
-            if is_via && !db.sql {
+            if matches!(&field.ty, FieldTy::Via(_)) && !db.sql {
                 return Err(crate::Error::invalid_schema(format!(
                     "field `{}::{}` declares a multi-step `via` relation, which \
                      requires a SQL-capable driver; the configured driver does not \

--- a/crates/toasty-core/src/schema/app/relation.rs
+++ b/crates/toasty-core/src/schema/app/relation.rs
@@ -9,7 +9,7 @@ mod belongs_to;
 pub use belongs_to::BelongsTo;
 
 mod has;
-pub use has::{Has, HasCardinality};
+pub use has::{Cardinality, Has};
 
 mod via;
-pub use via::{HasKind, Via};
+pub use via::Via;

--- a/crates/toasty-core/src/schema/app/relation/has.rs
+++ b/crates/toasty-core/src/schema/app/relation/has.rs
@@ -1,13 +1,12 @@
 use crate::{
-    schema::app::{BelongsTo, HasKind, Model, ModelId, Name, Schema},
+    schema::app::{BelongsTo, FieldId, Model, ModelId, Name, Schema},
     stmt,
 };
 
 /// The inverse side of a relationship.
 ///
-/// A `Has` field on model A reaches an associated model B either through a
-/// paired [`BelongsTo`] field on B that holds the foreign key, or by following a
-/// multi-step (`via`) path of existing relations. Its cardinality records
+/// A `Has` field on model A reaches an associated model B through a paired
+/// [`BelongsTo`] field on B that holds the foreign key. Its cardinality records
 /// whether the field represents "A has many Bs" or "A has one B".
 #[derive(Debug, Clone)]
 pub struct Has {
@@ -19,17 +18,15 @@ pub struct Has {
     pub expr_ty: stmt::Type,
 
     /// Whether this relation is one-to-many or one-to-one.
-    pub cardinality: HasCardinality,
+    pub cardinality: Cardinality,
 
-    /// How this relation reaches its target — a paired `BelongsTo`
-    /// ([`HasKind::Direct`]) or a [`Via`](super::Via) path
-    /// ([`HasKind::Via`]).
-    pub kind: HasKind,
+    /// The paired `BelongsTo` field on the target model.
+    pub pair_id: FieldId,
 }
 
-/// Cardinality for a [`Has`] relation.
+/// Cardinality for a relation field that reaches another model.
 #[derive(Debug, Clone)]
-pub enum HasCardinality {
+pub enum Cardinality {
     /// The relation yields zero or more associated items.
     Many {
         /// The singular name for one associated item (used in generated method
@@ -44,20 +41,17 @@ pub enum HasCardinality {
 impl Has {
     /// Returns `true` when this is a one-to-many relation.
     pub fn is_many(&self) -> bool {
-        matches!(self.cardinality, HasCardinality::Many { .. })
+        self.cardinality.is_many()
     }
 
     /// Returns `true` when this is a one-to-one relation.
     pub fn is_one(&self) -> bool {
-        matches!(self.cardinality, HasCardinality::One)
+        self.cardinality.is_one()
     }
 
     /// Returns the singular item name for a one-to-many relation.
     pub fn singular(&self) -> Option<&Name> {
-        match &self.cardinality {
-            HasCardinality::Many { singular } => Some(singular),
-            HasCardinality::One => None,
-        }
+        self.cardinality.singular()
     }
 
     /// Resolves the target [`Model`] from the given schema.
@@ -69,13 +63,28 @@ impl Has {
     ///
     /// # Panics
     ///
-    /// Panics if this is a multi-step (`via`) relation — it has no pair — or
-    /// if the paired field is not a `BelongsTo` variant.
+    /// Panics if the paired field is not a `BelongsTo` variant.
     pub fn pair<'a>(&self, schema: &'a Schema) -> &'a BelongsTo {
-        let pair = self
-            .kind
-            .pair_id()
-            .expect("`via` relation has no paired `BelongsTo`");
-        schema.field(pair).ty.as_belongs_to_unwrap()
+        schema.field(self.pair_id).ty.as_belongs_to_unwrap()
+    }
+}
+
+impl Cardinality {
+    /// Returns `true` when this relation yields zero or more items.
+    pub fn is_many(&self) -> bool {
+        matches!(self, Cardinality::Many { .. })
+    }
+
+    /// Returns `true` when this relation yields at most one item.
+    pub fn is_one(&self) -> bool {
+        matches!(self, Cardinality::One)
+    }
+
+    /// Returns the singular item name for a one-to-many relation.
+    pub fn singular(&self) -> Option<&Name> {
+        match self {
+            Cardinality::Many { singular } => Some(singular),
+            Cardinality::One => None,
+        }
     }
 }

--- a/crates/toasty-core/src/schema/app/relation/via.rs
+++ b/crates/toasty-core/src/schema/app/relation/via.rs
@@ -1,43 +1,7 @@
-use crate::{schema::app::FieldId, stmt};
-
-/// How a `Has` relation reaches its target.
-///
-/// Both relation kinds share this: the question — "is the target reached
-/// through a paired `BelongsTo`, or by following a path?" — is the same for
-/// has-many and has-one.
-#[derive(Debug, Clone)]
-pub enum HasKind {
-    /// The target is reached through a `BelongsTo` field on the target model.
-    /// Carries that paired `BelongsTo` field's id.
-    ///
-    /// If a `#[has_many(pair = <field>)]` / `#[has_one(pair = <field>)]` was
-    /// supplied, the macro resolves the id at schema-construction time.
-    /// Otherwise the linker fills it in by searching the target model for a
-    /// unique `BelongsTo` back to the source.
-    Direct(FieldId),
-
-    /// The target is reached by following a [`Via`] path of existing
-    /// relations rather than pairing with a single `BelongsTo`.
-    Via(Via),
-}
-
-impl HasKind {
-    /// The paired `BelongsTo` field id, or `None` for a `via` relation.
-    pub fn pair_id(&self) -> Option<FieldId> {
-        match self {
-            HasKind::Direct(pair) => Some(*pair),
-            HasKind::Via(_) => None,
-        }
-    }
-
-    /// The [`Via`] path, or `None` for a direct relation.
-    pub fn via(&self) -> Option<&Via> {
-        match self {
-            HasKind::Via(via) => Some(via),
-            HasKind::Direct(_) => None,
-        }
-    }
-}
+use crate::{
+    schema::app::{Cardinality, Model, ModelId, Name, Schema},
+    stmt,
+};
 
 /// A multi-step relation path.
 ///
@@ -51,6 +15,16 @@ impl HasKind {
 /// Rust compile error rather than a runtime schema validation failure.
 #[derive(Debug, Clone)]
 pub struct Via {
+    /// The [`ModelId`] of the associated (target) model.
+    pub target: ModelId,
+
+    /// The expression type this field evaluates to from the application's
+    /// perspective.
+    pub expr_ty: stmt::Type,
+
+    /// Whether this relation is one-to-many or one-to-one.
+    pub cardinality: Cardinality,
+
     /// The resolved field path, rooted at the model that declares the via
     /// relation.
     pub path: stmt::Path,
@@ -58,7 +32,37 @@ pub struct Via {
 
 impl Via {
     /// Create a `Via` from its fully resolved field path.
-    pub fn new(path: stmt::Path) -> Self {
-        Self { path }
+    pub fn new(
+        target: ModelId,
+        expr_ty: stmt::Type,
+        cardinality: Cardinality,
+        path: stmt::Path,
+    ) -> Self {
+        Self {
+            target,
+            expr_ty,
+            cardinality,
+            path,
+        }
+    }
+
+    /// Returns `true` when this is a one-to-many relation.
+    pub fn is_many(&self) -> bool {
+        self.cardinality.is_many()
+    }
+
+    /// Returns `true` when this is a one-to-one relation.
+    pub fn is_one(&self) -> bool {
+        self.cardinality.is_one()
+    }
+
+    /// Returns the singular item name for a one-to-many relation.
+    pub fn singular(&self) -> Option<&Name> {
+        self.cardinality.singular()
+    }
+
+    /// Resolves the target [`Model`] from the given schema.
+    pub fn target<'a>(&self, schema: &'a Schema) -> &'a Model {
+        schema.model(self.target)
     }
 }

--- a/crates/toasty-core/src/schema/app/schema.rs
+++ b/crates/toasty-core/src/schema/app/schema.rs
@@ -1,4 +1,4 @@
-use super::{EnumVariant, Field, FieldId, FieldTy, HasKind, Model, ModelId, VariantId};
+use super::{EnumVariant, Field, FieldId, FieldTy, Model, ModelId, VariantId};
 
 use crate::{Result, stmt};
 use indexmap::IndexMap;
@@ -171,6 +171,9 @@ impl Schema {
                 FieldTy::Has(has) => {
                     current_field = has.target(self).as_root_unwrap().fields.get(*step)?;
                 }
+                FieldTy::Via(via) => {
+                    current_field = via.target(self).as_root_unwrap().fields.get(*step)?;
+                }
             };
         }
 
@@ -324,22 +327,18 @@ impl Builder {
                 if let FieldTy::Has(has) = &field.ty
                     && has.is_many()
                 {
-                    // `via` relations have no pair to link.
-                    let HasKind::Direct(pair) = has.kind else {
-                        continue;
-                    };
                     let target = has.target;
                     let field_name = field.name.app_unwrap().to_string();
-                    let pair = if pair.is_placeholder() {
+                    let pair = if has.pair_id.is_placeholder() {
                         self.find_has_many_pair(src, target, &field_name)?
                     } else {
-                        self.validate_pair(src, target, &field_name, pair)?;
-                        pair
+                        self.validate_pair(src, target, &field_name, has.pair_id)?;
+                        has.pair_id
                     };
                     self.models[curr].as_root_mut_unwrap().fields[index]
                         .ty
                         .as_has_mut_unwrap()
-                        .kind = HasKind::Direct(pair);
+                        .pair_id = pair;
                 }
             }
         }
@@ -356,13 +355,9 @@ impl Builder {
 
                 match &field.ty {
                     FieldTy::Has(has) if has.is_one() => {
-                        // `via` relations have no pair to link.
-                        let HasKind::Direct(pair) = has.kind else {
-                            continue;
-                        };
                         let target = has.target;
                         let field_name = field.name.app_unwrap().to_string();
-                        let pair = if pair.is_placeholder() {
+                        let pair = if has.pair_id.is_placeholder() {
                             match self.find_belongs_to_pair(src, target, &field_name)? {
                                 Some(pair) => pair,
                                 None => {
@@ -374,14 +369,14 @@ impl Builder {
                                 }
                             }
                         } else {
-                            self.validate_pair(src, target, &field_name, pair)?;
-                            pair
+                            self.validate_pair(src, target, &field_name, has.pair_id)?;
+                            has.pair_id
                         };
 
                         self.models[curr].as_root_mut_unwrap().fields[index]
                             .ty
                             .as_has_mut_unwrap()
-                            .kind = HasKind::Direct(pair);
+                            .pair_id = pair;
                     }
                     FieldTy::BelongsTo(belongs_to) => {
                         assert!(!belongs_to.foreign_key.is_placeholder());
@@ -421,7 +416,7 @@ impl Builder {
                             pair = match &self.models[target].as_root_unwrap().fields[target_index]
                                 .ty
                             {
-                                FieldTy::Has(has) if has.kind.pair_id() == Some(field_id) => {
+                                FieldTy::Has(has) if has.pair_id == field_id => {
                                     assert!(pair.is_none());
                                     Some(
                                         self.models[target].as_root_unwrap().fields[target_index]

--- a/crates/toasty-core/src/schema/builder/table.rs
+++ b/crates/toasty-core/src/schema/builder/table.rs
@@ -458,7 +458,9 @@ impl BuildMapping<'_> {
                 Ok(self.map_table_column_to_model(column_id, primitive))
             }
             app::FieldTy::Embedded(_) => self.populate_embed_default_returning(field, mapping),
-            app::FieldTy::BelongsTo(_) | app::FieldTy::Has(_) => Ok(stmt::Value::Null.into()),
+            app::FieldTy::BelongsTo(_) | app::FieldTy::Has(_) | app::FieldTy::Via(_) => {
+                Ok(stmt::Value::Null.into())
+            }
         }
     }
 
@@ -756,7 +758,9 @@ impl BuildMapping<'_> {
                     _ => unreachable!("invalid schema"),
                 }
             }
-            app::FieldTy::BelongsTo(_) | app::FieldTy::Has(_) => Ok(stmt::Value::Null.into()),
+            app::FieldTy::BelongsTo(_) | app::FieldTy::Has(_) | app::FieldTy::Via(_) => {
+                Ok(stmt::Value::Null.into())
+            }
         }
     }
 }
@@ -799,7 +803,7 @@ impl<'a, 'b> MapField<'a, 'b> {
                     _ => unreachable!(),
                 }
             }
-            app::FieldTy::BelongsTo(_) | app::FieldTy::Has(_) => {
+            app::FieldTy::BelongsTo(_) | app::FieldTy::Has(_) | app::FieldTy::Via(_) => {
                 assert!(!self.in_enum_variant);
                 let bit = self.build.next_bit();
                 Ok(mapping::Field::Relation(mapping::FieldRelation {

--- a/crates/toasty-core/src/schema/verify.rs
+++ b/crates/toasty-core/src/schema/verify.rs
@@ -96,12 +96,8 @@ impl Verify<'_> {
                 continue;
             };
             for field in &root.fields {
-                // A direct has-many must have a linked pair; a `via` has-many
-                // has none.
-                if let Some(has_many) = field.ty.as_has_many()
-                    && let Some(pair) = has_many.kind.pair_id()
-                {
-                    assert_ne!(pair, FieldId::placeholder());
+                if let Some(has_many) = field.ty.as_has_many() {
+                    assert_ne!(has_many.pair_id, FieldId::placeholder());
                 }
 
                 if let Some(belongs_to) = field.ty.as_belongs_to() {

--- a/crates/toasty-core/src/schema/verify/relations_are_indexed.rs
+++ b/crates/toasty-core/src/schema/verify/relations_are_indexed.rs
@@ -19,6 +19,7 @@ impl Verify<'_> {
         match &field.ty {
             FieldTy::BelongsTo(rel) => self.verify_belongs_to_is_indexed(rel),
             FieldTy::Has(rel) => self.verify_has_relation_is_indexed_field(owner, field, rel),
+            FieldTy::Via(_) => Ok(()),
             _ => Ok(()),
         }
     }
@@ -34,12 +35,7 @@ impl Verify<'_> {
         field: &Field,
         rel: &app::Has,
     ) -> Result<()> {
-        // A `via` relation has no pair of its own; each step it traverses is
-        // a relation that is verified on its own model.
-        let Some(pair) = rel.kind.pair_id() else {
-            return Ok(());
-        };
-        self.verify_has_relation_is_indexed(owner, field, rel.target(&self.schema.app), pair)
+        self.verify_has_relation_is_indexed(owner, field, rel.target(&self.schema.app), rel.pair_id)
     }
 
     fn verify_has_relation_is_indexed(

--- a/crates/toasty-core/tests/schema_missing_model.rs
+++ b/crates/toasty-core/tests/schema_missing_model.rs
@@ -93,13 +93,13 @@ fn has_many_target_not_registered() {
             FieldTy::Has(Has {
                 target: MISSING,
                 expr_ty: stmt::Type::list(stmt::Type::Unknown),
-                cardinality: HasCardinality::Many {
+                cardinality: Cardinality::Many {
                     singular: Name::new("talk"),
                 },
-                kind: HasKind::Direct(FieldId {
+                pair_id: FieldId {
                     model: MISSING,
                     index: 0,
-                }),
+                },
             }),
         )],
     )];
@@ -121,11 +121,11 @@ fn has_one_target_not_registered() {
             FieldTy::Has(Has {
                 target: MISSING,
                 expr_ty: stmt::Type::Unknown,
-                cardinality: HasCardinality::One,
-                kind: HasKind::Direct(FieldId {
+                cardinality: Cardinality::One,
+                pair_id: FieldId {
                     model: MISSING,
                     index: 0,
-                }),
+                },
             }),
         )],
     )];

--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -1066,7 +1066,7 @@ impl<'a, 'b> LowerStatement<'a, 'b> {
 
                     match &field.ty {
                         app::FieldTy::Primitive(_) | app::FieldTy::Embedded(_) => {}
-                        app::FieldTy::Has(_) => todo!(),
+                        app::FieldTy::Has(_) | app::FieldTy::Via(_) => todo!(),
                         app::FieldTy::BelongsTo(rel) => {
                             *operand = key_field_refs(
                                 nesting,

--- a/crates/toasty/src/engine/lower/association.rs
+++ b/crates/toasty/src/engine/lower/association.rs
@@ -102,11 +102,11 @@ impl<'a> RewriteVia<'a> {
             // Direct has-one / has-many: filter the target by its paired
             // `BelongsTo` against the source query. Via relations were
             // already unfolded, so only direct kinds reach this arm.
-            app::FieldTy::Has(app::Has {
-                kind: app::HasKind::Direct(pair),
-                ..
-            }) => stmt::Expr::in_subquery(stmt::Expr::ref_self_field(*pair), *association.source)
-                .into(),
+            app::FieldTy::Has(has) => stmt::Expr::in_subquery(
+                stmt::Expr::ref_self_field(has.pair_id),
+                *association.source,
+            )
+            .into(),
             _ => todo!("field={field:#?}"),
         }
     }
@@ -149,10 +149,7 @@ impl<'a> RewriteVia<'a> {
         // in place of the via field and continue. Handles via-of-via
         // naturally because the recursion re-examines the spliced steps.
         let via_path = match &field.ty {
-            app::FieldTy::Has(app::Has {
-                kind: app::HasKind::Via(via),
-                ..
-            }) => Some(via.path.projection.as_slice()),
+            app::FieldTy::Via(via) => Some(via.path.projection.as_slice()),
             _ => None,
         };
         if let Some(via_steps) = via_path {
@@ -173,6 +170,7 @@ impl<'a> RewriteVia<'a> {
 
         let next_model_id = match &field.ty {
             app::FieldTy::Has(rel) => rel.target,
+            app::FieldTy::Via(rel) => rel.target,
             app::FieldTy::BelongsTo(rel) => rel.target,
             other => todo!("non-relation field in via path: {other:#?}"),
         };

--- a/crates/toasty/src/engine/lower/include.rs
+++ b/crates/toasty/src/engine/lower/include.rs
@@ -297,7 +297,7 @@ impl LowerStatement<'_, '_> {
         // the database executing the join, so it is SQL-only — a key-value
         // backend would need a cascade of per-step queries instead.
         let via = match &field.ty {
-            app::FieldTy::Has(rel) => rel.kind.via(),
+            app::FieldTy::Via(via) => Some(via),
             _ => None,
         };
         if let Some(via) = via {
@@ -316,7 +316,7 @@ impl LowerStatement<'_, '_> {
                     rel.target,
                     stmt::Expr::eq(
                         stmt::Expr::ref_parent_model(),
-                        stmt::Expr::ref_self_field(direct_pair(&rel.kind)),
+                        stmt::Expr::ref_self_field(rel.pair_id),
                     ),
                 );
                 if rel.is_one() {
@@ -384,14 +384,6 @@ impl FieldIncludes {
     fn self_included(&self) -> bool {
         self.include_self || !self.sub_paths.is_empty()
     }
-}
-
-/// The paired `BelongsTo` field of a direct has-relation. `.include()` of a
-/// `via` relation is rejected earlier in `build_relation_subquery`, so any
-/// relation reaching the direct-relation path has a pair.
-fn direct_pair(kind: &app::HasKind) -> app::FieldId {
-    kind.pair_id()
-        .expect("`via` relation reached the direct-relation include path")
 }
 
 /// Find the include paths that target field index `i` and split them by

--- a/crates/toasty/src/engine/lower/lift_in_subquery.rs
+++ b/crates/toasty/src/engine/lower/lift_in_subquery.rs
@@ -182,9 +182,7 @@ pub(super) fn lift_in_subquery(
     // something this pass can handle.
     match &field.ty {
         FieldTy::BelongsTo(belongs_to) => lift_belongs_to_in_subquery(cx, belongs_to, query),
-        FieldTy::Has(has) if has.kind.pair_id().is_some() => {
-            lift_has_n_in_subquery(has.target, has.pair(&cx.schema().app), query)
-        }
+        FieldTy::Has(has) => lift_has_n_in_subquery(has.target, has.pair(&cx.schema().app), query),
         _ => None,
     }
 }
@@ -213,6 +211,7 @@ pub(super) fn try_lift_relation_path_comparison(
 
     let target_model_id = match &field.ty {
         FieldTy::Has(rel) => rel.target,
+        FieldTy::Via(rel) => rel.target,
         FieldTy::BelongsTo(rel) => rel.target,
         _ => return None,
     };

--- a/crates/toasty/src/engine/lower/relation.rs
+++ b/crates/toasty/src/engine/lower/relation.rs
@@ -222,12 +222,7 @@ impl LowerStatement<'_, '_> {
 
     fn plan_mut_has_many(&mut self, field: &Field, op: Mutation, source: &mut dyn RelationSource) {
         let has_many = field.ty.as_has_many_unwrap();
-        // `via` relations are read-only — no mutation methods are generated
-        // for them, so this is only reached for direct relations.
-        let pair = has_many
-            .kind
-            .pair_id()
-            .expect("cannot mutate through a multi-step `via` relation");
+        let pair = has_many.pair_id;
         let pair = self.field(pair);
 
         self.plan_mut_has_n(field, pair, op, source);
@@ -235,10 +230,7 @@ impl LowerStatement<'_, '_> {
 
     fn plan_mut_has_one(&mut self, field: &Field, op: Mutation, source: &mut dyn RelationSource) {
         let has_one = field.ty.as_has_one_unwrap();
-        let pair = has_one
-            .kind
-            .pair_id()
-            .expect("cannot mutate through a multi-step `via` relation");
+        let pair = has_one.pair_id;
         let pair = self.field(pair);
 
         self.plan_mut_has_n(field, pair, op, source);

--- a/crates/toasty/src/engine/lower/via_join.rs
+++ b/crates/toasty/src/engine/lower/via_join.rs
@@ -38,7 +38,10 @@ impl LowerStatement<'_, '_> {
 
         let schema = self.schema();
         let model = self.model_unwrap();
-        let single = !model.fields[field_index].ty.is_has_many();
+        let single = match &model.fields[field_index].ty {
+            app::FieldTy::Via(via) => via.is_one(),
+            _ => unreachable!("build_via_include_subquery called on non-via field"),
+        };
         let nullable = model.fields[field_index].nullable();
         let join = ViaJoin::resolve(schema, model.id, via);
 
@@ -255,7 +258,7 @@ fn flatten_via_steps(
         // If this step itself names a `via` relation, splice the nested
         // path in place of it and continue (handles via-of-via naturally).
         let nested_via = match &field.ty {
-            app::FieldTy::Has(rel) => rel.kind.via(),
+            app::FieldTy::Via(via) => Some(via),
             _ => None,
         };
         if let Some(via) = nested_via {

--- a/crates/toasty/src/schema/has_many.rs
+++ b/crates/toasty/src/schema/has_many.rs
@@ -54,25 +54,20 @@ fn has_many_field_ty<T: Relation>(
     pair: Option<FieldId>,
     via: Option<stmt::Path>,
 ) -> FieldTy {
-    FieldTy::Has(app::Has {
-        target: <T::Model as Register>::id(),
-        expr_ty: stmt::Type::List(Box::new(stmt::Type::Model(<T::Model as Register>::id()))),
-        cardinality: app::HasCardinality::Many { singular },
-        kind: has_kind(pair, via),
-    })
-}
+    let target = <T::Model as Register>::id();
+    let expr_ty = stmt::Type::List(Box::new(stmt::Type::Model(target)));
+    let cardinality = app::Cardinality::Many { singular };
 
-/// Build a [`HasKind`](app::HasKind) from the macro-supplied `pair` / `via`
-/// attributes. `via` declares a multi-step relation and carries the fully
-/// resolved [`stmt::Path`] emitted by the derive; otherwise the relation is
-/// direct, and a direct relation with no explicit `pair` gets a placeholder
-/// that the schema linker resolves.
-pub(super) fn has_kind(pair: Option<FieldId>, via: Option<stmt::Path>) -> app::HasKind {
     match via {
-        Some(path) => app::HasKind::Via(app::Via::new(path)),
-        None => app::HasKind::Direct(pair.unwrap_or(FieldId {
-            model: ModelId(usize::MAX),
-            index: usize::MAX,
-        })),
+        Some(path) => FieldTy::Via(app::Via::new(target, expr_ty, cardinality, path)),
+        None => FieldTy::Has(app::Has {
+            target,
+            expr_ty,
+            cardinality,
+            pair_id: pair.unwrap_or(FieldId {
+                model: ModelId(usize::MAX),
+                index: usize::MAX,
+            }),
+        }),
     }
 }

--- a/crates/toasty/src/schema/has_one.rs
+++ b/crates/toasty/src/schema/has_one.rs
@@ -1,6 +1,6 @@
-use super::has_many::has_kind;
 use super::{Deferred, HasOneField, Load, Register, Relation};
 
+use toasty_core::schema::app::ModelId;
 use toasty_core::schema::app::{self, FieldId, FieldTy};
 use toasty_core::stmt;
 
@@ -42,10 +42,20 @@ impl<T: Relation> HasOneField for T {
 }
 
 fn has_one_field_ty<T: Relation>(pair: Option<FieldId>, via: Option<stmt::Path>) -> FieldTy {
-    FieldTy::Has(app::Has {
-        target: <T::Model as Register>::id(),
-        expr_ty: stmt::Type::Model(<T::Model as Register>::id()),
-        cardinality: app::HasCardinality::One,
-        kind: has_kind(pair, via),
-    })
+    let target = <T::Model as Register>::id();
+    let expr_ty = stmt::Type::Model(target);
+    let cardinality = app::Cardinality::One;
+
+    match via {
+        Some(path) => FieldTy::Via(app::Via::new(target, expr_ty, cardinality, path)),
+        None => FieldTy::Has(app::Has {
+            target,
+            expr_ty,
+            cardinality,
+            pair_id: pair.unwrap_or(FieldId {
+                model: ModelId(usize::MAX),
+                index: usize::MAX,
+            }),
+        }),
+    }
 }


### PR DESCRIPTION
## Summary

- Split multi-step `via` relations out of `FieldTy::Has` into `FieldTy::Via`.
- Make `Has` direct-only by storing the paired relation as `pair_id: FieldId`.
- Rename `HasCardinality` to `Cardinality` and share it between direct `Has` and `Via` fields.
- Update schema linking, verification, and relation lowering to branch on direct and via field variants explicitly.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

This is a schema representation refactor. Query behavior is intended to stay unchanged; existing via relation integration tests still pass.