### PR TITLE
refactor!: delete Relation trait, tighten relation field shapes

### DIFF
--- a/crates/toasty-macros/src/model/expand.rs
+++ b/crates/toasty-macros/src/model/expand.rs
@@ -407,7 +407,7 @@ impl Expand<'_> {
     }
 
     /// Generates a field accessor method for a `BelongsTo` or `HasOne`
-    /// relation using the target's `Relation::OneField`.
+    /// relation using the target model's `Model::OneField`.
     fn expand_one_relation_field_method(
         &self,
         field_ident: &syn::Ident,
@@ -421,8 +421,8 @@ impl Expand<'_> {
         let span = field_ident.span();
 
         quote_spanned! { span=>
-            #vis fn #field_ident(&self) -> <<#ty as #field_trait>::Target as #toasty::Relation>::OneField<__Origin> {
-                <<#ty as #field_trait>::Target as #toasty::Relation>::OneField::from_path(
+            #vis fn #field_ident(&self) -> <<#ty as #field_trait>::Model as #toasty::Model>::OneField<__Origin> {
+                <<<#ty as #field_trait>::Model as #toasty::Model>::OneField<__Origin>>::from_path(
                     self.path().chain(
                         #toasty::Path::<#model_ident, _>::from_field_index(#field_offset)
                     )

--- a/crates/toasty-macros/src/model/expand/create.rs
+++ b/crates/toasty-macros/src/model/expand/create.rs
@@ -143,10 +143,9 @@ impl Expand<'_> {
                 match &field.ty {
                     FieldTy::BelongsTo(rel) => {
                         let ty = &rel.ty;
-                        let target = quote!(<#ty as #toasty::BelongsToField>::Target);
 
                         quote! {
-                            #vis fn #name(mut self, #name: impl #toasty::IntoExpr<<#target as #toasty::Relation>::Expr>) -> Self {
+                            #vis fn #name(mut self, #name: impl #toasty::IntoExpr<<#ty as #toasty::BelongsToField>::Expr>) -> Self {
                                 // Silences unused field warning when the field is set on creation.
                                 if false {
                                     let m = <#model_ident as #toasty::Load>::load(Default::default()).unwrap();
@@ -162,15 +161,15 @@ impl Expand<'_> {
                         let singular = &rel.singular.ident;
                         let plural = name;
                         let ty = &rel.ty;
-                        let target = quote!(<#ty as #toasty::HasManyField>::Target);
+                        let target = quote!(<#ty as #toasty::HasManyField>::Model);
 
                         quote! {
-                            #vis fn #singular(mut self, #singular: impl #toasty::IntoExpr<<#target as #toasty::Relation>::Expr>) -> Self {
+                            #vis fn #singular(mut self, #singular: impl #toasty::IntoExpr<#target>) -> Self {
                                 self.stmt.insert(#index_tokenized, #singular.into_expr());
                                 self
                             }
 
-                            #vis fn #plural(mut self, #plural: impl #toasty::IntoExpr<#toasty::List<<#target as #toasty::Relation>::Model>>) -> Self {
+                            #vis fn #plural(mut self, #plural: impl #toasty::IntoExpr<#toasty::List<#target>>) -> Self {
                                 self.stmt.insert_all(#index_tokenized, #plural.into_expr());
                                 self
                             }
@@ -178,10 +177,9 @@ impl Expand<'_> {
                     }
                     FieldTy::HasOne(rel) => {
                         let ty = &rel.ty;
-                        let target = quote!(<#ty as #toasty::HasOneField>::Target);
 
                         quote! {
-                            #vis fn #name(mut self, #name: impl #toasty::IntoExpr<<#target as #toasty::Relation>::Expr>) -> Self {
+                            #vis fn #name(mut self, #name: impl #toasty::IntoExpr<<#ty as #toasty::HasOneField>::Expr>) -> Self {
                                 self.stmt.set(#index_tokenized, #name.into_expr());
                                 self
                             }

--- a/crates/toasty-macros/src/model/expand/fields.rs
+++ b/crates/toasty-macros/src/model/expand/fields.rs
@@ -91,8 +91,8 @@ impl Expand<'_> {
                         };
 
                         quote_spanned! { span=>
-                            #vis fn #field_ident(&self) -> <<#ty as #toasty::HasManyField>::Target as #toasty::Relation>::ManyField<__Origin> {
-                                <<#ty as #toasty::HasManyField>::Target as #toasty::Relation>::ManyField::from_path(#path)
+                            #vis fn #field_ident(&self) -> <<#ty as #toasty::HasManyField>::Model as #toasty::Model>::ManyField<__Origin> {
+                                <<<#ty as #toasty::HasManyField>::Model as #toasty::Model>::ManyField<__Origin>>::from_path(#path)
                             }
                         }
                     }
@@ -384,8 +384,8 @@ impl Expand<'_> {
         let span = field_ident.span();
 
         quote_spanned! { span=>
-            #vis fn #field_ident(&self) -> <<#ty as #field_trait>::Target as #toasty::Relation>::ManyField<__Origin> {
-                <<#ty as #field_trait>::Target as #toasty::Relation>::ManyField::from_path(
+            #vis fn #field_ident(&self) -> <<#ty as #field_trait>::Model as #toasty::Model>::ManyField<__Origin> {
+                <<<#ty as #field_trait>::Model as #toasty::Model>::ManyField<__Origin>>::from_path(
                     self.path().chain(
                         #toasty::Path::<#model_ident, _>::from_field_index(#field_offset)
                     )

--- a/crates/toasty-macros/src/model/expand/model.rs
+++ b/crates/toasty-macros/src/model/expand/model.rs
@@ -134,6 +134,11 @@ impl Expand<'_> {
                 type UpdateQuery = #update_struct_ident;
                 type Path<__Origin> = #field_struct_ident<__Origin>;
                 type PrimaryKey = #primary_key_ty;
+                type Many = Many;
+                type ManyField<__Origin> = #field_list_struct_ident<__Origin>;
+                type One = One;
+                type OneField<__Origin> = #field_struct_ident<__Origin>;
+                type OptionOne = OptionOne;
 
                 const CREATE_META: #toasty::CreateMeta = #toasty::CreateMeta {
                     fields: &[ #create_meta_fields ],
@@ -144,26 +149,14 @@ impl Expand<'_> {
                     #field_struct_ident::from_path(path)
                 }
 
-                fn find_by_primary_key(id: #toasty::stmt::Expr<Self::PrimaryKey>) -> Self::Query {
-                    #find_by_primary_key_body
-                }
-            }
-
-            impl #toasty::Relation for #model_ident {
-                type Model = #model_ident;
-                type Expr = #model_ident;
-                type Query = #query_struct_ident;
-                type Create = #create_struct_ident;
-                type Many = Many;
-                type ManyField<__Origin> = #field_list_struct_ident<__Origin>;
-                type One = One;
-                type OneField<__Origin> = #field_struct_ident<__Origin>;
-                type OptionOne = OptionOne;
-
                 fn new_many_field<__Origin>(
-                    path: #toasty::Path<__Origin, #toasty::List<Self::Model>>,
+                    path: #toasty::Path<__Origin, #toasty::List<Self>>,
                 ) -> #field_list_struct_ident<__Origin> {
                     #field_list_struct_ident::from_path(path)
+                }
+
+                fn find_by_primary_key(id: #toasty::stmt::Expr<Self::PrimaryKey>) -> Self::Query {
+                    #find_by_primary_key_body
                 }
 
                 #field_name_to_id

--- a/crates/toasty-macros/src/model/expand/query.rs
+++ b/crates/toasty-macros/src/model/expand/query.rs
@@ -162,14 +162,14 @@ impl Expand<'_> {
         let toasty = &self.toasty;
         let vis = &self.model.vis;
         let ty = &rel.ty;
-        let target = quote!(<#ty as #toasty::BelongsToField>::Target);
+        let target = quote!(<#ty as #toasty::BelongsToField>::Model);
         let model_ident = &self.model.ident;
         let field_ident = &field.name.ident;
 
         quote! {
-            #vis fn #field_ident(mut self) -> <#target as #toasty::Relation>::Query {
+            #vis fn #field_ident(mut self) -> <#target as #toasty::Model>::Query {
                 use #toasty::IntoStatement;
-                <#target as #toasty::Relation>::Query::from_stmt(
+                <<#target as #toasty::Model>::Query>::from_stmt(
                     #toasty::stmt::Association::many_via_one(
                         self.stmt, #model_ident::fields().#field_ident().into()
                     ).into_statement().into_query().unwrap()
@@ -182,14 +182,14 @@ impl Expand<'_> {
         let toasty = &self.toasty;
         let vis = &self.model.vis;
         let ty = &rel.ty;
-        let target = quote!(<#ty as #toasty::HasManyField>::Target);
+        let target = quote!(<#ty as #toasty::HasManyField>::Model);
         let model_ident = &self.model.ident;
         let field_ident = &field.name.ident;
 
         quote! {
-            #vis fn #field_ident(mut self) -> <#target as #toasty::Relation>::Query {
+            #vis fn #field_ident(mut self) -> <#target as #toasty::Model>::Query {
                 use #toasty::IntoStatement;
-                <#target as #toasty::Relation>::Query::from_stmt(
+                <<#target as #toasty::Model>::Query>::from_stmt(
                     #toasty::stmt::Association::many(
                         self.stmt, #model_ident::fields().#field_ident().into()
                     ).into_statement().into_query().unwrap()
@@ -202,14 +202,14 @@ impl Expand<'_> {
         let toasty = &self.toasty;
         let vis = &self.model.vis;
         let ty = &rel.ty;
-        let target = quote!(<#ty as #toasty::HasOneField>::Target);
+        let target = quote!(<#ty as #toasty::HasOneField>::Model);
         let model_ident = &self.model.ident;
         let field_ident = &field.name.ident;
 
         quote! {
-            #vis fn #field_ident(mut self) -> <#target as #toasty::Relation>::Query {
+            #vis fn #field_ident(mut self) -> <#target as #toasty::Model>::Query {
                 use #toasty::IntoStatement;
-                <#target as #toasty::Relation>::Query::from_stmt(
+                <<#target as #toasty::Model>::Query>::from_stmt(
                     #toasty::stmt::Association::many_via_one(
                         self.stmt, #model_ident::fields().#field_ident().into()
                     ).into_statement().into_query().unwrap()

--- a/crates/toasty-macros/src/model/expand/relation.rs
+++ b/crates/toasty-macros/src/model/expand/relation.rs
@@ -234,8 +234,8 @@ impl Expand<'_> {
                 let field_offset = util::int(field.id);
 
                 Some(quote! {
-                    #vis fn #field_ident(self) -> <<#ty as #field_trait>::Target as #toasty::Relation>::Many {
-                        <<#ty as #field_trait>::Target as #toasty::Relation>::Many::from_stmt(
+                    #vis fn #field_ident(self) -> <<#ty as #field_trait>::Model as #toasty::Model>::Many {
+                        <<<#ty as #field_trait>::Model as #toasty::Model>::Many>::from_stmt(
                             self.stmt.chain_field(#field_offset)
                         )
                     }
@@ -270,7 +270,7 @@ impl Expand<'_> {
         let vis = &self.model.vis;
         let field_ident = &field.name.ident;
         let ty = &rel.ty;
-        let target_ty = quote!(<#ty as #toasty::BelongsToField>::Target);
+        let target_ty = quote!(<#ty as #toasty::BelongsToField>::Model);
 
         let operands = rel.foreign_key.iter().map(|fk_field| {
             let source = &self.model.fields[fk_field.source];
@@ -285,7 +285,7 @@ impl Expand<'_> {
             quote! {
                 #toasty::Field::key_constraint(
                     &self.#source_field_ident,
-                    <#target_ty as #toasty::Relation>::Model::fields().#target_field().into(),
+                    #target_ty::fields().#target_field().into(),
                 )
             }
         });
@@ -311,7 +311,7 @@ impl Expand<'_> {
         );
 
         quote! {
-            #vis fn #field_ident(&self) -> <#target_ty as #toasty::Relation>::One {
+            #vis fn #field_ident(&self) -> <#ty as #toasty::BelongsToField>::One {
                 // Suppress the unused field warning
                 if false {
                     let _ = &self.#field_ident;
@@ -319,8 +319,8 @@ impl Expand<'_> {
 
                 {
                     use #toasty::IntoStatement;
-                    <#target_ty as #toasty::Relation>::One::from_stmt(
-                        <#target_ty as #toasty::Relation>::Model::filter(#filter).into_statement().into_query().unwrap()
+                    <<#ty as #toasty::BelongsToField>::One>::from_stmt(
+                        #target_ty::filter(#filter).into_statement().into_query().unwrap()
                     )
                 }
             }
@@ -340,7 +340,7 @@ impl Expand<'_> {
         let vis = &self.model.vis;
         let field_ident = &field.name.ident;
         let ty = &rel.ty;
-        let target = quote!(<#ty as #toasty::HasManyField>::Target);
+        let target = quote!(<#ty as #toasty::HasManyField>::Model);
 
         // A `via` relation reaches its target through a path of existing
         // relations; it has no paired `BelongsTo`, so skip the back-reference
@@ -364,7 +364,7 @@ impl Expand<'_> {
         };
 
         quote! {
-            #vis fn #field_ident(&self) -> <#target as #toasty::Relation>::Many {
+            #vis fn #field_ident(&self) -> <#target as #toasty::Model>::Many {
                 // Suppress the unused field warning
                 if false {
                     let _ = &self.#field_ident;
@@ -374,7 +374,7 @@ impl Expand<'_> {
 
                 {
                     use #toasty::IntoStatement;
-                    <#target as #toasty::Relation>::Many::from_stmt(
+                    <<#target as #toasty::Model>::Many>::from_stmt(
                         #toasty::stmt::Association::many(
                             self.into_statement().into_query().unwrap().to_list(),
                             Self::fields().#field_ident().into()
@@ -390,7 +390,6 @@ impl Expand<'_> {
         let vis = &self.model.vis;
         let field_ident = &field.name.ident;
         let ty = &rel.ty;
-        let target = quote!(<#ty as #toasty::HasOneField>::Target);
 
         // A `via` relation reaches its target through a path of existing
         // relations; it has no paired `BelongsTo`, so skip the back-reference
@@ -414,7 +413,7 @@ impl Expand<'_> {
         };
 
         quote! {
-            #vis fn #field_ident(&self) -> <#target as #toasty::Relation>::One {
+            #vis fn #field_ident(&self) -> <#ty as #toasty::HasOneField>::One {
                 // Suppress the unused field warning
                 if false {
                     let _ = &self.#field_ident;
@@ -424,7 +423,7 @@ impl Expand<'_> {
 
                 {
                     use #toasty::IntoStatement;
-                    <#target as #toasty::Relation>::One::from_stmt(
+                    <<#ty as #toasty::HasOneField>::One>::from_stmt(
                         #toasty::stmt::Association::one(
                             self.into_statement().into_query().unwrap().to_list(),
                             Self::fields().#field_ident().into()
@@ -501,8 +500,8 @@ impl Expand<'_> {
                 fn verify<#verify_t: Verify<#verify_a>, #verify_a>(_: &#verify_t) {
                 }
 
-                let instance = load::<<<#ty as #field_trait>::Target as #toasty::Relation>::Model>();
-                verify::<_, <<#ty as #field_trait>::Target as #toasty::Relation>::Model>(instance.#verify_pair_belongs_to_exists_for_field());
+                let instance = load::<<#ty as #field_trait>::Model>();
+                verify::<_, <#ty as #field_trait>::Model>(instance.#verify_pair_belongs_to_exists_for_field());
             }
         }
     }

--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -137,14 +137,14 @@ impl Expand<'_> {
                                     index: #source,
                                 },
                                 target: {
-                                    type __RelationTarget = <#ty as #toasty::BelongsToField>::Target;
-                                    <__RelationTarget as #toasty::Relation>::field_name_to_id(#target)
+                                    type __RelationTarget = <#ty as #toasty::BelongsToField>::Model;
+                                    <__RelationTarget as #toasty::Model>::field_name_to_id(#target)
                                 },
                             }
                         }
                     });
 
-                    nullable = quote!(<#ty as #toasty::BelongsToField>::nullable());
+                    nullable = quote!(<#ty as #toasty::BelongsToField>::NULLABLE);
                     deferred = quote!(<#ty as #toasty::BelongsToField>::DEFERRED);
                     field_ty = quote!(<#ty as #toasty::BelongsToField>::belongs_to_field_ty(
                         #toasty::core::schema::app::ForeignKey {
@@ -158,7 +158,7 @@ impl Expand<'_> {
                     let pair = expand_pair(toasty, quote!(#toasty::HasManyField), ty, rel.pair.as_ref());
                     let via = expand_via(toasty, model_ident, rel.via.as_ref());
 
-                    nullable = quote!(<#ty as #toasty::HasManyField>::nullable());
+                    nullable = quote!(<#ty as #toasty::HasManyField>::NULLABLE);
                     deferred = quote!(<#ty as #toasty::HasManyField>::DEFERRED);
                     field_ty = quote!(<#ty as #toasty::HasManyField>::has_many_field_ty(#singular_name, #pair, #via));
                 }
@@ -167,7 +167,7 @@ impl Expand<'_> {
                     let pair = expand_pair(toasty, quote!(#toasty::HasOneField), ty, rel.pair.as_ref());
                     let via = expand_via(toasty, model_ident, rel.via.as_ref());
 
-                    nullable = quote!(<#ty as #toasty::HasOneField>::nullable());
+                    nullable = quote!(<#ty as #toasty::HasOneField>::NULLABLE);
                     deferred = quote!(<#ty as #toasty::HasOneField>::DEFERRED);
                     field_ty = quote!(<#ty as #toasty::HasOneField>::has_one_field_ty(#pair, #via));
                 }
@@ -450,28 +450,19 @@ impl Expand<'_> {
                 FieldTy::BelongsTo(rel) => {
                     let ty = &rel.ty;
                     quote! {
-                        {
-                            type __RelationTarget = <#ty as #toasty::BelongsToField>::Target;
-                            <<__RelationTarget as #toasty::Relation>::Model as #toasty::Register>::register(model_set);
-                        }
+                        <<#ty as #toasty::BelongsToField>::Model as #toasty::Register>::register(model_set);
                     }
                 }
                 FieldTy::HasMany(rel) => {
                     let ty = &rel.ty;
                     quote! {
-                        {
-                            type __RelationTarget = <#ty as #toasty::HasManyField>::Target;
-                            <<__RelationTarget as #toasty::Relation>::Model as #toasty::Register>::register(model_set);
-                        }
+                        <<#ty as #toasty::HasManyField>::Model as #toasty::Register>::register(model_set);
                     }
                 }
                 FieldTy::HasOne(rel) => {
                     let ty = &rel.ty;
                     quote! {
-                        {
-                            type __RelationTarget = <#ty as #toasty::HasOneField>::Target;
-                            <<__RelationTarget as #toasty::Relation>::Model as #toasty::Register>::register(model_set);
-                        }
+                        <<#ty as #toasty::HasOneField>::Model as #toasty::Register>::register(model_set);
                     }
                 }
             })
@@ -503,8 +494,8 @@ fn expand_pair(
             let name = ident.to_string();
             quote! {
                 Some({
-                    type __RelationTarget = <#target_ty as #field_trait>::Target;
-                    <__RelationTarget as #toasty::Relation>::field_name_to_id(#name)
+                    type __RelationTarget = <#target_ty as #field_trait>::Model;
+                    <__RelationTarget as #toasty::Model>::field_name_to_id(#name)
                 })
             }
         }

--- a/crates/toasty-macros/src/model/expand/update.rs
+++ b/crates/toasty-macros/src/model/expand/update.rs
@@ -51,15 +51,14 @@ impl Expand<'_> {
             match &field.ty {
             FieldTy::BelongsTo(rel) => {
                 let ty = &rel.ty;
-                let target = quote!(<#ty as #toasty::BelongsToField>::Target);
 
                 quote! {
-                    #vis fn #field_ident(mut self, #field_ident: impl #toasty::Assign<<#target as #toasty::Relation>::Expr>) -> Self {
+                    #vis fn #field_ident(mut self, #field_ident: impl #toasty::Assign<<#ty as #toasty::BelongsToField>::Expr>) -> Self {
                         self.#set_field_ident(#field_ident);
                         self
                     }
 
-                    #vis fn #set_field_ident(&mut self, #field_ident: impl #toasty::Assign<<#target as #toasty::Relation>::Expr>) -> &mut Self {
+                    #vis fn #set_field_ident(&mut self, #field_ident: impl #toasty::Assign<<#ty as #toasty::BelongsToField>::Expr>) -> &mut Self {
                         let projection = #projection;
                         #field_ident.assign(&mut self.assignments, projection);
                         self
@@ -68,15 +67,15 @@ impl Expand<'_> {
             }
             FieldTy::HasMany(rel) => {
                 let ty = &rel.ty;
-                let target = quote!(<#ty as #toasty::HasManyField>::Target);
+                let target = quote!(<#ty as #toasty::HasManyField>::Model);
 
                 quote! {
-                    #vis fn #field_ident(mut self, #field_ident: impl #toasty::Assign<#toasty::List<<#target as #toasty::Relation>::Expr>>) -> Self {
+                    #vis fn #field_ident(mut self, #field_ident: impl #toasty::Assign<#toasty::List<#target>>) -> Self {
                         self.#set_field_ident(#field_ident);
                         self
                     }
 
-                    #vis fn #set_field_ident(&mut self, #field_ident: impl #toasty::Assign<#toasty::List<<#target as #toasty::Relation>::Expr>>) -> &mut Self {
+                    #vis fn #set_field_ident(&mut self, #field_ident: impl #toasty::Assign<#toasty::List<#target>>) -> &mut Self {
                         let projection = #projection;
                         #field_ident.assign(&mut self.assignments, projection);
                         self
@@ -85,15 +84,14 @@ impl Expand<'_> {
             }
             FieldTy::HasOne(rel) => {
                 let ty = &rel.ty;
-                let target = quote!(<#ty as #toasty::HasOneField>::Target);
 
                 quote! {
-                    #vis fn #field_ident(mut self, #field_ident: impl #toasty::Assign<<#target as #toasty::Relation>::Expr>) -> Self {
+                    #vis fn #field_ident(mut self, #field_ident: impl #toasty::Assign<<#ty as #toasty::HasOneField>::Expr>) -> Self {
                         self.#set_field_ident(#field_ident);
                         self
                     }
 
-                    #vis fn #set_field_ident(&mut self, #field_ident: impl #toasty::Assign<<#target as #toasty::Relation>::Expr>) -> &mut Self {
+                    #vis fn #set_field_ident(&mut self, #field_ident: impl #toasty::Assign<<#ty as #toasty::HasOneField>::Expr>) -> &mut Self {
                         let projection = #projection;
                         #field_ident.assign(&mut self.assignments, projection);
                         self

--- a/crates/toasty/src/codegen_support.rs
+++ b/crates/toasty/src/codegen_support.rs
@@ -15,7 +15,7 @@ pub use crate::{
     schema::create_meta::{assert_create_fields, const_contains},
     schema::{
         Auto, BelongsToField, CreateField, CreateMeta, Deferred, DiscoverItem, Embed, Field,
-        HasManyField, HasOneField, Load, Model, Register, Relation, Scope, ValidateCreate,
+        HasManyField, HasOneField, Load, Model, Register, Scope, ValidateCreate,
         generate_unique_id,
     },
     stmt::CreateMany,

--- a/crates/toasty/src/schema.rs
+++ b/crates/toasty/src/schema.rs
@@ -40,7 +40,7 @@ pub use register::{DiscoverItem, Register, generate_unique_id};
 mod num;
 
 mod relation;
-pub use relation::{BelongsToField, HasManyField, HasOneField, Relation};
+pub use relation::{BelongsToField, HasManyField, HasOneField};
 
 mod scope;
 pub use scope::Scope;

--- a/crates/toasty/src/schema/belongs_to.rs
+++ b/crates/toasty/src/schema/belongs_to.rs
@@ -1,16 +1,49 @@
-use super::{BelongsToField, Deferred, Load, Register, Relation};
+use super::{BelongsToField, Deferred, Load, Model, Register};
 
 use toasty_core::schema::app::{self, FieldTy, ForeignKey};
 use toasty_core::stmt;
 
-impl<T: Relation> BelongsToField for Deferred<T> {
-    type Target = T;
+impl<M: Model> BelongsToField for M {
+    type Model = M;
+    type One = M::One;
+    type Expr = M;
 
-    fn nullable() -> bool {
-        <T as Relation>::nullable()
+    const DEFERRED: bool = false;
+    const NULLABLE: bool = false;
+
+    fn reload(target: &mut Self, value: stmt::Value) -> crate::Result<()> {
+        <Self as Load>::reload(target, value)
     }
 
+    fn belongs_to_field_ty(foreign_key: ForeignKey) -> FieldTy {
+        belongs_to_field_ty::<M>(foreign_key)
+    }
+}
+
+impl<M: Model> BelongsToField for Option<M> {
+    type Model = M;
+    type One = M::OptionOne;
+    type Expr = Option<M>;
+
+    const DEFERRED: bool = false;
+    const NULLABLE: bool = true;
+
+    fn reload(target: &mut Self, value: stmt::Value) -> crate::Result<()> {
+        <Self as Load>::reload(target, value)
+    }
+
+    fn belongs_to_field_ty(foreign_key: ForeignKey) -> FieldTy {
+        belongs_to_field_ty::<M>(foreign_key)
+    }
+}
+
+impl<M: Model> BelongsToField for Deferred<M> {
+    type Model = M;
+    type One = M::One;
+    type Expr = M;
+
     const DEFERRED: bool = true;
+    const NULLABLE: bool = false;
 
     fn reload(target: &mut Self, _value: stmt::Value) -> crate::Result<()> {
         target.unload();
@@ -18,32 +51,32 @@ impl<T: Relation> BelongsToField for Deferred<T> {
     }
 
     fn belongs_to_field_ty(foreign_key: ForeignKey) -> FieldTy {
-        belongs_to_field_ty::<T>(foreign_key)
+        belongs_to_field_ty::<M>(foreign_key)
     }
 }
 
-impl<T: Relation> BelongsToField for T {
-    type Target = T;
+impl<M: Model> BelongsToField for Deferred<Option<M>> {
+    type Model = M;
+    type One = M::OptionOne;
+    type Expr = Option<M>;
 
-    fn nullable() -> bool {
-        <T as Relation>::nullable()
-    }
+    const DEFERRED: bool = true;
+    const NULLABLE: bool = true;
 
-    const DEFERRED: bool = false;
-
-    fn reload(target: &mut Self, value: stmt::Value) -> crate::Result<()> {
-        <Self as Load>::reload(target, value)
+    fn reload(target: &mut Self, _value: stmt::Value) -> crate::Result<()> {
+        target.unload();
+        Ok(())
     }
 
     fn belongs_to_field_ty(foreign_key: ForeignKey) -> FieldTy {
-        belongs_to_field_ty::<T>(foreign_key)
+        belongs_to_field_ty::<M>(foreign_key)
     }
 }
 
-fn belongs_to_field_ty<T: Relation>(foreign_key: ForeignKey) -> FieldTy {
+fn belongs_to_field_ty<M: Model>(foreign_key: ForeignKey) -> FieldTy {
     FieldTy::BelongsTo(app::BelongsTo {
-        target: <T::Model as Register>::id(),
-        expr_ty: stmt::Type::Model(<T::Model as Register>::id()),
+        target: <M as Register>::id(),
+        expr_ty: stmt::Type::Model(<M as Register>::id()),
         // The pair is populated at runtime.
         pair: None,
         foreign_key,

--- a/crates/toasty/src/schema/has_many.rs
+++ b/crates/toasty/src/schema/has_many.rs
@@ -1,15 +1,29 @@
-use super::{Deferred, HasManyField, Load, Register, Relation};
+use super::{Deferred, HasManyField, Load, Model, Register};
 
 use toasty_core::schema::Name;
 use toasty_core::schema::app::{self, FieldId, FieldTy, ModelId};
 use toasty_core::stmt;
 
-impl<T: Relation> HasManyField for Deferred<Vec<T>> {
-    type Target = T;
+impl<M: Model> HasManyField for Vec<M> {
+    type Model = M;
 
-    fn nullable() -> bool {
-        <T as Relation>::nullable()
+    const DEFERRED: bool = false;
+
+    fn reload(target: &mut Self, value: stmt::Value) -> crate::Result<()> {
+        <Self as Load>::reload(target, value)
     }
+
+    fn has_many_field_ty(
+        singular: Name,
+        pair: Option<FieldId>,
+        via: Option<stmt::Path>,
+    ) -> FieldTy {
+        has_many_field_ty::<M>(singular, pair, via)
+    }
+}
+
+impl<M: Model> HasManyField for Deferred<Vec<M>> {
+    type Model = M;
 
     const DEFERRED: bool = true;
 
@@ -23,38 +37,16 @@ impl<T: Relation> HasManyField for Deferred<Vec<T>> {
         pair: Option<FieldId>,
         via: Option<stmt::Path>,
     ) -> FieldTy {
-        has_many_field_ty::<T>(singular, pair, via)
+        has_many_field_ty::<M>(singular, pair, via)
     }
 }
 
-impl<T: Relation> HasManyField for Vec<T> {
-    type Target = T;
-
-    fn nullable() -> bool {
-        <T as Relation>::nullable()
-    }
-
-    const DEFERRED: bool = false;
-
-    fn reload(target: &mut Self, value: stmt::Value) -> crate::Result<()> {
-        <Self as Load>::reload(target, value)
-    }
-
-    fn has_many_field_ty(
-        singular: Name,
-        pair: Option<FieldId>,
-        via: Option<stmt::Path>,
-    ) -> FieldTy {
-        has_many_field_ty::<T>(singular, pair, via)
-    }
-}
-
-fn has_many_field_ty<T: Relation>(
+fn has_many_field_ty<M: Model>(
     singular: Name,
     pair: Option<FieldId>,
     via: Option<stmt::Path>,
 ) -> FieldTy {
-    let target = <T::Model as Register>::id();
+    let target = <M as Register>::id();
     let expr_ty = stmt::Type::List(Box::new(stmt::Type::Model(target)));
     let cardinality = app::Cardinality::Many { singular };
 

--- a/crates/toasty/src/schema/has_one.rs
+++ b/crates/toasty/src/schema/has_one.rs
@@ -1,17 +1,50 @@
-use super::{Deferred, HasOneField, Load, Register, Relation};
+use super::{Deferred, HasOneField, Load, Model, Register};
 
 use toasty_core::schema::app::ModelId;
 use toasty_core::schema::app::{self, FieldId, FieldTy};
 use toasty_core::stmt;
 
-impl<T: Relation> HasOneField for Deferred<T> {
-    type Target = T;
+impl<M: Model> HasOneField for M {
+    type Model = M;
+    type One = M::One;
+    type Expr = M;
 
-    fn nullable() -> bool {
-        <T as Relation>::nullable()
+    const DEFERRED: bool = false;
+    const NULLABLE: bool = false;
+
+    fn reload(target: &mut Self, value: stmt::Value) -> crate::Result<()> {
+        <Self as Load>::reload(target, value)
     }
 
+    fn has_one_field_ty(pair: Option<FieldId>, via: Option<stmt::Path>) -> FieldTy {
+        has_one_field_ty::<M>(pair, via)
+    }
+}
+
+impl<M: Model> HasOneField for Option<M> {
+    type Model = M;
+    type One = M::OptionOne;
+    type Expr = Option<M>;
+
+    const DEFERRED: bool = false;
+    const NULLABLE: bool = true;
+
+    fn reload(target: &mut Self, value: stmt::Value) -> crate::Result<()> {
+        <Self as Load>::reload(target, value)
+    }
+
+    fn has_one_field_ty(pair: Option<FieldId>, via: Option<stmt::Path>) -> FieldTy {
+        has_one_field_ty::<M>(pair, via)
+    }
+}
+
+impl<M: Model> HasOneField for Deferred<M> {
+    type Model = M;
+    type One = M::One;
+    type Expr = M;
+
     const DEFERRED: bool = true;
+    const NULLABLE: bool = false;
 
     fn reload(target: &mut Self, _value: stmt::Value) -> crate::Result<()> {
         target.unload();
@@ -19,30 +52,30 @@ impl<T: Relation> HasOneField for Deferred<T> {
     }
 
     fn has_one_field_ty(pair: Option<FieldId>, via: Option<stmt::Path>) -> FieldTy {
-        has_one_field_ty::<T>(pair, via)
+        has_one_field_ty::<M>(pair, via)
     }
 }
 
-impl<T: Relation> HasOneField for T {
-    type Target = T;
+impl<M: Model> HasOneField for Deferred<Option<M>> {
+    type Model = M;
+    type One = M::OptionOne;
+    type Expr = Option<M>;
 
-    fn nullable() -> bool {
-        <T as Relation>::nullable()
-    }
+    const DEFERRED: bool = true;
+    const NULLABLE: bool = true;
 
-    const DEFERRED: bool = false;
-
-    fn reload(target: &mut Self, value: stmt::Value) -> crate::Result<()> {
-        <Self as Load>::reload(target, value)
+    fn reload(target: &mut Self, _value: stmt::Value) -> crate::Result<()> {
+        target.unload();
+        Ok(())
     }
 
     fn has_one_field_ty(pair: Option<FieldId>, via: Option<stmt::Path>) -> FieldTy {
-        has_one_field_ty::<T>(pair, via)
+        has_one_field_ty::<M>(pair, via)
     }
 }
 
-fn has_one_field_ty<T: Relation>(pair: Option<FieldId>, via: Option<stmt::Path>) -> FieldTy {
-    let target = <T::Model as Register>::id();
+fn has_one_field_ty<M: Model>(pair: Option<FieldId>, via: Option<stmt::Path>) -> FieldTy {
+    let target = <M as Register>::id();
     let expr_ty = stmt::Type::Model(target);
     let cardinality = app::Cardinality::One;
 

--- a/crates/toasty/src/schema/model.rs
+++ b/crates/toasty/src/schema/model.rs
@@ -1,12 +1,18 @@
 use super::create_meta::CreateMeta;
 use super::{Load, Register};
-use crate::stmt::{Expr, IntoExpr, IntoInsert, Path};
+use crate::stmt::{Expr, IntoExpr, IntoInsert, List, Path};
+
+use toasty_core::schema::app::FieldId;
 
 /// Trait for root models that map to database tables and can be queried.
 ///
 /// Root models have primary keys, can be queried independently, and support
 /// full CRUD operations. They extend `Register` with queryability and
-/// deserialization capabilities.
+/// deserialization capabilities, and carry the relation-target metadata
+/// that the [`HasManyField`](super::HasManyField),
+/// [`HasOneField`](super::HasOneField), and
+/// [`BelongsToField`](super::BelongsToField) traits project through when
+/// describing a field that references this model.
 pub trait Model: Register + Load<Output = Self> + Sized {
     /// Query builder type for this model
     type Query;
@@ -34,20 +40,30 @@ pub trait Model: Register + Load<Output = Self> + Sized {
     /// extractor for any `M: Model<PrimaryKey = Uuid>`.
     type PrimaryKey;
 
+    /// The has-many relation wrapper type for this model.
+    type Many;
+
+    /// The field accessor type used when this model appears as the "many" side
+    /// of a has-many relation, parameterized by the origin model.
+    type ManyField<Origin>;
+
+    /// The has-one relation wrapper type for this model (non-nullable).
+    type One;
+
+    /// The field accessor type used when this model appears as the "one" side
+    /// of a has-one relation, parameterized by the origin model.
+    type OneField<Origin>;
+
+    /// The optional has-one relation wrapper type, used when the foreign key
+    /// is nullable so the association is optional.
+    type OptionOne;
+
     /// Metadata about the model's fields for compile-time validation of
     /// `create!` invocations.
     const CREATE_META: CreateMeta;
 
     /// Construct a model path from a [`Path`] targeting this model.
     fn new_path<Origin>(path: Path<Origin, Self>) -> Self::Path<Origin>;
-
-    /// Build a query that filters this model by its primary key.
-    ///
-    /// `id` takes any expression that evaluates to the model's
-    /// [`PrimaryKey`](Self::PrimaryKey) type — bare PK values via their
-    /// `IntoExpr` impl, subqueries that return a PK, or any other
-    /// [`Expr`] of the correct type.
-    fn find_by_primary_key(id: Expr<Self::PrimaryKey>) -> Self::Query;
 
     /// Construct a path rooted at this model.
     fn new_root_path() -> Self::Path<Self> {
@@ -58,4 +74,21 @@ pub trait Model: Register + Load<Output = Self> + Sized {
     fn new_create() -> Self::Create {
         Self::Create::default()
     }
+
+    /// Construct a [`ManyField`](Self::ManyField) from a path targeting a list
+    /// of this model.
+    fn new_many_field<Origin>(path: Path<Origin, List<Self>>) -> Self::ManyField<Origin>;
+
+    /// Map a field name string to its [`FieldId`].
+    ///
+    /// Panics if `name` does not match any field on the model.
+    fn field_name_to_id(name: &str) -> FieldId;
+
+    /// Build a query that filters this model by its primary key.
+    ///
+    /// `id` takes any expression that evaluates to the model's
+    /// [`PrimaryKey`](Self::PrimaryKey) type — bare PK values via their
+    /// `IntoExpr` impl, subqueries that return a PK, or any other
+    /// [`Expr`] of the correct type.
+    fn find_by_primary_key(id: Expr<Self::PrimaryKey>) -> Self::Query;
 }

--- a/crates/toasty/src/schema/option.rs
+++ b/crates/toasty/src/schema/option.rs
@@ -1,5 +1,4 @@
-use super::{Load, Relation};
-use toasty_core::schema::app::FieldId;
+use super::Load;
 use toasty_core::stmt::{self, Value};
 
 impl<T: Load> Load for Option<T> {
@@ -34,31 +33,5 @@ impl<T: Load> Load for Option<T> {
     fn reload(target: &mut Self::Output, value: Value) -> Result<(), crate::Error> {
         *target = Self::load(value)?;
         Ok(())
-    }
-}
-
-impl<T: Relation> Relation for Option<T> {
-    type Model = T::Model;
-    type Expr = Option<T::Model>;
-    type Query = T::Query;
-    type Create = T::Create;
-    type Many = T::Many;
-    type ManyField<__Origin> = T::ManyField<__Origin>;
-    type One = T::OptionOne;
-    type OneField<__Origin> = T::OneField<__Origin>;
-    type OptionOne = T::OptionOne;
-
-    fn new_many_field<__Origin>(
-        path: crate::stmt::Path<__Origin, crate::stmt::List<Self::Model>>,
-    ) -> Self::ManyField<__Origin> {
-        T::new_many_field(path)
-    }
-
-    fn field_name_to_id(name: &str) -> FieldId {
-        T::field_name_to_id(name)
-    }
-
-    fn nullable() -> bool {
-        true
     }
 }

--- a/crates/toasty/src/schema/relation.rs
+++ b/crates/toasty/src/schema/relation.rs
@@ -1,85 +1,26 @@
 use super::{Load, Model};
-use crate::stmt::{IntoExpr, IntoInsert, List, Path};
 
 use toasty_core::schema::Name;
 use toasty_core::schema::app::{FieldId, FieldTy, ForeignKey};
 use toasty_core::stmt;
 
-/// Describes how a model participates in associations.
-///
-/// This trait is implemented by `#[derive(Model)]` and provides the associated
-/// types that generated relation code uses to construct query builders, create
-/// builders, and field accessors for the relation target.
-///
-/// Users do not implement this trait manually.
-pub trait Relation: Load<Output = Self> {
-    /// The target model
-    type Model: Model;
-
-    /// The target expression (e.g. `Option<Model>`)
-    type Expr;
-
-    /// The query builder type for querying this relation's target.
-    type Query;
-
-    /// Create builder type for this relation's target model
-    type Create: Default + IntoInsert<Model = Self::Model> + IntoExpr<Self::Model>;
-
-    /// HasMany relation type
-    type Many;
-
-    /// The field accessor type used when this model appears as the "many" side
-    /// of a has-many relation, parameterized by the origin model.
-    type ManyField<Origin>;
-
-    /// The has-one relation wrapper type for this model.
-    type One;
-
-    /// The field accessor type used when this model appears as the "one" side
-    /// of a has-one relation, parameterized by the origin model.
-    type OneField<Origin>;
-
-    /// The optional has-one relation wrapper type. Used when the foreign key
-    /// is nullable, making the association optional.
-    type OptionOne;
-
-    /// Return a fresh, default-initialized create builder.
-    fn new_create() -> Self::Create {
-        Self::Create::default()
-    }
-
-    /// Construct a `ManyField` from a path targeting a list of the model.
-    fn new_many_field<Origin>(path: Path<Origin, List<Self::Model>>) -> Self::ManyField<Origin>;
-
-    /// Map a field name string to its [`FieldId`].
-    ///
-    /// Panics if `name` does not match any field on the model.
-    fn field_name_to_id(name: &str) -> FieldId;
-
-    /// Returns `true` if this relation target is nullable (i.e., wrapped in
-    /// `Option`). The default is `false`.
-    fn nullable() -> bool {
-        false
-    }
-}
-
 /// A Rust field type that represents a `#[has_many]` relation.
 ///
-/// This is implemented by [`Deferred<Vec<T>>`](super::Deferred) for lazy
-/// relations and by `Vec<T>` for eager relations. The target model/query-builder
-/// metadata stays on [`Relation`]; this trait only describes how the field
-/// itself contributes relation schema metadata.
+/// Implemented by [`Vec<M>`](Vec) (eager) and
+/// [`Deferred<Vec<M>>`](super::Deferred) (lazy) where `M: Model`. The set of
+/// impls is the source of truth for which Rust shapes are valid as a
+/// has-many field: anything outside those two combinations does not satisfy
+/// the trait.
 pub trait HasManyField: Load<Output = Self> {
-    /// The relation target type carried by this field.
-    type Target: Relation;
-
-    /// Returns `true` if this relation field is nullable.
-    fn nullable() -> bool {
-        <Self::Target as Relation>::nullable()
-    }
+    /// The target model that this field references.
+    type Model: Model;
 
     /// Whether the field stores its value in a deferred load slot.
     const DEFERRED: bool;
+
+    /// A has-many is a collection; the collection itself is always present
+    /// even when empty, so a has-many field is never nullable.
+    const NULLABLE: bool = false;
 
     /// Reloads this relation field from a returned value.
     fn reload(target: &mut Self, value: stmt::Value) -> crate::Result<()>;
@@ -100,20 +41,29 @@ pub trait HasManyField: Load<Output = Self> {
 
 /// A Rust field type that represents a `#[has_one]` relation.
 ///
-/// This is implemented by [`Deferred<T>`](super::Deferred) for lazy relations
-/// and by `T` for eager relations. `T` may be `Option<Model>` for nullable
-/// `has_one` fields.
+/// Implemented by `M`, `Option<M>`, `Deferred<M>`, and `Deferred<Option<M>>`
+/// where `M: Model`. The `Option<...>` wrappers carry nullability; the
+/// `Deferred<...>` wrappers carry deferred loading. Anything outside this
+/// shape does not satisfy the trait.
 pub trait HasOneField: Load<Output = Self> {
-    /// The relation target type carried by this field.
-    type Target: Relation;
+    /// The target model that this field references.
+    type Model: Model;
 
-    /// Returns `true` if this relation field is nullable.
-    fn nullable() -> bool {
-        <Self::Target as Relation>::nullable()
-    }
+    /// The "one-side" accessor type produced by the field accessor. Resolves
+    /// to [`Model::One`] for non-nullable impls and [`Model::OptionOne`] for
+    /// nullable impls.
+    type One;
+
+    /// The expression-level type used in create/update setters. Resolves to
+    /// the unwrapped `Self::Model` for non-nullable impls and `Option<Self::Model>`
+    /// for nullable impls.
+    type Expr;
 
     /// Whether the field stores its value in a deferred load slot.
     const DEFERRED: bool;
+
+    /// Whether the field is nullable (i.e. wrapped in `Option`).
+    const NULLABLE: bool;
 
     /// Reloads this relation field from a returned value.
     fn reload(target: &mut Self, value: stmt::Value) -> crate::Result<()>;
@@ -132,20 +82,29 @@ pub trait HasOneField: Load<Output = Self> {
 
 /// A Rust field type that represents a `#[belongs_to]` relation.
 ///
-/// This is implemented by [`Deferred<T>`](super::Deferred) for lazy relations
-/// and by `T` for eager relations. `T` may be `Option<Model>` for nullable
-/// `belongs_to` fields.
+/// Implemented by `M`, `Option<M>`, `Deferred<M>`, and `Deferred<Option<M>>`
+/// where `M: Model`. The `Option<...>` wrappers carry nullability; the
+/// `Deferred<...>` wrappers carry deferred loading. Anything outside this
+/// shape does not satisfy the trait.
 pub trait BelongsToField: Load<Output = Self> {
-    /// The relation target type carried by this field.
-    type Target: Relation;
+    /// The target model that this field references.
+    type Model: Model;
 
-    /// Returns `true` if this relation field is nullable.
-    fn nullable() -> bool {
-        <Self::Target as Relation>::nullable()
-    }
+    /// The "one-side" accessor type produced by the field accessor. Resolves
+    /// to [`Model::One`] for non-nullable impls and [`Model::OptionOne`] for
+    /// nullable impls.
+    type One;
+
+    /// The expression-level type used in create/update setters. Resolves to
+    /// the unwrapped `Self::Model` for non-nullable impls and `Option<Self::Model>`
+    /// for nullable impls.
+    type Expr;
 
     /// Whether the field stores its value in a deferred load slot.
     const DEFERRED: bool;
+
+    /// Whether the field is nullable (i.e. wrapped in `Option`).
+    const NULLABLE: bool;
 
     /// Reloads this relation field from a returned value.
     fn reload(target: &mut Self, value: stmt::Value) -> crate::Result<()>;

--- a/crates/toasty/tests/relation_load.rs
+++ b/crates/toasty/tests/relation_load.rs
@@ -1,7 +1,6 @@
 use toasty::Deferred;
 use toasty::schema::{
     self, BelongsToField, CreateMeta, HasManyField, HasOneField, Load, Model, ModelSet, Register,
-    Relation,
 };
 use toasty::stmt::{Expr, Insert, IntoExpr, IntoInsert, Path};
 use toasty_core::stmt::{self, Value};
@@ -54,6 +53,11 @@ impl Model for Dummy {
     type UpdateQuery = ();
     type Path<Origin> = Path<Origin, Self>;
     type PrimaryKey = i64;
+    type Many = ();
+    type ManyField<Origin> = ();
+    type One = ();
+    type OneField<Origin> = ();
+    type OptionOne = ();
 
     const CREATE_META: CreateMeta = CreateMeta {
         fields: &[],
@@ -62,6 +66,12 @@ impl Model for Dummy {
 
     fn new_path<Origin>(path: Path<Origin, Self>) -> Self::Path<Origin> {
         path
+    }
+
+    fn new_many_field<Origin>(_path: Path<Origin, toasty::stmt::List<Self>>) {}
+
+    fn field_name_to_id(_name: &str) -> schema::app::FieldId {
+        panic!("not needed for relation lazy-slot decode tests")
     }
 
     fn find_by_primary_key(_id: Expr<Self::PrimaryKey>) -> Self::Query {}
@@ -85,37 +95,22 @@ impl IntoExpr<Dummy> for DummyCreate {
     }
 }
 
-impl Relation for Dummy {
-    type Model = Dummy;
-    type Expr = Dummy;
-    type Query = ();
-    type Create = DummyCreate;
-    type Many = ();
-    type ManyField<Origin> = ();
-    type One = ();
-    type OneField<Origin> = ();
-    type OptionOne = ();
-
-    fn new_many_field<Origin>(_path: Path<Origin, toasty::stmt::List<Self::Model>>) {}
-
-    fn field_name_to_id(_name: &str) -> schema::app::FieldId {
-        panic!("not needed for relation lazy-slot decode tests")
-    }
-}
-
-fn assert_has_many_field<F: HasManyField<Target = Dummy>>() {}
-
-fn assert_has_one_field<F: HasOneField<Target = Target>, Target: Relation>() {}
-
-fn assert_belongs_to_field<F: BelongsToField<Target = Target>, Target: Relation>() {}
+fn assert_has_many_field<F: HasManyField<Model = Dummy>>() {}
+fn assert_has_one_field<F: HasOneField<Model = Dummy>>() {}
+fn assert_belongs_to_field<F: BelongsToField<Model = Dummy>>() {}
 
 #[test]
 fn deferred_relation_field_shapes_are_supported() {
+    assert_has_many_field::<Vec<Dummy>>();
     assert_has_many_field::<Deferred<Vec<Dummy>>>();
 
-    assert_has_one_field::<Deferred<Dummy>, Dummy>();
-    assert_has_one_field::<Deferred<Option<Dummy>>, Option<Dummy>>();
+    assert_has_one_field::<Dummy>();
+    assert_has_one_field::<Option<Dummy>>();
+    assert_has_one_field::<Deferred<Dummy>>();
+    assert_has_one_field::<Deferred<Option<Dummy>>>();
 
-    assert_belongs_to_field::<Deferred<Dummy>, Dummy>();
-    assert_belongs_to_field::<Deferred<Option<Dummy>>, Option<Dummy>>();
+    assert_belongs_to_field::<Dummy>();
+    assert_belongs_to_field::<Option<Dummy>>();
+    assert_belongs_to_field::<Deferred<Dummy>>();
+    assert_belongs_to_field::<Deferred<Option<Dummy>>>();
 }


### PR DESCRIPTION
Fold the `Relation` trait into `Model` and rewrite the impls of
`HasManyField`, `HasOneField`, and `BelongsToField` to enumerate the
exact set of Rust shapes each accepts. The old `impl<T: Relation>`
blankets paired with `impl<T: Relation> Relation for Option<T>` let
nonsensical types like `Vec<Option<User>>: HasManyField` and
`Option<Option<User>>: HasOneField` satisfy the field traits. The new
impls restrict each trait to shapes that make sense at the schema
layer:

- `HasManyField`: `Vec<M>`, `Deferred<Vec<M>>`
- `HasOneField`, `BelongsToField`: `M`, `Option<M>`, `Deferred<M>`,
  `Deferred<Option<M>>`

`Self::Model` on each field trait points at the unwrapped `M: Model`
directly; nullability and load-deferral live on the impl as `NULLABLE`
and `DEFERRED` consts. `HasOneField` and `BelongsToField` carry their
own `One` and `Expr` associated types that pick between `M::One` /
`M::OptionOne` and `M` / `Option<M>` based on the impl, removing the
need for `Option<T>` to itself implement a relation trait.

`Model` absorbs the relation-target metadata (`Many`, `One`,
`ManyField<Origin>`, `OneField<Origin>`, `OptionOne`, `new_many_field`,
`field_name_to_id`) so generated code projects through the model
directly. The `Relation` trait and `impl Relation for Option<T>` are
gone.

BREAKING CHANGE: The `Relation` trait is removed. Models no longer get
an `impl Relation`; the metadata it carried now lives on `Model`. Code
that named `<T as Relation>::X` must switch to `<T as Model>::X` for
target-relative projections, or to `<F as HasOneField>::X` /
`BelongsToField::X` for nullability-sensitive projections (`One`,
`Expr`). Field types that were tolerated under the old blanket impls
but are nonsensical (`Vec<Option<M>>` as has-many, `Option<Option<M>>`
as has-one / belongs-to, and similar `Deferred<...>` variants) no
longer satisfy the field traits and must be rewritten to one of the
shapes listed above.

https://claude.ai/code/session_01EcAR1gsGnsDyPuU6B9zS6a