### PR TITLE
fix: cap SQLite auto-increment integer storage at 4 bytes

### DIFF
--- a/crates/toasty-core/src/driver/capability.rs
+++ b/crates/toasty-core/src/driver/capability.rs
@@ -58,6 +58,15 @@ pub struct Capability {
     /// Whether the database has an auto increment modifier for integer columns.
     pub auto_increment: bool,
 
+    /// Maximum storage width, in bytes, for auto-increment integer columns.
+    ///
+    /// Backends that require a particular declared type for auto-increment
+    /// columns use this to cap the storage type selected from the Rust field
+    /// type. SQLite requires the declared type to be `INTEGER` when using
+    /// `AUTOINCREMENT`; Toasty's SQLite serializer emits that spelling for
+    /// `Integer(4)`.
+    pub max_auto_increment_integer_width: Option<u8>,
+
     /// Whether the database supports `VARCHAR(n)` column types natively.
     ///
     /// Must be consistent with [`StorageTypes::varchar`]: when `true`,
@@ -476,6 +485,7 @@ impl Capability {
         returning_from_mutation: true,
         primary_key_ne_predicate: true,
         auto_increment: true,
+        max_auto_increment_integer_width: Some(4),
         bigdecimal_implemented: false,
 
         native_varchar: true,
@@ -551,6 +561,7 @@ impl Capability {
         schema_mutations: SchemaMutations::POSTGRESQL,
         select_for_update: true,
         auto_increment: true,
+        max_auto_increment_integer_width: None,
         bigdecimal_implemented: false,
 
         // PostgreSQL has the `^@` prefix-match operator.
@@ -606,6 +617,7 @@ impl Capability {
         select_for_update: true,
         returning_from_mutation: false,
         auto_increment: true,
+        max_auto_increment_integer_width: None,
         bigdecimal_implemented: true,
 
         // MySQL has inline ENUM('a', 'b') column types
@@ -670,6 +682,7 @@ impl Capability {
         returning_from_mutation: false,
         primary_key_ne_predicate: false,
         auto_increment: false,
+        max_auto_increment_integer_width: None,
         bigdecimal_implemented: false,
         native_varchar: false,
         native_enum: false,

--- a/crates/toasty-core/src/schema/builder/table.rs
+++ b/crates/toasty-core/src/schema/builder/table.rs
@@ -991,10 +991,14 @@ impl<'a, 'b> MapField<'a, 'b> {
     /// `field.nullable || self.in_enum_variant`, and auto-increment from
     /// `field.is_auto_increment()`.
     fn create_column(&mut self, field: &app::Field, primitive: &app::FieldPrimitive) -> ColumnId {
-        let mut storage_ty = db::Type::from_app(
+        let is_auto_increment = (field.is_auto_increment() || self.inherited_auto_increment)
+            && self.build.db.auto_increment;
+
+        let mut storage_ty = db::Type::from_app_column(
             &primitive.ty,
             primitive.storage_ty.as_ref(),
-            &self.build.db.storage_types,
+            self.build.db,
+            is_auto_increment,
         )
         .expect("unsupported storage type");
 
@@ -1018,8 +1022,7 @@ impl<'a, 'b> MapField<'a, 'b> {
             storage_ty,
             nullable: field.nullable || self.in_enum_variant,
             primary_key: false,
-            auto_increment: (field.is_auto_increment() || self.inherited_auto_increment)
-                && self.build.db.auto_increment,
+            auto_increment: is_auto_increment,
             versionable: field.is_versionable(),
         });
 

--- a/crates/toasty-core/src/schema/db/ty.rs
+++ b/crates/toasty-core/src/schema/db/ty.rs
@@ -169,6 +169,26 @@ impl Type {
         }
     }
 
+    pub(crate) fn from_app_column(
+        ty: &stmt::Type,
+        hint: Option<&Type>,
+        db: &driver::Capability,
+        auto_increment: bool,
+    ) -> Result<Type> {
+        let mut storage_ty = Self::from_app(ty, hint, &db.storage_types)?;
+
+        if auto_increment && let Some(max) = db.max_auto_increment_integer_width {
+            match &mut storage_ty {
+                Type::Integer(size) | Type::UnsignedInteger(size) if *size > max => {
+                    *size = max;
+                }
+                _ => {}
+            }
+        }
+
+        Ok(storage_ty)
+    }
+
     /// Determines the [`stmt::Type`] closest to this [`db::Type`] that should be used
     /// as an intermediate conversion step to lessen the work done by each individual driver.
     pub fn bridge_type(&self, ty: &stmt::Type) -> stmt::Type {

--- a/crates/toasty-driver-integration-suite/src/tests/field_auto.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/field_auto.rs
@@ -58,6 +58,32 @@ pub async fn auto_increment_explicit(test: &mut Test) -> Result<()> {
     Ok(())
 }
 
+#[driver_test(requires(auto_increment))]
+pub async fn auto_increment_i64_key(test: &mut Test) -> Result<()> {
+    #[derive(toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: i64,
+
+        name: String,
+    }
+
+    let mut db = test.setup_db(models!(Item)).await;
+
+    let first = toasty::create!(Item { name: "first" })
+        .exec(&mut db)
+        .await?;
+    let second = toasty::create!(Item { name: "second" })
+        .exec(&mut db)
+        .await?;
+
+    assert_eq!(first.id, 1);
+    assert_eq!(second.id, 2);
+
+    Ok(())
+}
+
 #[driver_test(id(ID), requires(auto_increment))]
 pub async fn auto_increment_implicit(test: &mut Test) -> Result<()> {
     #[derive(toasty::Model)]

--- a/crates/toasty-sql/tests/migration_create_table.rs
+++ b/crates/toasty-sql/tests/migration_create_table.rs
@@ -152,7 +152,7 @@ fn create_table_with_nullable_column() {
 fn create_table_with_auto_increment_sqlite() {
     let from = Schema::default();
 
-    let mut id_col = make_column(0, 0, "id", Type::Integer(8));
+    let mut id_col = make_column(0, 0, "id", Type::Integer(4));
     id_col.auto_increment = true;
 
     let to = Schema {
@@ -170,10 +170,9 @@ fn create_table_with_auto_increment_sqlite() {
     let sql = serialize_migration(&stmts, "sqlite");
 
     assert_eq!(sql.len(), 1);
-    assert!(
-        sql[0].contains("AUTOINCREMENT") || sql[0].contains("PRIMARY KEY"),
-        "expected auto increment handling, got: {}",
-        sql[0]
+    assert_eq!(
+        sql[0],
+        "CREATE TABLE \"counters\" (\n    \"id\" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,\n    \"value\" INTEGER NOT NULL\n);"
     );
 }
 

--- a/tests/tests/sqlite.rs
+++ b/tests/tests/sqlite.rs
@@ -58,3 +58,17 @@ async fn in_memory_caps_user_max_pool_size() {
 
     assert_eq!(db.pool().status().max_size, 1);
 }
+
+#[tokio::test]
+async fn auto_i64_key_uses_sqlite_integer_storage_type() {
+    let db = toasty::Db::builder()
+        .models(toasty::models!(PoolItem))
+        .build(toasty_driver_sqlite::Sqlite::in_memory())
+        .await
+        .unwrap();
+
+    let id = &db.schema().db.tables[0].columns[0];
+
+    assert_eq!(id.storage_ty, toasty::schema::db::Type::Integer(4));
+    assert!(id.auto_increment);
+}


### PR DESCRIPTION
## Summary
- Add a driver capability for the maximum auto-increment integer width and set SQLite to `4` bytes.
- Apply that cap during DB schema construction so SQLite auto-increment keys use `INTEGER`-compatible storage at the schema layer.
- Add regression coverage for `#[auto] i64` keys through schema inspection and end-to-end SQLite schema setup.

Fixes: #960

## Testing
- `cargo fmt`
- `cargo test -p toasty-sql create_table_with_auto_increment_sqlite`
- `cargo test -p tests --features sqlite auto_i64_key_uses_sqlite_integer_storage_type`
- `cargo test -p tests --features sqlite auto_increment_i64_key`
- `cargo test -p toasty-core test_validate_sqlite_capability`