### PR TITLE
refactor(engine): move UpdateTarget::Query rewrite into lower

### DIFF
--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -4,6 +4,7 @@ mod expr_pattern;
 mod include;
 mod insert;
 mod lift_in_subquery;
+mod lift_update_query;
 mod paginate;
 mod relation;
 mod returning;
@@ -94,10 +95,14 @@ impl LoweringState<'_> {
         // converts `Source::Model` into `Source::Table`.  The IN-subquery
         // lift fires here too: code paths outside the lowering walk (e.g.
         // `ApplyInsertScope::apply_expr`) see the already-lifted form.
-        // The eq/ne operand rewrite (model→PK, BelongsTo→FK) fires inside
-        // the lowering walk itself via `LowerStatement::visit_expr_binary_op_mut`.
+        // `UpdateTarget::Query` is lifted into `UpdateTarget::Model` with
+        // the inner query's filter merged onto the outer update before the
+        // walk sees the target.  The eq/ne operand rewrite (model→PK,
+        // BelongsTo→FK) fires inside the lowering walk itself via
+        // `LowerStatement::visit_expr_binary_op_mut`.
         association::RewriteVia::new(expr_cx).rewrite(&mut stmt);
         lift_in_subquery::LiftInSubquery::new(expr_cx).rewrite(&mut stmt);
+        lift_update_query::LiftUpdateQuery::new().rewrite(&mut stmt);
 
         Simplify::with_context(expr_cx, self.engine.capability).visit_mut(&mut stmt);
 

--- a/crates/toasty/src/engine/lower/lift_update_query.rs
+++ b/crates/toasty/src/engine/lower/lift_update_query.rs
@@ -1,0 +1,50 @@
+//! Pre-lowering rewrite that converts `Update { target: Query(q), .. }`
+//! into `Update { target: Model(m), filter: filter ∧ q.filter, .. }`.
+//!
+//! [`LiftUpdateQuery`] runs as a whole-statement pre-pass before the
+//! main lowering walk.  The visitor overrides `visit_stmt_update_mut`
+//! to lift the inner select's source model out as the new
+//! `UpdateTarget::Model` and merge its filter into the outer update's
+//! filter.
+//!
+//! `UpdateTarget::Query` is the app-shaped form of "update the rows
+//! produced by this query".  The db-level form is always
+//! `UpdateTarget::Table`; the lowering walk's
+//! `LowerStatement::visit_update_target_mut` panics on
+//! `UpdateTarget::Query`.  The lift fires before lowering so the walk
+//! only ever sees `UpdateTarget::Model`, which it converts to
+//! `UpdateTarget::Table`.
+
+use toasty_core::stmt::{self, VisitMut};
+
+/// Pre-lowering pass that lifts `UpdateTarget::Query` into
+/// `UpdateTarget::Model` with the inner query's filter merged onto the
+/// outer update.
+pub(super) struct LiftUpdateQuery;
+
+impl LiftUpdateQuery {
+    pub(super) fn new() -> Self {
+        Self
+    }
+
+    pub(super) fn rewrite(&mut self, stmt: &mut stmt::Statement) {
+        self.visit_mut(stmt);
+    }
+}
+
+impl VisitMut for LiftUpdateQuery {
+    fn visit_stmt_update_mut(&mut self, stmt: &mut stmt::Update) {
+        if let stmt::UpdateTarget::Query(query) = &mut stmt.target {
+            let stmt::ExprSet::Select(select) = &mut query.body else {
+                todo!()
+            };
+
+            assert!(select.returning.is_model());
+
+            stmt.filter.add_filter(select.filter.take());
+            stmt.target = stmt::UpdateTarget::Model(select.source.model_id_unwrap());
+        }
+
+        stmt::visit_mut::visit_stmt_update_mut(self, stmt);
+    }
+}

--- a/crates/toasty/src/engine/simplify.rs
+++ b/crates/toasty/src/engine/simplify.rs
@@ -223,22 +223,9 @@ impl VisitMut for Simplify<'_> {
     }
 
     fn visit_stmt_update_mut(&mut self, stmt: &mut stmt::Update) {
-        // If the update target is a query, start by simplifying the query, then
-        // rewriting it to be a filter.
-        if let stmt::UpdateTarget::Query(query) = &mut stmt.target {
-            self.visit_stmt_query_mut(query);
-
-            let stmt::ExprSet::Select(select) = &mut query.body else {
-                todo!()
-            };
-
-            assert!(select.returning.is_model());
-
-            stmt.filter.add_filter(select.filter.take());
-
-            stmt.target = stmt::UpdateTarget::Model(select.source.model_id_unwrap());
-        }
-
+        // `UpdateTarget::Query` is lifted into `UpdateTarget::Model` by the
+        // pre-lowering `lower::lift_update_query::LiftUpdateQuery` pass, not
+        // here.
         self.visit_update_target_mut(&mut stmt.target);
 
         let mut s = self.scope(&stmt.target);


### PR DESCRIPTION
## Summary

`UpdateTarget::Query` is the app-shaped form of "update the rows produced by this query".  The db-level form is always `UpdateTarget::Table`, and the lowering walk's `visit_update_target_mut` panics on the query form.  The rewrite that lifts the inner select's source model out as `UpdateTarget::Model` and merges its filter onto the outer update lived in `Simplify::visit_stmt_update_mut`; this moves it into a new `LiftUpdateQuery` pre-pass next to `RewriteVia` and `LiftInSubquery`.

Catalogued in the lower-then-simplify design doc by #896.

## Type of change

<!-- Check one. -->

- [ ] Small / obvious change — bug fix, docs, internal cleanup, or test
- [X] Implements a previously accepted [design](https://github.com/tokio-rs/toasty/blob/main/docs/dev/design/lower-then-simplify.md)
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [X] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [X] `cargo fmt` and `cargo clippy` are clean
- [X] `cargo test` passes
- [ ] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [ ] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers

N/A
