### PR TITLE
feat!: remove singular has-many create-builder methods

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/field_auto.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/field_auto.rs
@@ -160,8 +160,8 @@ pub async fn auto_increment_with_associations(test: &mut Test) -> Result<()> {
 
     for i in 1..10 {
         let u = Parent::create()
-            .child(Child::create())
-            .child(Child::create())
+            .children([Child::create()])
+            .children([Child::create()])
             .exec(&mut db)
             .await?;
         assert_eq!(u.id, i);

--- a/crates/toasty-driver-integration-suite/src/tests/relation_eager.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_eager.rs
@@ -173,7 +173,7 @@ pub async fn eager_has_many_create_returning_loads_relations(t: &mut Test) -> Re
 
     let user = User::create()
         .name("Alice")
-        .post(Post::create().title("hello"))
+        .posts([Post::create().title("hello")])
         .exec(&mut db)
         .await?;
 

--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_batch_create.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_batch_create.rs
@@ -7,7 +7,7 @@ pub async fn user_batch_create_todos_one_level_basic_fk(test: &mut Test) -> Resu
     // Create a user with some todos
     let user = User::create()
         .name("Ann Chovey")
-        .todo(Todo::create().title("Make pizza"))
+        .todos([Todo::create().title("Make pizza")])
         .exec(&mut db)
         .await?;
 
@@ -31,11 +31,9 @@ pub async fn user_batch_create_todos_two_levels_basic_fk(test: &mut Test) -> Res
     // Create a user with some todos
     let user = User::create()
         .name("Ann Chovey")
-        .todo(
-            Todo::create()
-                .title("Make pizza")
-                .category(Category::create().name("Eating")),
-        )
+        .todos([Todo::create()
+            .title("Make pizza")
+            .category(Category::create().name("Eating"))])
         .exec(&mut db)
         .await?;
     assert_eq!(user.name, "Ann Chovey");
@@ -56,16 +54,12 @@ pub async fn user_batch_create_todos_two_levels_basic_fk(test: &mut Test) -> Res
     // Create more than one todo per user
     let user = User::create()
         .name("John Doe")
-        .todo(
-            Todo::create()
-                .title("do something")
-                .category(Category::create().name("things")),
-        )
-        .todo(
-            Todo::create()
-                .title("do something else")
-                .category(Category::create().name("other things")),
-        )
+        .todos([Todo::create()
+            .title("do something")
+            .category(Category::create().name("things"))])
+        .todos([Todo::create()
+            .title("do something else")
+            .category(Category::create().name("other things"))])
         .exec(&mut db)
         .await?;
 
@@ -101,8 +95,8 @@ pub async fn user_batch_create_todos_set_category_by_value(test: &mut Test) -> R
 
     let user = User::create()
         .name("John Doe")
-        .todo(Todo::create().title("Pizza").category(&category))
-        .todo(Todo::create().title("Hamburger").category(&category))
+        .todos([Todo::create().title("Pizza").category(&category)])
+        .todos([Todo::create().title("Hamburger").category(&category)])
         .exec(&mut db)
         .await?;
 
@@ -179,8 +173,8 @@ pub async fn user_batch_create_todos_with_optional_field(test: &mut Test) -> Res
     // This operation currently panics due to unimplemented code path
     let user = User::create()
         .name("Ann Chovey")
-        .todo(Todo::create().title("Make pizza"))
-        .todo(Todo::create().title("Sleep"))
+        .todos([Todo::create().title("Make pizza")])
+        .todos([Todo::create().title("Sleep")])
         .exec(&mut db)
         .await?;
 
@@ -235,8 +229,8 @@ pub async fn user_batch_create_two_todos_simple(test: &mut Test) -> Result<()> {
     let user = User::create()
         .name("Ann Chovey")
         .email("ann.chovey@example.com")
-        .todo(Todo::create().title("Make pizza"))
-        .todo(Todo::create().title("Sleep"))
+        .todos([Todo::create().title("Make pizza")])
+        .todos([Todo::create().title("Sleep")])
         .exec(&mut db)
         .await?;
 

--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_boxed_fk.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_boxed_fk.rs
@@ -104,8 +104,8 @@ pub async fn boxed_u64_fk_batch_create(test: &mut Test) -> Result<()> {
     let user = User::create()
         .id(1)
         .name("Bob")
-        .todo(Todo::create().id(1).title("First task"))
-        .todo(Todo::create().id(2).title("Second task"))
+        .todos([Todo::create().id(1).title("First task")])
+        .todos([Todo::create().id(2).title("Second task")])
         .exec(&mut db)
         .await?;
 
@@ -235,8 +235,8 @@ pub async fn arc_u64_fk_crud(test: &mut Test) -> Result<()> {
     let user2 = User::create()
         .id(2)
         .name("Bob")
-        .todo(Todo::create().id(3).title("Batch 1"))
-        .todo(Todo::create().id(4).title("Batch 2"))
+        .todos([Todo::create().id(3).title("Batch 1")])
+        .todos([Todo::create().id(4).title("Batch 2")])
         .exec(&mut db)
         .await?;
 
@@ -311,8 +311,8 @@ pub async fn rc_u64_fk_crud(test: &mut Test) -> Result<()> {
     let user2 = User::create()
         .id(2)
         .name("Bob")
-        .todo(Todo::create().id(3).title("Batch 1"))
-        .todo(Todo::create().id(4).title("Batch 2"))
+        .todos([Todo::create().id(3).title("Batch 1")])
+        .todos([Todo::create().id(4).title("Batch 2")])
         .exec(&mut db)
         .await?;
 

--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs
@@ -335,7 +335,7 @@ pub async fn composite_associate_new_user_with_todo_on_update_via_creation(
     let u1 = User::create()
         .revision(1)
         .name("User 1")
-        .todo(Todo::create().title("hello world"))
+        .todos([Todo::create().title("hello world")])
         .exec(&mut db)
         .await?;
 
@@ -359,7 +359,7 @@ pub async fn composite_associate_new_user_with_todo_on_update_query_via_creation
     let u1 = User::create()
         .revision(1)
         .name("User 1")
-        .todo(Todo::create().title("a todo"))
+        .todos([Todo::create().title("a todo")])
         .exec(&mut db)
         .await?;
 
@@ -390,7 +390,7 @@ pub async fn composite_assign_todo_that_already_has_user_on_create(test: &mut Te
     let u2 = User::create()
         .revision(1)
         .name("User 2")
-        .todo(&todo)
+        .todos([&todo])
         .exec(&mut db)
         .await?;
 
@@ -504,7 +504,7 @@ pub async fn composite_user_batch_create_todos_one_level(test: &mut Test) -> Res
 
     let user = User::create()
         .name("Ann Chovey")
-        .todo(Todo::create().title("Make pizza"))
+        .todos([Todo::create().title("Make pizza")])
         .exec(&mut db)
         .await?;
 
@@ -525,8 +525,8 @@ pub async fn composite_user_batch_create_two_todos_simple(test: &mut Test) -> Re
 
     let user = User::create()
         .name("Ann Chovey")
-        .todo(Todo::create().title("Make pizza"))
-        .todo(Todo::create().title("Sleep"))
+        .todos([Todo::create().title("Make pizza")])
+        .todos([Todo::create().title("Sleep")])
         .exec(&mut db)
         .await?;
 
@@ -576,8 +576,8 @@ pub async fn composite_user_batch_create_todos_with_optional_field(test: &mut Te
 
     let user = User::create()
         .name("Ann Chovey")
-        .todo(Todo::create().title("Make pizza"))
-        .todo(Todo::create().title("Sleep"))
+        .todos([Todo::create().title("Make pizza")])
+        .todos([Todo::create().title("Sleep")])
         .exec(&mut db)
         .await?;
 
@@ -618,8 +618,8 @@ pub async fn composite_remove_add_single_relation_option_belongs_to(test: &mut T
     let mut db = test.setup_db(models!(User, Todo)).await;
 
     let user = User::create()
-        .todo(Todo::create())
-        .todo(Todo::create())
+        .todos([Todo::create()])
+        .todos([Todo::create()])
         .exec(&mut db)
         .await?;
 
@@ -764,9 +764,9 @@ pub async fn composite_basic_has_many_and_belongs_to_preload(test: &mut Test) ->
 
     let user = User::create()
         .name("Alice")
-        .todo(Todo::create().title("todo 1"))
-        .todo(Todo::create().title("todo 2"))
-        .todo(Todo::create().title("todo 3"))
+        .todos([Todo::create().title("todo 1")])
+        .todos([Todo::create().title("todo 2")])
+        .todos([Todo::create().title("todo 3")])
         .exec(&mut db)
         .await?;
 
@@ -837,8 +837,8 @@ pub async fn composite_preload_has_many_with_optional_belongs_to(test: &mut Test
 
     let user = User::create()
         .name("Alice")
-        .todo(Todo::create().title("alpha"))
-        .todo(Todo::create().title("beta"))
+        .todos([Todo::create().title("alpha")])
+        .todos([Todo::create().title("beta")])
         .exec(&mut db)
         .await?;
 
@@ -857,8 +857,8 @@ pub async fn composite_nested_has_many_then_belongs_to_required(test: &mut Test)
 
     let user = User::create()
         .name("Alice")
-        .todo(Todo::create().title("alpha"))
-        .todo(Todo::create().title("beta"))
+        .todos([Todo::create().title("alpha")])
+        .todos([Todo::create().title("beta")])
         .exec(&mut db)
         .await?;
 

--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_crud.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_crud.rs
@@ -1005,7 +1005,7 @@ pub async fn associate_new_user_with_todo_on_update_via_creation(test: &mut Test
     // Create a user with a todo
     let u1 = User::create()
         .name("User 1")
-        .todo(Todo::create().title("hello world"))
+        .todos([Todo::create().title("hello world")])
         .exec(&mut db)
         .await?;
 
@@ -1030,7 +1030,7 @@ pub async fn associate_new_user_with_todo_on_update_query_via_creation(
     // Create a user with a todo
     let u1 = User::create()
         .name("User 1")
-        .todo(Todo::create().title("a todo"))
+        .todos([Todo::create().title("a todo")])
         .exec(&mut db)
         .await?;
 
@@ -1078,7 +1078,7 @@ pub async fn update_user_with_null_todo_is_err(test: &mut Test) -> Result<()> {
     let mut db = test.setup_db(models!(User, Todo)).await;
 
     // Create a user with a todo
-    let u1 = User::create().todo(Todo::create()).exec(&mut db).await?;
+    let u1 = User::create().todos([Todo::create()]).exec(&mut db).await?;
 
     // Get the todo
     let todos: Vec<_> = u1.todos().exec(&mut db).await?;
@@ -1111,7 +1111,7 @@ pub async fn assign_todo_that_already_has_user_on_create(test: &mut Test) -> Res
 
     let u2 = User::create()
         .name("User 2")
-        .todo(&todo)
+        .todos([&todo])
         .exec(&mut db)
         .await?;
 

--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_link_unlink.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_link_unlink.rs
@@ -31,8 +31,8 @@ pub async fn remove_add_single_relation_option_belongs_to(test: &mut Test) -> Re
 
     // Create a user with some todos
     let user = User::create()
-        .todo(Todo::create())
-        .todo(Todo::create())
+        .todos([Todo::create()])
+        .todos([Todo::create()])
         .exec(&mut db)
         .await?;
 
@@ -55,7 +55,7 @@ pub async fn remove_add_single_relation_option_belongs_to(test: &mut Test) -> Re
 
     // Create a second user w/ a TODO. We will ensure that unlinking *only*
     // unlinks records currently associated with the base model.
-    let u2 = User::create().todo(Todo::create()).exec(&mut db).await?;
+    let u2 = User::create().todos([Todo::create()]).exec(&mut db).await?;
     let u2_todos = u2.todos().exec(&mut db).await?;
 
     // Try unlinking u2's todo via user. This should fail

--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_n_plus_1.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_n_plus_1.rs
@@ -13,9 +13,9 @@ pub async fn hello_world(test: &mut Test) -> Result<()> {
     // Create a user with a few todos
     let user = User::create()
         .name("x")
-        .todo(Todo::create().category(&cat1).title("one"))
-        .todo(Todo::create().category(&cat2).title("two"))
-        .todo(Todo::create().category(&cat2).title("three"))
+        .todos([Todo::create().category(&cat1).title("one")])
+        .todos([Todo::create().category(&cat2).title("two")])
+        .todos([Todo::create().category(&cat2).title("three")])
         .exec(&mut db)
         .await?;
 
@@ -62,17 +62,17 @@ pub async fn query_by_index_optimization(test: &mut Test) -> Result<()> {
     // Create a board with 5 users
     let board = Board::create()
         .name("Test Board")
-        .user(User::create().name("User 1"))
-        .user(User::create().name("User 2"))
-        .user(User::create().name("User 3"))
-        .user(User::create().name("User 4"))
-        .user(User::create().name("User 5"))
+        .users([User::create().name("User 1")])
+        .users([User::create().name("User 2")])
+        .users([User::create().name("User 3")])
+        .users([User::create().name("User 4")])
+        .users([User::create().name("User 5")])
         .exec(&mut db)
         .await?;
 
     Board::create()
         .name("Test Board2")
-        .user(User::create().name("User 6"))
+        .users([User::create().name("User 6")])
         .exec(&mut db)
         .await?;
 

--- a/crates/toasty-driver-integration-suite/src/tests/relation_preload.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_preload.rs
@@ -45,9 +45,9 @@ pub async fn basic_has_many_and_belongs_to_preload(test: &mut Test) -> Result<()
     // Create a user with a few todos
     let user = User::create()
         .name("Alice")
-        .todo(Todo::create().title("todo 1"))
-        .todo(Todo::create().title("todo 2"))
-        .todo(Todo::create().title("todo 3"))
+        .todos([Todo::create().title("todo 1")])
+        .todos([Todo::create().title("todo 2")])
+        .todos([Todo::create().title("todo 3")])
         .exec(&mut db)
         .await?;
 
@@ -402,9 +402,9 @@ pub async fn combined_has_many_and_has_one_preload(test: &mut Test) -> Result<()
     let user = User::create()
         .name("Bob Smith")
         .profile(Profile::create().bio("Developer"))
-        .todo(Todo::create().title("Task 1"))
-        .todo(Todo::create().title("Task 2"))
-        .todo(Todo::create().title("Task 3"))
+        .todos([Todo::create().title("Task 1")])
+        .todos([Todo::create().title("Task 2")])
+        .todos([Todo::create().title("Task 3")])
         .exec(&mut db)
         .await?;
 
@@ -532,8 +532,8 @@ pub async fn preload_has_many_with_optional_belongs_to(test: &mut Test) -> Resul
     // Create a user with linked todos
     let user = User::create()
         .name("Alice")
-        .todo(Todo::create().title("Task 1"))
-        .todo(Todo::create().title("Task 2"))
+        .todos([Todo::create().title("Task 1")])
+        .todos([Todo::create().title("Task 2")])
         .exec(&mut db)
         .await?;
 
@@ -761,19 +761,15 @@ pub async fn nested_has_many_preload(test: &mut Test) {
     // Create a user with todos, each with steps
     let user = User::create()
         .name("Alice")
-        .todo(
-            Todo::create()
-                .title("Todo 1")
-                .step(Step::create().description("Step 1a"))
-                .step(Step::create().description("Step 1b")),
-        )
-        .todo(
-            Todo::create()
-                .title("Todo 2")
-                .step(Step::create().description("Step 2a"))
-                .step(Step::create().description("Step 2b"))
-                .step(Step::create().description("Step 2c")),
-        )
+        .todos([Todo::create()
+            .title("Todo 1")
+            .steps([Step::create().description("Step 1a")])
+            .steps([Step::create().description("Step 1b")])])
+        .todos([Todo::create()
+            .title("Todo 2")
+            .steps([Step::create().description("Step 2a")])
+            .steps([Step::create().description("Step 2b")])
+            .steps([Step::create().description("Step 2c")])])
         .exec(&mut db)
         .await
         .unwrap();
@@ -860,12 +856,10 @@ pub async fn nested_has_many_then_has_one_optional(test: &mut Test) -> Result<()
 
     let user = User::create()
         .name("Alice")
-        .post(
-            Post::create()
-                .title("P1")
-                .detail(Detail::create().body("D1")),
-        )
-        .post(Post::create().title("P2")) // no detail
+        .posts([Post::create()
+            .title("P1")
+            .detail(Detail::create().body("D1"))])
+        .posts([Post::create().title("P2")]) // no detail
         .exec(&mut db)
         .await?;
 
@@ -950,16 +944,12 @@ pub async fn nested_has_many_then_has_one_required(test: &mut Test) -> Result<()
 
     let user = User::create()
         .name("Bob")
-        .account(
-            Account::create()
-                .label("A1")
-                .settings(Settings::create().theme("dark")),
-        )
-        .account(
-            Account::create()
-                .label("A2")
-                .settings(Settings::create().theme("light")),
-        )
+        .accounts([Account::create()
+            .label("A1")
+            .settings(Settings::create().theme("dark"))])
+        .accounts([Account::create()
+            .label("A2")
+            .settings(Settings::create().theme("light"))])
         .exec(&mut db)
         .await?;
 
@@ -1037,8 +1027,8 @@ pub async fn nested_has_many_then_belongs_to_required(test: &mut Test) -> Result
 
     let cat = Category::create()
         .name("Electronics")
-        .item(Item::create().title("Phone").brand(&brand_a))
-        .item(Item::create().title("Laptop").brand(&brand_b))
+        .items([Item::create().title("Phone").brand(&brand_a)])
+        .items([Item::create().title("Laptop").brand(&brand_b)])
         .exec(&mut db)
         .await?;
 
@@ -1113,8 +1103,8 @@ pub async fn nested_has_many_then_shared_belongs_to(test: &mut Test) -> Result<(
     let brand = Brand::create().name("BrandA").exec(&mut db).await?;
     let cat = Category::create()
         .name("Electronics")
-        .item(Item::create().title("Phone").brand(&brand))
-        .item(Item::create().title("Laptop").brand(&brand))
+        .items([Item::create().title("Phone").brand(&brand)])
+        .items([Item::create().title("Laptop").brand(&brand)])
         .exec(&mut db)
         .await?;
 
@@ -1187,8 +1177,8 @@ pub async fn nested_has_many_then_belongs_to_optional(test: &mut Test) -> Result
 
     let team = Team::create()
         .name("Engineering")
-        .task(Task::create().title("Assigned").assignee(&person))
-        .task(Task::create().title("Unassigned"))
+        .tasks([Task::create().title("Assigned").assignee(&person)])
+        .tasks([Task::create().title("Unassigned")])
         .exec(&mut db)
         .await?;
 
@@ -1277,8 +1267,8 @@ pub async fn nested_has_one_optional_then_has_many(test: &mut Test) -> Result<()
         .profile(
             Profile::create()
                 .bio("hi")
-                .badge(Badge::create().label("Gold"))
-                .badge(Badge::create().label("Silver")),
+                .badges([Badge::create().label("Gold")])
+                .badges([Badge::create().label("Silver")]),
         )
         .exec(&mut db)
         .await?;
@@ -1371,8 +1361,8 @@ pub async fn nested_has_one_required_then_has_many(test: &mut Test) -> Result<()
         .invoice(
             Invoice::create()
                 .code("INV-001")
-                .line_item(LineItem::create().description("Widget"))
-                .line_item(LineItem::create().description("Gadget")),
+                .line_items([LineItem::create().description("Widget")])
+                .line_items([LineItem::create().description("Gadget")]),
         )
         .exec(&mut db)
         .await?;
@@ -1712,8 +1702,8 @@ pub async fn nested_belongs_to_required_then_has_many(test: &mut Test) -> Result
 
     let post = Post::create()
         .title("Hello")
-        .tag(Tag::create().label("rust"))
-        .tag(Tag::create().label("orm"))
+        .tags([Tag::create().label("rust")])
+        .tags([Tag::create().label("orm")])
         .exec(&mut db)
         .await?;
 
@@ -1802,7 +1792,7 @@ pub async fn nested_belongs_to_required_then_has_one_optional(test: &mut Test) -
     let user = User::create()
         .name("Alice")
         .profile(Profile::create().bio("developer"))
-        .todo(Todo::create().title("Task 1"))
+        .todos([Todo::create().title("Task 1")])
         .exec(&mut db)
         .await?;
 
@@ -1820,7 +1810,7 @@ pub async fn nested_belongs_to_required_then_has_one_optional(test: &mut Test) -
     // User without profile
     let user2 = User::create()
         .name("Bob")
-        .todo(Todo::create().title("Task 2"))
+        .todos([Todo::create().title("Task 2")])
         .exec(&mut db)
         .await?;
 
@@ -1893,11 +1883,9 @@ pub async fn nested_belongs_to_required_then_belongs_to_required(test: &mut Test
 
     let user = User::create()
         .name("Alice")
-        .todo(
-            Todo::create()
-                .title("T1")
-                .step(Step::create().description("S1")),
-        )
+        .todos([Todo::create()
+            .title("T1")
+            .steps([Step::create().description("S1")])])
         .exec(&mut db)
         .await?;
 
@@ -1969,8 +1957,8 @@ pub async fn nested_belongs_to_optional_then_has_many(test: &mut Test) -> Result
 
     let project = Project::create()
         .name("Proj1")
-        .member(Member::create().name("Alice"))
-        .member(Member::create().name("Bob"))
+        .members([Member::create().name("Alice")])
+        .members([Member::create().name("Bob")])
         .exec(&mut db)
         .await?;
 
@@ -2164,7 +2152,7 @@ pub async fn nested_belongs_to_required_then_has_one_required(test: &mut Test) -
     let user = User::create()
         .name("Alice")
         .config(Config::create().theme("dark"))
-        .todo(Todo::create().title("Task"))
+        .todos([Todo::create().title("Task")])
         .exec(&mut db)
         .await?;
 
@@ -2238,12 +2226,10 @@ pub async fn nested_has_many_then_has_many_with_empty_leaves(test: &mut Test) {
 
     let user = User::create()
         .name("Alice")
-        .todo(
-            Todo::create()
-                .title("With Steps")
-                .step(Step::create().description("S1")),
-        )
-        .todo(Todo::create().title("No Steps")) // empty nested
+        .todos([Todo::create()
+            .title("With Steps")
+            .steps([Step::create().description("S1")])])
+        .todos([Todo::create().title("No Steps")]) // empty nested
         .exec(&mut db)
         .await
         .unwrap();

--- a/crates/toasty-driver-integration-suite/src/tests/tx_atomic_stmt.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/tx_atomic_stmt.rs
@@ -13,7 +13,7 @@ pub async fn multi_op_create_wraps_in_transaction(t: &mut Test) -> Result<()> {
     t.log().clear();
     let user = User::create()
         .name("Alice")
-        .todo(Todo::create().title("task"))
+        .todos([Todo::create().title("task")])
         .exec(&mut db)
         .await?;
 
@@ -98,14 +98,14 @@ pub async fn create_with_has_many_rolls_back_on_failure(t: &mut Test) -> Result<
 
     // Seed the title that will cause the second INSERT to fail.
     User::create()
-        .todo(Todo::create().title("taken"))
+        .todos([Todo::create().title("taken")])
         .exec(&mut db)
         .await?;
 
     t.log().clear();
     assert_err!(
         User::create()
-            .todo(Todo::create().title("taken"))
+            .todos([Todo::create().title("taken")])
             .exec(&mut db)
             .await
     );
@@ -316,7 +316,7 @@ pub async fn rmw_uses_savepoints(t: &mut Test) -> Result<()> {
 
     let mut db = t.setup_db(models!(User, Todo)).await;
 
-    let user = User::create().todo(Todo::create()).exec(&mut db).await?;
+    let user = User::create().todos([Todo::create()]).exec(&mut db).await?;
     let todos: Vec<_> = user.todos().exec(&mut db).await?;
 
     t.log().clear();
@@ -378,7 +378,7 @@ pub async fn rmw_condition_failure_issues_rollback_to_savepoint(t: &mut Test) ->
     let mut db = t.setup_db(models!(User, Todo)).await;
 
     let user1 = User::create().exec(&mut db).await?;
-    let user2 = User::create().todo(Todo::create()).exec(&mut db).await?;
+    let user2 = User::create().todos([Todo::create()]).exec(&mut db).await?;
     let u2_todos: Vec<_> = user2.todos().exec(&mut db).await?;
 
     t.log().clear();

--- a/crates/toasty-driver-integration-suite/src/tests/tx_interactive.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/tx_interactive.rs
@@ -434,7 +434,7 @@ pub async fn multi_op_inside_tx_uses_savepoints(t: &mut Test) -> Result<()> {
     let mut tx = db.transaction().await?;
     let user = User::create()
         .name("Alice")
-        .todo(Todo::create().title("task"))
+        .todos([Todo::create().title("task")])
         .exec(&mut tx)
         .await?;
     tx.commit().await?;

--- a/crates/toasty-macros/src/model/expand/create.rs
+++ b/crates/toasty-macros/src/model/expand/create.rs
@@ -158,17 +158,11 @@ impl Expand<'_> {
                         }
                     }
                     FieldTy::HasMany(rel) => {
-                        let singular = &rel.singular.ident;
                         let plural = name;
                         let ty = &rel.ty;
                         let target = quote!(<#ty as #toasty::RelationManyField>::Model);
 
                         quote! {
-                            #vis fn #singular(mut self, #singular: impl #toasty::IntoExpr<#target>) -> Self {
-                                self.stmt.insert(#index_tokenized, #singular.into_expr());
-                                self
-                            }
-
                             #vis fn #plural(mut self, #plural: impl #toasty::IntoExpr<#toasty::List<#target>>) -> Self {
                                 self.stmt.insert_all(#index_tokenized, #plural.into_expr());
                                 self


### PR DESCRIPTION
## Summary
- Removed singular has-many setters from macro-generated create builders
- Updated integration tests to use the plural list setters with one-element arrays where needed
- Confirmed `create!` already expands through plural nested field setters, so it did not need a codegen path change

## Testing
- `cargo fmt`
- `cargo check -p toasty-macros`
- `cargo test -p tests --no-run` and `cargo check -p toasty-driver-integration-suite` progressed into the integration suite but were interrupted by the environment before completing