### PR TITLE
feat: reject create() on multi-step relation scopes at compile time

### DIFF
--- a/crates/toasty-macros/src/create/expand.rs
+++ b/crates/toasty-macros/src/create/expand.rs
@@ -48,7 +48,7 @@ fn expand_scoped(expr: &syn::Expr, fields: &FieldSet) -> TokenStream {
 
     let scope_fields_call =
         quote_spanned! { span=> toasty::codegen_support::scope_fields(&__scope) };
-    let create_call = quote_spanned! { span=> __scope.create() };
+    let create_call = quote_spanned! { span=> toasty::codegen_support::create_in_scope(__scope) };
 
     let monomorphize_check = expand_monomorphize_check(&field_names);
 
@@ -57,7 +57,7 @@ fn expand_scoped(expr: &syn::Expr, fields: &FieldSet) -> TokenStream {
             let __scope = #expr;
 
             #monomorphize_check
-            fn __force_check<__S: toasty::codegen_support::ValidateCreate>(_: &__S) {
+            fn __force_check<__S: toasty::codegen_support::CreateScope>(_: &__S) {
                 let _ = __Check::<__S>::__ASSERT;
             }
             __force_check(&__scope);
@@ -178,10 +178,10 @@ fn field_name_strs(fields: &FieldSet) -> Vec<String> {
 /// `__check_create_fields` method instead, which has field-specific messages.
 fn expand_monomorphize_check(field_names: &[String]) -> TokenStream {
     quote! {
-        struct __Check<__S: toasty::codegen_support::ValidateCreate>(
+        struct __Check<__S: toasty::codegen_support::CreateScope>(
             std::marker::PhantomData<__S>,
         );
-        impl<__S: toasty::codegen_support::ValidateCreate> __Check<__S> {
+        impl<__S: toasty::codegen_support::CreateScope> __Check<__S> {
             const __ASSERT: () = toasty::codegen_support::assert_create_fields(
                 __S::CREATE_META,
                 &[ #( #field_names ),* ],

--- a/crates/toasty-macros/src/model/expand/create.rs
+++ b/crates/toasty-macros/src/model/expand/create.rs
@@ -158,30 +158,38 @@ impl Expand<'_> {
                         }
                     }
                     FieldTy::HasMany(rel) => {
-                        let singular = &rel.singular.ident;
-                        let plural = name;
-                        let ty = &rel.ty;
-                        let target = quote!(<#ty as #toasty::RelationManyField>::Model);
+                        if rel.via.is_some() {
+                            TokenStream::new()
+                        } else {
+                            let singular = &rel.singular.ident;
+                            let plural = name;
+                            let ty = &rel.ty;
+                            let target = quote!(<#ty as #toasty::RelationManyField>::Model);
 
-                        quote! {
-                            #vis fn #singular(mut self, #singular: impl #toasty::IntoExpr<#target>) -> Self {
-                                self.stmt.insert(#index_tokenized, #singular.into_expr());
-                                self
-                            }
+                            quote! {
+                                #vis fn #singular(mut self, #singular: impl #toasty::IntoExpr<#target>) -> Self {
+                                    self.stmt.insert(#index_tokenized, #singular.into_expr());
+                                    self
+                                }
 
-                            #vis fn #plural(mut self, #plural: impl #toasty::IntoExpr<#toasty::List<#target>>) -> Self {
-                                self.stmt.insert_all(#index_tokenized, #plural.into_expr());
-                                self
+                                #vis fn #plural(mut self, #plural: impl #toasty::IntoExpr<#toasty::List<#target>>) -> Self {
+                                    self.stmt.insert_all(#index_tokenized, #plural.into_expr());
+                                    self
+                                }
                             }
                         }
                     }
                     FieldTy::HasOne(rel) => {
-                        let ty = &rel.ty;
+                        if rel.via.is_some() {
+                            TokenStream::new()
+                        } else {
+                            let ty = &rel.ty;
 
-                        quote! {
-                            #vis fn #name(mut self, #name: impl #toasty::IntoExpr<<#ty as #toasty::RelationOneField>::Expr>) -> Self {
-                                self.stmt.set(#index_tokenized, #name.into_expr());
-                                self
+                            quote! {
+                                #vis fn #name(mut self, #name: impl #toasty::IntoExpr<<#ty as #toasty::RelationOneField>::Expr>) -> Self {
+                                    self.stmt.set(#index_tokenized, #name.into_expr());
+                                    self
+                                }
                             }
                         }
                     }

--- a/crates/toasty-macros/src/model/expand/model.rs
+++ b/crates/toasty-macros/src/model/expand/model.rs
@@ -134,11 +134,14 @@ impl Expand<'_> {
                 type UpdateQuery = #update_struct_ident;
                 type Path<__Origin> = #field_struct_ident<__Origin>;
                 type PrimaryKey = #primary_key_ty;
-                type Many = Many;
+                type Many = Many<#toasty::Direct>;
+                type ViaMany = Many<#toasty::Via>;
                 type ManyField<__Origin> = #field_list_struct_ident<__Origin>;
-                type One = One;
+                type One = One<#toasty::Direct>;
+                type ViaOne = One<#toasty::Via>;
                 type OneField<__Origin> = #field_struct_ident<__Origin>;
-                type OptionOne = OptionOne;
+                type OptionOne = OptionOne<#toasty::Direct>;
+                type ViaOptionOne = OptionOne<#toasty::Via>;
 
                 const CREATE_META: #toasty::CreateMeta = #toasty::CreateMeta {
                     fields: &[ #create_meta_fields ],

--- a/crates/toasty-macros/src/model/expand/relation.rs
+++ b/crates/toasty-macros/src/model/expand/relation.rs
@@ -28,21 +28,27 @@ impl Expand<'_> {
         let chain_methods = self.expand_many_chain_methods();
 
         quote! {
-            #vis struct Many {
+            #vis struct Many<Kind = #toasty::Direct> {
                 stmt: #toasty::stmt::Association<#toasty::List<#model_ident>>,
+                _kind: std::marker::PhantomData<Kind>,
             }
 
-            #vis struct One {
+            #vis struct One<Kind = #toasty::Direct> {
                 stmt: #toasty::stmt::Query<#model_ident>,
+                _kind: std::marker::PhantomData<Kind>,
             }
 
-            #vis struct OptionOne {
+            #vis struct OptionOne<Kind = #toasty::Direct> {
                 stmt: #toasty::stmt::Query<#toasty::Option<#model_ident>>,
+                _kind: std::marker::PhantomData<Kind>,
             }
 
-            impl Many {
-                pub fn from_stmt(stmt: #toasty::stmt::Association<#toasty::List<#model_ident>>) -> Many {
-                    Many { stmt }
+            impl<Kind> Many<Kind> {
+                pub fn from_stmt(stmt: #toasty::stmt::Association<#toasty::List<#model_ident>>) -> Many<Kind> {
+                    Many {
+                        stmt,
+                        _kind: std::marker::PhantomData,
+                    }
                 }
 
                 #filter_methods
@@ -64,12 +70,15 @@ impl Expand<'_> {
                     #query_ident::from_stmt(select.and(filter))
                 }
 
-                #vis fn create(self) -> #create_builder_ident {
-                    let mut builder = #create_builder_ident::default();
-                    builder.stmt.set_scope(self.stmt);
-                    builder
+                #vis fn create(self) -> <Self as #toasty::Scope>::Create
+                where
+                    Self: #toasty::CreateScope,
+                {
+                    <Self as #toasty::CreateScope>::create_in_scope(self)
                 }
+            }
 
+            impl Many<#toasty::Direct> {
                 /// Add an item to the association
                 #vis async fn insert(self, executor: &mut dyn #toasty::Executor, item: impl #toasty::IntoExpr<#model_ident>) -> #toasty::Result<()> {
                     executor.exec(self.stmt.insert(item)).await
@@ -81,7 +90,7 @@ impl Expand<'_> {
                 }
             }
 
-            impl #toasty::IntoStatement for Many {
+            impl<Kind> #toasty::IntoStatement for Many<Kind> {
                 type Returning = #toasty::List<#model_ident>;
 
                 fn into_statement(self) -> #toasty::Statement<#toasty::List<#model_ident>> {
@@ -90,24 +99,28 @@ impl Expand<'_> {
                 }
             }
 
-            impl One {
-                #vis fn from_stmt(stmt: #toasty::stmt::Query<#toasty::List<#model_ident>>) -> One {
-                    One { stmt: stmt.one() }
-                }
-
-                /// Create a new associated record
-                #vis fn create(self) -> #create_builder_ident {
-                    let mut builder = #create_builder_ident::default();
-                    builder.stmt.set_scope(self.stmt);
-                    builder
+            impl<Kind> One<Kind> {
+                #vis fn from_stmt(stmt: #toasty::stmt::Query<#toasty::List<#model_ident>>) -> One<Kind> {
+                    One {
+                        stmt: stmt.one(),
+                        _kind: std::marker::PhantomData,
+                    }
                 }
 
                 #vis async fn exec(self, executor: &mut dyn #toasty::Executor) -> #toasty::Result<#model_ident> {
                     self.stmt.exec(executor).await
                 }
+
+                /// Create a new associated record.
+                #vis fn create(self) -> <Self as #toasty::Scope>::Create
+                where
+                    Self: #toasty::CreateScope,
+                {
+                    <Self as #toasty::CreateScope>::create_in_scope(self)
+                }
             }
 
-            impl #toasty::IntoStatement for One {
+            impl<Kind> #toasty::IntoStatement for One<Kind> {
                 type Returning = #model_ident;
 
                 fn into_statement(self) -> #toasty::Statement<#model_ident> {
@@ -116,25 +129,29 @@ impl Expand<'_> {
                 }
             }
 
-            impl OptionOne {
-                pub fn from_stmt(stmt: #toasty::stmt::Query<#toasty::List<#model_ident>>) -> OptionOne {
-                    OptionOne { stmt: stmt.first() }
-                }
-
-                /// Create a new associated record
-                #vis fn create(self) -> #create_builder_ident {
-                    let mut builder = #create_builder_ident::default();
-                    builder.stmt.set_scope(self.stmt);
-                    builder
+            impl<Kind> OptionOne<Kind> {
+                pub fn from_stmt(stmt: #toasty::stmt::Query<#toasty::List<#model_ident>>) -> OptionOne<Kind> {
+                    OptionOne {
+                        stmt: stmt.first(),
+                        _kind: std::marker::PhantomData,
+                    }
                 }
 
                 #vis async fn exec(self, executor: &mut dyn #toasty::Executor) -> #toasty::Result<#toasty::Option<#model_ident>> {
                     self.stmt.exec(executor).await
                 }
+
+                /// Create a new associated record.
+                #vis fn create(self) -> <Self as #toasty::Scope>::Create
+                where
+                    Self: #toasty::CreateScope,
+                {
+                    <Self as #toasty::CreateScope>::create_in_scope(self)
+                }
             }
 
             #[diagnostic::do_not_recommend]
-            impl #toasty::Scope for Many {
+            impl<Kind> #toasty::Scope for Many<Kind> {
                 type Item = #toasty::List<#model_ident>;
                 type Path<__Origin> = #field_list_struct_ident<__Origin>;
                 type Create = #create_builder_ident;
@@ -153,7 +170,7 @@ impl Expand<'_> {
             }
 
             #[diagnostic::do_not_recommend]
-            impl #toasty::Scope for One {
+            impl<Kind> #toasty::Scope for One<Kind> {
                 type Item = #model_ident;
                 type Path<__Origin> = #field_struct_ident<__Origin>;
                 type Create = #create_builder_ident;
@@ -172,7 +189,7 @@ impl Expand<'_> {
             }
 
             #[diagnostic::do_not_recommend]
-            impl #toasty::Scope for OptionOne {
+            impl<Kind> #toasty::Scope for OptionOne<Kind> {
                 type Item = #model_ident;
                 type Path<__Origin> = #field_struct_ident<__Origin>;
                 type Create = #create_builder_ident;
@@ -191,31 +208,59 @@ impl Expand<'_> {
             }
 
             #[diagnostic::do_not_recommend]
-            impl #toasty::ValidateCreate for Many {
+            impl<Kind> #toasty::ValidateCreate for Many<Kind> {
                 const CREATE_META: &'static #toasty::CreateMeta =
                     &<#model_ident as #toasty::Model>::CREATE_META;
             }
 
             #[diagnostic::do_not_recommend]
-            impl #toasty::ValidateCreate for One {
+            impl #toasty::CreateScope for Many<#toasty::Direct> {
+                fn create_in_scope(self) -> <Self as #toasty::Scope>::Create {
+                    let mut builder = #create_builder_ident::default();
+                    builder.stmt.set_scope(self.stmt);
+                    builder
+                }
+            }
+
+            #[diagnostic::do_not_recommend]
+            impl<Kind> #toasty::ValidateCreate for One<Kind> {
                 const CREATE_META: &'static #toasty::CreateMeta =
                     &<#model_ident as #toasty::Model>::CREATE_META;
             }
 
             #[diagnostic::do_not_recommend]
-            impl #toasty::ValidateCreate for OptionOne {
+            impl #toasty::CreateScope for One<#toasty::Direct> {
+                fn create_in_scope(self) -> <Self as #toasty::Scope>::Create {
+                    let mut builder = #create_builder_ident::default();
+                    builder.stmt.set_scope(self.stmt);
+                    builder
+                }
+            }
+
+            #[diagnostic::do_not_recommend]
+            impl<Kind> #toasty::ValidateCreate for OptionOne<Kind> {
                 const CREATE_META: &'static #toasty::CreateMeta =
                     &<#model_ident as #toasty::Model>::CREATE_META;
+            }
+
+            #[diagnostic::do_not_recommend]
+            impl #toasty::CreateScope for OptionOne<#toasty::Direct> {
+                fn create_in_scope(self) -> <Self as #toasty::Scope>::Create {
+                    let mut builder = #create_builder_ident::default();
+                    builder.stmt.set_scope(self.stmt);
+                    builder
+                }
             }
         }
     }
 
     /// For each relation field on this model, emit a method on `Many` that
-    /// chains the field as the next path step and returns the target's `Many`.
+    /// chains the field as the next path step and returns the target's
+    /// `ViaMany`.
     /// This is the runtime analog of [`expand_list_relation_field_method`] on
     /// the field-list builder — a list-context traversal always yields a list,
     /// so all relation kinds (HasMany / HasOne / BelongsTo) flatten to the
-    /// target's `Many`.
+    /// target's `ViaMany`.
     pub(super) fn expand_many_chain_methods(&self) -> TokenStream {
         let toasty = &self.toasty;
         let vis = &self.model.vis;
@@ -234,8 +279,8 @@ impl Expand<'_> {
                 let field_offset = util::int(field.id);
 
                 Some(quote! {
-                    #vis fn #field_ident(self) -> <<#ty as #field_trait>::Model as #toasty::Model>::Many {
-                        <<<#ty as #field_trait>::Model as #toasty::Model>::Many>::from_stmt(
+                    #vis fn #field_ident(self) -> <<#ty as #field_trait>::Model as #toasty::Model>::ViaMany {
+                        <<<#ty as #field_trait>::Model as #toasty::Model>::ViaMany>::from_stmt(
                             self.stmt.chain_field(#field_offset)
                         )
                     }
@@ -341,6 +386,11 @@ impl Expand<'_> {
         let field_ident = &field.name.ident;
         let ty = &rel.ty;
         let target = quote!(<#ty as #toasty::RelationManyField>::Model);
+        let relation_scope = if rel.via.is_some() {
+            quote!(ViaMany)
+        } else {
+            quote!(Many)
+        };
 
         // A `via` relation reaches its target through a path of existing
         // relations; it has no paired `BelongsTo`, so skip the back-reference
@@ -364,7 +414,7 @@ impl Expand<'_> {
         };
 
         quote! {
-            #vis fn #field_ident(&self) -> <#target as #toasty::Model>::Many {
+            #vis fn #field_ident(&self) -> <#target as #toasty::Model>::#relation_scope {
                 // Suppress the unused field warning
                 if false {
                     let _ = &self.#field_ident;
@@ -374,7 +424,7 @@ impl Expand<'_> {
 
                 {
                     use #toasty::IntoStatement;
-                    <<#target as #toasty::Model>::Many>::from_stmt(
+                    <<#target as #toasty::Model>::#relation_scope>::from_stmt(
                         #toasty::stmt::Association::many(
                             self.into_statement().into_query().unwrap().to_list(),
                             Self::fields().#field_ident().into()
@@ -390,6 +440,11 @@ impl Expand<'_> {
         let vis = &self.model.vis;
         let field_ident = &field.name.ident;
         let ty = &rel.ty;
+        let relation_scope = if rel.via.is_some() {
+            quote!(ViaOne)
+        } else {
+            quote!(One)
+        };
 
         // A `via` relation reaches its target through a path of existing
         // relations; it has no paired `BelongsTo`, so skip the back-reference
@@ -413,7 +468,7 @@ impl Expand<'_> {
         };
 
         quote! {
-            #vis fn #field_ident(&self) -> <#ty as #toasty::RelationOneField>::One {
+            #vis fn #field_ident(&self) -> <#ty as #toasty::RelationOneField>::#relation_scope {
                 // Suppress the unused field warning
                 if false {
                     let _ = &self.#field_ident;
@@ -423,7 +478,7 @@ impl Expand<'_> {
 
                 {
                     use #toasty::IntoStatement;
-                    <<#ty as #toasty::RelationOneField>::One>::from_stmt(
+                    <<#ty as #toasty::RelationOneField>::#relation_scope>::from_stmt(
                         #toasty::stmt::Association::one(
                             self.into_statement().into_query().unwrap().to_list(),
                             Self::fields().#field_ident().into()

--- a/crates/toasty-macros/src/model/expand/update.rs
+++ b/crates/toasty-macros/src/model/expand/update.rs
@@ -66,35 +66,51 @@ impl Expand<'_> {
                 }
             }
             FieldTy::HasMany(rel) => {
-                let ty = &rel.ty;
-                let target = quote!(<#ty as #toasty::RelationManyField>::Model);
+                if rel.via.is_some() {
+                    // Relation setters mutate membership through `Assign`
+                    // (set/insert/remove/apply). A via field has no direct
+                    // pair FK, and `Assignment` does not preserve enough type
+                    // information to reject only insert/create while accepting
+                    // narrower operations like remove.
+                    TokenStream::new()
+                } else {
+                    let ty = &rel.ty;
+                    let target = quote!(<#ty as #toasty::RelationManyField>::Model);
 
-                quote! {
-                    #vis fn #field_ident(mut self, #field_ident: impl #toasty::Assign<#toasty::List<#target>>) -> Self {
-                        self.#set_field_ident(#field_ident);
-                        self
-                    }
+                    quote! {
+                        #vis fn #field_ident(mut self, #field_ident: impl #toasty::Assign<#toasty::List<#target>>) -> Self {
+                            self.#set_field_ident(#field_ident);
+                            self
+                        }
 
-                    #vis fn #set_field_ident(&mut self, #field_ident: impl #toasty::Assign<#toasty::List<#target>>) -> &mut Self {
-                        let projection = #projection;
-                        #field_ident.assign(&mut self.assignments, projection);
-                        self
+                        #vis fn #set_field_ident(&mut self, #field_ident: impl #toasty::Assign<#toasty::List<#target>>) -> &mut Self {
+                            let projection = #projection;
+                            #field_ident.assign(&mut self.assignments, projection);
+                            self
+                        }
                     }
                 }
             }
             FieldTy::HasOne(rel) => {
-                let ty = &rel.ty;
+                if rel.via.is_some() {
+                    // See the has-many via case above. Any has-one membership
+                    // assignment would require choosing or creating an
+                    // intermediate record, which this setter cannot express.
+                    TokenStream::new()
+                } else {
+                    let ty = &rel.ty;
 
-                quote! {
-                    #vis fn #field_ident(mut self, #field_ident: impl #toasty::Assign<<#ty as #toasty::RelationOneField>::Expr>) -> Self {
-                        self.#set_field_ident(#field_ident);
-                        self
-                    }
+                    quote! {
+                        #vis fn #field_ident(mut self, #field_ident: impl #toasty::Assign<<#ty as #toasty::RelationOneField>::Expr>) -> Self {
+                            self.#set_field_ident(#field_ident);
+                            self
+                        }
 
-                    #vis fn #set_field_ident(&mut self, #field_ident: impl #toasty::Assign<<#ty as #toasty::RelationOneField>::Expr>) -> &mut Self {
-                        let projection = #projection;
-                        #field_ident.assign(&mut self.assignments, projection);
-                        self
+                        #vis fn #set_field_ident(&mut self, #field_ident: impl #toasty::Assign<<#ty as #toasty::RelationOneField>::Expr>) -> &mut Self {
+                            let projection = #projection;
+                            #field_ident.assign(&mut self.assignments, projection);
+                            self
+                        }
                     }
                 }
             }

--- a/crates/toasty/src/codegen_support.rs
+++ b/crates/toasty/src/codegen_support.rs
@@ -14,8 +14,9 @@ pub use crate::{
     Db, Error, Executor, Result, Statement,
     schema::create_meta::{assert_create_fields, const_contains},
     schema::{
-        Auto, CreateField, CreateMeta, Deferred, DiscoverItem, Embed, Field, Load, Model, Register,
-        RelationManyField, RelationOneField, Scope, ValidateCreate, generate_unique_id,
+        Auto, CreateField, CreateMeta, CreateScope, Deferred, Direct, DiscoverItem, Embed, Field,
+        Load, Model, Register, RelationManyField, RelationOneField, Scope, ValidateCreate, Via,
+        generate_unique_id,
     },
     stmt::CreateMany,
     stmt::{self, Assign, IntoExpr, IntoInsert, IntoStatement, List, Path},
@@ -41,8 +42,13 @@ pub type FieldExprTarget<F> = <F as Field>::ExprTarget;
 /// obtain the field struct for nested builders. Because the macro has no
 /// type information, it cannot call `S::new_path_root()` directly — this function
 /// lets Rust infer `S` from the scope argument.
-pub fn scope_fields<S: Scope>(_scope: &S) -> S::Path<S::Item> {
+pub fn scope_fields<S: CreateScope>(_scope: &S) -> S::Path<S::Item> {
     S::new_path_root()
+}
+
+/// Create a record inside a scoped create target.
+pub fn create_in_scope<S: CreateScope>(scope: S) -> S::Create {
+    S::create_in_scope(scope)
 }
 
 /// Convert a value into an untyped [`core::stmt::Expr`] via the typed

--- a/crates/toasty/src/schema.rs
+++ b/crates/toasty/src/schema.rs
@@ -36,12 +36,12 @@ pub use register::{DiscoverItem, Register, generate_unique_id};
 mod num;
 
 mod relation;
-pub use relation::{RelationManyField, RelationOneField};
+pub use relation::{Direct, RelationManyField, RelationOneField, Via};
 
 mod relation_one;
 
 mod scope;
-pub use scope::Scope;
+pub use scope::{CreateScope, Scope};
 
 use crate::Result;
 

--- a/crates/toasty/src/schema/create_meta.rs
+++ b/crates/toasty/src/schema/create_meta.rs
@@ -20,6 +20,11 @@ pub struct CreateField {
 /// Implemented on fields structs and relation scope types so that
 /// the `create!` macro can validate field sets through monomorphization.
 #[doc(hidden)]
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` does not carry Toasty create-field metadata",
+    label = "this type cannot be validated as a create target",
+    note = "Only Toasty model field paths and direct relation create scopes carry create-field metadata."
+)]
 pub trait ValidateCreate {
     const CREATE_META: &'static CreateMeta;
 }

--- a/crates/toasty/src/schema/model.rs
+++ b/crates/toasty/src/schema/model.rs
@@ -42,12 +42,18 @@ pub trait Model: Register + Load<Output = Self> + Sized {
     /// The has-many relation wrapper type for this model.
     type Many;
 
+    /// The has-many relation wrapper type for multi-step scopes.
+    type ViaMany;
+
     /// The field accessor type used when this model appears as the "many" side
     /// of a has-many relation, parameterized by the origin model.
     type ManyField<Origin>;
 
     /// The has-one relation wrapper type for this model (non-nullable).
     type One;
+
+    /// The has-one relation wrapper type for multi-step scopes (non-nullable).
+    type ViaOne;
 
     /// The field accessor type used when this model appears as the "one" side
     /// of a has-one relation, parameterized by the origin model.
@@ -56,6 +62,9 @@ pub trait Model: Register + Load<Output = Self> + Sized {
     /// The optional has-one relation wrapper type, used when the foreign key
     /// is nullable so the association is optional.
     type OptionOne;
+
+    /// The optional has-one relation wrapper type for multi-step scopes.
+    type ViaOptionOne;
 
     /// Metadata about the model's fields for compile-time validation of
     /// `create!` invocations.

--- a/crates/toasty/src/schema/relation.rs
+++ b/crates/toasty/src/schema/relation.rs
@@ -4,6 +4,19 @@ use toasty_core::schema::Name;
 use toasty_core::schema::app::{FieldId, FieldTy, ForeignKey};
 use toasty_core::stmt;
 
+/// Marker for a direct relation scope.
+///
+/// Direct relation scopes can create new records because Toasty can populate
+/// the target foreign key from the source record.
+pub enum Direct {}
+
+/// Marker for a multi-step relation scope.
+///
+/// Via relation scopes are queryable, but do not expose relation-scoped
+/// creation because creating the target would require materializing one or
+/// more intermediate records.
+pub enum Via {}
+
 /// A Rust field type that represents a `#[has_many]` relation.
 ///
 /// Implemented by [`Vec<M>`](Vec) (eager) and
@@ -57,6 +70,11 @@ pub trait RelationOneField: Load<Output = Self> {
     /// to [`Model::One`] for non-nullable impls and [`Model::OptionOne`] for
     /// nullable impls.
     type One;
+
+    /// The multi-step "one-side" accessor type produced by `via` relation
+    /// accessors. Resolves to [`Model::ViaOne`] for non-nullable impls and
+    /// [`Model::ViaOptionOne`] for nullable impls.
+    type ViaOne;
 
     /// The expression-level type used in create/update setters. Resolves to
     /// the unwrapped `Self::Model` for non-nullable impls and `Option<Self::Model>`

--- a/crates/toasty/src/schema/relation_one.rs
+++ b/crates/toasty/src/schema/relation_one.rs
@@ -7,6 +7,7 @@ use toasty_core::stmt;
 impl<M: Model> RelationOneField for M {
     type Model = M;
     type One = M::One;
+    type ViaOne = M::ViaOne;
     type Expr = M;
 
     const DEFERRED: bool = false;
@@ -28,6 +29,7 @@ impl<M: Model> RelationOneField for M {
 impl<M: Model> RelationOneField for Option<M> {
     type Model = M;
     type One = M::OptionOne;
+    type ViaOne = M::ViaOptionOne;
     type Expr = Option<M>;
 
     const DEFERRED: bool = false;
@@ -49,6 +51,7 @@ impl<M: Model> RelationOneField for Option<M> {
 impl<M: Model> RelationOneField for Deferred<M> {
     type Model = M;
     type One = M::One;
+    type ViaOne = M::ViaOne;
     type Expr = M;
 
     const DEFERRED: bool = true;
@@ -71,6 +74,7 @@ impl<M: Model> RelationOneField for Deferred<M> {
 impl<M: Model> RelationOneField for Deferred<Option<M>> {
     type Model = M;
     type One = M::OptionOne;
+    type ViaOne = M::ViaOptionOne;
     type Expr = Option<M>;
 
     const DEFERRED: bool = true;

--- a/crates/toasty/src/schema/scope.rs
+++ b/crates/toasty/src/schema/scope.rs
@@ -1,10 +1,16 @@
-use crate::stmt::Path;
+use crate::{schema::ValidateCreate, stmt::Path};
 
 /// A scope represents a context that contains items of a particular type.
 ///
 /// Generated relation query types are scopes whose items are instances of the
 /// target model. The trait provides associated types for building typed paths
 /// and create builders within the scope.
+#[diagnostic::on_unimplemented(
+    message = "this expression cannot be used as a Toasty create scope",
+    label = "this expression does not support scoped creation",
+    note = "Only direct relation scopes support scoped creation.",
+    note = "Multi-step (`via`) relation scopes can be queried and filtered, but Toasty cannot create records through them because that would require creating or choosing intermediate records."
+)]
 pub trait Scope {
     /// The item type contained in this scope.
     type Item;
@@ -26,4 +32,21 @@ pub trait Scope {
     /// This is used by the `create!` macro to obtain field accessors for
     /// nested builders without needing to know the concrete model type.
     fn new_path_root() -> Self::Path<Self::Item>;
+}
+
+/// A scope that supports creating records inside the scope.
+///
+/// This is intentionally narrower than [`Scope`]. A multi-step (`via`) relation
+/// has field accessors and can be queried, but it cannot safely create records
+/// because there is no direct foreign key for Toasty to populate.
+#[doc(hidden)]
+#[diagnostic::on_unimplemented(
+    message = "this scope does not support scoped creation",
+    label = "this relation scope cannot create records",
+    note = "Only direct relation scopes support scoped creation.",
+    note = "Multi-step (`via`) relation scopes can be queried and filtered, but Toasty cannot create records through them because that would require creating or choosing intermediate records."
+)]
+pub trait CreateScope: Scope + ValidateCreate {
+    /// Create a record inside this scope.
+    fn create_in_scope(self) -> Self::Create;
 }

--- a/crates/toasty/tests/relation_load.rs
+++ b/crates/toasty/tests/relation_load.rs
@@ -54,10 +54,13 @@ impl Model for Dummy {
     type Path<Origin> = Path<Origin, Self>;
     type PrimaryKey = i64;
     type Many = ();
+    type ViaMany = ();
     type ManyField<Origin> = ();
     type One = ();
+    type ViaOne = ();
     type OneField<Origin> = ();
     type OptionOne = ();
+    type ViaOptionOne = ();
 
     const CREATE_META: CreateMeta = CreateMeta {
         fields: &[],

--- a/tests/tests/ui/create_scoped_not_scope.stderr
+++ b/tests/tests/ui/create_scoped_not_scope.stderr
@@ -1,30 +1,15 @@
-error[E0277]: the trait bound `i64: toasty::schema::ValidateCreate` is not satisfied
+error[E0277]: this scope does not support scoped creation
   --> tests/ui/create_scoped_not_scope.rs:11:13
    |
 11 |     let _ = toasty::create!(in 42_i64 { name: "Carl" });
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `toasty::schema::ValidateCreate` is not implemented for `i64`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this relation scope cannot create records
    |
+   = help: the trait `toasty::schema::CreateScope` is not implemented for `i64`
+   = note: Only direct relation scopes support scoped creation.
+   = note: Multi-step (`via`) relation scopes can be queried and filtered, but Toasty cannot create records through them because that would require creating or choosing intermediate records.
 note: required by a bound in `__force_check`
   --> tests/ui/create_scoped_not_scope.rs:11:13
    |
 11 |     let _ = toasty::create!(in 42_i64 { name: "Carl" });
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `__force_check`
    = note: this error originates in the macro `toasty::create` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the trait bound `i64: toasty::schema::Scope` is not satisfied
-  --> tests/ui/create_scoped_not_scope.rs:11:32
-   |
-11 |     let _ = toasty::create!(in 42_i64 { name: "Carl" });
-   |                                ^^^^^^ the trait `toasty::schema::Scope` is not implemented for `i64`
-   |
-note: required by a bound in `toasty::codegen_support::scope_fields`
-  --> $WORKSPACE/crates/toasty/src/codegen_support.rs
-   |
-   | pub fn scope_fields<S: Scope>(_scope: &S) -> S::Path<S::Item> {
-   |                        ^^^^^ required by this bound in `scope_fields`
-
-error[E0599]: no method named `create` found for type `i64` in the current scope
-  --> tests/ui/create_scoped_not_scope.rs:11:32
-   |
-11 |     let _ = toasty::create!(in 42_i64 { name: "Carl" });
-   |                                ^^^^^^ method not found in `i64`

--- a/tests/tests/ui/create_via_relation_field.rs
+++ b/tests/tests/ui/create_via_relation_field.rs
@@ -1,0 +1,48 @@
+#[derive(Debug, toasty::Model)]
+struct User {
+    #[key]
+    id: i64,
+
+    name: String,
+
+    #[has_many]
+    todos: toasty::Deferred<Vec<Todo>>,
+
+    #[has_many(via = todos.tags)]
+    tags: toasty::Deferred<Vec<Tag>>,
+}
+
+#[derive(Debug, toasty::Model)]
+struct Todo {
+    #[key]
+    id: i64,
+
+    user_id: i64,
+
+    #[belongs_to(key = user_id, references = id)]
+    user: toasty::Deferred<User>,
+
+    #[has_many]
+    tags: toasty::Deferred<Vec<Tag>>,
+}
+
+#[derive(Debug, toasty::Model)]
+struct Tag {
+    #[key]
+    id: i64,
+
+    todo_id: i64,
+
+    #[belongs_to(key = todo_id, references = id)]
+    todo: toasty::Deferred<Todo>,
+
+    name: String,
+}
+
+fn main() {
+    let _ = toasty::create!(User {
+        id: 1,
+        name: "Alice",
+        tags: [{ id: 1, name: "urgent" }],
+    });
+}

--- a/tests/tests/ui/create_via_relation_field.stderr
+++ b/tests/tests/ui/create_via_relation_field.stderr
@@ -1,0 +1,14 @@
+error[E0599]: no method named `tags` found for struct `UserCreate` in the current scope
+  --> tests/ui/create_via_relation_field.rs:46:9
+   |
+ 2 |   struct User {
+   |          ---- method `tags` not found for this struct
+...
+43 |       let _ = toasty::create!(User {
+   |  _____________________________-
+44 | |         id: 1,
+45 | |         name: "Alice",
+46 | |         tags: [{ id: 1, name: "urgent" }],
+   | |        -^^^^ method not found in `UserCreate`
+   | |________|
+   |

--- a/tests/tests/ui/create_via_scoped_macro.rs
+++ b/tests/tests/ui/create_via_scoped_macro.rs
@@ -1,0 +1,48 @@
+#[derive(Debug, toasty::Model)]
+struct User {
+    #[key]
+    id: i64,
+
+    #[has_many]
+    todos: toasty::Deferred<Vec<Todo>>,
+
+    #[has_many(via = todos.tags)]
+    tags: toasty::Deferred<Vec<Tag>>,
+}
+
+#[derive(Debug, toasty::Model)]
+struct Todo {
+    #[key]
+    id: i64,
+
+    user_id: i64,
+
+    #[belongs_to(key = user_id, references = id)]
+    user: toasty::Deferred<User>,
+
+    #[has_many]
+    tags: toasty::Deferred<Vec<Tag>>,
+}
+
+#[derive(Debug, toasty::Model)]
+struct Tag {
+    #[key]
+    id: i64,
+
+    todo_id: i64,
+
+    #[belongs_to(key = todo_id, references = id)]
+    todo: toasty::Deferred<Todo>,
+
+    name: String,
+}
+
+fn main() {
+    let user = User {
+        id: 1,
+        todos: Default::default(),
+        tags: Default::default(),
+    };
+
+    let _ = toasty::create!(in user.tags() { id: 1, name: "urgent" });
+}

--- a/tests/tests/ui/create_via_scoped_macro.stderr
+++ b/tests/tests/ui/create_via_scoped_macro.stderr
@@ -1,0 +1,19 @@
+error[E0277]: this scope does not support scoped creation
+  --> tests/ui/create_via_scoped_macro.rs:47:13
+   |
+47 |     let _ = toasty::create!(in user.tags() { id: 1, name: "urgent" });
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this relation scope cannot create records
+   |
+help: the trait `toasty::schema::CreateScope` is not implemented for `_::Many<toasty::schema::Via>`
+  --> tests/ui/create_via_scoped_macro.rs:27:17
+   |
+27 | #[derive(Debug, toasty::Model)]
+   |                 ^^^^^^^^^^^^^
+   = note: Only direct relation scopes support scoped creation.
+   = note: Multi-step (`via`) relation scopes can be queried and filtered, but Toasty cannot create records through them because that would require creating or choosing intermediate records.
+note: required by a bound in `__force_check`
+  --> tests/ui/create_via_scoped_macro.rs:47:13
+   |
+47 |     let _ = toasty::create!(in user.tags() { id: 1, name: "urgent" });
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `__force_check`
+   = note: this error originates in the macro `toasty::create` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/tests/ui/relation_chain_create.rs
+++ b/tests/tests/ui/relation_chain_create.rs
@@ -1,0 +1,44 @@
+#[derive(Debug, toasty::Model)]
+struct User {
+    #[key]
+    id: i64,
+
+    #[has_many]
+    todos: toasty::Deferred<Vec<Todo>>,
+}
+
+#[derive(Debug, toasty::Model)]
+struct Todo {
+    #[key]
+    id: i64,
+
+    user_id: i64,
+
+    #[belongs_to(key = user_id, references = id)]
+    user: toasty::Deferred<User>,
+
+    #[has_many]
+    tags: toasty::Deferred<Vec<Tag>>,
+}
+
+#[derive(Debug, toasty::Model)]
+struct Tag {
+    #[key]
+    id: i64,
+
+    todo_id: i64,
+
+    #[belongs_to(key = todo_id, references = id)]
+    todo: toasty::Deferred<Todo>,
+
+    name: String,
+}
+
+fn main() {
+    let user = User {
+        id: 1,
+        todos: Default::default(),
+    };
+
+    let _ = user.todos().tags().create().name("urgent");
+}

--- a/tests/tests/ui/relation_chain_create.stderr
+++ b/tests/tests/ui/relation_chain_create.stderr
@@ -1,0 +1,19 @@
+error[E0277]: this scope does not support scoped creation
+  --> tests/ui/relation_chain_create.rs:43:33
+   |
+43 |     let _ = user.todos().tags().create().name("urgent");
+   |                                 ^^^^^^ this relation scope cannot create records
+   |
+help: the trait `toasty::schema::CreateScope` is not implemented for `_::Many<toasty::schema::Via>`
+  --> tests/ui/relation_chain_create.rs:24:17
+   |
+24 | #[derive(Debug, toasty::Model)]
+   |                 ^^^^^^^^^^^^^
+   = note: Only direct relation scopes support scoped creation.
+   = note: Multi-step (`via`) relation scopes can be queried and filtered, but Toasty cannot create records through them because that would require creating or choosing intermediate records.
+note: required by a bound in `_::Many::<Kind>::create`
+  --> tests/ui/relation_chain_create.rs:24:17
+   |
+24 | #[derive(Debug, toasty::Model)]
+   |                 ^^^^^^^^^^^^^ required by this bound in `Many::<Kind>::create`
+   = note: this error originates in the derive macro `toasty::Model` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/tests/ui/relation_via_one_scoped_create.rs
+++ b/tests/tests/ui/relation_via_one_scoped_create.rs
@@ -1,0 +1,48 @@
+#[derive(Debug, toasty::Model)]
+struct User {
+    #[key]
+    id: i64,
+
+    #[has_one]
+    account: toasty::Deferred<Option<Account>>,
+
+    #[has_one(via = account.subscription)]
+    subscription: toasty::Deferred<Option<Subscription>>,
+}
+
+#[derive(Debug, toasty::Model)]
+struct Account {
+    #[key]
+    id: i64,
+
+    user_id: Option<i64>,
+
+    #[belongs_to(key = user_id, references = id)]
+    user: toasty::Deferred<Option<User>>,
+
+    #[has_one]
+    subscription: toasty::Deferred<Option<Subscription>>,
+}
+
+#[derive(Debug, toasty::Model)]
+struct Subscription {
+    #[key]
+    id: i64,
+
+    account_id: Option<i64>,
+
+    #[belongs_to(key = account_id, references = id)]
+    account: toasty::Deferred<Option<Account>>,
+
+    plan: String,
+}
+
+fn main() {
+    let user = User {
+        id: 1,
+        account: Default::default(),
+        subscription: Default::default(),
+    };
+
+    let _ = user.subscription().create().plan("pro");
+}

--- a/tests/tests/ui/relation_via_one_scoped_create.stderr
+++ b/tests/tests/ui/relation_via_one_scoped_create.stderr
@@ -1,0 +1,19 @@
+error[E0277]: this scope does not support scoped creation
+  --> tests/ui/relation_via_one_scoped_create.rs:47:33
+   |
+47 |     let _ = user.subscription().create().plan("pro");
+   |                                 ^^^^^^ this relation scope cannot create records
+   |
+help: the trait `toasty::schema::CreateScope` is not implemented for `_::OptionOne<toasty::schema::Via>`
+  --> tests/ui/relation_via_one_scoped_create.rs:27:17
+   |
+27 | #[derive(Debug, toasty::Model)]
+   |                 ^^^^^^^^^^^^^
+   = note: Only direct relation scopes support scoped creation.
+   = note: Multi-step (`via`) relation scopes can be queried and filtered, but Toasty cannot create records through them because that would require creating or choosing intermediate records.
+note: required by a bound in `_::OptionOne::<Kind>::create`
+  --> tests/ui/relation_via_one_scoped_create.rs:27:17
+   |
+27 | #[derive(Debug, toasty::Model)]
+   |                 ^^^^^^^^^^^^^ required by this bound in `OptionOne::<Kind>::create`
+   = note: this error originates in the derive macro `toasty::Model` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/tests/ui/relation_via_scoped_create.rs
+++ b/tests/tests/ui/relation_via_scoped_create.rs
@@ -1,0 +1,48 @@
+#[derive(Debug, toasty::Model)]
+struct User {
+    #[key]
+    id: i64,
+
+    #[has_many]
+    todos: toasty::Deferred<Vec<Todo>>,
+
+    #[has_many(via = todos.tags)]
+    tags: toasty::Deferred<Vec<Tag>>,
+}
+
+#[derive(Debug, toasty::Model)]
+struct Todo {
+    #[key]
+    id: i64,
+
+    user_id: i64,
+
+    #[belongs_to(key = user_id, references = id)]
+    user: toasty::Deferred<User>,
+
+    #[has_many]
+    tags: toasty::Deferred<Vec<Tag>>,
+}
+
+#[derive(Debug, toasty::Model)]
+struct Tag {
+    #[key]
+    id: i64,
+
+    todo_id: i64,
+
+    #[belongs_to(key = todo_id, references = id)]
+    todo: toasty::Deferred<Todo>,
+
+    name: String,
+}
+
+fn main() {
+    let user = User {
+        id: 1,
+        todos: Default::default(),
+        tags: Default::default(),
+    };
+
+    let _ = user.tags().create().name("urgent");
+}

--- a/tests/tests/ui/relation_via_scoped_create.stderr
+++ b/tests/tests/ui/relation_via_scoped_create.stderr
@@ -1,0 +1,19 @@
+error[E0277]: this scope does not support scoped creation
+  --> tests/ui/relation_via_scoped_create.rs:47:25
+   |
+47 |     let _ = user.tags().create().name("urgent");
+   |                         ^^^^^^ this relation scope cannot create records
+   |
+help: the trait `toasty::schema::CreateScope` is not implemented for `_::Many<toasty::schema::Via>`
+  --> tests/ui/relation_via_scoped_create.rs:27:17
+   |
+27 | #[derive(Debug, toasty::Model)]
+   |                 ^^^^^^^^^^^^^
+   = note: Only direct relation scopes support scoped creation.
+   = note: Multi-step (`via`) relation scopes can be queried and filtered, but Toasty cannot create records through them because that would require creating or choosing intermediate records.
+note: required by a bound in `_::Many::<Kind>::create`
+  --> tests/ui/relation_via_scoped_create.rs:27:17
+   |
+27 | #[derive(Debug, toasty::Model)]
+   |                 ^^^^^^^^^^^^^ required by this bound in `Many::<Kind>::create`
+   = note: this error originates in the derive macro `toasty::Model` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/tests/ui/update_via_relation_insert.rs
+++ b/tests/tests/ui/update_via_relation_insert.rs
@@ -1,0 +1,53 @@
+#[derive(Debug, toasty::Model)]
+struct User {
+    #[key]
+    id: i64,
+
+    name: String,
+
+    #[has_many]
+    todos: toasty::Deferred<Vec<Todo>>,
+
+    #[has_many(via = todos.tags)]
+    tags: toasty::Deferred<Vec<Tag>>,
+}
+
+#[derive(Debug, toasty::Model)]
+struct Todo {
+    #[key]
+    id: i64,
+
+    user_id: i64,
+
+    #[belongs_to(key = user_id, references = id)]
+    user: toasty::Deferred<User>,
+
+    #[has_many]
+    tags: toasty::Deferred<Vec<Tag>>,
+}
+
+#[derive(Debug, toasty::Model)]
+struct Tag {
+    #[key]
+    id: i64,
+
+    todo_id: i64,
+
+    #[belongs_to(key = todo_id, references = id)]
+    todo: toasty::Deferred<Todo>,
+
+    name: String,
+}
+
+fn main() {
+    let mut user = User {
+        id: 1,
+        name: "Alice".to_string(),
+        todos: Default::default(),
+        tags: Default::default(),
+    };
+
+    let _ = user
+        .update()
+        .tags(toasty::stmt::insert(Tag::create().id(1).name("urgent")));
+}

--- a/tests/tests/ui/update_via_relation_insert.stderr
+++ b/tests/tests/ui/update_via_relation_insert.stderr
@@ -1,0 +1,21 @@
+error[E0599]: no method named `tags` found for struct `UserUpdate<__toasty_T>` in the current scope
+  --> tests/ui/update_via_relation_insert.rs:52:10
+   |
+ 1 |   #[derive(Debug, toasty::Model)]
+   |                   ------------- method `tags` not found for this struct
+...
+50 |       let _ = user
+   |               ----
+   |               |
+   |  _____________method `tags` is available on `&mut User`
+   | |
+51 | |         .update()
+52 | |         .tags(toasty::stmt::insert(Tag::create().id(1).name("urgent")));
+   | |         -^^^^ method not found in `UserUpdate<&mut User>`
+   | |_________|
+   |
+   |
+help: one of the expressions' fields has a method of the same name
+   |
+52 |         .target.tags(toasty::stmt::insert(Tag::create().id(1).name("urgent")));
+   |          +++++++


### PR DESCRIPTION
## Summary
- Add a `Via` relation scope marker and generate separate direct vs. via relation wrappers.
- Restrict scoped `create()` to direct relation scopes only, so multi-step and via relations fail at compile time instead of at runtime.
- Improve diagnostics for invalid scoped creation with targeted `on_unimplemented` messages.
- Update create/update macro expansion and add UI coverage for via relation creation cases.

## Testing
- `cargo fmt`
- `cargo test -p tests --test ui`
- `cargo test`