### PR TITLE
fix(postgresql): accept libpq query-param connection options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,32 @@ jobs:
         - name: cargo run --bin example-hello-toasty
           run: cargo run --bin example-hello-toasty --features postgresql
 
+    test-postgresql-uds:
+        needs: check
+        name: PostgreSQL Unix-socket connectivity smoke test
+        runs-on: ubuntu-latest
+        # Uses the runner's preinstalled PostgreSQL rather than the service
+        # container, since service containers do not expose their UNIX
+        # socket to the host. Peer auth maps the runner OS user to a
+        # matching superuser role.
+        env:
+            TOASTY_TEST_POSTGRES_UDS_URL: postgresql:///runner?host=/var/run/postgresql&user=runner
+        steps:
+        - uses: actions/checkout@v6
+        - uses: dtolnay/rust-toolchain@master
+          with:
+            toolchain: ${{ env.RUST_STABLE_VERSION }}
+        - uses: Swatinem/rust-cache@v2
+          with:
+            save-if: ${{ github.ref == 'refs/heads/main' }}
+        - name: Start PostgreSQL and provision runner role
+          run: |
+            sudo systemctl start postgresql
+            sudo -u postgres createuser --superuser "$USER"
+            sudo -u postgres createdb "$USER"
+        - name: cargo test connect_via_unix_socket
+          run: cargo test --no-default-features --features postgresql --test postgresql connect_via_unix_socket -- --exact
+
     test-dynamodb:
         needs: check
         name: Run tests for DynamoDB

--- a/crates/toasty-driver-postgresql/src/lib.rs
+++ b/crates/toasty-driver-postgresql/src/lib.rs
@@ -116,13 +116,6 @@ impl PostgreSQL {
             )));
         }
 
-        let host = url.host_str().ok_or_else(|| {
-            toasty_core::Error::invalid_connection_url(format!(
-                "missing host in connection URL; url={}",
-                url
-            ))
-        })?;
-
         if url.path().is_empty() {
             return Err(toasty_core::Error::invalid_connection_url(format!(
                 "no database specified - missing path in connection URL; url={}",
@@ -131,7 +124,18 @@ impl PostgreSQL {
         }
 
         let mut config = Config::new();
-        config.host(host);
+
+        // Host comes from the URL authority when present; otherwise from a
+        // `host=` query parameter (the libpq-compatible spelling that lets
+        // URLs reference Unix-domain sockets, e.g. `?host=/tmp`, since
+        // URL syntax cannot encode a path as the authority).
+        let mut host_set = false;
+        if let Some(host) = url.host_str()
+            && !host.is_empty()
+        {
+            config.host(host);
+            host_set = true;
+        }
 
         let dbname = percent_decode_str(url.path().trim_start_matches('/'))
             .decode_utf8()
@@ -157,10 +161,44 @@ impl PostgreSQL {
             config.password(percent_decode_str(password).collect::<Vec<u8>>());
         }
 
+        // libpq lets standard connection parameters appear in the query
+        // string; honor the ones a Toasty user can reasonably set so that
+        // `postgresql:///mydb?host=/tmp&user=alice` reaches the server.
         for (key, value) in url.query_pairs() {
-            if key == "application_name" {
-                config.application_name(&*value);
+            match key.as_ref() {
+                "host" => {
+                    config.host(&*value);
+                    host_set = true;
+                }
+                "port" => {
+                    let port = value.parse::<u16>().map_err(|_| {
+                        toasty_core::Error::invalid_connection_url(format!(
+                            "invalid port in connection URL query parameter: {value}"
+                        ))
+                    })?;
+                    config.port(port);
+                }
+                "user" => {
+                    config.user(&*value);
+                }
+                "password" => {
+                    config.password(value.as_bytes());
+                }
+                "dbname" => {
+                    config.dbname(&*value);
+                }
+                "application_name" => {
+                    config.application_name(&*value);
+                }
+                _ => {}
             }
+        }
+
+        if !host_set {
+            return Err(toasty_core::Error::invalid_connection_url(format!(
+                "missing host in connection URL; url={}",
+                url
+            )));
         }
 
         #[cfg(feature = "tls")]
@@ -614,5 +652,84 @@ impl toasty_core::driver::Connection for Connection {
             .await
             .map(|_| ())
             .map_err(toasty_core::Error::connection_lost)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use tokio_postgres::config::Host;
+
+    fn cfg(url: &str) -> Config {
+        PostgreSQL::new(url).expect("valid URL").config
+    }
+
+    #[test]
+    fn host_in_url_authority() {
+        let c = cfg("postgresql://example.com/mydb");
+        assert_eq!(c.get_hosts(), &[Host::Tcp("example.com".into())]);
+        assert_eq!(c.get_dbname(), Some("mydb"));
+    }
+
+    #[test]
+    fn unix_socket_via_host_query_param() {
+        // Regression for #984: libpq lets a Unix-socket directory be
+        // supplied via `?host=/path`, since URL syntax cannot put a
+        // filesystem path in the authority.
+        let c = cfg("postgresql:///mydb?host=/tmp&user=myuser");
+        assert_eq!(c.get_hosts(), &[Host::Unix(PathBuf::from("/tmp"))]);
+        assert_eq!(c.get_user(), Some("myuser"));
+        assert_eq!(c.get_dbname(), Some("mydb"));
+    }
+
+    #[test]
+    fn query_param_host_overrides_url_authority() {
+        // libpq query parameters override URL components, so a `host=`
+        // query string wins over a host in the URL authority.
+        let c = cfg("postgresql://example.com/mydb?host=/var/run/postgresql");
+        assert_eq!(
+            c.get_hosts(),
+            &[
+                Host::Tcp("example.com".into()),
+                Host::Unix(PathBuf::from("/var/run/postgresql")),
+            ]
+        );
+    }
+
+    #[test]
+    fn query_param_port_user_password_dbname() {
+        let c = cfg(
+            "postgresql:///placeholder?host=/tmp&port=5433&user=alice&password=s3cret&dbname=real",
+        );
+        assert_eq!(c.get_hosts(), &[Host::Unix(PathBuf::from("/tmp"))]);
+        assert_eq!(c.get_ports(), &[5433]);
+        assert_eq!(c.get_user(), Some("alice"));
+        assert_eq!(c.get_password(), Some(&b"s3cret"[..]));
+        assert_eq!(c.get_dbname(), Some("real"));
+    }
+
+    #[test]
+    fn application_name_query_param() {
+        let c = cfg("postgresql://localhost/mydb?application_name=my_app");
+        assert_eq!(c.get_application_name(), Some("my_app"));
+    }
+
+    #[test]
+    fn missing_host_rejected() {
+        let err = PostgreSQL::new("postgresql:///mydb").unwrap_err();
+        assert!(
+            err.to_string().contains("missing host"),
+            "expected missing-host error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn invalid_port_query_param_rejected() {
+        let err = PostgreSQL::new("postgresql:///mydb?host=/tmp&port=not-a-number").unwrap_err();
+        assert!(
+            err.to_string().contains("invalid port"),
+            "expected invalid-port error, got: {err}"
+        );
     }
 }

--- a/crates/toasty-driver-postgresql/src/lib.rs
+++ b/crates/toasty-driver-postgresql/src/lib.rs
@@ -653,7 +653,6 @@ impl toasty_core::driver::Connection for Connection {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
     use tokio_postgres::config::Host;
 
     fn cfg(url: &str) -> Config {
@@ -667,29 +666,51 @@ mod tests {
         assert_eq!(c.get_dbname(), Some("mydb"));
     }
 
-    #[test]
-    fn unix_socket_via_host_query_param() {
-        // Regression for #984: libpq lets a Unix-socket directory be
-        // supplied via `?host=/path`, since URL syntax cannot put a
-        // filesystem path in the authority.
-        let c = cfg("postgresql:///mydb?host=/tmp&user=myuser");
-        assert_eq!(c.get_hosts(), &[Host::Unix(PathBuf::from("/tmp"))]);
-        assert_eq!(c.get_user(), Some("myuser"));
-        assert_eq!(c.get_dbname(), Some("mydb"));
-    }
+    // `Host::Unix` only exists on Unix targets in tokio-postgres, so the
+    // tests that assert socket-path resolution are gated to those
+    // platforms. Windows builds still exercise the URL-parsing path via
+    // the non-Unix tests below.
+    #[cfg(unix)]
+    mod unix_socket {
+        use super::*;
+        use std::path::PathBuf;
 
-    #[test]
-    fn query_param_host_overrides_url_authority() {
-        // libpq semantics: a `host=` query parameter replaces (not
-        // appends to) the URL authority host. tokio-postgres's
-        // `Config::host` is additive across calls, so an authority
-        // host would otherwise be tried first and the configured
-        // socket reached only as a fallback.
-        let c = cfg("postgresql://example.com/mydb?host=/var/run/postgresql");
-        assert_eq!(
-            c.get_hosts(),
-            &[Host::Unix(PathBuf::from("/var/run/postgresql"))]
-        );
+        #[test]
+        fn unix_socket_via_host_query_param() {
+            // Regression for #984: libpq lets a Unix-socket directory be
+            // supplied via `?host=/path`, since URL syntax cannot put a
+            // filesystem path in the authority.
+            let c = cfg("postgresql:///mydb?host=/tmp&user=myuser");
+            assert_eq!(c.get_hosts(), &[Host::Unix(PathBuf::from("/tmp"))]);
+            assert_eq!(c.get_user(), Some("myuser"));
+            assert_eq!(c.get_dbname(), Some("mydb"));
+        }
+
+        #[test]
+        fn query_param_host_overrides_url_authority() {
+            // libpq semantics: a `host=` query parameter replaces (not
+            // appends to) the URL authority host. tokio-postgres's
+            // `Config::host` is additive across calls, so an authority
+            // host would otherwise be tried first and the configured
+            // socket reached only as a fallback.
+            let c = cfg("postgresql://example.com/mydb?host=/var/run/postgresql");
+            assert_eq!(
+                c.get_hosts(),
+                &[Host::Unix(PathBuf::from("/var/run/postgresql"))]
+            );
+        }
+
+        #[test]
+        fn query_param_port_user_password_dbname() {
+            let c = cfg(
+                "postgresql:///placeholder?host=/tmp&port=5433&user=alice&password=s3cret&dbname=real",
+            );
+            assert_eq!(c.get_hosts(), &[Host::Unix(PathBuf::from("/tmp"))]);
+            assert_eq!(c.get_ports(), &[5433]);
+            assert_eq!(c.get_user(), Some("alice"));
+            assert_eq!(c.get_password(), Some(&b"s3cret"[..]));
+            assert_eq!(c.get_dbname(), Some("real"));
+        }
     }
 
     #[test]
@@ -698,18 +719,6 @@ mod tests {
         // must replace the URL authority port for the same reason.
         let c = cfg("postgresql://example.com:5432/mydb?port=5433");
         assert_eq!(c.get_ports(), &[5433]);
-    }
-
-    #[test]
-    fn query_param_port_user_password_dbname() {
-        let c = cfg(
-            "postgresql:///placeholder?host=/tmp&port=5433&user=alice&password=s3cret&dbname=real",
-        );
-        assert_eq!(c.get_hosts(), &[Host::Unix(PathBuf::from("/tmp"))]);
-        assert_eq!(c.get_ports(), &[5433]);
-        assert_eq!(c.get_user(), Some("alice"));
-        assert_eq!(c.get_password(), Some(&b"s3cret"[..]));
-        assert_eq!(c.get_dbname(), Some("real"));
     }
 
     #[test]

--- a/crates/toasty-driver-postgresql/src/lib.rs
+++ b/crates/toasty-driver-postgresql/src/lib.rs
@@ -125,28 +125,12 @@ impl PostgreSQL {
 
         let mut config = Config::new();
 
-        // Host comes from the URL authority when present; otherwise from a
-        // `host=` query parameter (the libpq-compatible spelling that lets
-        // URLs reference Unix-domain sockets, e.g. `?host=/tmp`, since
-        // URL syntax cannot encode a path as the authority).
-        let mut host_set = false;
-        if let Some(host) = url.host_str()
-            && !host.is_empty()
-        {
-            config.host(host);
-            host_set = true;
-        }
-
         let dbname = percent_decode_str(url.path().trim_start_matches('/'))
             .decode_utf8()
             .map_err(|_| {
                 toasty_core::Error::invalid_connection_url("database name is not valid UTF-8")
             })?;
         config.dbname(&*dbname);
-
-        if let Some(port) = url.port() {
-            config.port(port);
-        }
 
         if !url.username().is_empty() {
             let user = percent_decode_str(url.username())
@@ -164,19 +148,23 @@ impl PostgreSQL {
         // libpq lets standard connection parameters appear in the query
         // string; honor the ones a Toasty user can reasonably set so that
         // `postgresql:///mydb?host=/tmp&user=alice` reaches the server.
+        // Single-valued setters (user, password, dbname, application_name)
+        // replace earlier calls, so we can apply them inline; host and
+        // port are list-valued — staged into Options below so a query
+        // parameter cleanly overrides the URL component instead of being
+        // appended as a fallback tokio-postgres would try first.
+        let mut host: Option<String> = None;
+        let mut port: Option<u16> = None;
+
         for (key, value) in url.query_pairs() {
             match key.as_ref() {
-                "host" => {
-                    config.host(&*value);
-                    host_set = true;
-                }
+                "host" => host = Some(value.into_owned()),
                 "port" => {
-                    let port = value.parse::<u16>().map_err(|_| {
+                    port = Some(value.parse::<u16>().map_err(|_| {
                         toasty_core::Error::invalid_connection_url(format!(
                             "invalid port in connection URL query parameter: {value}"
                         ))
-                    })?;
-                    config.port(port);
+                    })?);
                 }
                 "user" => {
                     config.user(&*value);
@@ -194,11 +182,18 @@ impl PostgreSQL {
             }
         }
 
-        if !host_set {
-            return Err(toasty_core::Error::invalid_connection_url(format!(
-                "missing host in connection URL; url={}",
-                url
-            )));
+        let host = host
+            .or_else(|| url.host_str().filter(|h| !h.is_empty()).map(String::from))
+            .ok_or_else(|| {
+                toasty_core::Error::invalid_connection_url(format!(
+                    "missing host in connection URL; url={}",
+                    url
+                ))
+            })?;
+        config.host(&host);
+
+        if let Some(port) = port.or_else(|| url.port()) {
+            config.port(port);
         }
 
         #[cfg(feature = "tls")]
@@ -685,16 +680,24 @@ mod tests {
 
     #[test]
     fn query_param_host_overrides_url_authority() {
-        // libpq query parameters override URL components, so a `host=`
-        // query string wins over a host in the URL authority.
+        // libpq semantics: a `host=` query parameter replaces (not
+        // appends to) the URL authority host. tokio-postgres's
+        // `Config::host` is additive across calls, so an authority
+        // host would otherwise be tried first and the configured
+        // socket reached only as a fallback.
         let c = cfg("postgresql://example.com/mydb?host=/var/run/postgresql");
         assert_eq!(
             c.get_hosts(),
-            &[
-                Host::Tcp("example.com".into()),
-                Host::Unix(PathBuf::from("/var/run/postgresql")),
-            ]
+            &[Host::Unix(PathBuf::from("/var/run/postgresql"))]
         );
+    }
+
+    #[test]
+    fn query_param_port_overrides_url_port() {
+        // `Config::port` is additive too, so a `port=` query parameter
+        // must replace the URL authority port for the same reason.
+        let c = cfg("postgresql://example.com:5432/mydb?port=5433");
+        assert_eq!(c.get_ports(), &[5433]);
     }
 
     #[test]

--- a/tests/tests/postgresql.rs
+++ b/tests/tests/postgresql.rs
@@ -141,3 +141,23 @@ async fn url_encoding() {
         .await
         .expect("failed to drop test role");
 }
+
+/// Connectivity smoke test for Unix-domain sockets (regression for #984).
+///
+/// The driver must accept libpq-style `?host=/path` URLs so the
+/// directory containing the PG socket can be specified — URL syntax
+/// cannot encode a filesystem path as the authority. Skipped when
+/// `TOASTY_TEST_POSTGRES_UDS_URL` is unset so the default test runs
+/// stay green on machines without a socket-accessible PG.
+#[tokio::test]
+async fn connect_via_unix_socket() {
+    let Ok(url) = std::env::var("TOASTY_TEST_POSTGRES_UDS_URL") else {
+        eprintln!("TOASTY_TEST_POSTGRES_UDS_URL unset; skipping UDS connectivity test");
+        return;
+    };
+
+    toasty::Db::builder()
+        .connect(&url)
+        .await
+        .expect("PostgreSQL connection over Unix-domain socket failed");
+}


### PR DESCRIPTION
## Summary

The driver rejected `postgresql:///mydb?host=/tmp&user=myuser` with
"missing host" because it only read the URL authority. libpq URLs put
Unix-socket directories in `?host=/path` — URL syntax has no way to
encode a filesystem path as the authority. Defer the host check until
after query-string processing and honor the standard libpq params
(`host`, `port`, `user`, `password`, `dbname`) there.

`tokio_postgres::Config::host("/path")` already classifies leading-`/`
hosts as `Host::Unix`, so no socket-specific code is needed.

Closes #984

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] \`cargo fmt\` and \`cargo clippy\` are clean
- [x] \`cargo test\` passes

## Notes for reviewers

Two test layers:

1. Unit tests in \`crates/toasty-driver-postgresql/src/lib.rs\` cover the
   URL → \`Config\` mapping for each new code path (Unix socket via
   \`?host=\`, query-param override of URL authority, port/user/password/
   dbname/application_name via query, missing-host and invalid-port
   error paths).
2. A new CI job \`test-postgresql-uds\` starts the runner's preinstalled
   PG 16 and runs \`connect_via_unix_socket\` against an actual UDS
   socket — separate from \`test-postgresql\` because the service
   container's socket isn't host-visible and would collide on :5432.
   The test is gated on \`TOASTY_TEST_POSTGRES_UDS_URL\` so default
   developer runs stay green.