### PR TITLE
fix(engine): lift relation-path IN-subquery through BelongsTo chains

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/relation_filter_association.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_filter_association.rs
@@ -152,3 +152,55 @@ pub async fn filter_by_nested_has_one_chain(t: &mut Test) -> Result<()> {
 
     Ok(())
 }
+
+/// Filter through `BelongsTo → HasMany` with `.any()` — the queried model's
+/// parent owns a collection, and the filter is a quantifier over that
+/// collection (here, "sibling" todos sharing the same category).
+///
+/// Path `todo.category.todos.any(title == "salad")` lowers to an
+/// `Expr::InSubquery` whose LHS is an `Expr::Project` through the
+/// `BelongsTo`. Single-hop `parent.children.any(...)` already lifts (see
+/// `relation_has_many_filter::filter_parent_by_child_field`); previously the
+/// `BelongsTo`-then-`HasMany` chain hit a `todo!()` in
+/// `LiftInSubquery::lift_in_subquery`.
+#[driver_test(
+    id(ID),
+    requires(sql),
+    scenario(crate::scenarios::has_many_multi_relation)
+)]
+pub async fn filter_by_belongs_to_has_many_any(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let food = toasty::create!(Category { name: "food" })
+        .exec(&mut db)
+        .await?;
+    let drink = toasty::create!(Category { name: "drink" })
+        .exec(&mut db)
+        .await?;
+    let user = toasty::create!(User { name: "Anchovy" })
+        .exec(&mut db)
+        .await?;
+
+    toasty::create!(Todo::[
+        { title: "salad", user: &user, category: &food  },
+        { title: "sushi", user: &user, category: &food  },
+        { title: "tea",   user: &user, category: &drink },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    // Todos whose category has at least one todo titled "salad" — i.e.,
+    // every todo in the "food" category.
+    let todos: Vec<Todo> = Todo::filter(
+        Todo::fields()
+            .category()
+            .todos()
+            .any(Todo::fields().title().eq("salad")),
+    )
+    .exec(&mut db)
+    .await?;
+
+    assert_eq_unordered!(todos.iter().map(|t| &t.title[..]), ["salad", "sushi"]);
+
+    Ok(())
+}

--- a/crates/toasty/src/engine/lower/lift_in_subquery.rs
+++ b/crates/toasty/src/engine/lower/lift_in_subquery.rs
@@ -165,8 +165,13 @@ pub(super) fn lift_in_subquery(
 ) -> Option<stmt::Expr> {
     // The expression is a path expression referencing a relation.
     let field = match expr {
-        stmt::Expr::Project(_) => {
-            todo!()
+        // `Project(Ref(rel), [head, ...tail])` — the path traverses through a
+        // relation field (`rel`) before reaching the relation the subquery
+        // targets. Re-root the path at `rel`'s target model and rebuild as a
+        // nested IN-subquery on that model, then recurse to lift the outer
+        // `rel` hop.
+        stmt::Expr::Project(project_expr) => {
+            return lift_projection_in_subquery(cx, project_expr, query);
         }
         stmt::Expr::Reference(expr_reference @ stmt::ExprReference::Field { .. }) => {
             cx.resolve_expr_reference(expr_reference).as_field_unwrap()
@@ -186,6 +191,54 @@ pub(super) fn lift_in_subquery(
         FieldTy::Has(has) => lift_has_n_in_subquery(has.target, has.pair(&cx.schema().app), query),
         _ => None,
     }
+}
+
+/// Lift `project(ref_self_field(rel), [head, ...tail]) IN (query)` by
+/// re-rooting the path at `rel`'s target model and wrapping the original
+/// subquery in a nested IN-subquery on that model.
+///
+/// Example: `Release.project.topics IN (SELECT FROM Topic WHERE ...)` becomes
+/// `Release.project IN (SELECT FROM Project WHERE Project.topics IN
+/// (SELECT FROM Topic WHERE ...))`, after which the outer `BelongsTo` hop
+/// is lifted by [`lift_in_subquery`]'s standard branch. The inner subquery's
+/// IN is left for the [`LiftInSubquery`] visitor's children walk to lift on
+/// the next pass.
+fn lift_projection_in_subquery(
+    cx: &ExprContext,
+    project_expr: &stmt::ExprProject,
+    query: &stmt::Query,
+) -> Option<stmt::Expr> {
+    let Expr::Reference(expr_ref) = &*project_expr.base else {
+        return None;
+    };
+    let ResolvedRef::Field(field) = cx.resolve_expr_reference(expr_ref) else {
+        return None;
+    };
+
+    let target_model_id = match &field.ty {
+        FieldTy::Has(rel) => rel.target,
+        FieldTy::Via(rel) => rel.target,
+        FieldTy::BelongsTo(rel) => rel.target,
+        _ => return None,
+    };
+
+    let (head_idx, tail) = project_expr.projection.as_slice().split_first()?;
+    let target_field = Expr::ref_self_field(FieldId {
+        model: target_model_id,
+        index: *head_idx,
+    });
+    let inner_lhs = if tail.is_empty() {
+        target_field
+    } else {
+        Expr::project(target_field, stmt::Projection::from(tail))
+    };
+
+    let new_subquery = stmt::Query::new_select(
+        stmt::Source::from(target_model_id),
+        Expr::in_subquery(inner_lhs, query.clone()),
+    );
+
+    lift_in_subquery(cx, &project_expr.base, &new_subquery)
 }
 
 /// Lift `project(ref_self_field(rel), [idx, ...]) op other` into a

--- a/crates/toasty/src/engine/lower/lift_in_subquery.rs
+++ b/crates/toasty/src/engine/lower/lift_in_subquery.rs
@@ -30,7 +30,7 @@
 //! a `LiftInSubquery`.
 
 use toasty_core::{
-    schema::app::{BelongsTo, FieldId, FieldTy, ModelId},
+    schema::app::{self, BelongsTo, FieldId, FieldTy, ModelId},
     stmt::{self, Expr, ExprContext, IntoExprTarget, ResolvedRef, Visit, VisitMut},
 };
 
@@ -193,16 +193,45 @@ pub(super) fn lift_in_subquery(
     }
 }
 
-/// Lift `project(ref_self_field(rel), [head, ...tail]) IN (query)` by
-/// re-rooting the path at `rel`'s target model and wrapping the original
-/// subquery in a nested IN-subquery on that model.
+/// Lifts an `IN`-subquery whose left side is a path through a relation field.
 ///
-/// Example: `Release.project.topics IN (SELECT FROM Topic WHERE ...)` becomes
-/// `Release.project IN (SELECT FROM Project WHERE Project.topics IN
-/// (SELECT FROM Topic WHERE ...))`, after which the outer `BelongsTo` hop
-/// is lifted by [`lift_in_subquery`]'s standard branch. The inner subquery's
-/// IN is left for the [`LiftInSubquery`] visitor's children walk to lift on
-/// the next pass.
+/// `.any()` on a relation chain — for example, `Release.project.topics.any(name
+/// == "rust")` — builds an `InSubquery` whose LHS projects through the
+/// chain:
+///
+/// ```text
+/// InSubquery {
+///     expr:  Project(Ref(Release.project), [Project.topics_idx]),
+///     query: SELECT FROM Topic WHERE name == "rust",
+/// }
+/// ```
+///
+/// Two paths handle this:
+///
+/// **Fused.** [`try_fuse_paired_relations`] recognizes the common
+/// `BelongsTo → Has` chain over a shared primary key and emits a single
+/// FK-on-FK `IN` that bypasses the intermediate model:
+///
+/// ```text
+/// Release.project_id IN (SELECT Topic.project_id FROM Topic WHERE name == "rust")
+/// ```
+///
+/// **General.** For chains the fast path doesn't match (multi-hop
+/// projections, non-paired relations), re-root the projection at the
+/// relation's target model and wrap the original subquery in a nested `IN`
+/// against that model, then recurse on the outer hop. For the same input,
+/// the fallback produces:
+///
+/// ```text
+/// Release.project IN (
+///     SELECT FROM Project
+///     WHERE Project.topics IN (SELECT FROM Topic WHERE name == "rust")
+/// )
+/// ```
+///
+/// The recursive call lifts the outer `Release.project` hop via the standard
+/// `BelongsTo` branch; the inner `Project.topics` hop is lifted on the next
+/// visitor pass when [`LiftInSubquery`]'s children walk reaches it.
 fn lift_projection_in_subquery(
     cx: &ExprContext,
     project_expr: &stmt::ExprProject,
@@ -223,6 +252,14 @@ fn lift_projection_in_subquery(
     };
 
     let (head_idx, tail) = project_expr.projection.as_slice().split_first()?;
+
+    if tail.is_empty()
+        && let Some(direct) =
+            try_fuse_paired_relations(cx, field, target_model_id, *head_idx, query)
+    {
+        return Some(direct);
+    }
+
     let target_field = Expr::ref_self_field(FieldId {
         model: target_model_id,
         index: *head_idx,
@@ -239,6 +276,111 @@ fn lift_projection_in_subquery(
     );
 
     lift_in_subquery(cx, &project_expr.base, &new_subquery)
+}
+
+/// Fuses a `BelongsTo → Has` chain into a single FK-on-FK `IN` when both
+/// relations meet at the same primary key.
+///
+/// # Example
+///
+/// Given the schema:
+///
+/// ```text
+/// Todo     { category_id: Category.id, ... }   // BelongsTo  Todo.category
+/// Category { todos: HasMany Todo, ... }        // Has, paired with Todo.category
+/// ```
+///
+/// The path `Todo.category.todos` lifts as follows:
+///
+/// ```text
+/// // Input
+/// InSubquery {
+///     expr:  Project(Ref(Todo.category), [Category.todos_idx]),
+///     query: SELECT FROM Todo WHERE title == "salad",
+/// }
+///
+/// // Output
+/// InSubquery {
+///     expr:  Ref(Todo.category_id),
+///     query: SELECT Todo.category_id FROM Todo WHERE title == "salad",
+/// }
+/// ```
+///
+/// The outer relation's FK source columns become the LHS; the inner
+/// relation's paired-BelongsTo FK source columns become the subquery's
+/// returning list. The user's original filter is preserved verbatim.
+///
+/// # Why the fusion is sound
+///
+/// Composing the two hops without fusion routes through the intermediate
+/// model:
+///
+/// ```text
+/// Todo.category_id IN (
+///     SELECT Category.id FROM Category
+///     WHERE Category.id IN (SELECT Todo.category_id FROM Todo WHERE title == "salad")
+/// )
+/// ```
+///
+/// Both FKs target `Category.id`, so every value the innermost subquery
+/// returns exists in `Category.id` under FK integrity (which the engine
+/// already assumes). The middle filter therefore admits every row the inner
+/// returns, and the middle `SELECT Category.id` simply re-emits them. The
+/// `Category` scan is a no-op and can be dropped.
+///
+/// Returns `None` when the chain doesn't match the pattern — outer isn't a
+/// `BelongsTo`, inner isn't a `Has`, or the FK columns don't line up.
+fn try_fuse_paired_relations(
+    cx: &ExprContext,
+    outer_field: &app::Field,
+    target_model_id: ModelId,
+    head_idx: usize,
+    query: &stmt::Query,
+) -> Option<stmt::Expr> {
+    let outer_belongs_to = match &outer_field.ty {
+        FieldTy::BelongsTo(rel) => rel,
+        _ => return None,
+    };
+
+    let target_model = cx.schema().app.model(target_model_id).as_root_unwrap();
+    let head_field = target_model.fields.get(head_idx)?;
+    let inner_has = match &head_field.ty {
+        FieldTy::Has(has) => has,
+        _ => return None,
+    };
+    let inner_pair = inner_has.pair(&cx.schema().app);
+
+    // Both FKs must reference the same PK columns in the same order.
+    if outer_belongs_to.foreign_key.fields.len() != inner_pair.foreign_key.fields.len() {
+        return None;
+    }
+    for (outer_fk, inner_fk) in outer_belongs_to
+        .foreign_key
+        .fields
+        .iter()
+        .zip(inner_pair.foreign_key.fields.iter())
+    {
+        if outer_fk.target != inner_fk.target {
+            return None;
+        }
+    }
+
+    let mut fused_subquery = query.clone();
+    fused_subquery.body.as_select_mut_unwrap().returning = stmt::Returning::Project(
+        super::key_field_refs(0, inner_pair.foreign_key.fields.iter().map(|fk| fk.source)),
+    );
+
+    Some(stmt::Expr::in_subquery(
+        super::key_field_refs(
+            0,
+            outer_belongs_to
+                .foreign_key
+                .fields
+                .iter()
+                .map(|fk| fk.source),
+        ),
+        fused_subquery,
+    ))
 }
 
 /// Lift `project(ref_self_field(rel), [idx, ...]) op other` into a

--- a/crates/toasty/src/engine/lower/tests/lift_in_subquery.rs
+++ b/crates/toasty/src/engine/lower/tests/lift_in_subquery.rs
@@ -12,7 +12,9 @@ use toasty_core::{
         Builder, app,
         app::{FieldId, ModelId},
     },
-    stmt::{self, Expr, ExprBinaryOp, ExprContext, Query, Value},
+    stmt::{
+        self, Expr, ExprBinaryOp, ExprContext, ExprInSubquery, Projection, Query, Returning, Value,
+    },
 };
 
 #[allow(dead_code)]
@@ -44,8 +46,11 @@ struct UserPostSchema {
     schema: toasty_core::Schema,
     user_model: ModelId,
     user_id: FieldId,
+    user_posts: FieldId,
     post_model: ModelId,
+    post_id: FieldId,
     post_user: FieldId,
+    post_user_id: FieldId,
 }
 
 impl UserPostSchema {
@@ -60,28 +65,25 @@ impl UserPostSchema {
         let user_model = User::id();
         let post_model = Post::id();
 
-        // Find field IDs by name from the generated schema
-        let user_id = schema
-            .app
-            .model(user_model)
-            .as_root_unwrap()
-            .field_by_name("id")
-            .unwrap()
-            .id;
-        let post_user = schema
-            .app
-            .model(post_model)
-            .as_root_unwrap()
-            .field_by_name("user")
-            .unwrap()
-            .id;
+        let field = |model, name| {
+            schema
+                .app
+                .model(model)
+                .as_root_unwrap()
+                .field_by_name(name)
+                .unwrap()
+                .id
+        };
 
         Self {
+            user_id: field(user_model, "id"),
+            user_posts: field(user_model, "posts"),
+            post_id: field(post_model, "id"),
+            post_user: field(post_model, "user"),
+            post_user_id: field(post_model, "user_id"),
             schema,
             user_model,
-            user_id,
             post_model,
-            post_user,
         }
     }
 }
@@ -115,4 +117,101 @@ fn belongs_to_lifts_fk_constraint_to_direct_eq() {
         Expr::Reference(stmt::ExprReference::Field { index: 1, .. })
     ));
     assert!(matches!(*rhs, Expr::Value(Value::I64(42))));
+}
+
+/// `Project(Ref(BelongsTo), [HasIdx])` paired across a shared PK fuses into a
+/// single `outer_fk IN (SELECT inner_fk FROM target WHERE …)` — the
+/// intermediate routing model (`User` here) is skipped.
+///
+/// Input AST for `Post.user.posts IN (SELECT FROM Post WHERE id == 42)`:
+///   - LHS: `Project(Ref(Post.user), [User.posts_idx])`
+///   - RHS: `SELECT FROM Post WHERE Post.id == 42`
+///
+/// Expected fused output:
+///   `Post.user_id IN (SELECT Post.user_id FROM Post WHERE Post.id == 42)`.
+#[test]
+fn belongs_to_has_many_fuses_to_direct_fk() {
+    let s = UserPostSchema::new();
+    let cx = ExprContext::new(&s.schema);
+    let post_source: stmt::Source = s.post_model.into();
+    let scoped_cx = cx.scope(&post_source);
+
+    let expr = Expr::project(
+        Expr::ref_self_field(s.post_user),
+        Projection::single(s.user_posts.index),
+    );
+    let inner_filter = Expr::eq(
+        Expr::ref_self_field(s.post_id),
+        Expr::Value(Value::from(42i64)),
+    );
+    let query = Query::new_select(s.post_model, inner_filter);
+
+    let lifted = lift_in_subquery(&scoped_cx, &expr, &query).expect("lift to succeed");
+
+    let Expr::InSubquery(ExprInSubquery {
+        expr: lhs,
+        query: fused,
+    }) = lifted
+    else {
+        panic!("expected InSubquery, got {lifted:?}");
+    };
+
+    // Outer LHS is the FK column on Post (no projection through a relation).
+    assert!(matches!(
+        *lhs,
+        Expr::Reference(stmt::ExprReference::Field { nesting: 0, index })
+            if index == s.post_user_id.index
+    ));
+
+    let select = fused.body.as_select_unwrap();
+
+    // No routing through User: the fused subquery scans Post directly.
+    assert_eq!(select.source.model_id_unwrap(), s.post_model);
+
+    // Projects the FK column (Post.user_id), not Post's PK.
+    let Returning::Project(returning) = &select.returning else {
+        panic!("expected Returning::Project, got {:?}", select.returning);
+    };
+    let Expr::Reference(stmt::ExprReference::Field {
+        index: ret_index, ..
+    }) = returning
+    else {
+        panic!("expected single-column field projection, got {returning:?}");
+    };
+    assert_eq!(*ret_index, s.post_user_id.index);
+
+    // The inner filter passes through unchanged: `Post.id == 42`.
+    let Some(Expr::BinaryOp(ExprBinaryOp { op, lhs, rhs })) = &select.filter.expr else {
+        panic!("expected BinaryOp filter, got {:?}", select.filter.expr);
+    };
+    assert!(op.is_eq());
+    assert!(matches!(
+        **lhs,
+        Expr::Reference(stmt::ExprReference::Field { index, .. })
+            if index == s.post_id.index
+    ));
+    assert!(matches!(**rhs, Expr::Value(Value::I64(42))));
+}
+
+/// `Project` with a non-relation base bails (no lift, no panic) — the lift is
+/// only meaningful when the path passes through a relation field.
+#[test]
+fn project_with_non_relation_base_returns_none() {
+    let s = UserPostSchema::new();
+    let cx = ExprContext::new(&s.schema);
+    let post_source: stmt::Source = s.post_model.into();
+    let scoped_cx = cx.scope(&post_source);
+
+    // `Project(Ref(Post.id), [0])` — projecting through a scalar PK field, not
+    // a relation. The lift can't re-root this; it must return None.
+    let expr = Expr::project(Expr::ref_self_field(s.post_id), Projection::single(0));
+    let query = Query::new_select(
+        s.post_model,
+        Expr::eq(
+            Expr::ref_self_field(s.post_id),
+            Expr::Value(Value::from(1i64)),
+        ),
+    );
+
+    assert!(lift_in_subquery(&scoped_cx, &expr, &query).is_none());
 }


### PR DESCRIPTION
## Summary

`lift_in_subquery` hit `todo!()` when an `Expr::InSubquery`'s LHS was an `Expr::Project` through a relation field — the shape `.any()` produces on a `BelongsTo → HasMany` chain (e.g. `release.project.topics.any(name == \"rust\")`). The function only handled bare `Expr::Reference` LHSes.

Reported on the Toasty Discord by a user who hit it while writing a search query against their migrated codebase.

The fix lifts projection LHSes by re-rooting the path at the relation's target model and wrapping the original subquery in a nested `IN` on that model, then recursing on the outer hop. A fast path collapses the common `BelongsTo → Has` case over a shared primary key into a single FK-on-FK `IN`, skipping the intermediate model:

```text
// before fast path
Todo.category_id IN (
    SELECT Category.id FROM Category WHERE Category.id IN (
        SELECT Todo.category_id FROM Todo WHERE title = 'salad'
    )
)

// after fast path
Todo.category_id IN (
    SELECT Todo.category_id FROM Todo WHERE title = 'salad'
)
```

The middle `SELECT Category.id WHERE Category.id IN …` is a no-op under FK integrity, which the engine already assumes. Multi-hop chains and non-paired relations fall through to the wrap-and-recurse general path.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] \`cargo fmt\` and \`cargo clippy\` are clean
- [x] \`cargo test\` passes

## Notes for reviewers

Two commits: the fix and the fast-path fusion. Worth reviewing separately — the fix alone produces correct-but-redundant SQL; the fusion is the perf cleanup on top.

A follow-up issue will track extending the fusion across multi-hop chains (current `tail.is_empty()` restricts it to single-hop pairs).

Coverage:
- Integration test `relation_filter_association::filter_by_belongs_to_has_many_any` reproduces the original panic and asserts the query returns the expected rows.
- Unit tests in `engine/lower/tests/lift_in_subquery` assert the fused shape (FK on the LHS, FK in the subquery's returning, intermediate model dropped) and that a non-relation \`Project\` base bails without panicking.