### PR TITLE
fix(engine): lift relation-path LIKE into a foreign-key subquery

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/relation_filter_association.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_filter_association.rs
@@ -87,6 +87,49 @@ pub async fn filter_by_belongs_to_field(test: &mut Test) -> Result<()> {
     Ok(())
 }
 
+/// Filters through a relation field with `.like()`, e.g. finding profiles
+/// whose user's name starts with "al". `LIKE` lowers to `Expr::Like`, not
+/// `Expr::BinaryOp`, so the rewrite that turns a relation-path comparison into
+/// a foreign-key subquery has to handle it explicitly; without that the query
+/// panics.
+///
+/// Covers both relation directions: `BelongsTo` (child filtered by parent)
+/// and `Has` (parent filtered by child).
+#[driver_test(
+    id(ID),
+    requires(sql),
+    scenario(crate::scenarios::has_one_optional_belongs_to)
+)]
+pub async fn filter_by_relation_field_like(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    toasty::create!(User::[
+        { name: "alice", profile: { bio: "alice's bio" } },
+        { name: "bob",   profile: { bio: "bob's bio" } },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    // BelongsTo: filter children by a LIKE on the parent's field.
+    let profiles: Vec<Profile> = Profile::filter(Profile::fields().user().name().like("al%"))
+        .exec(&mut db)
+        .await?;
+    assert_eq!(
+        profiles.iter().map(|p| p.bio.as_str()).collect::<Vec<_>>(),
+        ["alice's bio"]
+    );
+
+    // Has: filter parents by a LIKE on the child's field.
+    let users: Vec<User> = User::filter(User::fields().profile().bio().like("%'s bio"))
+        .exec(&mut db)
+        .await?;
+    let mut names: Vec<_> = users.iter().map(|u| u.name.as_str()).collect();
+    names.sort_unstable();
+    assert_eq!(names, ["alice", "bob"]);
+
+    Ok(())
+}
+
 /// Filter through three chained HasOne associations: `A.b.c.name == ...`.
 #[driver_test(id(ID), requires(sql))]
 pub async fn filter_by_nested_has_one_chain(t: &mut Test) -> Result<()> {

--- a/crates/toasty/src/engine/lower/lift_in_subquery.rs
+++ b/crates/toasty/src/engine/lower/lift_in_subquery.rs
@@ -13,9 +13,17 @@
 //!   foreign-key IN subquery against the related table.
 //!
 //! - [`try_lift_relation_path_comparison`] fires on `Expr::BinaryOp` where
-//!   one side is `project(ref_self_field(relation_field), [idx, ...])`.
-//!   It synthesises a subquery on the target model with the comparison
-//!   re-rooted there, then defers to [`lift_in_subquery`].
+//!   one side walks a relation field. For example, filtering profiles by
+//!   their user's name (`profile.user.name = 'alice'`) rewrites to:
+//!
+//!   ```text
+//!   Profile.user_id IN (SELECT User.id FROM User WHERE User.name = 'alice')
+//!   ```
+//!
+//! - [`try_lift_relation_path_like`] does the same for `LIKE`/`ILIKE`
+//!   (`profile.user.name LIKE 'al%'`). These are `Expr::Like`, not
+//!   `Expr::BinaryOp`, so they need their own entry point. Both rewrites
+//!   share [`lift_relation_path_predicate`].
 //!
 //! A pre-pass is necessary (rather than folding into
 //! `LowerStatement::visit_expr_mut` per #823's pattern) because not every
@@ -79,6 +87,11 @@ impl VisitMut for LiftInSubquery<'_> {
                     && let Some(lifted) =
                         try_lift_relation_path_comparison(&self.cx, commuted, &e.rhs, &e.lhs)
                 {
+                    *expr = lifted;
+                }
+            }
+            stmt::Expr::Like(e) => {
+                if let Some(lifted) = try_lift_relation_path_like(&self.cx, e) {
                     *expr = lifted;
                 }
             }
@@ -188,17 +201,79 @@ pub(super) fn lift_in_subquery(
     }
 }
 
-/// Lift `project(ref_self_field(rel), [idx, ...]) op other` into a
-/// foreign-key-based comparison by synthesising an IN subquery on the
-/// relation's target model and deferring to [`lift_in_subquery`].
+/// Rewrites a comparison that walks a relation field into a foreign-key
+/// subquery.
 ///
-/// Returns `None` when `project_side` is not a project through a
-/// relation field reference.
+/// `Profile::filter(Profile::fields().user().name().eq("alice"))` starts as
+/// the filter `profile.user.name = 'alice'`, where the left side projects
+/// through the `user` relation. This moves the comparison into a subquery on
+/// the target model and defers to [`lift_in_subquery`]:
+///
+/// ```text
+/// Profile.user_id IN (SELECT User.id FROM User WHERE User.name = 'alice')
+/// ```
+///
+/// Returns `None` when `project_side` does not walk a relation field.
 pub(super) fn try_lift_relation_path_comparison(
     cx: &ExprContext,
     op: stmt::BinaryOp,
     project_side: &stmt::Expr,
     other_side: &stmt::Expr,
+) -> Option<stmt::Expr> {
+    lift_relation_path_predicate(cx, project_side, |target_lhs| {
+        Expr::binary_op(target_lhs, op, other_side.clone())
+    })
+}
+
+/// Rewrites a `LIKE`/`ILIKE` that walks a relation field into a foreign-key
+/// subquery — [`try_lift_relation_path_comparison`] for pattern matches.
+///
+/// `Profile::filter(Profile::fields().user().name().like("al%"))` rewrites to:
+///
+/// ```text
+/// Profile.user_id IN (SELECT User.id FROM User WHERE User.name LIKE 'al%')
+/// ```
+///
+/// `LIKE`/`ILIKE` are `Expr::Like`, not `Expr::BinaryOp`, so they never reach
+/// [`try_lift_relation_path_comparison`] and need this entry point. Without
+/// it the `user.name` path stays a projection through the relation, which the
+/// rest of lowering cannot turn into a column and so panics.
+///
+/// Returns `None` when the pattern's subject does not walk a relation field.
+pub(super) fn try_lift_relation_path_like(
+    cx: &ExprContext,
+    like: &stmt::ExprLike,
+) -> Option<stmt::Expr> {
+    lift_relation_path_predicate(cx, &like.expr, |target_lhs| {
+        stmt::ExprLike {
+            expr: Box::new(target_lhs),
+            pattern: like.pattern.clone(),
+            escape: like.escape,
+            case_insensitive: like.case_insensitive,
+        }
+        .into()
+    })
+}
+
+/// Shared core of the relation-path lifts.
+///
+/// `project_side` is the side of the predicate that walks a relation — the
+/// `profile.user.name` in `profile.user.name = 'alice'`. It is a projection
+/// whose first step names the `user` relation field on `Profile` and whose
+/// remaining steps index into `User`. This re-roots the path at the target
+/// model (so it reads `User.name`), builds a `SELECT` over `User` whose filter
+/// `make_filter` produces from the re-rooted path, and defers to
+/// [`lift_in_subquery`] to turn the relation reference into the foreign-key
+/// `IN` form.
+///
+/// `make_filter` is the only difference between callers: a binary op for
+/// comparisons, a `LIKE` for pattern matches.
+///
+/// Returns `None` when `project_side` does not walk a relation field.
+fn lift_relation_path_predicate(
+    cx: &ExprContext,
+    project_side: &stmt::Expr,
+    make_filter: impl FnOnce(stmt::Expr) -> stmt::Expr,
 ) -> Option<stmt::Expr> {
     let Expr::Project(project_expr) = project_side else {
         return None;
@@ -217,9 +292,9 @@ pub(super) fn try_lift_relation_path_comparison(
         _ => return None,
     };
 
-    // Re-root the projection at the target model: the leading index
-    // points at the relation field itself, the rest indexes into the
-    // related model's fields.
+    // The first step names the relation field on the source model; the
+    // rest index into the target model. Drop the first step and re-root the
+    // remainder at the target model.
     let (head_idx, tail) = project_expr.projection.as_slice().split_first()?;
     let target_field = Expr::ref_self_field(FieldId {
         model: target_model_id,
@@ -231,10 +306,8 @@ pub(super) fn try_lift_relation_path_comparison(
         Expr::project(target_field, stmt::Projection::from(tail))
     };
 
-    let subquery = stmt::Query::new_select(
-        stmt::Source::from(target_model_id),
-        Expr::binary_op(target_lhs, op, other_side.clone()),
-    );
+    let subquery =
+        stmt::Query::new_select(stmt::Source::from(target_model_id), make_filter(target_lhs));
 
     lift_in_subquery(cx, &project_expr.base, &subquery)
 }


### PR DESCRIPTION
## Summary

`.like()` on a field reached through a relation panicked, while `.eq()` on
the same path worked:

```rust
Profile::filter(Profile::fields().user().name().like("al%"))  // panic
Profile::filter(Profile::fields().user().name().eq("alice"))  // fine
```

The pre-lowering pass that turns a relation-path comparison into a foreign-key
subquery only fired on `Expr::BinaryOp`. `LIKE`/`ILIKE` lower to `Expr::Like`,
so the `user.name` path stayed a projection through the relation that the rest
of lowering could not resolve to a column, hitting a `todo!()` in
`Value::entry`.

Add `try_lift_relation_path_like` and route `Expr::Like` through it. It and
`try_lift_relation_path_comparison` now share `lift_relation_path_predicate`,
which builds the subquery on the target model — the two differ only in the
predicate they reconstruct (a binary op vs. a `LIKE`, preserving `escape` and
`case_insensitive` so `.ilike()` is covered too):

```text
Profile.user_id IN (SELECT User.id FROM User WHERE User.name LIKE 'al%')
```

Reported on the Toasty Discord by a user migrating a search query. This is a
separate root cause from #990 (which fixed the `Expr::Project`-LHS `todo!()`
for `.any()` chains) — verified that #990 alone does not fix it.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

Coverage: `relation_filter_association::filter_by_relation_field_like`
exercises both relation directions — `BelongsTo` (child filtered by parent)
and `Has` (parent filtered by child).