### PR TITLE
feat: derive Clone and add Deserialize for Deferred<T>

### DIFF
--- a/crates/toasty/src/schema/deferred.rs
+++ b/crates/toasty/src/schema/deferred.rs
@@ -12,6 +12,7 @@ use std::fmt;
 /// value.
 ///
 /// `Deferred<Option<T>>` is supported when the column is nullable.
+#[derive(Clone)]
 pub struct Deferred<T> {
     value: Option<Box<T>>,
 }
@@ -178,6 +179,10 @@ impl<T: fmt::Debug> fmt::Debug for Deferred<T> {
     }
 }
 
+/// Serializes transparently as the inner value: a loaded `Deferred<T>` encodes
+/// exactly as the `T` it holds, and an unloaded one as `null`. Round-trips with
+/// the [`Deserialize`](serde_core::Deserialize) impl below, preserving load
+/// state.
 #[cfg(feature = "serde")]
 impl<T: serde_core::Serialize> serde_core::Serialize for Deferred<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -185,5 +190,20 @@ impl<T: serde_core::Serialize> serde_core::Serialize for Deferred<T> {
         S: serde_core::Serializer,
     {
         self.value.serialize(serializer)
+    }
+}
+
+/// Deserializes transparently from the inner value, mirroring the
+/// [`Serialize`](serde_core::Serialize) impl above: a present value loads the
+/// field, `null` leaves it unloaded.
+#[cfg(feature = "serde")]
+impl<'de, T: serde_core::Deserialize<'de>> serde_core::Deserialize<'de> for Deferred<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde_core::Deserializer<'de>,
+    {
+        Ok(Self {
+            value: Option::<Box<T>>::deserialize(deserializer)?,
+        })
     }
 }


### PR DESCRIPTION
## Summary

`Deferred<T>` is now `Clone` when `T: Clone`, and gains a `Deserialize` impl to
match the existing transparent `Serialize`. A loaded value encodes as the bare
inner `T`; any present value (including `null`) deserializes back as loaded.

The unloaded state has no transparent encoding of its own, so deferred fields
are expected to be skipped rather than serialized:

```rust
#[serde(skip_serializing_if = "Deferred::is_unloaded", default)]
notes: Deferred<Option<String>>,
```

This mirrors how the old `HasMany` relation wrapper handled serde (transparent,
unloaded omitted). Distinguishing unloaded from a loaded `Deferred<Option<_>>`
holding `None` would require a non-transparent wrapper (the `lazy_slot` Value
encoding does this internally); we keep the wire format transparent and document
the skip pattern instead.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

`Deserialize` treats a *present* `null` as loaded, not unloaded — that's what
makes a loaded `Deferred<Option<_>>: None` round-trip. The unloaded round-trip
relies on the field being annotated as above; without the annotation an unloaded
field serializes to `null` and reads back as loaded.