### PR TITLE
chore: release v0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,21 +72,21 @@ unsafe_code = "deny"
 
 [workspace.dependencies]
 # Toasty crates
-toasty = { version = "0.7.0", path = "crates/toasty" }
-toasty-cli = { version = "0.7.0", path = "crates/toasty-cli" }
-toasty-core = { version = "0.7.0", path = "crates/toasty-core" }
-toasty-macros = { version = "0.7.0", path = "crates/toasty-macros" }
-toasty-sql = { version = "0.7.0", path = "crates/toasty-sql" }
+toasty = { version = "0.8.0", path = "crates/toasty" }
+toasty-cli = { version = "0.8.0", path = "crates/toasty-cli" }
+toasty-core = { version = "0.8.0", path = "crates/toasty-core" }
+toasty-macros = { version = "0.8.0", path = "crates/toasty-macros" }
+toasty-sql = { version = "0.8.0", path = "crates/toasty-sql" }
 # Driver implementations
-toasty-driver-dynamodb = { version = "0.7.0", path = "crates/toasty-driver-dynamodb" }
-toasty-driver-mysql = { version = "0.7.0", path = "crates/toasty-driver-mysql" }
-toasty-driver-postgresql = { version = "0.7.0", path = "crates/toasty-driver-postgresql" }
-toasty-driver-sqlite = { version = "0.7.0", path = "crates/toasty-driver-sqlite" }
-toasty-driver-turso = { version = "0.7.0", path = "crates/toasty-driver-turso" }
+toasty-driver-dynamodb = { version = "0.8.0", path = "crates/toasty-driver-dynamodb" }
+toasty-driver-mysql = { version = "0.8.0", path = "crates/toasty-driver-mysql" }
+toasty-driver-postgresql = { version = "0.8.0", path = "crates/toasty-driver-postgresql" }
+toasty-driver-sqlite = { version = "0.8.0", path = "crates/toasty-driver-sqlite" }
+toasty-driver-turso = { version = "0.8.0", path = "crates/toasty-driver-turso" }
 
 # Driver integration test suite dependencies
-toasty-driver-integration-suite = { version = "0.7.0", path = "crates/toasty-driver-integration-suite" }
-toasty-driver-integration-suite-macros = { version = "0.7.0", path = "crates/toasty-driver-integration-suite-macros" }
+toasty-driver-integration-suite = { version = "0.8.0", path = "crates/toasty-driver-integration-suite" }
+toasty-driver-integration-suite-macros = { version = "0.8.0", path = "crates/toasty-driver-integration-suite-macros" }
 
 # Other crates
 assert-struct = "0.4.2"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <div align="center">
   <h3>The cozy, easy ORM for Rust</h3>
-  <a href="https://tokio-rs.github.io/toasty/0.7.0/guide/">Guide</a> •
+  <a href="https://tokio-rs.github.io/toasty/0.8.0/guide/">Guide</a> •
   <a href="https://docs.rs/toasty">API Docs</a> •
   <a href="https://crates.io/crates/toasty">Crates.io</a> •
   <a href="https://discord.gg/tokio">Discord</a>

--- a/crates/toasty-cli/CHANGELOG.md
+++ b/crates/toasty-cli/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-cli-v0.7.0...toasty-cli-v0.8.0) - 2026-07-06
+
+### Added
+
+- Emit one toasty::query event per statement and propagate caller spans ([#1071])
+- Infer `key` and `references` in `#[belongs_to]` ([#1063])
+
+### Fixed
+
+- Include the path in Toasty config load errors ([#1036])
+
+[#1036]: https://github.com/tokio-rs/toasty/pull/1036
+[#1063]: https://github.com/tokio-rs/toasty/pull/1063
+[#1071]: https://github.com/tokio-rs/toasty/pull/1071
+
 ## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-cli-v0.6.1...toasty-cli-v0.7.0) - 2026-05-29
 
 ### Added

--- a/crates/toasty-cli/Cargo.toml
+++ b/crates/toasty-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-cli"
-version = "0.7.0"
+version = "0.8.0"
 description = "Command-line interface for Toasty schema management"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-core/CHANGELOG.md
+++ b/crates/toasty-core/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-core-v0.7.0...toasty-core-v0.8.0) - 2026-07-06
+
+### Added
+
+- Emit one toasty::query event per statement and propagate caller spans ([#1071])
+- Support #[version] optimistic concurrency on SQL drivers ([#1065])
+- Automatically infer `key` and `references` in `#[belongs_to]` ([#1063])
+- Share columns across enum variants via #[column("name")] ([#1064])
+- Add escape support for LIKE expressions ([#1039])
+- Add set_* replace-variants to Query builder ([#1037])
+- Allow indexes on unit enums ([#1027])
+- Add between operator to query DSL ([#1029])
+- Support Option<EmbeddedType> model fields ([#1021])
+- Support scalar terminal fields in has_many relations ([#1012])
+
+### Fixed
+
+- Avoid panic when updating a mixed enum to a unit variant ([#1069])
+- Truncate auto-generated index names that exceed the backend limit ([#1023])
+- Encode bool values correctly in DynamoDB to match key attribute type ([#945])
+
+### Changed
+
+- [**breaking**] Derive default table names at compile time ([#1070])
+- [**breaking**] Make UpdateByKey returning columns explicit ([#1024])
+
+[#945]: https://github.com/tokio-rs/toasty/pull/945
+[#1012]: https://github.com/tokio-rs/toasty/pull/1012
+[#1021]: https://github.com/tokio-rs/toasty/pull/1021
+[#1023]: https://github.com/tokio-rs/toasty/pull/1023
+[#1024]: https://github.com/tokio-rs/toasty/pull/1024
+[#1027]: https://github.com/tokio-rs/toasty/pull/1027
+[#1029]: https://github.com/tokio-rs/toasty/pull/1029
+[#1037]: https://github.com/tokio-rs/toasty/pull/1037
+[#1039]: https://github.com/tokio-rs/toasty/pull/1039
+[#1063]: https://github.com/tokio-rs/toasty/pull/1063
+[#1064]: https://github.com/tokio-rs/toasty/pull/1064
+[#1065]: https://github.com/tokio-rs/toasty/pull/1065
+[#1069]: https://github.com/tokio-rs/toasty/pull/1069
+[#1070]: https://github.com/tokio-rs/toasty/pull/1070
+[#1071]: https://github.com/tokio-rs/toasty/pull/1071
+
 ## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-core-v0.6.1...toasty-core-v0.7.0) - 2026-05-29
 
 ### Added

--- a/crates/toasty-core/Cargo.toml
+++ b/crates/toasty-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-core"
-version = "0.7.0"
+version = "0.8.0"
 description = "Core types, schema representations, and driver interface for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-dynamodb/CHANGELOG.md
+++ b/crates/toasty-driver-dynamodb/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-dynamodb-v0.7.0...toasty-driver-dynamodb-v0.8.0) - 2026-07-06
+
+### Added
+
+- Emit one `toasty::query` event per statement and propagate caller spans ([#1071])
+- Infer `key` and `references` in `#[belongs_to]` ([#1063])
+- Add `between` operator to query DSL ([#1029])
+- Support `Option<EmbeddedType>` model fields ([#1021])
+- Support composite unique indices ([#1018])
+
+### Fixed
+
+- Make multi-key delete and update consistent ([#1053])
+- Encode bool values as N("1"/"0") to match key attribute type ([#945])
+
+### Changed
+
+- [**breaking**] Make UpdateByKey returning columns explicit ([#1024])
+
+[#945]: https://github.com/tokio-rs/toasty/pull/945
+[#1018]: https://github.com/tokio-rs/toasty/pull/1018
+[#1021]: https://github.com/tokio-rs/toasty/pull/1021
+[#1024]: https://github.com/tokio-rs/toasty/pull/1024
+[#1029]: https://github.com/tokio-rs/toasty/pull/1029
+[#1053]: https://github.com/tokio-rs/toasty/pull/1053
+[#1063]: https://github.com/tokio-rs/toasty/pull/1063
+[#1071]: https://github.com/tokio-rs/toasty/pull/1071
+
 ## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-dynamodb-v0.6.1...toasty-driver-dynamodb-v0.7.0) - 2026-05-29
 
 ### Added

--- a/crates/toasty-driver-dynamodb/Cargo.toml
+++ b/crates/toasty-driver-dynamodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-dynamodb"
-version = "0.7.0"
+version = "0.8.0"
 description = "Amazon DynamoDB driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-integration-suite-macros/CHANGELOG.md
+++ b/crates/toasty-driver-integration-suite-macros/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-macros-v0.7.0...toasty-driver-integration-suite-macros-v0.8.0) - 2026-07-06
+
+### Added
+
+- infer `key` and `references` in `#[belongs_to]` ([#1063])
+
+[#1063]: https://github.com/tokio-rs/toasty/pull/1063
+
 ## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-macros-v0.6.1...toasty-driver-integration-suite-macros-v0.7.0) - 2026-05-29
 
 ### Added

--- a/crates/toasty-driver-integration-suite-macros/Cargo.toml
+++ b/crates/toasty-driver-integration-suite-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-integration-suite-macros"
-version = "0.7.0"
+version = "0.8.0"
 description = "Proc macros for the Toasty driver integration test suite"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-integration-suite/CHANGELOG.md
+++ b/crates/toasty-driver-integration-suite/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-v0.7.0...toasty-driver-integration-suite-v0.8.0) - 2026-07-06
+
+### Added
+
+- emit one toasty::query event per statement and propagate caller spans ([#1071])
+- support #[version] optimistic concurrency on SQL drivers ([#1065])
+- infer `key` and `references` in `#[belongs_to]` ([#1063])
+- share columns across enum variants via #[column("name")] ([#1064])
+- add escape support for like expr ([#1039])
+- allow index on unit enum ([#1027])
+- add between operator to query DSL ([#1029])
+- support Option<EmbeddedType> model fields ([#1021])
+- support composite unique indices ([#1018])
+- support scalar terminal fields in has_many via ([#1012])
+
+### Fixed
+
+- avoid panic when updating a mixed enum to a unit variant ([#1069])
+- fix decoding of OR'd variant filters ([#1067])
+- make multi-key delete and update consistent ([#1053])
+- truncate auto-generated index names that exceed the backend limit ([#1023])
+- increment #[version] field on query-based updates ([#1022])
+- fix boolean values in DynamoDB keys ([#945])
+
+### Changed
+
+- [**breaking**] make UpdateByKey returning columns explicit ([#1024])
+- [**breaking**] unify per-model query structs into Query<T> ([#995])
+- [**breaking**] remove the Register trait ([#1006])
+
+[#945]: https://github.com/tokio-rs/toasty/pull/945
+[#995]: https://github.com/tokio-rs/toasty/pull/995
+[#1006]: https://github.com/tokio-rs/toasty/pull/1006
+[#1012]: https://github.com/tokio-rs/toasty/pull/1012
+[#1018]: https://github.com/tokio-rs/toasty/pull/1018
+[#1021]: https://github.com/tokio-rs/toasty/pull/1021
+[#1022]: https://github.com/tokio-rs/toasty/pull/1022
+[#1023]: https://github.com/tokio-rs/toasty/pull/1023
+[#1024]: https://github.com/tokio-rs/toasty/pull/1024
+[#1027]: https://github.com/tokio-rs/toasty/pull/1027
+[#1029]: https://github.com/tokio-rs/toasty/pull/1029
+[#1039]: https://github.com/tokio-rs/toasty/pull/1039
+[#1053]: https://github.com/tokio-rs/toasty/pull/1053
+[#1063]: https://github.com/tokio-rs/toasty/pull/1063
+[#1064]: https://github.com/tokio-rs/toasty/pull/1064
+[#1065]: https://github.com/tokio-rs/toasty/pull/1065
+[#1067]: https://github.com/tokio-rs/toasty/pull/1067
+[#1069]: https://github.com/tokio-rs/toasty/pull/1069
+[#1071]: https://github.com/tokio-rs/toasty/pull/1071
+
 ## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-v0.6.1...toasty-driver-integration-suite-v0.7.0) - 2026-05-29
 
 ### Added

--- a/crates/toasty-driver-integration-suite/Cargo.toml
+++ b/crates/toasty-driver-integration-suite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-integration-suite"
-version = "0.7.0"
+version = "0.8.0"
 description = "Integration test suite for Toasty database drivers"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-mysql/CHANGELOG.md
+++ b/crates/toasty-driver-mysql/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-mysql-v0.7.0...toasty-driver-mysql-v0.8.0) - 2026-07-06
+
+### Added
+
+- Emit one `toasty::query` event per statement and propagate caller spans ([#1071])
+- Infer `key` and `references` in `#[belongs_to]` ([#1063])
+
+[#1063]: https://github.com/tokio-rs/toasty/pull/1063
+[#1071]: https://github.com/tokio-rs/toasty/pull/1071
+
 ## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-mysql-v0.6.1...toasty-driver-mysql-v0.7.0) - 2026-05-29
 
 ### Added

--- a/crates/toasty-driver-mysql/Cargo.toml
+++ b/crates/toasty-driver-mysql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-mysql"
-version = "0.7.0"
+version = "0.8.0"
 description = "MySQL driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-postgresql/CHANGELOG.md
+++ b/crates/toasty-driver-postgresql/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-postgresql-v0.7.0...toasty-driver-postgresql-v0.8.0) - 2026-07-06
+
+### Added
+
+- Emit one toasty::query event per statement and propagate caller spans ([#1071])
+- Infer `key` and `references` in `#[belongs_to]` ([#1063])
+
+[#1063]: https://github.com/tokio-rs/toasty/pull/1063
+[#1071]: https://github.com/tokio-rs/toasty/pull/1071
+
 ## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-postgresql-v0.6.1...toasty-driver-postgresql-v0.7.0) - 2026-05-29
 
 ### Added

--- a/crates/toasty-driver-postgresql/Cargo.toml
+++ b/crates/toasty-driver-postgresql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-postgresql"
-version = "0.7.0"
+version = "0.8.0"
 description = "PostgreSQL driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-sqlite/CHANGELOG.md
+++ b/crates/toasty-driver-sqlite/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-sqlite-v0.7.0...toasty-driver-sqlite-v0.8.0) - 2026-07-06
+
+### Added
+
+- Emit one toasty::query event per statement and propagate caller spans ([#1071])
+- Automatically infer `key` and `references` in `#[belongs_to]` ([#1063])
+- Add Serde serialization and deserialization for `toasty::Json<T>` ([#1035])
+
+### Fixed
+
+- SQLite driver properly propagates errors instead of panicking in `exec_sql` ([#1007])
+
+[#1007]: https://github.com/tokio-rs/toasty/pull/1007
+[#1035]: https://github.com/tokio-rs/toasty/pull/1035
+[#1063]: https://github.com/tokio-rs/toasty/pull/1063
+[#1071]: https://github.com/tokio-rs/toasty/pull/1071
+
 ## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-sqlite-v0.6.1...toasty-driver-sqlite-v0.7.0) - 2026-05-29
 
 ### Added

--- a/crates/toasty-driver-sqlite/Cargo.toml
+++ b/crates/toasty-driver-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-sqlite"
-version = "0.7.0"
+version = "0.8.0"
 description = "SQLite driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-turso/CHANGELOG.md
+++ b/crates/toasty-driver-turso/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-turso-v0.7.0...toasty-driver-turso-v0.8.0) - 2026-07-06
+
+### Added
+
+- Emit one toasty::query event per statement and propagate caller spans ([#1071])
+- Infer `key` and `references` in `#[belongs_to]` ([#1063])
+- Implement serde serialization and deserialization for toasty::Json<T> ([#1035])
+
+[#1035]: https://github.com/tokio-rs/toasty/pull/1035
+[#1063]: https://github.com/tokio-rs/toasty/pull/1063
+[#1071]: https://github.com/tokio-rs/toasty/pull/1071
+
 ## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-turso-v0.6.1...toasty-driver-turso-v0.7.0) - 2026-05-29
 
 ### Added

--- a/crates/toasty-driver-turso/Cargo.toml
+++ b/crates/toasty-driver-turso/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-turso"
-version = "0.7.0"
+version = "0.8.0"
 description = "Turso (SQLite-compatible) driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-macros/CHANGELOG.md
+++ b/crates/toasty-macros/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-macros-v0.7.0...toasty-macros-v0.8.0) - 2026-07-06
+
+### Added
+
+- Infer `key` and `references` in `#[belongs_to]` ([#1063])
+- Share columns across enum variants via `#[column("name")]` ([#1064])
+- Index unit enum types ([#1027])
+- Between operator for queries ([#1029])
+- Composite unique indices ([#1018])
+- Support scalar terminal fields in `has_many` ([#1012])
+
+### Changed
+
+- [**breaking**] Derive default table names at compile time ([#1070])
+- [**breaking**] Rename `RelationManyField`/`RelationOneField` associated type to `Target` ([#1015])
+- [**breaking**] Align `stmt::Query` with per-model `Query` ([#1011])
+- [**breaking**] Unify per-model query structs into `Query<T>` ([#995])
+- [**breaking**] Remove the `Register` trait ([#1006])
+- Remove compile-time field validation from `create!` macro ([#997])
+
+[#995]: https://github.com/tokio-rs/toasty/pull/995
+[#997]: https://github.com/tokio-rs/toasty/pull/997
+[#1006]: https://github.com/tokio-rs/toasty/pull/1006
+[#1011]: https://github.com/tokio-rs/toasty/pull/1011
+[#1012]: https://github.com/tokio-rs/toasty/pull/1012
+[#1015]: https://github.com/tokio-rs/toasty/pull/1015
+[#1018]: https://github.com/tokio-rs/toasty/pull/1018
+[#1027]: https://github.com/tokio-rs/toasty/pull/1027
+[#1029]: https://github.com/tokio-rs/toasty/pull/1029
+[#1063]: https://github.com/tokio-rs/toasty/pull/1063
+[#1064]: https://github.com/tokio-rs/toasty/pull/1064
+[#1070]: https://github.com/tokio-rs/toasty/pull/1070
+
 ## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-macros-v0.6.1...toasty-macros-v0.7.0) - 2026-05-29
 
 ### Added

--- a/crates/toasty-macros/Cargo.toml
+++ b/crates/toasty-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-macros"
-version = "0.7.0"
+version = "0.8.0"
 description = "Derive macros for Toasty models and embeds"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-sql/CHANGELOG.md
+++ b/crates/toasty-sql/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-sql-v0.7.0...toasty-sql-v0.8.0) - 2026-07-06
+
+### Added
+
+- Support #[version] attribute for optimistic concurrency on SQL drivers ([#1065])
+- Automatically infer key and references in #[belongs_to] relationships ([#1063])
+- Add escape support for LIKE expressions ([#1039])
+- Add BETWEEN operator to query DSL ([#1029])
+
+### Fixed
+
+- Fix incorrect results in OR'd variant filters when decoding enums ([#1067])
+
+[#1029]: https://github.com/tokio-rs/toasty/pull/1029
+[#1039]: https://github.com/tokio-rs/toasty/pull/1039
+[#1063]: https://github.com/tokio-rs/toasty/pull/1063
+[#1065]: https://github.com/tokio-rs/toasty/pull/1065
+[#1067]: https://github.com/tokio-rs/toasty/pull/1067
+
 ## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-sql-v0.6.1...toasty-sql-v0.7.0) - 2026-05-29
 
 ### Added

--- a/crates/toasty-sql/Cargo.toml
+++ b/crates/toasty-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-sql"
-version = "0.7.0"
+version = "0.8.0"
 description = "SQL serialization layer for Toasty database drivers"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty/CHANGELOG.md
+++ b/crates/toasty/CHANGELOG.md
@@ -7,6 +7,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-v0.7.0...toasty-v0.8.0) - 2026-07-06
+
+### Added
+
+- Emit one toasty::query event per statement and propagate caller spans ([#1071])
+- Support #[version] optimistic concurrency on SQL drivers ([#1065])
+- Infer `key` and `references` in `#[belongs_to]` ([#1063])
+- Share columns across enum variants via #[column("name")] ([#1064])
+- Add escape support for LIKE expressions ([#1039])
+- Add set_* replace-variants to Query builder ([#1037])
+- Implement serde serialization and deserialization for toasty::Json<T> ([#1035])
+- Allow index on unit enum ([#1027])
+- Add between operator to query DSL ([#1029])
+- Support Option<EmbeddedType> model fields ([#1021])
+- Support scalar terminal fields in has_many relations ([#1012])
+
+### Fixed
+
+- Avoid panic when updating a mixed enum to a unit variant ([#1069])
+- Fix enum decoding for OR'd variant filters ([#1067])
+- Make multi-key delete and update consistent ([#1053])
+- Increment #[version] field on query-based updates ([#1022])
+
+### Changed
+
+- [**breaking**] Make UpdateByKey returning columns explicit ([#1024])
+- [**breaking**] Rename RelationManyField/RelationOneField assoc type to Target ([#1015])
+- [**breaking**] Align stmt::Query with per-model Query ([#1011])
+- [**breaking**] Unify per-model query structs into Query<T> ([#995])
+- [**breaking**] Remove the Register trait ([#1006])
+- Remove compile-time field validation from create! macro ([#997])
+
+[#995]: https://github.com/tokio-rs/toasty/pull/995
+[#997]: https://github.com/tokio-rs/toasty/pull/997
+[#1006]: https://github.com/tokio-rs/toasty/pull/1006
+[#1011]: https://github.com/tokio-rs/toasty/pull/1011
+[#1012]: https://github.com/tokio-rs/toasty/pull/1012
+[#1015]: https://github.com/tokio-rs/toasty/pull/1015
+[#1021]: https://github.com/tokio-rs/toasty/pull/1021
+[#1022]: https://github.com/tokio-rs/toasty/pull/1022
+[#1024]: https://github.com/tokio-rs/toasty/pull/1024
+[#1027]: https://github.com/tokio-rs/toasty/pull/1027
+[#1029]: https://github.com/tokio-rs/toasty/pull/1029
+[#1035]: https://github.com/tokio-rs/toasty/pull/1035
+[#1037]: https://github.com/tokio-rs/toasty/pull/1037
+[#1039]: https://github.com/tokio-rs/toasty/pull/1039
+[#1053]: https://github.com/tokio-rs/toasty/pull/1053
+[#1063]: https://github.com/tokio-rs/toasty/pull/1063
+[#1064]: https://github.com/tokio-rs/toasty/pull/1064
+[#1065]: https://github.com/tokio-rs/toasty/pull/1065
+[#1067]: https://github.com/tokio-rs/toasty/pull/1067
+[#1069]: https://github.com/tokio-rs/toasty/pull/1069
+[#1071]: https://github.com/tokio-rs/toasty/pull/1071
+
 ## [0.7.0](https://github.com/tokio-rs/toasty/compare/toasty-v0.6.1...toasty-v0.7.0) - 2026-05-29
 
 ### Added

--- a/crates/toasty/Cargo.toml
+++ b/crates/toasty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty"
-version = "0.7.0"
+version = "0.8.0"
 description = "An async ORM for Rust supporting SQL and NoSQL databases"
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `toasty-core`: 0.7.0 -> 0.8.0 (⚠ API breaking changes)
* `toasty-driver-dynamodb`: 0.7.0 -> 0.8.0 (✓ API compatible changes)
* `toasty-sql`: 0.7.0 -> 0.8.0 (✓ API compatible changes)
* `toasty-driver-mysql`: 0.7.0 -> 0.8.0 (✓ API compatible changes)
* `toasty-driver-postgresql`: 0.7.0 -> 0.8.0 (✓ API compatible changes)
* `toasty-driver-sqlite`: 0.7.0 -> 0.8.0 (✓ API compatible changes)
* `toasty-driver-turso`: 0.7.0 -> 0.8.0 (✓ API compatible changes)
* `toasty-macros`: 0.7.0 -> 0.8.0
* `toasty`: 0.7.0 -> 0.8.0 (⚠ API breaking changes)
* `toasty-cli`: 0.7.0 -> 0.8.0 (✓ API compatible changes)
* `toasty-driver-integration-suite-macros`: 0.7.0 -> 0.8.0
* `toasty-driver-integration-suite`: 0.7.0 -> 0.8.0 (✓ API compatible changes)

### ⚠ `toasty-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Capability.max_identifier_length in /tmp/.tmpg5T7Mh/toasty/crates/toasty-core/src/driver/capability.rs:81
  field Capability.bool_key_type in /tmp/.tmpg5T7Mh/toasty/crates/toasty-core/src/driver/capability.rs:243
  field FieldStruct.presence in /tmp/.tmpg5T7Mh/toasty/crates/toasty-core/src/schema/mapping/field.rs:253
  field Via.terminal in /tmp/.tmpg5T7Mh/toasty/crates/toasty-core/src/schema/app/relation/via.rs:48

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant ExprSet:Delete in /tmp/.tmpg5T7Mh/toasty/crates/toasty-core/src/stmt/expr_set.rs:29
  variant Expr:Between in /tmp/.tmpg5T7Mh/toasty/crates/toasty-core/src/stmt/expr.rs:51

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  toasty_core::schema::app::Via::new takes 4 parameters in /tmp/.tmpZ08ap9/toasty-core/src/schema/app/relation/via.rs:35, but now takes 5 parameters in /tmp/.tmpg5T7Mh/toasty/crates/toasty-core/src/schema/app/relation/via.rs:53

--- failure trait_method_parameter_count_changed: pub trait method parameter count changed ---

Description:
A trait method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-item-signature
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_method_parameter_count_changed.ron

Failed in:
  Driver::connect now takes 1 instead of 0 parameters, in file /tmp/.tmpg5T7Mh/toasty/crates/toasty-core/src/driver.rs:129
```

### ⚠ `toasty` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_missing.ron

Failed in:
  enum toasty::schema::Direct, previously in file /tmp/.tmpZ08ap9/toasty/src/schema/relation.rs:11
  enum toasty::schema::Via, previously in file /tmp/.tmpZ08ap9/toasty/src/schema/relation.rs:18

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function toasty::schema::create_meta::const_contains, previously in file /tmp/.tmpZ08ap9/toasty/src/schema/create_meta.rs:57
  function toasty::schema::create_meta::assert_create_fields, previously in file /tmp/.tmpZ08ap9/toasty/src/schema/create_meta.rs:41

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  Path::root, previously in file /tmp/.tmpZ08ap9/toasty/src/stmt/path.rs:58
  Path::from_model_list, previously in file /tmp/.tmpZ08ap9/toasty/src/stmt/path.rs:71
  Path::from_field_index, previously in file /tmp/.tmpZ08ap9/toasty/src/stmt/path.rs:96
  Query::and, previously in file /tmp/.tmpZ08ap9/toasty/src/stmt/query.rs:122

--- failure method_receiver_mut_ref_became_owned: method receiver changed from mutable reference to owned value ---

Description:
A method's receiver changed from a mutable reference to an owned value. Ownership is transferred as part of the call, which is a breaking change.
        ref: https://doc.rust-lang.org/reference/items/associated-items.html#methods
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_receiver_mut_ref_became_owned.ron

Failed in:
  toasty::stmt::Query::include now takes Self, not &mut Self, in /tmp/.tmpg5T7Mh/toasty/crates/toasty/src/stmt/query.rs:190
  toasty::stmt::Query::order_by now takes Self, not &mut Self, in /tmp/.tmpg5T7Mh/toasty/crates/toasty/src/stmt/query.rs:218
  toasty::stmt::Query::limit now takes Self, not &mut Self, in /tmp/.tmpg5T7Mh/toasty/crates/toasty/src/stmt/query.rs:277
  toasty::stmt::Query::offset now takes Self, not &mut Self, in /tmp/.tmpg5T7Mh/toasty/crates/toasty/src/stmt/query.rs:305
  toasty::stmt::Query::latest_by now takes Self, not &mut Self, in /tmp/.tmpg5T7Mh/toasty/crates/toasty/src/stmt/query.rs:611

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/module_missing.ron

Failed in:
  mod toasty::schema::create_meta, previously in file /tmp/.tmpZ08ap9/toasty/src/schema/create_meta.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct toasty::schema::create_meta::CreateMeta, previously in file /tmp/.tmpZ08ap9/toasty/src/schema/create_meta.rs:2
  struct toasty::schema::CreateMeta, previously in file /tmp/.tmpZ08ap9/toasty/src/schema/create_meta.rs:2
  struct toasty::schema::create_meta::CreateField, previously in file /tmp/.tmpZ08ap9/toasty/src/schema/create_meta.rs:11
  struct toasty::schema::CreateField, previously in file /tmp/.tmpZ08ap9/toasty/src/schema/create_meta.rs:11

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_missing.ron

Failed in:
  trait toasty::schema::Register, previously in file /tmp/.tmpZ08ap9/toasty/src/schema/register.rs:22

--- failure trait_removed_associated_constant: trait's associated constant was removed ---

Description:
A public trait's associated constant was removed or renamed.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_removed_associated_constant.ron

Failed in:
  associated constant RelationManyField::NULLABLE, previously at /tmp/.tmpZ08ap9/toasty/src/schema/relation.rs:36
  associated constant Model::CREATE_META, previously at /tmp/.tmpZ08ap9/toasty/src/schema/model.rs:71

--- failure trait_removed_associated_type: trait's associated type was removed ---

Description:
A public trait's associated type was removed or renamed.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_removed_associated_type.ron

Failed in:
  associated type RelationManyField::Model, previously at /tmp/.tmpZ08ap9/toasty/src/schema/relation.rs:29
  associated type RelationOneField::Model, previously at /tmp/.tmpZ08ap9/toasty/src/schema/relation.rs:67
  associated type RelationOneField::ViaOne, previously at /tmp/.tmpZ08ap9/toasty/src/schema/relation.rs:77
  associated type Model::Many, previously at /tmp/.tmpZ08ap9/toasty/src/schema/model.rs:43
  associated type Model::ViaMany, previously at /tmp/.tmpZ08ap9/toasty/src/schema/model.rs:46
  associated type Model::One, previously at /tmp/.tmpZ08ap9/toasty/src/schema/model.rs:53
  associated type Model::ViaOne, previously at /tmp/.tmpZ08ap9/toasty/src/schema/model.rs:56
  associated type Model::OptionOne, previously at /tmp/.tmpZ08ap9/toasty/src/schema/model.rs:64
  associated type Model::ViaOptionOne, previously at /tmp/.tmpZ08ap9/toasty/src/schema/model.rs:67

--- failure trait_removed_supertrait: supertrait removed or renamed ---

Description:
A supertrait was removed from a trait. Users of the trait can no longer assume it can also be used like its supertrait.
        ref: https://doc.rust-lang.org/reference/items/traits.html#supertraits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_removed_supertrait.ron

Failed in:
  supertrait toasty::schema::Register of trait Embed in file /tmp/.tmpg5T7Mh/toasty/crates/toasty/src/schema/embed.rs:13
  supertrait toasty::schema::Register of trait Model in file /tmp/.tmpg5T7Mh/toasty/crates/toasty/src/schema/model.rs:14
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `toasty-core`

<blockquote>

## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-core-v0.7.0...toasty-core-v0.8.0) - 2026-07-06

### Added

- Emit one toasty::query event per statement and propagate caller spans ([#1071])
- Support #[version] optimistic concurrency on SQL drivers ([#1065])
- Automatically infer `key` and `references` in `#[belongs_to]` ([#1063])
- Share columns across enum variants via #[column("name")] ([#1064])
- Add escape support for LIKE expressions ([#1039])
- Add set_* replace-variants to Query builder ([#1037])
- Allow indexes on unit enums ([#1027])
- Add between operator to query DSL ([#1029])
- Support Option<EmbeddedType> model fields ([#1021])
- Support scalar terminal fields in has_many relations ([#1012])

### Fixed

- Avoid panic when updating a mixed enum to a unit variant ([#1069])
- Truncate auto-generated index names that exceed the backend limit ([#1023])
- Encode bool values correctly in DynamoDB to match key attribute type ([#945])

### Changed

- [**breaking**] Derive default table names at compile time ([#1070])
- [**breaking**] Make UpdateByKey returning columns explicit ([#1024])

[#945]: https://github.com/tokio-rs/toasty/pull/945
[#1012]: https://github.com/tokio-rs/toasty/pull/1012
[#1021]: https://github.com/tokio-rs/toasty/pull/1021
[#1023]: https://github.com/tokio-rs/toasty/pull/1023
[#1024]: https://github.com/tokio-rs/toasty/pull/1024
[#1027]: https://github.com/tokio-rs/toasty/pull/1027
[#1029]: https://github.com/tokio-rs/toasty/pull/1029
[#1037]: https://github.com/tokio-rs/toasty/pull/1037
[#1039]: https://github.com/tokio-rs/toasty/pull/1039
[#1063]: https://github.com/tokio-rs/toasty/pull/1063
[#1064]: https://github.com/tokio-rs/toasty/pull/1064
[#1065]: https://github.com/tokio-rs/toasty/pull/1065
[#1069]: https://github.com/tokio-rs/toasty/pull/1069
[#1070]: https://github.com/tokio-rs/toasty/pull/1070
[#1071]: https://github.com/tokio-rs/toasty/pull/1071
</blockquote>

## `toasty-driver-dynamodb`

<blockquote>

## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-dynamodb-v0.7.0...toasty-driver-dynamodb-v0.8.0) - 2026-07-06

### Added

- Emit one `toasty::query` event per statement and propagate caller spans ([#1071])
- Infer `key` and `references` in `#[belongs_to]` ([#1063])
- Add `between` operator to query DSL ([#1029])
- Support `Option<EmbeddedType>` model fields ([#1021])
- Support composite unique indices ([#1018])

### Fixed

- Make multi-key delete and update consistent ([#1053])
- Encode bool values as N("1"/"0") to match key attribute type ([#945])

### Changed

- [**breaking**] Make UpdateByKey returning columns explicit ([#1024])

[#945]: https://github.com/tokio-rs/toasty/pull/945
[#1018]: https://github.com/tokio-rs/toasty/pull/1018
[#1021]: https://github.com/tokio-rs/toasty/pull/1021
[#1024]: https://github.com/tokio-rs/toasty/pull/1024
[#1029]: https://github.com/tokio-rs/toasty/pull/1029
[#1053]: https://github.com/tokio-rs/toasty/pull/1053
[#1063]: https://github.com/tokio-rs/toasty/pull/1063
[#1071]: https://github.com/tokio-rs/toasty/pull/1071
</blockquote>

## `toasty-sql`

<blockquote>

## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-sql-v0.7.0...toasty-sql-v0.8.0) - 2026-07-06

### Added

- Support #[version] attribute for optimistic concurrency on SQL drivers ([#1065])
- Automatically infer key and references in #[belongs_to] relationships ([#1063])
- Add escape support for LIKE expressions ([#1039])
- Add BETWEEN operator to query DSL ([#1029])

### Fixed

- Fix incorrect results in OR'd variant filters when decoding enums ([#1067])

[#1029]: https://github.com/tokio-rs/toasty/pull/1029
[#1039]: https://github.com/tokio-rs/toasty/pull/1039
[#1063]: https://github.com/tokio-rs/toasty/pull/1063
[#1065]: https://github.com/tokio-rs/toasty/pull/1065
[#1067]: https://github.com/tokio-rs/toasty/pull/1067
</blockquote>

## `toasty-driver-mysql`

<blockquote>

## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-mysql-v0.7.0...toasty-driver-mysql-v0.8.0) - 2026-07-06

### Added

- Emit one `toasty::query` event per statement and propagate caller spans ([#1071])
- Infer `key` and `references` in `#[belongs_to]` ([#1063])

[#1063]: https://github.com/tokio-rs/toasty/pull/1063
[#1071]: https://github.com/tokio-rs/toasty/pull/1071
</blockquote>

## `toasty-driver-postgresql`

<blockquote>

## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-postgresql-v0.7.0...toasty-driver-postgresql-v0.8.0) - 2026-07-06

### Added

- Emit one toasty::query event per statement and propagate caller spans ([#1071])
- Infer `key` and `references` in `#[belongs_to]` ([#1063])

[#1063]: https://github.com/tokio-rs/toasty/pull/1063
[#1071]: https://github.com/tokio-rs/toasty/pull/1071
</blockquote>

## `toasty-driver-sqlite`

<blockquote>

## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-sqlite-v0.7.0...toasty-driver-sqlite-v0.8.0) - 2026-07-06

### Added

- Emit one toasty::query event per statement and propagate caller spans ([#1071])
- Automatically infer `key` and `references` in `#[belongs_to]` ([#1063])
- Add Serde serialization and deserialization for `toasty::Json<T>` ([#1035])

### Fixed

- SQLite driver properly propagates errors instead of panicking in `exec_sql` ([#1007])

[#1007]: https://github.com/tokio-rs/toasty/pull/1007
[#1035]: https://github.com/tokio-rs/toasty/pull/1035
[#1063]: https://github.com/tokio-rs/toasty/pull/1063
[#1071]: https://github.com/tokio-rs/toasty/pull/1071
</blockquote>

## `toasty-driver-turso`

<blockquote>

## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-turso-v0.7.0...toasty-driver-turso-v0.8.0) - 2026-07-06

### Added

- Emit one toasty::query event per statement and propagate caller spans ([#1071])
- Infer `key` and `references` in `#[belongs_to]` ([#1063])
- Implement serde serialization and deserialization for toasty::Json<T> ([#1035])

[#1035]: https://github.com/tokio-rs/toasty/pull/1035
[#1063]: https://github.com/tokio-rs/toasty/pull/1063
[#1071]: https://github.com/tokio-rs/toasty/pull/1071
</blockquote>

## `toasty-macros`

<blockquote>

## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-macros-v0.7.0...toasty-macros-v0.8.0) - 2026-07-06

### Added

- Infer `key` and `references` in `#[belongs_to]` ([#1063])
- Share columns across enum variants via `#[column("name")]` ([#1064])
- Index unit enum types ([#1027])
- Between operator for queries ([#1029])
- Composite unique indices ([#1018])
- Support scalar terminal fields in `has_many` ([#1012])

### Changed

- [**breaking**] Derive default table names at compile time ([#1070])
- [**breaking**] Rename `RelationManyField`/`RelationOneField` associated type to `Target` ([#1015])
- [**breaking**] Align `stmt::Query` with per-model `Query` ([#1011])
- [**breaking**] Unify per-model query structs into `Query<T>` ([#995])
- [**breaking**] Remove the `Register` trait ([#1006])
- Remove compile-time field validation from `create!` macro ([#997])

[#995]: https://github.com/tokio-rs/toasty/pull/995
[#997]: https://github.com/tokio-rs/toasty/pull/997
[#1006]: https://github.com/tokio-rs/toasty/pull/1006
[#1011]: https://github.com/tokio-rs/toasty/pull/1011
[#1012]: https://github.com/tokio-rs/toasty/pull/1012
[#1015]: https://github.com/tokio-rs/toasty/pull/1015
[#1018]: https://github.com/tokio-rs/toasty/pull/1018
[#1027]: https://github.com/tokio-rs/toasty/pull/1027
[#1029]: https://github.com/tokio-rs/toasty/pull/1029
[#1063]: https://github.com/tokio-rs/toasty/pull/1063
[#1064]: https://github.com/tokio-rs/toasty/pull/1064
[#1070]: https://github.com/tokio-rs/toasty/pull/1070
</blockquote>

## `toasty`

<blockquote>

## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-v0.7.0...toasty-v0.8.0) - 2026-07-06

### Added

- Emit one toasty::query event per statement and propagate caller spans ([#1071])
- Support #[version] optimistic concurrency on SQL drivers ([#1065])
- Infer `key` and `references` in `#[belongs_to]` ([#1063])
- Share columns across enum variants via #[column("name")] ([#1064])
- Add escape support for LIKE expressions ([#1039])
- Add set_* replace-variants to Query builder ([#1037])
- Implement serde serialization and deserialization for toasty::Json<T> ([#1035])
- Allow index on unit enum ([#1027])
- Add between operator to query DSL ([#1029])
- Support Option<EmbeddedType> model fields ([#1021])
- Support scalar terminal fields in has_many relations ([#1012])

### Fixed

- Avoid panic when updating a mixed enum to a unit variant ([#1069])
- Fix enum decoding for OR'd variant filters ([#1067])
- Make multi-key delete and update consistent ([#1053])
- Increment #[version] field on query-based updates ([#1022])

### Changed

- [**breaking**] Make UpdateByKey returning columns explicit ([#1024])
- [**breaking**] Rename RelationManyField/RelationOneField assoc type to Target ([#1015])
- [**breaking**] Align stmt::Query with per-model Query ([#1011])
- [**breaking**] Unify per-model query structs into Query<T> ([#995])
- [**breaking**] Remove the Register trait ([#1006])
- Remove compile-time field validation from create! macro ([#997])

[#995]: https://github.com/tokio-rs/toasty/pull/995
[#997]: https://github.com/tokio-rs/toasty/pull/997
[#1006]: https://github.com/tokio-rs/toasty/pull/1006
[#1011]: https://github.com/tokio-rs/toasty/pull/1011
[#1012]: https://github.com/tokio-rs/toasty/pull/1012
[#1015]: https://github.com/tokio-rs/toasty/pull/1015
[#1021]: https://github.com/tokio-rs/toasty/pull/1021
[#1022]: https://github.com/tokio-rs/toasty/pull/1022
[#1024]: https://github.com/tokio-rs/toasty/pull/1024
[#1027]: https://github.com/tokio-rs/toasty/pull/1027
[#1029]: https://github.com/tokio-rs/toasty/pull/1029
[#1035]: https://github.com/tokio-rs/toasty/pull/1035
[#1037]: https://github.com/tokio-rs/toasty/pull/1037
[#1039]: https://github.com/tokio-rs/toasty/pull/1039
[#1053]: https://github.com/tokio-rs/toasty/pull/1053
[#1063]: https://github.com/tokio-rs/toasty/pull/1063
[#1064]: https://github.com/tokio-rs/toasty/pull/1064
[#1065]: https://github.com/tokio-rs/toasty/pull/1065
[#1067]: https://github.com/tokio-rs/toasty/pull/1067
[#1069]: https://github.com/tokio-rs/toasty/pull/1069
[#1071]: https://github.com/tokio-rs/toasty/pull/1071
</blockquote>

## `toasty-cli`

<blockquote>

## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-cli-v0.7.0...toasty-cli-v0.8.0) - 2026-07-06

### Added

- Emit one toasty::query event per statement and propagate caller spans ([#1071])
- Infer `key` and `references` in `#[belongs_to]` ([#1063])

### Fixed

- Include the path in Toasty config load errors ([#1036])

[#1036]: https://github.com/tokio-rs/toasty/pull/1036
[#1063]: https://github.com/tokio-rs/toasty/pull/1063
[#1071]: https://github.com/tokio-rs/toasty/pull/1071
</blockquote>

## `toasty-driver-integration-suite-macros`

<blockquote>

## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-macros-v0.7.0...toasty-driver-integration-suite-macros-v0.8.0) - 2026-07-06

### Added

- infer `key` and `references` in `#[belongs_to]` ([#1063])

[#1063]: https://github.com/tokio-rs/toasty/pull/1063
</blockquote>

## `toasty-driver-integration-suite`

<blockquote>

## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-v0.7.0...toasty-driver-integration-suite-v0.8.0) - 2026-07-06

### Added

- emit one toasty::query event per statement and propagate caller spans ([#1071])
- support #[version] optimistic concurrency on SQL drivers ([#1065])
- infer `key` and `references` in `#[belongs_to]` ([#1063])
- share columns across enum variants via #[column("name")] ([#1064])
- add escape support for like expr ([#1039])
- allow index on unit enum ([#1027])
- add between operator to query DSL ([#1029])
- support Option<EmbeddedType> model fields ([#1021])
- support composite unique indices ([#1018])
- support scalar terminal fields in has_many via ([#1012])

### Fixed

- avoid panic when updating a mixed enum to a unit variant ([#1069])
- fix decoding of OR'd variant filters ([#1067])
- make multi-key delete and update consistent ([#1053])
- truncate auto-generated index names that exceed the backend limit ([#1023])
- increment #[version] field on query-based updates ([#1022])
- fix boolean values in DynamoDB keys ([#945])

### Changed

- [**breaking**] make UpdateByKey returning columns explicit ([#1024])
- [**breaking**] unify per-model query structs into Query<T> ([#995])
- [**breaking**] remove the Register trait ([#1006])

[#945]: https://github.com/tokio-rs/toasty/pull/945
[#995]: https://github.com/tokio-rs/toasty/pull/995
[#1006]: https://github.com/tokio-rs/toasty/pull/1006
[#1012]: https://github.com/tokio-rs/toasty/pull/1012
[#1018]: https://github.com/tokio-rs/toasty/pull/1018
[#1021]: https://github.com/tokio-rs/toasty/pull/1021
[#1022]: https://github.com/tokio-rs/toasty/pull/1022
[#1023]: https://github.com/tokio-rs/toasty/pull/1023
[#1024]: https://github.com/tokio-rs/toasty/pull/1024
[#1027]: https://github.com/tokio-rs/toasty/pull/1027
[#1029]: https://github.com/tokio-rs/toasty/pull/1029
[#1039]: https://github.com/tokio-rs/toasty/pull/1039
[#1053]: https://github.com/tokio-rs/toasty/pull/1053
[#1063]: https://github.com/tokio-rs/toasty/pull/1063
[#1064]: https://github.com/tokio-rs/toasty/pull/1064
[#1065]: https://github.com/tokio-rs/toasty/pull/1065
[#1067]: https://github.com/tokio-rs/toasty/pull/1067
[#1069]: https://github.com/tokio-rs/toasty/pull/1069
[#1071]: https://github.com/tokio-rs/toasty/pull/1071
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).