### PR TITLE
fix(sqlite): propagate errors instead of unwrapping in exec_sql

### DIFF
--- a/crates/toasty-driver-sqlite/src/lib.rs
+++ b/crates/toasty-driver-sqlite/src/lib.rs
@@ -180,7 +180,10 @@ impl Connection {
     ) -> Result<ExecResponse> {
         tracing::debug!(db.system = "sqlite", db.statement = %sql_str, params = typed_params.len(), "executing SQL");
 
-        let mut stmt = self.connection.prepare_cached(sql_str).unwrap();
+        let mut stmt = self
+            .connection
+            .prepare_cached(sql_str)
+            .map_err(toasty_core::Error::driver_operation_failed)?;
 
         let params = typed_params
             .into_iter()
@@ -197,7 +200,7 @@ impl Connection {
 
         let mut rows = stmt
             .query(rusqlite::params_from_iter(params.iter()))
-            .unwrap();
+            .map_err(toasty_core::Error::driver_operation_failed)?;
 
         let mut values = vec![];
         let column_count = rows.as_ref().map(|stmt| stmt.column_count()).unwrap_or(0);


### PR DESCRIPTION

<!--
PR title uses Conventional Commits, e.g.
    feat: add upsert support
    fix: handle composite key in IN-list rewrite
See CONTRIBUTING.md for the full process.
-->

## Summary

Replaces two `unwrap` calls in the SQLite driver's `exec_sql` method with proper error propagation by mapping the driver-specific error to `toasty_core::Error::driver_operation_failed`. 
Previously, a failed `prepare_cached` or `query` call would panic, whereas now the error is returned to the caller. 

## Type of change

<!-- Check one. -->

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test
- [ ] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`):
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [ ] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [ ] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers

N/A
