### PR TITLE
refactor!: align stmt::Query with per-model Query

### DIFF
--- a/crates/toasty-macros/src/model/expand/model.rs
+++ b/crates/toasty-macros/src/model/expand/model.rs
@@ -75,7 +75,7 @@ impl Expand<'_> {
                 }
 
                 #vis fn filter(expr: #toasty::stmt::Expr<bool>) -> #query_struct_ident {
-                    #query_struct_ident::from_stmt(#toasty::stmt::Query::filter(expr))
+                    #query_struct_ident::from_stmt(#toasty::stmt::Query::all().filter(expr))
                 }
 
                 #vis fn delete(self) -> #toasty::stmt::Delete<()> {

--- a/crates/toasty-macros/src/model/expand/query.rs
+++ b/crates/toasty-macros/src/model/expand/query.rs
@@ -121,31 +121,35 @@ impl Expand<'_> {
 
                 #vis fn filter(self, expr: #toasty::stmt::Expr<bool>) -> Self {
                     Self {
-                        stmt: self.stmt.and(expr),
+                        stmt: self.stmt.filter(expr),
                     }
                 }
 
-                #vis fn order_by(mut self, order_by: impl Into<#toasty::stmt::OrderBy>) -> Self {
-                    self.stmt.order_by(order_by);
-                    self
+                #vis fn order_by(self, order_by: impl Into<#toasty::stmt::OrderBy>) -> Self {
+                    Self {
+                        stmt: self.stmt.order_by(order_by),
+                    }
                 }
 
                 #vis fn latest_by<#include_ty>(
-                    mut self,
+                    self,
                     field: #toasty::stmt::Path<#model_ident, #include_ty>,
                 ) -> Self {
-                    self.stmt.latest_by(field);
-                    self
+                    Self {
+                        stmt: self.stmt.latest_by(field),
+                    }
                 }
 
-                #vis fn limit(mut self, n: usize) -> Self {
-                    self.stmt.limit(n);
-                    self
+                #vis fn limit(self, n: usize) -> Self {
+                    Self {
+                        stmt: self.stmt.limit(n),
+                    }
                 }
 
-                #vis fn offset(mut self, n: usize) -> Self {
-                    self.stmt.offset(n);
-                    self
+                #vis fn offset(self, n: usize) -> Self {
+                    Self {
+                        stmt: self.stmt.offset(n),
+                    }
                 }
 
                 /// Add an item to the relation this query was scoped from.
@@ -398,11 +402,12 @@ impl Expand<'_> {
         // on a model whose only includable thing lives inside an embed.
         Some(quote! {
             #vis fn include<#include_ty>(
-                mut self,
+                self,
                 path: impl #toasty::Into<#toasty::Path<#model_ident, #include_ty>>,
             ) -> Self {
-                self.stmt.include(path.into());
-                self
+                Self {
+                    stmt: self.stmt.include(path.into()),
+                }
             }
         })
     }

--- a/crates/toasty/src/stmt/association.rs
+++ b/crates/toasty/src/stmt/association.rs
@@ -67,7 +67,7 @@ impl<M: Model> Association<List<M>> {
     /// use toasty::stmt::{Association, List, Query};
     /// use toasty::schema::Model;
     ///
-    /// let source = Query::<List<User>>::filter(User::fields().id().eq(1));
+    /// let source = Query::<List<User>>::all().filter(User::fields().id().eq(1));
     /// let path = User::path_field::<List<Todo>>(2);
     /// let _assoc = Association::many(source, path);
     /// ```
@@ -150,7 +150,7 @@ impl<M: Model> Association<List<M>> {
     /// use toasty::stmt::{Association, Expr, List, Query};
     /// use toasty::schema::Model;
     ///
-    /// let source = Query::<List<User>>::filter(User::fields().id().eq(1));
+    /// let source = Query::<List<User>>::all().filter(User::fields().id().eq(1));
     /// let path = User::path_field::<List<Todo>>(2);
     /// let assoc = Association::many(source, path);
     ///
@@ -197,7 +197,7 @@ impl<M: Model> Association<List<M>> {
     /// use toasty::stmt::{Association, Expr, List, Query};
     /// use toasty::schema::Model;
     ///
-    /// let source = Query::<List<User>>::filter(User::fields().id().eq(1));
+    /// let source = Query::<List<User>>::all().filter(User::fields().id().eq(1));
     /// let path = User::path_field::<List<Todo>>(2);
     /// let assoc = Association::many(source, path);
     ///
@@ -279,7 +279,7 @@ impl<M: Model> Association<M> {
     /// use toasty::stmt::{Association, List, Query};
     /// use toasty::schema::Model;
     ///
-    /// let source = Query::<List<Todo>>::filter(Todo::fields().id().eq(1));
+    /// let source = Query::<List<Todo>>::all().filter(Todo::fields().id().eq(1));
     /// let path = Todo::path_field::<User>(1);
     /// let _assoc = Association::one(source, path);
     /// ```

--- a/crates/toasty/src/stmt/delete.rs
+++ b/crates/toasty/src/stmt/delete.rs
@@ -30,7 +30,7 @@ use toasty_core::stmt;
 /// # db.push_schema().await.unwrap();
 /// use toasty::stmt::{List, Query};
 ///
-/// Query::<List<User>>::filter(User::fields().id().eq(1))
+/// Query::<List<User>>::all().filter(User::fields().id().eq(1))
 ///     .delete()
 ///     .exec(&mut db)
 ///     .await

--- a/crates/toasty/src/stmt/paginate.rs
+++ b/crates/toasty/src/stmt/paginate.rs
@@ -28,8 +28,8 @@ use toasty_core::stmt;
 /// # db.push_schema().await.unwrap();
 /// use toasty::stmt::{List, Paginate, Query};
 ///
-/// let mut q = Query::<List<User>>::all();
-/// q.order_by(User::fields().name().asc());
+/// let q = Query::<List<User>>::all()
+///     .order_by(User::fields().name().asc());
 /// let page = Paginate::new(q, 20)
 ///     .exec(&mut db)
 ///     .await
@@ -69,8 +69,8 @@ impl<M> Paginate<M> {
     /// # }
     /// use toasty::stmt::{List, Paginate, Query};
     ///
-    /// let mut q = Query::<List<User>>::all();
-    /// q.order_by(User::fields().name().asc());
+    /// let q = Query::<List<User>>::all()
+    ///     .order_by(User::fields().name().asc());
     /// let _paginator = Paginate::new(q, 20);
     /// ```
     pub fn new(mut query: Query<List<M>>, per_page: usize) -> Self {
@@ -112,8 +112,8 @@ impl<M> Paginate<M> {
     /// # }
     /// use toasty::stmt::{List, Paginate, Query};
     ///
-    /// let mut q = Query::<List<User>>::all();
-    /// q.order_by(User::fields().id().asc());
+    /// let q = Query::<List<User>>::all()
+    ///     .order_by(User::fields().id().asc());
     /// let paginator = Paginate::new(q, 10)
     ///     .after(toasty_core::stmt::Value::from(42_i64));
     /// ```
@@ -148,8 +148,8 @@ impl<M> Paginate<M> {
     /// # }
     /// use toasty::stmt::{List, Paginate, Query};
     ///
-    /// let mut q = Query::<List<User>>::all();
-    /// q.order_by(User::fields().id().asc());
+    /// let q = Query::<List<User>>::all()
+    ///     .order_by(User::fields().id().asc());
     /// let paginator = Paginate::new(q, 10)
     ///     .before(toasty_core::stmt::Value::from(100_i64));
     /// ```
@@ -188,8 +188,8 @@ impl<M: Load> Paginate<M> {
     /// # db.push_schema().await.unwrap();
     /// use toasty::stmt::{List, Paginate, Query};
     ///
-    /// let mut q = Query::<List<User>>::all();
-    /// q.order_by(User::fields().name().asc());
+    /// let q = Query::<List<User>>::all()
+    ///     .order_by(User::fields().name().asc());
     /// let page = Paginate::new(q, 20)
     ///     .exec(&mut db)
     ///     .await

--- a/crates/toasty/src/stmt/path.rs
+++ b/crates/toasty/src/stmt/path.rs
@@ -307,7 +307,7 @@ impl<T, U> Path<T, U> {
     /// // A path targeting User values
     /// let path = User::path_root();
     /// // A subquery returning List<User>
-    /// let subquery = Query::<List<User>>::filter(User::fields().name().eq("Alice"));
+    /// let subquery = Query::<List<User>>::all().filter(User::fields().name().eq("Alice"));
     /// let filter = path.in_query(subquery);
     /// ```
     pub fn in_query<Q>(self, rhs: Q) -> Expr<bool>
@@ -329,8 +329,8 @@ impl<T, U> Path<T, U> {
     /// #     id: i64,
     /// #     name: String,
     /// # }
-    /// let mut q = User::all();
-    /// q.order_by(User::fields().name().asc());
+    /// let q = User::all()
+    ///     .order_by(User::fields().name().asc());
     /// ```
     pub fn asc(self) -> OrderByExpr {
         OrderByExpr {
@@ -350,8 +350,8 @@ impl<T, U> Path<T, U> {
     /// #     id: i64,
     /// #     name: String,
     /// # }
-    /// let mut q = User::all();
-    /// q.order_by(User::fields().name().desc());
+    /// let q = User::all()
+    ///     .order_by(User::fields().name().desc());
     /// ```
     pub fn desc(self) -> OrderByExpr {
         OrderByExpr {
@@ -396,7 +396,7 @@ impl<T, U> Path<T, List<U>> {
         U: crate::schema::Model,
     {
         // Build a query on the child model filtered by `filter`
-        let child_query = super::Query::<List<U>>::filter(filter);
+        let child_query = super::Query::<List<U>>::all().filter(filter);
         self.build_filter(move |path| stmt::Expr::in_subquery(path, child_query.untyped))
     }
 
@@ -435,7 +435,7 @@ impl<T, U> Path<T, List<U>> {
         U: crate::schema::Model,
     {
         // parent NOT IN (SELECT child_fk FROM child WHERE NOT filter)
-        let child_query = super::Query::<List<U>>::filter(filter.not());
+        let child_query = super::Query::<List<U>>::all().filter(filter.not());
         self.build_filter(move |path| {
             stmt::Expr::not(stmt::Expr::in_subquery(path, child_query.untyped))
         })

--- a/crates/toasty/src/stmt/query.rs
+++ b/crates/toasty/src/stmt/query.rs
@@ -22,7 +22,7 @@ use toasty_core::stmt::{self, Returning};
 /// # Building queries
 ///
 /// Start with a generated finder (e.g., `User::filter_by_name("Alice")`) or
-/// use [`Query::all`] / [`Query::filter`] directly:
+/// use [`Query::all`] and chain [`filter`](Query::filter):
 ///
 /// ```
 /// # #[derive(Debug, toasty::Model)]
@@ -38,12 +38,12 @@ use toasty_core::stmt::{self, Returning};
 /// let q = Query::<List<User>>::all();
 ///
 /// // Filtered
-/// let q = Query::<List<User>>::filter(User::fields().age().gt(18));
+/// let q = Query::<List<User>>::all().filter(User::fields().age().gt(18));
 ///
 /// // Chained
-/// let mut q = Query::<List<User>>::all()
-///     .and(User::fields().name().eq("Alice"));
-/// q.limit(10);
+/// let q = Query::<List<User>>::all()
+///     .filter(User::fields().name().eq("Alice"))
+///     .limit(10);
 /// ```
 ///
 /// # Execution
@@ -132,9 +132,9 @@ impl<T> Query<T> {
     /// use toasty::stmt::{List, Query};
     ///
     /// let q = Query::<List<User>>::all()
-    ///     .and(User::fields().name().eq("Alice"));
+    ///     .filter(User::fields().name().eq("Alice"));
     /// ```
-    pub fn and(mut self, filter: Expr<bool>) -> Self {
+    pub fn filter(mut self, filter: Expr<bool>) -> Self {
         self.untyped.add_filter(filter.untyped);
         self
     }
@@ -163,11 +163,10 @@ impl<T> Query<T> {
     /// use toasty::stmt::{List, Query};
     /// use toasty::schema::Model;
     ///
-    /// let mut q = Query::<List<User>>::all();
     /// // Include the field at index 1 (name)
-    /// q.include(User::path_field::<String>(1));
+    /// let q = Query::<List<User>>::all().include(User::path_field::<String>(1));
     /// ```
-    pub fn include(&mut self, path: impl Into<stmt::Path>) -> &mut Self {
+    pub fn include(mut self, path: impl Into<stmt::Path>) -> Self {
         self.untyped.include(path.into());
         self
     }
@@ -192,10 +191,10 @@ impl<T> Query<T> {
     /// # }
     /// use toasty::stmt::{List, Query};
     ///
-    /// let mut q = Query::<List<User>>::all();
-    /// q.order_by((User::fields().age().desc(), User::fields().name().asc()));
+    /// let q = Query::<List<User>>::all()
+    ///     .order_by((User::fields().age().desc(), User::fields().name().asc()));
     /// ```
-    pub fn order_by(&mut self, order_by: impl Into<stmt::OrderBy>) -> &mut Self {
+    pub fn order_by(mut self, order_by: impl Into<stmt::OrderBy>) -> Self {
         let order_by = order_by.into();
         match &mut self.untyped.order_by {
             Some(existing) => existing.exprs.extend(order_by.exprs),
@@ -223,10 +222,9 @@ impl<T> Query<T> {
     /// # }
     /// use toasty::stmt::{List, Query};
     ///
-    /// let mut q = Query::<List<User>>::all();
-    /// q.limit(10);
+    /// let q = Query::<List<User>>::all().limit(10);
     /// ```
-    pub fn limit(&mut self, n: usize) -> &mut Self {
+    pub fn limit(mut self, n: usize) -> Self {
         let n = i64::try_from(n).expect("limit exceeds i64::MAX");
         self.untyped.limit = Some(stmt::Limit::Offset(stmt::LimitOffset {
             limit: stmt::Value::from(n).into(),
@@ -252,11 +250,9 @@ impl<T> Query<T> {
     /// # }
     /// use toasty::stmt::{List, Query};
     ///
-    /// let mut q = Query::<List<User>>::all();
-    /// q.limit(10);
-    /// q.offset(20);
+    /// let q = Query::<List<User>>::all().limit(10).offset(20);
     /// ```
-    pub fn offset(&mut self, n: usize) -> &mut Self {
+    pub fn offset(mut self, n: usize) -> Self {
         let n = i64::try_from(n).expect("offset exceeds i64::MAX");
         self.untyped.limit = match self.untyped.limit.take() {
             Some(stmt::Limit::Offset(limit_offset)) => {
@@ -289,7 +285,7 @@ impl<T> Query<T> {
     /// # }
     /// use toasty::stmt::{List, Query};
     ///
-    /// let delete = Query::<List<User>>::filter(User::fields().name().eq("Alice"))
+    /// let delete = Query::<List<User>>::all().filter(User::fields().name().eq("Alice"))
     ///     .delete();
     /// ```
     pub fn delete(self) -> Delete<()> {
@@ -440,27 +436,6 @@ impl<T: Load> Query<T> {
 
 /// Methods for list queries: `Query<List<M>>`
 impl<M: Model> Query<List<M>> {
-    /// Create a query that selects records of `M` matching `expr`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # #[derive(Debug, toasty::Model)]
-    /// # struct User {
-    /// #     #[key]
-    /// #     id: i64,
-    /// #     name: String,
-    /// # }
-    /// use toasty::stmt::{List, Query};
-    ///
-    /// let q = Query::<List<User>>::filter(User::fields().name().eq("Alice"));
-    /// ```
-    pub fn filter(expr: Expr<bool>) -> Self {
-        let mut query = stmt::Query::new_select(M::id(), expr.untyped);
-        query.single = false;
-        Self::from_untyped(query)
-    }
-
     /// Convert this list query into a count query that returns the number of
     /// matching records as a `u64`.
     ///
@@ -581,10 +556,9 @@ impl<M: Model> Query<List<M>> {
     /// # }
     /// use toasty::stmt::{List, Query};
     ///
-    /// let mut q = Query::<List<User>>::all();
-    /// q.latest_by(User::fields().id());
+    /// let q = Query::<List<User>>::all().latest_by(User::fields().id());
     /// ```
-    pub fn latest_by<U>(&mut self, field: Path<M, U>) -> &mut Self {
+    pub fn latest_by<U>(self, field: Path<M, U>) -> Self {
         self.order_by(field.desc())
     }
 }

--- a/crates/toasty/tests/stmt_into_scope.rs
+++ b/crates/toasty/tests/stmt_into_scope.rs
@@ -57,7 +57,8 @@ fn into_scope_from_one_clears_single_and_limit() {
 fn into_scope_preserves_filter_body() {
     // The body (source + filter) should round-trip identically through
     // widening — only `single` / `limit` get reset.
-    let list_q: Query<List<User>> = Query::filter(User::fields().name().eq("alice"));
+    let list_q: Query<List<User>> =
+        Query::<List<User>>::all().filter(User::fields().name().eq("alice"));
     let from_list = untyped_query(IntoScope::<User>::into_scope(list_q.clone()));
 
     let from_option = untyped_query(IntoScope::<User>::into_scope(list_q.clone().first()));


### PR DESCRIPTION
## Summary

`toasty::stmt::Query` and the per-model generated `Query` had drifted into two builders with different ergonomics. This aligns `stmt::Query`'s public API to the per-model shape so the two feel the same — the per-model type is the canonical builder for app-level models, while `stmt::Query` is the type for projections and other non-model queries.

- rename `and` → `filter` (instance AND-combinator)
- make `include`/`order_by`/`limit`/`offset`/`latest_by` consume and return `Self` instead of `&mut self`, matching the per-model builder's chaining
- remove the static `Query::filter(expr)` constructor (it collided with the new instance `filter`); `Query::all().filter(expr)` is equivalent

`to_list` is intentionally left as-is for now.

**Breaking:** replace `q.and(..)` with `q.filter(..)`; replace `let mut q = ...; q.limit(n);` with `let q = ....limit(n);`; replace the static `Query::filter(expr)` with `Query::all().filter(expr)`.

## Type of change

- [x] Other: breaking API alignment refactor (existing public-API ergonomics; no new behavior)

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

`count`/`select` on the per-model `Query` still return `stmt::Query<…>` — projections deliberately exit the model wrapper into the generic query type, matching the split this PR is reinforcing.