### PR TITLE
feat: support scalar terminal fields in has_many via

### DIFF
--- a/crates/toasty-core/src/schema/app/relation/via.rs
+++ b/crates/toasty-core/src/schema/app/relation/via.rs
@@ -13,9 +13,20 @@ use crate::{
 /// (e.g. `User::fields().comments().article()`) and converts it into a
 /// [`stmt::Path`], so a misspelled or otherwise unresolvable segment is a
 /// Rust compile error rather than a runtime schema validation failure.
+///
+/// The terminal segment of the path is usually another relation (the via
+/// reaches a model). It may also be a **scalar field**, in which case the via
+/// projects that field through the relation path — e.g.
+/// `#[has_many(via = todos.tags.name)] tag_names: Vec<String>` collects the
+/// `name` of every tag reachable through todos. For a scalar terminal,
+/// [`terminal`](Self::terminal) holds the terminal field's index on
+/// [`target`](Self::target) (the model the relation chain reaches), and
+/// [`path`](Self::path) still includes that terminal step as its last element.
 #[derive(Debug, Clone)]
 pub struct Via {
-    /// The [`ModelId`] of the associated (target) model.
+    /// The [`ModelId`] of the model the relation chain reaches. For a relation
+    /// terminal this is the associated (target) model; for a scalar terminal
+    /// it is the model that owns the projected terminal field.
     pub target: ModelId,
 
     /// The expression type this field evaluates to from the application's
@@ -26,8 +37,15 @@ pub struct Via {
     pub cardinality: Cardinality,
 
     /// The resolved field path, rooted at the model that declares the via
-    /// relation.
+    /// relation. When [`terminal`](Self::terminal) is `Some`, the last element
+    /// of the path is the scalar terminal field (on [`target`](Self::target))
+    /// and the preceding elements form the relation chain.
     pub path: stmt::Path,
+
+    /// For a scalar-terminal via, the index of the projected terminal field on
+    /// [`target`](Self::target). `None` when the via reaches a model (the
+    /// terminal segment is itself a relation).
+    pub terminal: Option<usize>,
 }
 
 impl Via {
@@ -37,13 +55,21 @@ impl Via {
         expr_ty: stmt::Type,
         cardinality: Cardinality,
         path: stmt::Path,
+        terminal: Option<usize>,
     ) -> Self {
         Self {
             target,
             expr_ty,
             cardinality,
             path,
+            terminal,
         }
+    }
+
+    /// Returns `true` when the via projects a scalar terminal field rather than
+    /// reaching a model.
+    pub fn is_scalar(&self) -> bool {
+        self.terminal.is_some()
     }
 
     /// Returns `true` when this is a one-to-many relation.

--- a/crates/toasty-core/src/schema/app/schema.rs
+++ b/crates/toasty-core/src/schema/app/schema.rs
@@ -225,9 +225,108 @@ impl Builder {
         // All models have been discovered and initialized at some level, now do
         // the relation linking.
         self.link_relations()?;
+        self.resolve_via_targets()?;
         self.verify_no_eager_load_cycles()?;
 
         Ok(())
+    }
+
+    /// Resolve the `target` of every scalar-terminal `via` relation.
+    ///
+    /// A relation-terminal via knows its target at macro-expansion time (the
+    /// field's element type). A scalar-terminal via does not — the model that
+    /// owns the projected field is whatever the relation chain reaches — so the
+    /// derive leaves `target` unset and it is computed here by walking the
+    /// chain. Runs after [`link_relations`](Self::link_relations) so every
+    /// `Has`/`BelongsTo` target is final.
+    fn resolve_via_targets(&mut self) -> crate::Result<()> {
+        // Collect first; the walk borrows other models immutably.
+        let mut updates = Vec::new();
+
+        for curr in 0..self.models.len() {
+            if self.models[curr].is_embedded() {
+                continue;
+            }
+            let src = self.models[curr].id();
+            for index in 0..self.models[curr].as_root_unwrap().fields.len() {
+                let field = &self.models[curr].as_root_unwrap().fields[index];
+                let FieldTy::Via(via) = &field.ty else {
+                    continue;
+                };
+                let Some(terminal) = via.terminal else {
+                    continue;
+                };
+
+                // The relation chain is the path minus its terminal field.
+                let projection = via.path.projection.as_slice();
+                let relation_steps = &projection[..projection.len() - 1];
+                let field_name = field.name.app_unwrap().to_string();
+                let target = self.walk_via_relation_chain(src, relation_steps, &field_name)?;
+
+                // The terminal must be a stored scalar on the reached model.
+                let terminal_field = &self.models[&target].as_root_unwrap().fields[terminal];
+                if !matches!(terminal_field.ty, FieldTy::Primitive(_)) {
+                    return Err(crate::Error::invalid_schema(format!(
+                        "the `via` terminal `{}::{}` is not a scalar field",
+                        self.models[&target].name().upper_camel_case(),
+                        terminal_field.name.app_unwrap(),
+                    )));
+                }
+
+                updates.push((curr, index, target));
+            }
+        }
+
+        for (curr, index, target) in updates {
+            if let FieldTy::Via(via) = &mut self.models[curr].as_root_mut_unwrap().fields[index].ty
+            {
+                via.target = target;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Walk a via relation chain, splicing any nested via's own chain, and
+    /// return the model it reaches. Every step must be a relation.
+    fn walk_via_relation_chain(
+        &self,
+        declaring: ModelId,
+        steps: &[usize],
+        field_name: &str,
+    ) -> crate::Result<ModelId> {
+        let mut current = declaring;
+        let mut queue: Vec<usize> = steps.iter().rev().copied().collect();
+
+        while let Some(idx) = queue.pop() {
+            let field = &self.models[&current].as_root_unwrap().fields[idx];
+            match &field.ty {
+                FieldTy::Has(has) => current = has.target,
+                FieldTy::BelongsTo(belongs_to) => current = belongs_to.target,
+                // A nested via contributes its own relation chain (its terminal,
+                // if scalar, is not part of the path through it).
+                FieldTy::Via(inner) => {
+                    let inner_projection = inner.path.projection.as_slice();
+                    let inner_steps = match inner.terminal {
+                        Some(_) => &inner_projection[..inner_projection.len() - 1],
+                        None => inner_projection,
+                    };
+                    for step in inner_steps.iter().rev() {
+                        queue.push(*step);
+                    }
+                }
+                _ => {
+                    return Err(crate::Error::invalid_schema(format!(
+                        "the `via` path for `{}::{}` traverses `{}`, which is not a relation",
+                        self.models[&declaring].name().upper_camel_case(),
+                        field_name,
+                        field.name.app_unwrap(),
+                    )));
+                }
+            }
+        }
+
+        Ok(current)
     }
 
     fn verify_no_eager_load_cycles(&self) -> crate::Result<()> {

--- a/crates/toasty-driver-integration-suite/src/scenarios.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios.rs
@@ -34,6 +34,7 @@ pub mod user_org_project_todo;
 pub mod user_post_comment;
 pub mod user_profile_and_todos;
 pub mod user_profile_settings;
+pub mod user_tag_names;
 pub mod user_todo_step;
 pub mod user_two_children;
 pub mod user_unique_email;

--- a/crates/toasty-driver-integration-suite/src/scenarios/user_comment_article.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios/user_comment_article.rs
@@ -17,6 +17,10 @@ scenario! {
         // User → comments → article
         #[has_many(via = comments.article)]
         commented_articles: toasty::Deferred<Vec<Article>>,
+
+        // User → comments → article → title (scalar terminal)
+        #[has_many(via = comments.article.title)]
+        commented_article_titles: toasty::Deferred<Vec<String>>,
     }
 
     #[derive(Debug, toasty::Model)]

--- a/crates/toasty-driver-integration-suite/src/scenarios/user_comment_article.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios/user_comment_article.rs
@@ -21,6 +21,12 @@ scenario! {
         // User → comments → article → title (scalar terminal)
         #[has_many(via = comments.article.title)]
         commented_article_titles: toasty::Deferred<Vec<String>>,
+
+        // User → comments → body: a 2-step scalar terminal. The terminal field
+        // sits directly on the first relation's target, so the relation chain is
+        // a single step — the minimal scalar-via walk.
+        #[has_many(via = comments.body)]
+        comment_bodies: toasty::Deferred<Vec<String>>,
     }
 
     #[derive(Debug, toasty::Model)]

--- a/crates/toasty-driver-integration-suite/src/scenarios/user_org_project_todo.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios/user_org_project_todo.rs
@@ -32,6 +32,12 @@ scenario! {
         // The second step expands into another via path (via-of-via).
         #[has_many(via = organizations.todos)]
         nested_todos: toasty::Deferred<Vec<Todo>>,
+
+        // A via-of-via with a *scalar* terminal: the chain routes through
+        // `Organization::todos` (itself a via), then projects `Todo::title`.
+        // Exercises the nested-via splice on the scalar-terminal code paths.
+        #[has_many(via = organizations.todos.title)]
+        nested_todo_titles: toasty::Deferred<Vec<String>>,
     }
 
     #[derive(Debug, toasty::Model)]

--- a/crates/toasty-driver-integration-suite/src/scenarios/user_tag_names.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios/user_tag_names.rs
@@ -1,0 +1,46 @@
+use crate::prelude::*;
+
+scenario! {
+    //! A scalar-terminal `via` declared **without** `Deferred`, so the field is
+    //! an eager relation edge: it auto-loads whenever a `User` is queried, with
+    //! no explicit `.include()`. Every other via scenario wraps the field in
+    //! `Deferred`, leaving the `ViaManyField for Vec<E>` (`DEFERRED = false`)
+    //! impl — and via auto-loading — otherwise unexercised.
+
+    #![id(ID)]
+
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+
+        name: String,
+
+        #[has_many]
+        tags: toasty::Deferred<Vec<Tag>>,
+
+        // Non-deferred scalar via: an eager edge loaded on every `User` query.
+        #[has_many(via = tags.name)]
+        tag_names: Vec<String>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Tag {
+        #[key]
+        #[auto]
+        id: ID,
+
+        name: String,
+
+        #[index]
+        user_id: ID,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: toasty::Deferred<User>,
+    }
+
+    async fn setup(test: &mut Test) -> toasty::Db {
+        test.setup_db(models!(User, Tag)).await
+    }
+}

--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_via.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_via.rs
@@ -678,6 +678,43 @@ pub async fn include_scalar_via(test: &mut Test) -> Result<()> {
     Ok(())
 }
 
+/// A scalar-terminal `via` can also be navigated off a query (not just a
+/// loaded instance): `User::filter(…).article_titles()` yields the distinct
+/// titles reachable from the matched users.
+#[driver_test(
+    id(ID),
+    requires(sql),
+    scenario(crate::scenarios::user_comment_article)
+)]
+pub async fn query_chain_scalar_via(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let alice = toasty::create!(User { name: "Alice" })
+        .exec(&mut db)
+        .await?;
+
+    let articles = toasty::create!(Article::[{ title: "Rust" }, { title: "Toasty" }])
+        .exec(&mut db)
+        .await?;
+    let (rust, toasty_article) = (&articles[0], &articles[1]);
+
+    toasty::create!(Comment::[
+        { body: "a1", user: &alice, article: rust },
+        { body: "a2", user: &alice, article: rust },
+        { body: "a3", user: &alice, article: toasty_article },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let titles = User::filter(User::fields().name().eq("Alice"))
+        .commented_article_titles()
+        .exec(&mut db)
+        .await?;
+    assert_eq_unordered!(titles.iter().map(|t| &t[..]), ["Rust", "Toasty"]);
+
+    Ok(())
+}
+
 /// `.select()` of a scalar-terminal `via` returns the projected titles per
 /// parent row.
 #[driver_test(

--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_via.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_via.rs
@@ -410,6 +410,79 @@ pub async fn include_via_nested_via(test: &mut Test) -> Result<()> {
     Ok(())
 }
 
+/// A via-of-via with a **scalar terminal**: `nested_todo_titles` routes through
+/// `organizations.todos` — where `Organization::todos` is itself a via — then
+/// projects `Todo::title`. This drives the nested-via splice
+/// (`flatten_via_steps` / `RewriteVia`) on the *scalar*-terminal code paths,
+/// which the model via-of-via ([`include_via_nested_via`]) leaves untested.
+/// Distinct values still apply, so a title shared by todos in different orgs
+/// collapses to one. Navigation and `.include()` must agree.
+#[driver_test(
+    id(ID),
+    requires(sql),
+    scenario(crate::scenarios::user_org_project_todo)
+)]
+pub async fn scalar_via_of_via(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let alice = toasty::create!(User { name: "Alice" })
+        .exec(&mut db)
+        .await?;
+    let org_a = toasty::create!(Organization {
+        name: "A-Co",
+        user: &alice
+    })
+    .exec(&mut db)
+    .await?;
+    let org_b = toasty::create!(Organization {
+        name: "B-Co",
+        user: &alice
+    })
+    .exec(&mut db)
+    .await?;
+    let proj_a = toasty::create!(Project {
+        name: "p-a",
+        organization: &org_a
+    })
+    .exec(&mut db)
+    .await?;
+    let proj_b = toasty::create!(Project {
+        name: "p-b",
+        organization: &org_b
+    })
+    .exec(&mut db)
+    .await?;
+
+    // "y" appears under todos in *both* orgs — distinct values collapse it.
+    toasty::create!(Todo::[
+        { title: "x", project: &proj_a },
+        { title: "y", project: &proj_a },
+        { title: "y", project: &proj_b },
+        { title: "z", project: &proj_b },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    // Navigation projects the titles through the nested via.
+    let titles = alice.nested_todo_titles().exec(&mut db).await?;
+    assert_eq_unordered!(titles.iter().map(|t| &t[..]), ["x", "y", "z"]);
+
+    // `.include()` agrees.
+    let loaded = User::filter_by_id(alice.id)
+        .include(User::fields().nested_todo_titles())
+        .get(&mut db)
+        .await?;
+    let titles: Vec<&str> = loaded
+        .nested_todo_titles
+        .get()
+        .iter()
+        .map(|t| &t[..])
+        .collect();
+    assert_eq_unordered!(titles, ["x", "y", "z"]);
+
+    Ok(())
+}
+
 /// A user with no intermediates yields an empty included set — the
 /// `INNER JOIN` excludes them but the parent row is still returned.
 #[driver_test(
@@ -613,6 +686,107 @@ pub async fn query_scalar_via_returns_distinct_titles(test: &mut Test) -> Result
     Ok(())
 }
 
+/// Pins the **distinct *values*** decision against the alternative (distinct
+/// *targets*). The case that tells them apart is a user commenting on two
+/// *different* articles that happen to share a title: the model-via reaches two
+/// distinct targets, but the scalar via collapses their equal terminal values
+/// to one — `["Rust"]`, not `["Rust", "Rust"]`.
+///
+/// [`query_scalar_via_returns_distinct_titles`] can't distinguish the two
+/// semantics: it dedups a single target reached through several comments, which
+/// both semantics collapse identically. Navigation and `.include()` must agree.
+#[driver_test(
+    id(ID),
+    requires(sql),
+    scenario(crate::scenarios::user_comment_article)
+)]
+pub async fn scalar_via_distinct_values_across_distinct_targets(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let alice = toasty::create!(User { name: "Alice" })
+        .exec(&mut db)
+        .await?;
+
+    // Two *different* articles that happen to share the title "Rust".
+    let articles = toasty::create!(Article::[{ title: "Rust" }, { title: "Rust" }])
+        .exec(&mut db)
+        .await?;
+    let (rust_a, rust_b) = (&articles[0], &articles[1]);
+
+    toasty::create!(Comment::[
+        { body: "a1", user: &alice, article: rust_a },
+        { body: "a2", user: &alice, article: rust_b },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    // The targets are genuinely distinct: the model-via reaches both articles.
+    let commented = alice.commented_articles().exec(&mut db).await?;
+    assert_eq!(commented.len(), 2);
+
+    // ...but the scalar via yields distinct *values*: the shared title collapses
+    // to one. Distinct *targets* would instead give ["Rust", "Rust"].
+    let titles = alice.commented_article_titles().exec(&mut db).await?;
+    assert_eq_unordered!(titles.iter().map(|t| &t[..]), ["Rust"]);
+
+    // `.include()` agrees with navigation.
+    let loaded = User::filter_by_id(alice.id)
+        .include(User::fields().commented_article_titles())
+        .get(&mut db)
+        .await?;
+    let titles: Vec<&str> = loaded
+        .commented_article_titles
+        .get()
+        .iter()
+        .map(|t| &t[..])
+        .collect();
+    assert_eq_unordered!(titles, ["Rust"]);
+
+    Ok(())
+}
+
+/// A 2-step scalar via (`comments.body`): the terminal field sits directly on
+/// the first relation's target, so the relation chain is a single step
+/// (`[comments]`) — the minimal scalar-via walk, distinct from the 3-step
+/// `comments.article.title`. Distinct values still apply, so a body repeated
+/// across comments appears once. Navigation and `.include()` must agree.
+#[driver_test(
+    id(ID),
+    requires(sql),
+    scenario(crate::scenarios::user_comment_article)
+)]
+pub async fn query_scalar_via_two_step(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let alice = toasty::create!(User { name: "Alice" })
+        .exec(&mut db)
+        .await?;
+    let article = toasty::create!(Article { title: "Rust" })
+        .exec(&mut db)
+        .await?;
+
+    // "a1" twice, "a2" once — distinct *values* collapse "a1".
+    toasty::create!(Comment::[
+        { body: "a1", user: &alice, article: &article },
+        { body: "a1", user: &alice, article: &article },
+        { body: "a2", user: &alice, article: &article },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let bodies = alice.comment_bodies().exec(&mut db).await?;
+    assert_eq_unordered!(bodies.iter().map(|b| &b[..]), ["a1", "a2"]);
+
+    let loaded = User::filter_by_id(alice.id)
+        .include(User::fields().comment_bodies())
+        .get(&mut db)
+        .await?;
+    let bodies: Vec<&str> = loaded.comment_bodies.get().iter().map(|b| &b[..]).collect();
+    assert_eq_unordered!(bodies, ["a1", "a2"]);
+
+    Ok(())
+}
+
 /// `.include()` of a scalar-terminal `via` loads the projected titles onto each
 /// parent, grouped by user, with duplicates collapsed.
 #[driver_test(
@@ -750,6 +924,52 @@ pub async fn select_scalar_via(test: &mut Test) -> Result<()> {
     assert_eq!(1, titles_per_user.len());
     let titles: Vec<&str> = titles_per_user[0].iter().map(|t| &t[..]).collect();
     assert_eq_unordered!(titles, ["Rust", "Toasty"]);
+
+    Ok(())
+}
+
+/// A **non-deferred** scalar via (`tag_names: Vec<String>`, no `Deferred`) is an
+/// eager relation edge: querying the parent auto-loads the projected terminal
+/// values without an explicit `.include()`. Every other via scenario wraps the
+/// field in `Deferred`, so this is the only test exercising the
+/// `ViaManyField for Vec<E>` (`DEFERRED = false`) impl and via auto-loading. The
+/// load groups per user and collapses duplicate values, like the explicit
+/// `.include()` paths.
+#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::user_tag_names))]
+pub async fn eager_scalar_via_auto_loads(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let users = toasty::create!(User::[{ name: "Alice" }, { name: "Bob" }])
+        .exec(&mut db)
+        .await?;
+    let (alice, bob) = (&users[0], &users[1]);
+
+    toasty::create!(Tag::[
+        { name: "rust", user: alice },
+        { name: "rust", user: alice },
+        { name: "db", user: alice },
+        { name: "sql", user: bob },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    // No `.include()`: the eager via loads on a plain query.
+    let loaded: Vec<User> = User::all().exec(&mut db).await?;
+    assert_eq!(2, loaded.len());
+
+    for user in &loaded {
+        let names: Vec<&str> = user.tag_names.iter().map(|n| &n[..]).collect();
+        match &user.name[..] {
+            // "rust" was tagged twice but the via yields distinct values.
+            "Alice" => {
+                assert_eq_unordered!(names, ["rust", "db"]);
+            }
+            "Bob" => {
+                assert_eq_unordered!(names, ["sql"]);
+            }
+            other => panic!("unexpected user {other}"),
+        }
+    }
 
     Ok(())
 }

--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_via.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_via.rs
@@ -560,3 +560,159 @@ pub async fn select_via_has_one(test: &mut Test) -> Result<()> {
 
     Ok(())
 }
+
+// ===== Scalar-terminal `via`: the path ends in a field, not a relation =====
+//
+// `#[has_many(via = comments.article.title)] commented_article_titles:
+// Vec<String>` projects the `title` of every article a user has commented on.
+// The relation chain (`comments.article`) is the same as `commented_articles`;
+// the extra `.title` step makes the field a `Vec<String>` of distinct titles.
+
+/// Querying a scalar-terminal `via` projects the terminal field across the
+/// relation path, yielding distinct values — a title reached through several
+/// comments appears once.
+#[driver_test(
+    id(ID),
+    requires(sql),
+    scenario(crate::scenarios::user_comment_article)
+)]
+pub async fn query_scalar_via_returns_distinct_titles(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let users = toasty::create!(User::[{ name: "Alice" }, { name: "Bob" }])
+        .exec(&mut db)
+        .await?;
+    let (alice, bob) = (&users[0], &users[1]);
+
+    let articles = toasty::create!(Article::[
+        { title: "Rust" },
+        { title: "Toasty" },
+        { title: "SQL" },
+    ])
+    .exec(&mut db)
+    .await?;
+    let (rust, toasty_article, sql) = (&articles[0], &articles[1], &articles[2]);
+
+    // Alice → Rust (twice), Toasty.  Bob → SQL.
+    toasty::create!(Comment::[
+        { body: "a1", user: alice, article: rust },
+        { body: "a2", user: alice, article: rust },
+        { body: "a3", user: alice, article: toasty_article },
+        { body: "b1", user: bob, article: sql },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    // Rust appears once even though Alice commented on it twice.
+    let titles = alice.commented_article_titles().exec(&mut db).await?;
+    assert_eq_unordered!(titles.iter().map(|t| &t[..]), ["Rust", "Toasty"]);
+
+    let titles = bob.commented_article_titles().exec(&mut db).await?;
+    assert_eq_unordered!(titles.iter().map(|t| &t[..]), ["SQL"]);
+
+    Ok(())
+}
+
+/// `.include()` of a scalar-terminal `via` loads the projected titles onto each
+/// parent, grouped by user, with duplicates collapsed.
+#[driver_test(
+    id(ID),
+    requires(sql),
+    scenario(crate::scenarios::user_comment_article)
+)]
+pub async fn include_scalar_via(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let users = toasty::create!(User::[
+        { name: "Alice" },
+        { name: "Bob" },
+        { name: "Charlie" },
+    ])
+    .exec(&mut db)
+    .await?;
+    let (alice, bob) = (&users[0], &users[1]);
+
+    let articles = toasty::create!(Article::[
+        { title: "Rust" },
+        { title: "Toasty" },
+        { title: "SQL" },
+    ])
+    .exec(&mut db)
+    .await?;
+    let (rust, toasty_article, sql) = (&articles[0], &articles[1], &articles[2]);
+
+    toasty::create!(Comment::[
+        { body: "a1", user: alice, article: rust },
+        { body: "a2", user: alice, article: rust },
+        { body: "a3", user: alice, article: toasty_article },
+        { body: "b1", user: bob, article: sql },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let loaded: Vec<User> = User::all()
+        .include(User::fields().commented_article_titles())
+        .exec(&mut db)
+        .await?;
+    assert_eq!(3, loaded.len());
+
+    for user in &loaded {
+        let titles: Vec<&str> = user
+            .commented_article_titles
+            .get()
+            .iter()
+            .map(|t| &t[..])
+            .collect();
+        match &user.name[..] {
+            "Alice" => {
+                assert_eq_unordered!(titles, ["Rust", "Toasty"]);
+            }
+            "Bob" => {
+                assert_eq_unordered!(titles, ["SQL"]);
+            }
+            "Charlie" => assert!(titles.is_empty(), "Charlie has no comments; got {titles:?}"),
+            other => panic!("unexpected user {other}"),
+        }
+    }
+
+    Ok(())
+}
+
+/// `.select()` of a scalar-terminal `via` returns the projected titles per
+/// parent row.
+#[driver_test(
+    id(ID),
+    requires(sql),
+    scenario(crate::scenarios::user_comment_article)
+)]
+pub async fn select_scalar_via(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let alice = toasty::create!(User { name: "Alice" })
+        .exec(&mut db)
+        .await?;
+
+    let articles = toasty::create!(Article::[{ title: "Rust" }, { title: "Toasty" }])
+        .exec(&mut db)
+        .await?;
+    let (rust, toasty_article) = (&articles[0], &articles[1]);
+
+    toasty::create!(Comment::[
+        { body: "a1", user: &alice, article: rust },
+        { body: "a2", user: &alice, article: rust },
+        { body: "a3", user: &alice, article: toasty_article },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let titles_per_user: Vec<Vec<String>> = User::all()
+        .select(User::fields().commented_article_titles())
+        .exec(&mut db)
+        .await?;
+
+    assert_eq!(1, titles_per_user.len());
+    let titles: Vec<&str> = titles_per_user[0].iter().map(|t| &t[..]).collect();
+    assert_eq_unordered!(titles, ["Rust", "Toasty"]);
+
+    Ok(())
+}

--- a/crates/toasty-macros/src/model/expand/fields.rs
+++ b/crates/toasty-macros/src/model/expand/fields.rs
@@ -76,10 +76,10 @@ impl Expand<'_> {
                             // A `via` field is a projection handle: it only needs
                             // to be includable / selectable (`Into<stmt::Path>`),
                             // so expose a plain list path. The element comes from
-                            // `ManyViaElem`, which works for scalar terminals too
+                            // `ViaManyField`, which works for scalar terminals too
                             // (where there is no `RelationManyField::Model`).
                             quote_spanned! { span=>
-                                #vis fn #field_ident(&self) -> #toasty::Path<__Origin, #toasty::List<<#ty as #toasty::ManyViaElem>::Elem>> {
+                                #vis fn #field_ident(&self) -> #toasty::Path<__Origin, #toasty::List<<#ty as #toasty::ViaManyField>::Target>> {
                                     #path
                                 }
                             }
@@ -200,13 +200,13 @@ impl Expand<'_> {
                     HasMany(rel) if rel.via.is_some() => {
                         // See the `via` branch in `expand_field_struct`: a via
                         // field is a plain list-path projection handle, and its
-                        // element comes from `ManyViaElem` so scalar terminals
+                        // element comes from `ViaManyField` so scalar terminals
                         // work too.
                         let ty = &rel.ty;
                         let span = field_ident.span();
                         let schema_trait = self.schema_trait();
                         quote_spanned! { span=>
-                            #vis fn #field_ident(&self) -> #toasty::Path<__Origin, #toasty::List<<#ty as #toasty::ManyViaElem>::Elem>> {
+                            #vis fn #field_ident(&self) -> #toasty::Path<__Origin, #toasty::List<<#ty as #toasty::ViaManyField>::Target>> {
                                 self.path().chain(
                                     <#model_ident as #schema_trait>::path_field(#field_offset)
                                 )

--- a/crates/toasty-macros/src/model/expand/fields.rs
+++ b/crates/toasty-macros/src/model/expand/fields.rs
@@ -21,6 +21,15 @@ impl Expand<'_> {
                 #vis fn create(&self) -> #create_struct_ident {
                     #create_struct_ident::default()
                 }
+
+                /// The id of the model this path points at. Used by generated
+                /// `#[has_many(via = …)]` code to resolve the model that owns a
+                /// scalar terminal field when the relation-chain prefix ends in
+                /// a singular relation.
+                #[doc(hidden)]
+                #vis fn target_model_id(&self) -> #toasty::core::schema::app::ModelId {
+                    <#model_ident as #toasty::Model>::id()
+                }
             }
         } else {
             TokenStream::new()
@@ -63,9 +72,22 @@ impl Expand<'_> {
                             self.path().chain(<#model_ident as #field_schema_trait>::path_field(#field_offset))
                         };
 
-                        quote_spanned! { span=>
-                            #vis fn #field_ident(&self) -> <<#ty as #toasty::RelationManyField>::Model as #toasty::Model>::ManyField<__Origin> {
-                                <<<#ty as #toasty::RelationManyField>::Model as #toasty::Model>::ManyField<__Origin>>::from_path(#path)
+                        if rel.via.is_some() {
+                            // A `via` field is a projection handle: it only needs
+                            // to be includable / selectable (`Into<stmt::Path>`),
+                            // so expose a plain list path. The element comes from
+                            // `ManyViaElem`, which works for scalar terminals too
+                            // (where there is no `RelationManyField::Model`).
+                            quote_spanned! { span=>
+                                #vis fn #field_ident(&self) -> #toasty::Path<__Origin, #toasty::List<<#ty as #toasty::ManyViaElem>::Elem>> {
+                                    #path
+                                }
+                            }
+                        } else {
+                            quote_spanned! { span=>
+                                #vis fn #field_ident(&self) -> <<#ty as #toasty::RelationManyField>::Model as #toasty::Model>::ManyField<__Origin> {
+                                    <<<#ty as #toasty::RelationManyField>::Model as #toasty::Model>::ManyField<__Origin>>::from_path(#path)
+                                }
                             }
                         }
                     }
@@ -175,6 +197,22 @@ impl Expand<'_> {
                             &field_offset,
                         )
                     }
+                    HasMany(rel) if rel.via.is_some() => {
+                        // See the `via` branch in `expand_field_struct`: a via
+                        // field is a plain list-path projection handle, and its
+                        // element comes from `ManyViaElem` so scalar terminals
+                        // work too.
+                        let ty = &rel.ty;
+                        let span = field_ident.span();
+                        let schema_trait = self.schema_trait();
+                        quote_spanned! { span=>
+                            #vis fn #field_ident(&self) -> #toasty::Path<__Origin, #toasty::List<<#ty as #toasty::ManyViaElem>::Elem>> {
+                                self.path().chain(
+                                    <#model_ident as #schema_trait>::path_field(#field_offset)
+                                )
+                            }
+                        }
+                    }
                     HasMany(rel) => {
                         let ty = &rel.ty;
                         self.expand_list_relation_field_method(
@@ -198,7 +236,8 @@ impl Expand<'_> {
             TokenStream::new()
         };
 
-        // any() / all() are only available on root models (requires Model trait bound)
+        // any() / all() / target_model_id() are only available on root models
+        // (they require the `Model` trait bound).
         let any_method = if is_root {
             quote! {
                 /// Filter the parent model by a condition on the associated
@@ -214,6 +253,15 @@ impl Expand<'_> {
                 /// associated records).
                 #vis fn all(self, filter: #toasty::stmt::Expr<bool>) -> #toasty::stmt::Expr<bool> {
                     self.path.all(filter)
+                }
+
+                /// The id of the model this list path points at. Used by
+                /// generated `#[has_many(via = …)]` code to resolve the model
+                /// that owns a scalar terminal field from the relation-chain
+                /// prefix.
+                #[doc(hidden)]
+                #vis fn target_model_id(&self) -> #toasty::core::schema::app::ModelId {
+                    <#model_ident as #toasty::Model>::id()
                 }
             }
         } else {

--- a/crates/toasty-macros/src/model/expand/fields.rs
+++ b/crates/toasty-macros/src/model/expand/fields.rs
@@ -64,14 +64,18 @@ impl Expand<'_> {
                         };
 
                         if rel.via.is_some() {
-                            // A `via` field is a projection handle: it only needs
-                            // to be includable / selectable (`Into<stmt::Path>`),
-                            // so expose a plain list path. The element comes from
+                            // A `via` step returns its terminal's path handle
+                            // (`ViaTarget::Path`): a model terminal yields a
+                            // chainable `ManyField`, so a scalar terminal can
+                            // follow a via intermediate (`a.b.field` where `b` is
+                            // a via); a scalar terminal yields a plain list path,
+                            // a leaf. Both stay includable / selectable
+                            // (`Into<stmt::Path>`). The element type comes from
                             // `ViaManyField`, which works for scalar terminals too
                             // (where there is no `RelationManyField::Model`).
                             quote_spanned! { span=>
-                                #vis fn #field_ident(&self) -> #toasty::Path<__Origin, #toasty::List<<#ty as #toasty::ViaManyField>::Target>> {
-                                    #path
+                                #vis fn #field_ident(&self) -> <<#ty as #toasty::ViaManyField>::Target as #toasty::ViaTarget>::Path<__Origin> {
+                                    <<#ty as #toasty::ViaManyField>::Target as #toasty::ViaTarget>::new_path(#path)
                                 }
                             }
                         } else {
@@ -190,16 +194,19 @@ impl Expand<'_> {
                     }
                     HasMany(rel) if rel.via.is_some() => {
                         // See the `via` branch in `expand_field_struct`: a via
-                        // field is a plain list-path projection handle, and its
-                        // element comes from `ViaManyField` so scalar terminals
-                        // work too.
+                        // step returns its terminal's `ViaTarget::Path` handle —
+                        // a chainable `ManyField` for a model terminal, a plain
+                        // list path for a scalar terminal — and its element type
+                        // comes from `ViaManyField` so scalar terminals work too.
                         let ty = &rel.ty;
                         let span = field_ident.span();
                         let schema_trait = self.schema_trait();
                         quote_spanned! { span=>
-                            #vis fn #field_ident(&self) -> #toasty::Path<__Origin, #toasty::List<<#ty as #toasty::ViaManyField>::Target>> {
-                                self.path().chain(
-                                    <#model_ident as #schema_trait>::path_field(#field_offset)
+                            #vis fn #field_ident(&self) -> <<#ty as #toasty::ViaManyField>::Target as #toasty::ViaTarget>::Path<__Origin> {
+                                <<#ty as #toasty::ViaManyField>::Target as #toasty::ViaTarget>::new_path(
+                                    self.path().chain(
+                                        <#model_ident as #schema_trait>::path_field(#field_offset)
+                                    )
                                 )
                             }
                         }

--- a/crates/toasty-macros/src/model/expand/fields.rs
+++ b/crates/toasty-macros/src/model/expand/fields.rs
@@ -74,7 +74,7 @@ impl Expand<'_> {
                             // `ViaManyField`, which works for scalar terminals too
                             // (where there is no `RelationManyField::Model`).
                             quote_spanned! { span=>
-                                #vis fn #field_ident(&self) -> <<#ty as #toasty::ViaManyField>::Target as #toasty::ViaTarget>::Path<__Origin> {
+                                #vis fn #field_ident(&self) -> #toasty::ViaPath<#ty, __Origin> {
                                     <<#ty as #toasty::ViaManyField>::Target as #toasty::ViaTarget>::new_path(#path)
                                 }
                             }
@@ -202,7 +202,7 @@ impl Expand<'_> {
                         let span = field_ident.span();
                         let schema_trait = self.schema_trait();
                         quote_spanned! { span=>
-                            #vis fn #field_ident(&self) -> <<#ty as #toasty::ViaManyField>::Target as #toasty::ViaTarget>::Path<__Origin> {
+                            #vis fn #field_ident(&self) -> #toasty::ViaPath<#ty, __Origin> {
                                 <<#ty as #toasty::ViaManyField>::Target as #toasty::ViaTarget>::new_path(
                                     self.path().chain(
                                         <#model_ident as #schema_trait>::path_field(#field_offset)

--- a/crates/toasty-macros/src/model/expand/fields.rs
+++ b/crates/toasty-macros/src/model/expand/fields.rs
@@ -21,15 +21,6 @@ impl Expand<'_> {
                 #vis fn create(&self) -> #create_struct_ident {
                     #create_struct_ident::default()
                 }
-
-                /// The id of the model this path points at. Used by generated
-                /// `#[has_many(via = …)]` code to resolve the model that owns a
-                /// scalar terminal field when the relation-chain prefix ends in
-                /// a singular relation.
-                #[doc(hidden)]
-                #vis fn target_model_id(&self) -> #toasty::core::schema::app::ModelId {
-                    <#model_ident as #toasty::Model>::id()
-                }
             }
         } else {
             TokenStream::new()
@@ -236,8 +227,8 @@ impl Expand<'_> {
             TokenStream::new()
         };
 
-        // any() / all() / target_model_id() are only available on root models
-        // (they require the `Model` trait bound).
+        // any() / all() are only available on root models (they require the
+        // `Model` trait bound).
         let any_method = if is_root {
             quote! {
                 /// Filter the parent model by a condition on the associated
@@ -253,15 +244,6 @@ impl Expand<'_> {
                 /// associated records).
                 #vis fn all(self, filter: #toasty::stmt::Expr<bool>) -> #toasty::stmt::Expr<bool> {
                     self.path.all(filter)
-                }
-
-                /// The id of the model this list path points at. Used by
-                /// generated `#[has_many(via = …)]` code to resolve the model
-                /// that owns a scalar terminal field from the relation-chain
-                /// prefix.
-                #[doc(hidden)]
-                #vis fn target_model_id(&self) -> #toasty::core::schema::app::ModelId {
-                    <#model_ident as #toasty::Model>::id()
                 }
             }
         } else {

--- a/crates/toasty-macros/src/model/expand/model.rs
+++ b/crates/toasty-macros/src/model/expand/model.rs
@@ -171,6 +171,15 @@ impl Expand<'_> {
             // through the per-primitive `ViaTarget` impls instead.
             impl #toasty::ViaTarget for #model_ident {
                 type Query = #query_struct_ident<#toasty::List<#model_ident>>;
+                type Path<__Origin> = <#model_ident as #toasty::Model>::ManyField<__Origin>;
+
+                fn new_path<__Origin>(
+                    path: #toasty::Path<__Origin, #toasty::List<#model_ident>>,
+                ) -> Self::Path<__Origin> {
+                    // A model terminal keeps navigating, so hand back its
+                    // chainable `ManyField`.
+                    <#model_ident as #toasty::Model>::new_many_field(path)
+                }
 
                 fn via_field_ty(
                     singular: #toasty::core::schema::Name,

--- a/crates/toasty-macros/src/model/expand/model.rs
+++ b/crates/toasty-macros/src/model/expand/model.rs
@@ -177,7 +177,7 @@ impl Expand<'_> {
                     path: #toasty::core::stmt::Path,
                     _terminal_owner: #toasty::core::schema::app::ModelId,
                 ) -> #toasty::core::schema::app::FieldTy {
-                    #toasty::model_via_field_ty::<#model_ident>(singular, path)
+                    #toasty::via::model_via_field_ty::<#model_ident>(singular, path)
                 }
 
                 fn make_via_query(

--- a/crates/toasty-macros/src/model/expand/model.rs
+++ b/crates/toasty-macros/src/model/expand/model.rs
@@ -166,6 +166,29 @@ impl Expand<'_> {
                 #field_name_to_id
             }
 
+            // A relation-terminal `#[has_many(via = …)]` reaching this model
+            // keeps its rich per-model query builder. Scalar terminals route
+            // through the per-primitive `ViaManyField` impls instead.
+            impl #toasty::ViaManyField for #model_ident {
+                type Query = #query_struct_ident<#toasty::List<#model_ident>>;
+
+                fn via_field_ty(
+                    singular: #toasty::core::schema::Name,
+                    path: #toasty::core::stmt::Path,
+                    _terminal_owner: #toasty::core::schema::app::ModelId,
+                ) -> #toasty::core::schema::app::FieldTy {
+                    #toasty::model_via_field_ty::<#model_ident>(singular, path)
+                }
+
+                fn make_via_query(
+                    assoc: #toasty::stmt::Association<#toasty::List<#model_ident>>,
+                    _target: #toasty::core::schema::app::ModelId,
+                    _terminal: usize,
+                ) -> Self::Query {
+                    <#query_struct_ident<#toasty::List<#model_ident>>>::from_assoc_many(assoc)
+                }
+            }
+
             impl #toasty::stmt::IntoExpr<#model_ident> for #model_ident {
                 fn into_expr(self) -> #toasty::stmt::Expr<#model_ident> {
                     #into_expr_body_val
@@ -559,7 +582,13 @@ impl Expand<'_> {
                     }
                     FieldTy::HasMany(rel) => {
                         let ty = &rel.ty;
-                        quote!(#i => <#ty as #toasty::RelationManyField>::reload(&mut #field_access, value)?,)
+                        if rel.via.is_some() {
+                            // A via field has no `RelationManyField` impl (its
+                            // element may be a scalar); reload through `Load`.
+                            quote!(#i => <#ty as #toasty::Load>::reload(&mut #field_access, value)?,)
+                        } else {
+                            quote!(#i => <#ty as #toasty::RelationManyField>::reload(&mut #field_access, value)?,)
+                        }
                     }
                     FieldTy::HasOne(rel) => {
                         let ty = &rel.ty;

--- a/crates/toasty-macros/src/model/expand/model.rs
+++ b/crates/toasty-macros/src/model/expand/model.rs
@@ -175,15 +175,12 @@ impl Expand<'_> {
                 fn via_field_ty(
                     singular: #toasty::core::schema::Name,
                     path: #toasty::core::stmt::Path,
-                    _terminal_owner: #toasty::core::schema::app::ModelId,
                 ) -> #toasty::core::schema::app::FieldTy {
                     #toasty::via::model_via_field_ty::<#model_ident>(singular, path)
                 }
 
                 fn make_via_query(
                     assoc: #toasty::stmt::Association<#toasty::List<#model_ident>>,
-                    _target: #toasty::core::schema::app::ModelId,
-                    _terminal: usize,
                 ) -> Self::Query {
                     <#query_struct_ident<#toasty::List<#model_ident>>>::from_assoc_many(assoc)
                 }

--- a/crates/toasty-macros/src/model/expand/model.rs
+++ b/crates/toasty-macros/src/model/expand/model.rs
@@ -168,8 +168,8 @@ impl Expand<'_> {
 
             // A relation-terminal `#[has_many(via = …)]` reaching this model
             // keeps its rich per-model query builder. Scalar terminals route
-            // through the per-primitive `ViaManyField` impls instead.
-            impl #toasty::ViaManyField for #model_ident {
+            // through the per-primitive `ViaTarget` impls instead.
+            impl #toasty::ViaTarget for #model_ident {
                 type Query = #query_struct_ident<#toasty::List<#model_ident>>;
 
                 fn via_field_ty(

--- a/crates/toasty-macros/src/model/expand/query.rs
+++ b/crates/toasty-macros/src/model/expand/query.rs
@@ -366,12 +366,12 @@ impl Expand<'_> {
         let field_ident = &field.name.ident;
 
         quote! {
-            #vis fn #field_ident(self) -> <<#ty as #toasty::ViaManyField>::Target as #toasty::ViaTarget>::Query {
+            #vis fn #field_ident(self) -> <#ty as #toasty::ViaManyField>::Query {
                 let __assoc = #toasty::stmt::Association::from_source_and_path(
                     self.stmt,
                     #model_ident::fields().#field_ident(),
                 );
-                <<#ty as #toasty::ViaManyField>::Target as #toasty::ViaTarget>::make_via_query(__assoc)
+                <#ty as #toasty::ViaManyField>::make_via_query(__assoc)
             }
         }
     }

--- a/crates/toasty-macros/src/model/expand/query.rs
+++ b/crates/toasty-macros/src/model/expand/query.rs
@@ -367,9 +367,13 @@ impl Expand<'_> {
 
         quote! {
             #vis fn #field_ident(self) -> #toasty::ViaMany<#ty> {
+                // The accessor returns the terminal's `ViaTarget::Path` (a
+                // `ManyField` for a model terminal, a `Path` for a scalar);
+                // `.into()` collapses either into the `Path` the association
+                // needs.
                 let __assoc = #toasty::stmt::Association::from_source_and_path(
                     self.stmt,
-                    #model_ident::fields().#field_ident(),
+                    #model_ident::fields().#field_ident().into(),
                 );
                 <<#ty as #toasty::ViaManyField>::Target as #toasty::ViaTarget>::make_via_query(__assoc)
             }

--- a/crates/toasty-macros/src/model/expand/query.rs
+++ b/crates/toasty-macros/src/model/expand/query.rs
@@ -318,14 +318,9 @@ impl Expand<'_> {
             .iter()
             .filter_map(|field| match &field.ty {
                 FieldTy::BelongsTo(rel) => Some(self.expand_belongs_to_method(field, rel)),
-                // Skip `via` fields: the chained accessor returns
-                // `QueryMany<<ty as RelationManyField>::Model>`, but a scalar
-                // terminal (`Vec<String>`) has no `RelationManyField` impl, so
-                // it can't compile. The attribute doesn't reveal whether the
-                // terminal is a model or a scalar, so skip all vias uniformly.
-                // A via is navigated from a model instance instead
-                // (`user.tag_names()`, see relation.rs).
-                FieldTy::HasMany(rel) if rel.via.is_some() => None,
+                FieldTy::HasMany(rel) if rel.via.is_some() => {
+                    Some(self.expand_has_many_via_method(field, rel))
+                }
                 FieldTy::HasMany(rel) => Some(self.expand_has_many_method(field, rel)),
                 FieldTy::HasOne(rel) => Some(self.expand_has_one_method(field, rel)),
                 FieldTy::Primitive(..) => None,
@@ -353,6 +348,30 @@ impl Expand<'_> {
                     #model_ident::fields().#field_ident().into(),
                 );
                 <#toasty::QueryMany<#target>>::from_assoc_many(assoc)
+            }
+        }
+    }
+
+    /// Chained accessor for a `#[has_many(via = …)]` field. Builds an
+    /// association from the current query following the via field, then routes
+    /// through [`ViaTarget`] — keyed on the terminal type — so it works for a
+    /// model terminal (`QueryMany<M>`) and a scalar terminal
+    /// (`Query<List<scalar>>`) alike. Mirrors the instance accessor in
+    /// `relation.rs`; here the source query is `self.stmt` directly.
+    fn expand_has_many_via_method(&self, field: &Field, rel: &HasMany) -> TokenStream {
+        let toasty = &self.toasty;
+        let vis = &self.model.vis;
+        let ty = &rel.ty;
+        let model_ident = &self.model.ident;
+        let field_ident = &field.name.ident;
+
+        quote! {
+            #vis fn #field_ident(self) -> <<#ty as #toasty::ViaManyField>::Target as #toasty::ViaTarget>::Query {
+                let __assoc = #toasty::stmt::Association::from_source_and_path(
+                    self.stmt,
+                    #model_ident::fields().#field_ident(),
+                );
+                <<#ty as #toasty::ViaManyField>::Target as #toasty::ViaTarget>::make_via_query(__assoc)
             }
         }
     }

--- a/crates/toasty-macros/src/model/expand/query.rs
+++ b/crates/toasty-macros/src/model/expand/query.rs
@@ -318,10 +318,13 @@ impl Expand<'_> {
             .iter()
             .filter_map(|field| match &field.ty {
                 FieldTy::BelongsTo(rel) => Some(self.expand_belongs_to_method(field, rel)),
-                // A `via` relation is navigated from a model instance (see the
-                // relation method in `relation.rs`), not chained on a query: it
-                // has no paired FK to extend an association path through, and a
-                // scalar terminal has no `RelationManyField::Model`.
+                // Skip `via` fields: the chained accessor returns
+                // `QueryMany<<ty as RelationManyField>::Model>`, but a scalar
+                // terminal (`Vec<String>`) has no `RelationManyField` impl, so
+                // it can't compile. The attribute doesn't reveal whether the
+                // terminal is a model or a scalar, so skip all vias uniformly.
+                // A via is navigated from a model instance instead
+                // (`user.tag_names()`, see relation.rs).
                 FieldTy::HasMany(rel) if rel.via.is_some() => None,
                 FieldTy::HasMany(rel) => Some(self.expand_has_many_method(field, rel)),
                 FieldTy::HasOne(rel) => Some(self.expand_has_one_method(field, rel)),

--- a/crates/toasty-macros/src/model/expand/query.rs
+++ b/crates/toasty-macros/src/model/expand/query.rs
@@ -366,12 +366,12 @@ impl Expand<'_> {
         let field_ident = &field.name.ident;
 
         quote! {
-            #vis fn #field_ident(self) -> <#ty as #toasty::ViaManyField>::Query {
+            #vis fn #field_ident(self) -> #toasty::ViaMany<#ty> {
                 let __assoc = #toasty::stmt::Association::from_source_and_path(
                     self.stmt,
                     #model_ident::fields().#field_ident(),
                 );
-                <#ty as #toasty::ViaManyField>::make_via_query(__assoc)
+                <<#ty as #toasty::ViaManyField>::Target as #toasty::ViaTarget>::make_via_query(__assoc)
             }
         }
     }

--- a/crates/toasty-macros/src/model/expand/query.rs
+++ b/crates/toasty-macros/src/model/expand/query.rs
@@ -318,6 +318,11 @@ impl Expand<'_> {
             .iter()
             .filter_map(|field| match &field.ty {
                 FieldTy::BelongsTo(rel) => Some(self.expand_belongs_to_method(field, rel)),
+                // A `via` relation is navigated from a model instance (see the
+                // relation method in `relation.rs`), not chained on a query: it
+                // has no paired FK to extend an association path through, and a
+                // scalar terminal has no `RelationManyField::Model`.
+                FieldTy::HasMany(rel) if rel.via.is_some() => None,
                 FieldTy::HasMany(rel) => Some(self.expand_has_many_method(field, rel)),
                 FieldTy::HasOne(rel) => Some(self.expand_has_one_method(field, rel)),
                 FieldTy::Primitive(..) => None,

--- a/crates/toasty-macros/src/model/expand/relation.rs
+++ b/crates/toasty-macros/src/model/expand/relation.rs
@@ -113,14 +113,12 @@ impl Expand<'_> {
         // navigation method works whether the terminal is a model — keeping
         // the rich `QueryMany<M>` builder — or a scalar field, where it yields
         // a plain `Query<List<scalar>>` projecting that field.
-        if let Some(segments) = &rel.via {
-            let model_ident = &self.model.ident;
-            let terminal_ty = quote!(#toasty::List<<#ty as #toasty::ViaManyField>::Target>);
-            let full_path =
-                super::schema::expand_via_path(toasty, model_ident, segments, &terminal_ty);
-            let terminal_owner =
-                super::schema::expand_via_terminal_owner(toasty, model_ident, segments);
-
+        if rel.via.is_some() {
+            // The association references the via field; its target and (for a
+            // scalar terminal) terminal projection are resolved during lowering
+            // from the schema, so nothing here needs the path's shape. The
+            // declared element type is validated against the path by the typed
+            // accessor and by the `schema()` expansion's terminal pin.
             return quote! {
                 #vis fn #field_ident(&self) -> <<#ty as #toasty::ViaManyField>::Target as #toasty::ViaTarget>::Query {
                     // Suppress the unused field warning
@@ -135,20 +133,7 @@ impl Expand<'_> {
                             __source,
                             Self::fields().#field_ident(),
                         );
-                        // The terminal field (scalar terminals only) is the via
-                        // path's last step, on the model the relation chain
-                        // reaches.
-                        let __via_path: #toasty::core::stmt::Path = #full_path;
-                        let __terminal = *__via_path
-                            .projection
-                            .as_slice()
-                            .last()
-                            .expect("via path has at least one step");
-                        <<#ty as #toasty::ViaManyField>::Target as #toasty::ViaTarget>::make_via_query(
-                            __assoc,
-                            #terminal_owner,
-                            __terminal,
-                        )
+                        <<#ty as #toasty::ViaManyField>::Target as #toasty::ViaTarget>::make_via_query(__assoc)
                     }
                 }
             };

--- a/crates/toasty-macros/src/model/expand/relation.rs
+++ b/crates/toasty-macros/src/model/expand/relation.rs
@@ -115,7 +115,9 @@ impl Expand<'_> {
         // a plain `Query<List<scalar>>` projecting that field.
         if let Some(segments) = &rel.via {
             let model_ident = &self.model.ident;
-            let full_path = super::schema::expand_via_path(toasty, model_ident, segments);
+            let terminal_ty = quote!(#toasty::List<<#ty as #toasty::ViaManyField>::Target>);
+            let full_path =
+                super::schema::expand_via_path(toasty, model_ident, segments, &terminal_ty);
             let terminal_owner =
                 super::schema::expand_via_terminal_owner(toasty, model_ident, segments);
 

--- a/crates/toasty-macros/src/model/expand/relation.rs
+++ b/crates/toasty-macros/src/model/expand/relation.rs
@@ -120,7 +120,7 @@ impl Expand<'_> {
             // declared element type is validated against the path by the typed
             // accessor and by the `schema()` expansion's terminal pin.
             return quote! {
-                #vis fn #field_ident(&self) -> <#ty as #toasty::ViaManyField>::Query {
+                #vis fn #field_ident(&self) -> #toasty::ViaMany<#ty> {
                     // Suppress the unused field warning
                     if false {
                         let _ = &self.#field_ident;
@@ -133,7 +133,7 @@ impl Expand<'_> {
                             __source,
                             Self::fields().#field_ident(),
                         );
-                        <#ty as #toasty::ViaManyField>::make_via_query(__assoc)
+                        <<#ty as #toasty::ViaManyField>::Target as #toasty::ViaTarget>::make_via_query(__assoc)
                     }
                 }
             };

--- a/crates/toasty-macros/src/model/expand/relation.rs
+++ b/crates/toasty-macros/src/model/expand/relation.rs
@@ -109,7 +109,7 @@ impl Expand<'_> {
 
         // A `via` relation reaches its terminal through a path of existing
         // relations rather than a single foreign key. It routes through
-        // `ViaManyField` (keyed on the terminal element type) so the
+        // `ViaTarget` (keyed on the terminal element type) so the
         // navigation method works whether the terminal is a model — keeping
         // the rich `QueryMany<M>` builder — or a scalar field, where it yields
         // a plain `Query<List<scalar>>` projecting that field.
@@ -120,7 +120,7 @@ impl Expand<'_> {
                 super::schema::expand_via_terminal_owner(toasty, model_ident, segments);
 
             return quote! {
-                #vis fn #field_ident(&self) -> <<#ty as #toasty::ManyViaElem>::Elem as #toasty::ViaManyField>::Query {
+                #vis fn #field_ident(&self) -> <<#ty as #toasty::ViaManyField>::Target as #toasty::ViaTarget>::Query {
                     // Suppress the unused field warning
                     if false {
                         let _ = &self.#field_ident;
@@ -142,7 +142,7 @@ impl Expand<'_> {
                             .as_slice()
                             .last()
                             .expect("via path has at least one step");
-                        <<#ty as #toasty::ManyViaElem>::Elem as #toasty::ViaManyField>::make_via_query(
+                        <<#ty as #toasty::ViaManyField>::Target as #toasty::ViaTarget>::make_via_query(
                             __assoc,
                             #terminal_owner,
                             __terminal,

--- a/crates/toasty-macros/src/model/expand/relation.rs
+++ b/crates/toasty-macros/src/model/expand/relation.rs
@@ -129,9 +129,13 @@ impl Expand<'_> {
                     {
                         use #toasty::IntoStatement;
                         let __source = self.into_statement().into_query().unwrap().to_list();
+                        // The accessor returns the terminal's `ViaTarget::Path`
+                        // (a `ManyField` for a model terminal, a `Path` for a
+                        // scalar); `.into()` collapses either into the `Path` the
+                        // association needs.
                         let __assoc = #toasty::stmt::Association::from_source_and_path(
                             __source,
-                            Self::fields().#field_ident(),
+                            Self::fields().#field_ident().into(),
                         );
                         <<#ty as #toasty::ViaManyField>::Target as #toasty::ViaTarget>::make_via_query(__assoc)
                     }

--- a/crates/toasty-macros/src/model/expand/relation.rs
+++ b/crates/toasty-macros/src/model/expand/relation.rs
@@ -106,28 +106,67 @@ impl Expand<'_> {
         let vis = &self.model.vis;
         let field_ident = &field.name.ident;
         let ty = &rel.ty;
+
+        // A `via` relation reaches its terminal through a path of existing
+        // relations rather than a single foreign key. It routes through
+        // `ViaManyField` (keyed on the terminal element type) so the
+        // navigation method works whether the terminal is a model — keeping
+        // the rich `QueryMany<M>` builder — or a scalar field, where it yields
+        // a plain `Query<List<scalar>>` projecting that field.
+        if let Some(segments) = &rel.via {
+            let model_ident = &self.model.ident;
+            let full_path = super::schema::expand_via_path(toasty, model_ident, segments);
+            let terminal_owner =
+                super::schema::expand_via_terminal_owner(toasty, model_ident, segments);
+
+            return quote! {
+                #vis fn #field_ident(&self) -> <<#ty as #toasty::ManyViaElem>::Elem as #toasty::ViaManyField>::Query {
+                    // Suppress the unused field warning
+                    if false {
+                        let _ = &self.#field_ident;
+                    }
+
+                    {
+                        use #toasty::IntoStatement;
+                        let __source = self.into_statement().into_query().unwrap().to_list();
+                        let __assoc = #toasty::stmt::Association::from_source_and_path(
+                            __source,
+                            Self::fields().#field_ident(),
+                        );
+                        // The terminal field (scalar terminals only) is the via
+                        // path's last step, on the model the relation chain
+                        // reaches.
+                        let __via_path: #toasty::core::stmt::Path = #full_path;
+                        let __terminal = *__via_path
+                            .projection
+                            .as_slice()
+                            .last()
+                            .expect("via path has at least one step");
+                        <<#ty as #toasty::ManyViaElem>::Elem as #toasty::ViaManyField>::make_via_query(
+                            __assoc,
+                            #terminal_owner,
+                            __terminal,
+                        )
+                    }
+                }
+            };
+        }
+
         let target = quote!(<#ty as #toasty::RelationManyField>::Model);
 
-        // A `via` relation reaches its target through a path of existing
-        // relations; it has no paired `BelongsTo`, so skip the back-reference
-        // check that direct has-many relations emit.
-        let pair_check = if rel.via.is_some() {
-            quote! {}
-        } else {
-            let pair_ident = rel.pair.clone().unwrap_or(syn::Ident::new(
-                &self.model.name.ident.to_string(),
-                rel.span,
-            ));
-            self.expand_pair_belongs_to_check(PairBelongsToCheck {
-                pair_ident: &pair_ident,
-                field_ident,
-                ty,
-                field_trait: quote!(#toasty::RelationManyField),
-                rel_span: rel.span,
-                relation_kind: "HasMany",
-                label: "Has many associations require the target to include a back-reference",
-            })
-        };
+        let pair_ident = rel.pair.clone().unwrap_or(syn::Ident::new(
+            &self.model.name.ident.to_string(),
+            rel.span,
+        ));
+        let pair_check = self.expand_pair_belongs_to_check(PairBelongsToCheck {
+            pair_ident: &pair_ident,
+            field_ident,
+            ty,
+            field_trait: quote!(#toasty::RelationManyField),
+            rel_span: rel.span,
+            relation_kind: "HasMany",
+            label: "Has many associations require the target to include a back-reference",
+        });
 
         quote! {
             #vis fn #field_ident(&self) -> #toasty::QueryMany<#target> {

--- a/crates/toasty-macros/src/model/expand/relation.rs
+++ b/crates/toasty-macros/src/model/expand/relation.rs
@@ -120,7 +120,7 @@ impl Expand<'_> {
             // declared element type is validated against the path by the typed
             // accessor and by the `schema()` expansion's terminal pin.
             return quote! {
-                #vis fn #field_ident(&self) -> <<#ty as #toasty::ViaManyField>::Target as #toasty::ViaTarget>::Query {
+                #vis fn #field_ident(&self) -> <#ty as #toasty::ViaManyField>::Query {
                     // Suppress the unused field warning
                     if false {
                         let _ = &self.#field_ident;
@@ -133,7 +133,7 @@ impl Expand<'_> {
                             __source,
                             Self::fields().#field_ident(),
                         );
-                        <<#ty as #toasty::ViaManyField>::Target as #toasty::ViaTarget>::make_via_query(__assoc)
+                        <#ty as #toasty::ViaManyField>::make_via_query(__assoc)
                     }
                 }
             };

--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -598,14 +598,24 @@ pub(super) fn expand_via_path(
         chain = quote_spanned! { segment.span()=> #chain.#segment() };
     }
 
-    // Span the ascription to the terminal segment so a type mismatch points at
-    // the offending path step rather than the derive.
+    // Pin the typed path's terminal to `terminal_ty`. When it disagrees with
+    // the path, the `.into()` has no matching conversion. Point that failure at
+    // the offending path step rather than the derive:
+    //
+    // - Bind the chain to a local first, so the conversion's receiver is that
+    //   local (emitted at the terminal span) rather than the chain expression,
+    //   whose root `Model::fields()` carries the derive call site.
+    // - Span the whole target annotation — including the interpolated
+    //   `terminal_ty`, which `quote_spanned!` would otherwise leave at the
+    //   derive — to the terminal segment via `respan`.
     let span = segments
         .last()
         .map_or_else(proc_macro2::Span::call_site, syn::Ident::span);
+    let typed_path_ty = util::respan(quote!(#toasty::Path<#model_ident, #terminal_ty>), span);
     quote_spanned! { span=>
         {
-            let __via_typed: #toasty::Path<#model_ident, #terminal_ty> = (#chain).into();
+            let __via_chain = #chain;
+            let __via_typed: #typed_path_ty = __via_chain.into();
             let __via_untyped: #toasty::core::stmt::Path = __via_typed.into();
             __via_untyped
         }

--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -166,7 +166,7 @@ impl Expand<'_> {
                     let singular_name = expand_name(toasty, &rel.singular);
 
                     if let Some(segments) = &rel.via {
-                        // A `via` field routes through `ViaManyField`, keyed on
+                        // A `via` field routes through `ViaTarget`, keyed on
                         // the terminal element type, so it works whether the
                         // terminal is a model or a scalar — without requiring
                         // `RelationManyField` (which needs the element to be a
@@ -176,9 +176,9 @@ impl Expand<'_> {
 
                         // A has-many collection is always present, never null.
                         nullable = quote!(false);
-                        deferred = quote!(<#ty as #toasty::ManyViaElem>::DEFERRED);
+                        deferred = quote!(<#ty as #toasty::ViaManyField>::DEFERRED);
                         field_ty = quote!(
-                            <<#ty as #toasty::ManyViaElem>::Elem as #toasty::ViaManyField>::via_field_ty(
+                            <<#ty as #toasty::ViaManyField>::Target as #toasty::ViaTarget>::via_field_ty(
                                 #singular_name, #full_path, #terminal_owner,
                             )
                         );
@@ -590,7 +590,7 @@ pub(super) fn expand_via_path(
 /// segment, by chaining the path's relation prefix (all but the last segment)
 /// onto the model's `Fields` struct and reading its `target_model_id()`. For a
 /// scalar-terminal via this is the via target (the model the relation chain
-/// reaches); a relation-terminal via ignores it (the per-model `ViaManyField`
+/// reaches); a relation-terminal via ignores it (the per-model `ViaTarget`
 /// impl uses `Self::id()`).
 pub(super) fn expand_via_terminal_owner(
     toasty: &TokenStream,

--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -614,9 +614,10 @@ pub(super) fn expand_via_path(
     quote_spanned! { span=>
         {
             let __via_chain = #chain;
-            // The chain terminal is a `FieldList` for a plain relation step (a
-            // real conversion to `Path`) but already a `Path` for a scalar or
-            // via-of-via terminal, where `.into()` is identity — allow that.
+            // The chain terminal is a `FieldList`/`ManyField` for a relation or
+            // model via-of-via terminal (a real conversion to `Path`), but
+            // already a `Path` for a scalar terminal, where `.into()` is
+            // identity — allow that.
             #[allow(clippy::useless_conversion)]
             let __via_typed: #typed_path_ty = __via_chain.into();
             let __via_untyped: #toasty::core::stmt::Path = __via_typed.into();

--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -164,12 +164,31 @@ impl Expand<'_> {
                 FieldTy::HasMany(rel) => {
                     let ty = &rel.ty;
                     let singular_name = expand_name(toasty, &rel.singular);
-                    let pair = expand_pair(toasty, quote!(#toasty::RelationManyField), ty, rel.pair.as_ref());
-                    let via = expand_via(toasty, model_ident, rel.via.as_ref());
 
-                    nullable = quote!(<#ty as #toasty::RelationManyField>::NULLABLE);
-                    deferred = quote!(<#ty as #toasty::RelationManyField>::DEFERRED);
-                    field_ty = quote!(<#ty as #toasty::RelationManyField>::many_relation_field_ty(#singular_name, #pair, #via));
+                    if let Some(segments) = &rel.via {
+                        // A `via` field routes through `ViaManyField`, keyed on
+                        // the terminal element type, so it works whether the
+                        // terminal is a model or a scalar — without requiring
+                        // `RelationManyField` (which needs the element to be a
+                        // model).
+                        let full_path = expand_via_path(toasty, model_ident, segments);
+                        let terminal_owner = expand_via_terminal_owner(toasty, model_ident, segments);
+
+                        // A has-many collection is always present, never null.
+                        nullable = quote!(false);
+                        deferred = quote!(<#ty as #toasty::ManyViaElem>::DEFERRED);
+                        field_ty = quote!(
+                            <<#ty as #toasty::ManyViaElem>::Elem as #toasty::ViaManyField>::via_field_ty(
+                                #singular_name, #full_path, #terminal_owner,
+                            )
+                        );
+                    } else {
+                        let pair = expand_pair(toasty, quote!(#toasty::RelationManyField), ty, rel.pair.as_ref());
+
+                        nullable = quote!(<#ty as #toasty::RelationManyField>::NULLABLE);
+                        deferred = quote!(<#ty as #toasty::RelationManyField>::DEFERRED);
+                        field_ty = quote!(<#ty as #toasty::RelationManyField>::many_relation_field_ty(#singular_name, #pair, None));
+                    }
                 }
                 FieldTy::HasOne(rel) => {
                     let ty = &rel.ty;
@@ -462,6 +481,13 @@ impl Expand<'_> {
                         <<#ty as #toasty::RelationOneField>::Model as #toasty::Model>::register(model_set);
                     }
                 }
+                FieldTy::HasMany(rel) if rel.via.is_some() => {
+                    // A via relation reaches its terminal through existing
+                    // relation fields, each of which registers the models it
+                    // traverses; the terminal of a scalar via is not a model at
+                    // all. So a via field registers nothing of its own.
+                    TokenStream::new()
+                }
                 FieldTy::HasMany(rel) => {
                     let ty = &rel.ty;
                     quote! {
@@ -531,16 +557,52 @@ fn expand_via(
         return quote! { None };
     };
 
+    let path = expand_via_path(toasty, model_ident, segments);
+    quote! { Some(#path) }
+}
+
+/// Emit the fully-resolved [`stmt::Path`] for a `via` relation: chain the named
+/// segments onto the model's `Fields` struct (e.g.
+/// `User::fields().comments().article()`) and convert to an `stmt::Path`.
+/// Resolution happens at Rust-compile time — a misspelled segment surfaces as
+/// "no method named `foo` found", and an intermediate that is not navigable
+/// fails to chain, so only the terminal segment may be a scalar field.
+pub(super) fn expand_via_path(
+    toasty: &TokenStream,
+    model_ident: &syn::Ident,
+    segments: &[syn::Ident],
+) -> TokenStream {
     let mut chain = quote! { #model_ident::fields() };
     for segment in segments {
         chain = quote_spanned! { segment.span()=> #chain.#segment() };
     }
 
     quote! {
-        Some({
+        {
             let __via_typed: #toasty::Path<#model_ident, _> = (#chain).into();
             let __via_untyped: #toasty::core::stmt::Path = __via_typed.into();
             __via_untyped
-        })
+        }
     }
+}
+
+/// Emit the [`ModelId`] of the model that owns the via path's *terminal*
+/// segment, by chaining the path's relation prefix (all but the last segment)
+/// onto the model's `Fields` struct and reading its `target_model_id()`. For a
+/// scalar-terminal via this is the via target (the model the relation chain
+/// reaches); a relation-terminal via ignores it (the per-model `ViaManyField`
+/// impl uses `Self::id()`).
+pub(super) fn expand_via_terminal_owner(
+    toasty: &TokenStream,
+    model_ident: &syn::Ident,
+    segments: &[syn::Ident],
+) -> TokenStream {
+    let prefix = &segments[..segments.len() - 1];
+    let mut chain = quote! { #model_ident::fields() };
+    for segment in prefix {
+        chain = quote_spanned! { segment.span()=> #chain.#segment() };
+    }
+
+    let _ = toasty;
+    quote! { (#chain).target_model_id() }
 }

--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -175,14 +175,13 @@ impl Expand<'_> {
                             quote!(#toasty::List<<#ty as #toasty::ViaManyField>::Target>);
                         let full_path =
                             expand_via_path(toasty, model_ident, segments, &terminal_ty);
-                        let terminal_owner = expand_via_terminal_owner(toasty, model_ident, segments);
 
                         // A has-many collection is always present, never null.
                         nullable = quote!(false);
                         deferred = quote!(<#ty as #toasty::ViaManyField>::DEFERRED);
                         field_ty = quote!(
                             <<#ty as #toasty::ViaManyField>::Target as #toasty::ViaTarget>::via_field_ty(
-                                #singular_name, #full_path, #terminal_owner,
+                                #singular_name, #full_path,
                             )
                         );
                     } else {
@@ -624,25 +623,4 @@ pub(super) fn expand_via_path(
             __via_untyped
         }
     }
-}
-
-/// Emit the [`ModelId`] of the model that owns the via path's *terminal*
-/// segment, by chaining the path's relation prefix (all but the last segment)
-/// onto the model's `Fields` struct and reading its `target_model_id()`. For a
-/// scalar-terminal via this is the via target (the model the relation chain
-/// reaches); a relation-terminal via ignores it (the per-model `ViaTarget`
-/// impl uses `Self::id()`).
-pub(super) fn expand_via_terminal_owner(
-    toasty: &TokenStream,
-    model_ident: &syn::Ident,
-    segments: &[syn::Ident],
-) -> TokenStream {
-    let prefix = &segments[..segments.len() - 1];
-    let mut chain = quote! { #model_ident::fields() };
-    for segment in prefix {
-        chain = quote_spanned! { segment.span()=> #chain.#segment() };
-    }
-
-    let _ = toasty;
-    quote! { (#chain).target_model_id() }
 }

--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -180,9 +180,7 @@ impl Expand<'_> {
                         nullable = quote!(false);
                         deferred = quote!(<#ty as #toasty::ViaManyField>::DEFERRED);
                         field_ty = quote!(
-                            <<#ty as #toasty::ViaManyField>::Target as #toasty::ViaTarget>::via_field_ty(
-                                #singular_name, #full_path,
-                            )
+                            <#ty as #toasty::ViaManyField>::via_field_ty(#singular_name, #full_path)
                         );
                     } else {
                         let pair = expand_pair(toasty, quote!(#toasty::RelationManyField), ty, rel.pair.as_ref());

--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -171,7 +171,10 @@ impl Expand<'_> {
                         // terminal is a model or a scalar — without requiring
                         // `RelationManyField` (which needs the element to be a
                         // model).
-                        let full_path = expand_via_path(toasty, model_ident, segments);
+                        let terminal_ty =
+                            quote!(#toasty::List<<#ty as #toasty::ViaManyField>::Target>);
+                        let full_path =
+                            expand_via_path(toasty, model_ident, segments, &terminal_ty);
                         let terminal_owner = expand_via_terminal_owner(toasty, model_ident, segments);
 
                         // A has-many collection is always present, never null.
@@ -193,7 +196,15 @@ impl Expand<'_> {
                 FieldTy::HasOne(rel) => {
                     let ty = &rel.ty;
                     let pair = expand_pair(toasty, quote!(#toasty::RelationOneField), ty, rel.pair.as_ref());
-                    let via = expand_via(toasty, model_ident, rel.via.as_ref());
+                    // A has-one via reaches a single model; pin the path's
+                    // terminal to that model so a mismatched declaration is a
+                    // compile error rather than a runtime load failure.
+                    let via = expand_via(
+                        toasty,
+                        model_ident,
+                        rel.via.as_ref(),
+                        &quote!(<#ty as #toasty::RelationOneField>::Model),
+                    );
 
                     nullable = quote!(<#ty as #toasty::RelationOneField>::NULLABLE);
                     deferred = quote!(<#ty as #toasty::RelationOneField>::DEFERRED);
@@ -552,34 +563,49 @@ fn expand_via(
     toasty: &TokenStream,
     model_ident: &syn::Ident,
     via: Option<&Vec<syn::Ident>>,
+    terminal_ty: &TokenStream,
 ) -> TokenStream {
     let Some(segments) = via else {
         return quote! { None };
     };
 
-    let path = expand_via_path(toasty, model_ident, segments);
+    let path = expand_via_path(toasty, model_ident, segments, terminal_ty);
     quote! { Some(#path) }
 }
 
 /// Emit the fully-resolved [`stmt::Path`] for a `via` relation: chain the named
 /// segments onto the model's `Fields` struct (e.g.
 /// `User::fields().comments().article()`) and convert to an `stmt::Path`.
+///
 /// Resolution happens at Rust-compile time — a misspelled segment surfaces as
 /// "no method named `foo` found", and an intermediate that is not navigable
 /// fails to chain, so only the terminal segment may be a scalar field.
+///
+/// `terminal_ty` is the type the path's terminal must reach, derived from the
+/// declared field (e.g. `List<i64>` for `Vec<i64>`). Pinning the typed path's
+/// second parameter to it — rather than leaving it inferred — is what rejects a
+/// field whose declared element type disagrees with the path
+/// (`#[has_many(via = a.b.title)] x: Vec<i64>` where `title` is a `String`), so
+/// the mismatch is a compile error here instead of a runtime load failure.
 pub(super) fn expand_via_path(
     toasty: &TokenStream,
     model_ident: &syn::Ident,
     segments: &[syn::Ident],
+    terminal_ty: &TokenStream,
 ) -> TokenStream {
     let mut chain = quote! { #model_ident::fields() };
     for segment in segments {
         chain = quote_spanned! { segment.span()=> #chain.#segment() };
     }
 
-    quote! {
+    // Span the ascription to the terminal segment so a type mismatch points at
+    // the offending path step rather than the derive.
+    let span = segments
+        .last()
+        .map_or_else(proc_macro2::Span::call_site, syn::Ident::span);
+    quote_spanned! { span=>
         {
-            let __via_typed: #toasty::Path<#model_ident, _> = (#chain).into();
+            let __via_typed: #toasty::Path<#model_ident, #terminal_ty> = (#chain).into();
             let __via_untyped: #toasty::core::stmt::Path = __via_typed.into();
             __via_untyped
         }

--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -180,7 +180,9 @@ impl Expand<'_> {
                         nullable = quote!(false);
                         deferred = quote!(<#ty as #toasty::ViaManyField>::DEFERRED);
                         field_ty = quote!(
-                            <#ty as #toasty::ViaManyField>::via_field_ty(#singular_name, #full_path)
+                            <<#ty as #toasty::ViaManyField>::Target as #toasty::ViaTarget>::via_field_ty(
+                                #singular_name, #full_path,
+                            )
                         );
                     } else {
                         let pair = expand_pair(toasty, quote!(#toasty::RelationManyField), ty, rel.pair.as_ref());

--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -615,6 +615,10 @@ pub(super) fn expand_via_path(
     quote_spanned! { span=>
         {
             let __via_chain = #chain;
+            // The chain terminal is a `FieldList` for a plain relation step (a
+            // real conversion to `Path`) but already a `Path` for a scalar or
+            // via-of-via terminal, where `.into()` is identity — allow that.
+            #[allow(clippy::useless_conversion)]
             let __via_typed: #typed_path_ty = __via_chain.into();
             let __via_untyped: #toasty::core::stmt::Path = __via_typed.into();
             __via_untyped

--- a/crates/toasty-macros/src/model/expand/update.rs
+++ b/crates/toasty-macros/src/model/expand/update.rs
@@ -355,7 +355,13 @@ impl Expand<'_> {
                 }
                 FieldTy::HasMany(rel) => {
                     let ty = &rel.ty;
-                    quote!(#i => <#ty as #toasty::RelationManyField>::reload(&mut target.#field_ident, value)?,)
+                    if rel.via.is_some() {
+                        // A via field has no `RelationManyField` impl (its
+                        // element may be a scalar); reload through `Load`.
+                        quote!(#i => <#ty as #toasty::Load>::reload(&mut target.#field_ident, value)?,)
+                    } else {
+                        quote!(#i => <#ty as #toasty::RelationManyField>::reload(&mut target.#field_ident, value)?,)
+                    }
                 }
                 FieldTy::HasOne(rel) => {
                     let ty = &rel.ty;

--- a/crates/toasty-macros/src/model/expand/util.rs
+++ b/crates/toasty-macros/src/model/expand/util.rs
@@ -1,8 +1,32 @@
-use proc_macro2::TokenStream;
+use proc_macro2::{Group, Span, TokenStream, TokenTree};
 
 pub(crate) fn int(v: usize) -> TokenStream {
     use std::str::FromStr;
     TokenStream::from_str(&v.to_string()).expect("failed to parse int")
+}
+
+/// Rewrite every token's span to `span`, recursing into delimited groups.
+///
+/// `quote_spanned!` only spans the literal tokens it emits; interpolated
+/// `#vars` keep their original spans. When the span of an *entire* emitted
+/// fragment must point at one place — e.g. a synthesized type annotation whose
+/// trait-bound failure should blame a specific source token rather than the
+/// derive call site — run the fragment through this first.
+pub(crate) fn respan(tokens: TokenStream, span: Span) -> TokenStream {
+    tokens
+        .into_iter()
+        .map(|tree| match tree {
+            TokenTree::Group(group) => {
+                let mut respanned = Group::new(group.delimiter(), respan(group.stream(), span));
+                respanned.set_span(span);
+                TokenTree::Group(respanned)
+            }
+            mut tree => {
+                tree.set_span(span);
+                tree
+            }
+        })
+        .collect()
 }
 
 /// Creates a new identifier prefixed with `__toasty_` to avoid name collisions

--- a/crates/toasty/src/codegen_support.rs
+++ b/crates/toasty/src/codegen_support.rs
@@ -13,8 +13,9 @@ pub use crate::schema::inventory;
 pub use crate::{
     Db, Error, Executor, Result, Statement,
     schema::{
-        Auto, Deferred, DiscoverItem, Embed, Field, Load, Model, QueryMany, QueryOne,
-        QueryOptionOne, RelationManyField, RelationOneField, Scope, generate_unique_id,
+        Auto, Deferred, DiscoverItem, Embed, Field, Load, ManyViaElem, Model, QueryMany, QueryOne,
+        QueryOptionOne, RelationManyField, RelationOneField, Scope, ViaManyField,
+        generate_unique_id, model_via_field_ty,
     },
     stmt::CreateMany,
     stmt::{self, Assign, IntoExpr, IntoInsert, IntoStatement, List, Path},

--- a/crates/toasty/src/codegen_support.rs
+++ b/crates/toasty/src/codegen_support.rs
@@ -15,8 +15,8 @@ pub use crate::{
     Db, Error, Executor, Result, Statement,
     schema::{
         Auto, Deferred, DiscoverItem, Embed, Field, Load, Model, QueryMany, QueryOne,
-        QueryOptionOne, RelationManyField, RelationOneField, Scope, ViaManyField, ViaTarget,
-        generate_unique_id,
+        QueryOptionOne, RelationManyField, RelationOneField, Scope, ViaMany, ViaManyField,
+        ViaTarget, generate_unique_id,
     },
     stmt::CreateMany,
     stmt::{self, Assign, IntoExpr, IntoInsert, IntoStatement, List, Path},

--- a/crates/toasty/src/codegen_support.rs
+++ b/crates/toasty/src/codegen_support.rs
@@ -8,6 +8,7 @@ pub mod auto;
 pub mod newtype;
 pub mod storage;
 pub mod version;
+pub mod via;
 
 pub use crate::schema::inventory;
 pub use crate::{
@@ -15,7 +16,7 @@ pub use crate::{
     schema::{
         Auto, Deferred, DiscoverItem, Embed, Field, Load, ManyViaElem, Model, QueryMany, QueryOne,
         QueryOptionOne, RelationManyField, RelationOneField, Scope, ViaManyField,
-        generate_unique_id, model_via_field_ty,
+        generate_unique_id,
     },
     stmt::CreateMany,
     stmt::{self, Assign, IntoExpr, IntoInsert, IntoStatement, List, Path},

--- a/crates/toasty/src/codegen_support.rs
+++ b/crates/toasty/src/codegen_support.rs
@@ -14,8 +14,8 @@ pub use crate::schema::inventory;
 pub use crate::{
     Db, Error, Executor, Result, Statement,
     schema::{
-        Auto, Deferred, DiscoverItem, Embed, Field, Load, ManyViaElem, Model, QueryMany, QueryOne,
-        QueryOptionOne, RelationManyField, RelationOneField, Scope, ViaManyField,
+        Auto, Deferred, DiscoverItem, Embed, Field, Load, Model, QueryMany, QueryOne,
+        QueryOptionOne, RelationManyField, RelationOneField, Scope, ViaManyField, ViaTarget,
         generate_unique_id,
     },
     stmt::CreateMany,

--- a/crates/toasty/src/codegen_support.rs
+++ b/crates/toasty/src/codegen_support.rs
@@ -15,7 +15,7 @@ pub use crate::{
     Db, Error, Executor, Result, Statement,
     schema::{
         Auto, Deferred, DiscoverItem, Embed, Field, Load, Model, QueryMany, QueryOne,
-        QueryOptionOne, RelationManyField, RelationOneField, Scope, ViaMany, ViaManyField,
+        QueryOptionOne, RelationManyField, RelationOneField, Scope, ViaMany, ViaManyField, ViaPath,
         ViaTarget, generate_unique_id,
     },
     stmt::CreateMany,

--- a/crates/toasty/src/codegen_support/via.rs
+++ b/crates/toasty/src/codegen_support/via.rs
@@ -1,0 +1,24 @@
+//! Helpers for the `#[has_many(via = …)]` code the derive macro emits.
+
+use crate::schema::Model;
+
+use toasty_core::schema::Name;
+use toasty_core::schema::app::{self, FieldTy, Via};
+use toasty_core::stmt;
+
+/// Build the [`FieldTy::Via`] for a relation-terminal `#[has_many(via = …)]`
+/// field reaching model `M`. The per-model
+/// [`ViaManyField`](crate::schema::ViaManyField) impl the derive emits
+/// delegates here so the construction (and `Box`/type plumbing) stays in this
+/// crate.
+pub fn model_via_field_ty<M: Model>(singular: Name, path: stmt::Path) -> FieldTy {
+    let target = <M as Model>::id();
+    let expr_ty = stmt::Type::List(Box::new(stmt::Type::Model(target)));
+    FieldTy::Via(Via::new(
+        target,
+        expr_ty,
+        app::Cardinality::Many { singular },
+        path,
+        None,
+    ))
+}

--- a/crates/toasty/src/codegen_support/via.rs
+++ b/crates/toasty/src/codegen_support/via.rs
@@ -8,7 +8,7 @@ use toasty_core::stmt;
 
 /// Build the [`FieldTy::Via`] for a relation-terminal `#[has_many(via = …)]`
 /// field reaching model `M`. The per-model
-/// [`ViaManyField`](crate::schema::ViaManyField) impl the derive emits
+/// [`ViaTarget`](crate::schema::ViaTarget) impl the derive emits
 /// delegates here so the construction (and `Box`/type plumbing) stays in this
 /// crate.
 pub fn model_via_field_ty<M: Model>(singular: Name, path: stmt::Path) -> FieldTy {

--- a/crates/toasty/src/engine/lower/association.rs
+++ b/crates/toasty/src/engine/lower/association.rs
@@ -61,12 +61,24 @@ impl<'a> RewriteVia<'a> {
             && let stmt::Source::Model(model) = &mut select.source
             && let Some(via) = model.via.take()
         {
-            // A scalar-terminal via used as a query source selects the
-            // projected terminal column from the via target. The macro can't
-            // name the target (the model the relation chain reaches), so it
-            // leaves a placeholder source id and no projection; fill both in
-            // from the schema's resolved `Via` before unfolding the chain into
-            // a filter.
+            // Complete a scalar-terminal via used as a query source. For
+            // `#[has_many(via = todos.tags.name)]`, `user.tag_names()` selects
+            // the `name` column from `Tag` (the model the chain reaches), not
+            // whole `Tag` records:
+            //
+            //     SELECT DISTINCT tag.name      -- returning: project Tag.name
+            //     FROM tag                      -- source model: Tag (the via target)
+            //     WHERE <tag reachable from user>  -- the chain, unfolded below
+            //
+            // The navigation method can't build this: it runs in user code with
+            // no linked schema, so it can't name the target model and emits a
+            // placeholder source id with no projection. The resolved `Via` is
+            // available here, so set the source model (the FROM table) and the
+            // terminal projection (the RETURNING) before unfolding the chain
+            // into the WHERE filter.
+            //
+            // A model-terminal via has `terminal == None` — its source already
+            // selects whole target records — so this is a no-op there.
             let scalar_terminal =
                 self.schema()
                     .app

--- a/crates/toasty/src/engine/lower/association.rs
+++ b/crates/toasty/src/engine/lower/association.rs
@@ -61,6 +61,29 @@ impl<'a> RewriteVia<'a> {
             && let stmt::Source::Model(model) = &mut select.source
             && let Some(via) = model.via.take()
         {
+            // A scalar-terminal via used as a query source selects the
+            // projected terminal column from the via target. The macro can't
+            // name the target (the model the relation chain reaches), so it
+            // leaves a placeholder source id and no projection; fill both in
+            // from the schema's resolved `Via` before unfolding the chain into
+            // a filter.
+            let scalar_terminal =
+                self.schema()
+                    .app
+                    .resolve_field_path(&via.path)
+                    .and_then(|field| match &field.ty {
+                        app::FieldTy::Via(v) => v.terminal.map(|terminal| (v.target, terminal)),
+                        _ => None,
+                    });
+
+            if let Some((target, _)) = scalar_terminal {
+                model.id = target;
+            }
+            if let Some((target, terminal)) = scalar_terminal {
+                select.returning =
+                    stmt::Returning::Project(stmt::Path::field(target, terminal).into_stmt());
+            }
+
             // Create a new scope to indicate we are operating in the
             // context of stmt.target
             let mut s = self.scope(&select.source);

--- a/crates/toasty/src/engine/lower/association.rs
+++ b/crates/toasty/src/engine/lower/association.rs
@@ -147,9 +147,18 @@ impl<'a> RewriteVia<'a> {
 
         // If this step names a via relation, splice the via's resolved path
         // in place of the via field and continue. Handles via-of-via
-        // naturally because the recursion re-examines the spliced steps.
+        // naturally because the recursion re-examines the spliced steps. A
+        // scalar-terminal via contributes only its relation chain to the
+        // reachability filter — the terminal field is a projection, handled by
+        // the query's returning, not the filter.
         let via_path = match &field.ty {
-            app::FieldTy::Via(via) => Some(via.path.projection.as_slice()),
+            app::FieldTy::Via(via) => {
+                let projection = via.path.projection.as_slice();
+                Some(match via.terminal {
+                    Some(_) => &projection[..projection.len() - 1],
+                    None => projection,
+                })
+            }
             _ => None,
         };
         if let Some(via_steps) = via_path {

--- a/crates/toasty/src/engine/lower/returning.rs
+++ b/crates/toasty/src/engine/lower/returning.rs
@@ -61,6 +61,8 @@ impl LowerStatement<'_, '_> {
                 record[field.id.index] = match field.ty {
                     FieldTy::Has(ref rel) if rel.is_many() => stmt::Expr::list_from_vec(vec![]),
                     FieldTy::Has(_) => stmt::Expr::null(),
+                    FieldTy::Via(ref via) if via.is_many() => stmt::Expr::list_from_vec(vec![]),
+                    FieldTy::Via(_) => stmt::Expr::null(),
                     _ => unreachable!(),
                 };
                 continue;
@@ -370,7 +372,7 @@ impl LowerStatement<'_, '_> {
 }
 
 fn is_insert_local_eager_relation(field_ty: &FieldTy) -> bool {
-    matches!(field_ty, FieldTy::Has(_))
+    matches!(field_ty, FieldTy::Has(_) | FieldTy::Via(_))
 }
 
 fn first_model_field(path: &stmt::Path, model_id: ModelId) -> Option<usize> {

--- a/crates/toasty/src/engine/lower/via_join.rs
+++ b/crates/toasty/src/engine/lower/via_join.rs
@@ -54,12 +54,24 @@ impl LowerStatement<'_, '_> {
         let link_col = model_level_column_expr(schema, link_field, join.slot(1));
         let filter = stmt::Expr::eq(link_col.clone(), stmt::Expr::ref_field(1, parent_key_field));
 
-        // RETURNING `[link_col, target_record]`. The link column lands in
+        // RETURNING `[link_col, value]`. The link column lands in
         // `load_data_select_items` so the qualification resolves to a
-        // `SortLookup`; `target_record` is the schema's `default_returning`,
-        // whose column refs already point at table slot 0 (the target).
-        let target_record = schema.mapping_for(join.target()).default_returning.clone();
-        let returning = stmt::Expr::record_from_vec(vec![link_col, target_record]);
+        // `SortLookup`. For a relation terminal, `value` is the schema's
+        // `default_returning` (the whole target record). For a scalar terminal,
+        // it is the projected terminal column on the target (table slot 0) —
+        // the same shape as `.select(Target::fields().field())`.
+        let value = match via.terminal {
+            Some(terminal) => model_level_column_expr(
+                schema,
+                app::FieldId {
+                    model: join.target(),
+                    index: terminal,
+                },
+                0,
+            ),
+            None => schema.mapping_for(join.target()).default_returning.clone(),
+        };
+        let returning = stmt::Expr::record_from_vec(vec![link_col, value]);
 
         // `DISTINCT` collapses duplicate targets produced when the path fans
         // out (e.g. two comments on the same article) — matching a direct via
@@ -120,7 +132,15 @@ struct ViaJoin {
 
 impl ViaJoin {
     fn resolve(schema: &toasty_core::Schema, root: app::ModelId, via: &app::Via) -> ViaJoin {
-        let steps = flatten_via_steps(schema, root, via.path.projection.as_slice());
+        // For a scalar terminal the path's last step is the projected field,
+        // not a relation; the relation chain (which the JOIN walks) is
+        // everything before it.
+        let projection = via.path.projection.as_slice();
+        let relation_steps = match via.terminal {
+            Some(_) => &projection[..projection.len() - 1],
+            None => projection,
+        };
+        let steps = flatten_via_steps(schema, root, relation_steps);
         assert!(
             !steps.is_empty(),
             "via path must have at least one step (validated at schema build time)"

--- a/crates/toasty/src/schema.rs
+++ b/crates/toasty/src/schema.rs
@@ -41,7 +41,7 @@ mod scope;
 pub use scope::Scope;
 
 mod via;
-pub use via::{ManyViaElem, ViaManyField};
+pub use via::{ViaManyField, ViaTarget};
 
 use crate::Result;
 

--- a/crates/toasty/src/schema.rs
+++ b/crates/toasty/src/schema.rs
@@ -40,6 +40,9 @@ pub use relation_one::RelationOneField;
 mod scope;
 pub use scope::Scope;
 
+mod via;
+pub use via::{ManyViaElem, ViaManyField, model_via_field_ty};
+
 use crate::Result;
 
 pub use toasty_core::schema::{app, app::ModelSet, db, diff, mapping};

--- a/crates/toasty/src/schema.rs
+++ b/crates/toasty/src/schema.rs
@@ -41,7 +41,7 @@ mod scope;
 pub use scope::Scope;
 
 mod via;
-pub use via::{ViaManyField, ViaTarget};
+pub use via::{ViaMany, ViaManyField, ViaTarget};
 
 use crate::Result;
 

--- a/crates/toasty/src/schema.rs
+++ b/crates/toasty/src/schema.rs
@@ -41,7 +41,7 @@ mod scope;
 pub use scope::Scope;
 
 mod via;
-pub use via::{ViaMany, ViaManyField, ViaTarget};
+pub use via::{ViaMany, ViaManyField, ViaPath, ViaTarget};
 
 use crate::Result;
 

--- a/crates/toasty/src/schema.rs
+++ b/crates/toasty/src/schema.rs
@@ -41,7 +41,7 @@ mod scope;
 pub use scope::Scope;
 
 mod via;
-pub use via::{ManyViaElem, ViaManyField, model_via_field_ty};
+pub use via::{ManyViaElem, ViaManyField};
 
 use crate::Result;
 

--- a/crates/toasty/src/schema/has_many.rs
+++ b/crates/toasty/src/schema/has_many.rs
@@ -51,7 +51,7 @@ fn many_relation_field_ty<M: Model>(
     let cardinality = app::Cardinality::Many { singular };
 
     match via {
-        Some(path) => FieldTy::Via(app::Via::new(target, expr_ty, cardinality, path)),
+        Some(path) => FieldTy::Via(app::Via::new(target, expr_ty, cardinality, path, None)),
         None => FieldTy::Has(app::Has {
             target,
             expr_ty,

--- a/crates/toasty/src/schema/relation_one.rs
+++ b/crates/toasty/src/schema/relation_one.rs
@@ -168,7 +168,7 @@ fn has_one_relation_field_ty<M: Model>(pair: Option<FieldId>, via: Option<stmt::
     let cardinality = app::Cardinality::One;
 
     match via {
-        Some(path) => FieldTy::Via(app::Via::new(target, expr_ty, cardinality, path)),
+        Some(path) => FieldTy::Via(app::Via::new(target, expr_ty, cardinality, path, None)),
         None => FieldTy::Has(app::Has {
             target,
             expr_ty,

--- a/crates/toasty/src/schema/via.rs
+++ b/crates/toasty/src/schema/via.rs
@@ -1,0 +1,174 @@
+use super::{Deferred, Load, Model};
+use crate::stmt::{Association, List, Query};
+
+use toasty_core::schema::Name;
+use toasty_core::schema::app::{self, FieldTy, ModelId, Via};
+use toasty_core::stmt;
+
+/// Build the [`FieldTy::Via`] for a relation-terminal `#[has_many(via = …)]`
+/// field reaching model `M`. The per-model [`ViaManyField`] impl the derive
+/// emits delegates here so the construction (and `Box`/type plumbing) stays in
+/// this crate.
+pub fn model_via_field_ty<M: Model>(singular: Name, path: stmt::Path) -> FieldTy {
+    let target = <M as Model>::id();
+    let expr_ty = stmt::Type::List(Box::new(stmt::Type::Model(target)));
+    FieldTy::Via(Via::new(
+        target,
+        expr_ty,
+        app::Cardinality::Many { singular },
+        path,
+        None,
+    ))
+}
+
+/// Element extraction for a `#[has_many]` field's Rust type.
+///
+/// Blanket-implemented over `Vec<E>` and [`Deferred<Vec<E>>`](Deferred) for
+/// every `E`, so the derive can name a has-many field's element type — and
+/// route it through [`ViaManyField`] — without requiring `E: Model`. A single
+/// blanket impl per outer shape keeps it coherent with the per-element
+/// `ViaManyField` impls.
+pub trait ManyViaElem {
+    /// The collection's element type.
+    type Elem: ViaManyField;
+
+    /// Whether the field stores its value in a deferred load slot.
+    const DEFERRED: bool;
+}
+
+impl<E: ViaManyField> ManyViaElem for Vec<E> {
+    type Elem = E;
+    const DEFERRED: bool = false;
+}
+
+impl<E: ViaManyField> ManyViaElem for Deferred<Vec<E>> {
+    type Elem = E;
+    const DEFERRED: bool = true;
+}
+
+/// A type that can be the terminal element of a `#[has_many(via = …)]`
+/// relation.
+///
+/// A `via` relation reaches its terminal by following a path of existing
+/// relations. The terminal is usually another model (`via = comments.article`),
+/// but it may also be a **scalar field** (`via = todos.tags.name`), which
+/// projects that field across the relation path to yield `Vec<String>`.
+///
+/// This trait is keyed on the *terminal element type*, with disjoint concrete
+/// impls so they never overlap:
+///
+/// - The `#[derive(Model)]` macro emits an impl for each model, setting
+///   [`Query`](Self::Query) to that model's generated query builder (so a
+///   relation-terminal via keeps its rich `QueryMany<M>` API).
+/// - This module emits an impl for each scalar primitive, setting
+///   [`Query`](Self::Query) to the plain [`Query<List<Self>>`].
+pub trait ViaManyField {
+    /// The query builder returned by the generated has-many-via navigation
+    /// method.
+    type Query;
+
+    /// Build the [`FieldTy::Via`] for a `#[has_many(via = …)]` field whose
+    /// terminal element type is `Self`.
+    ///
+    /// `path` is the fully-resolved field path (rooted at the declaring
+    /// model), including the terminal step. `terminal_owner` is the model that
+    /// owns the path's last segment: a scalar terminal uses it as the via
+    /// target, while a model terminal ignores it in favour of `Self::id()`.
+    fn via_field_ty(singular: Name, path: stmt::Path, terminal_owner: ModelId) -> FieldTy;
+
+    /// Wrap a via-field association into the navigation query.
+    ///
+    /// `target` and `terminal` describe a scalar terminal (the model the
+    /// relation chain reaches and the projected field's index on it); a model
+    /// terminal ignores them.
+    fn make_via_query(
+        assoc: Association<List<Self>>,
+        target: ModelId,
+        terminal: usize,
+    ) -> Self::Query
+    where
+        Self: Sized;
+}
+
+/// Emit `ViaManyField` for scalar primitives. Each impl is concrete, so it
+/// stays disjoint from the per-model impls the derive macro generates.
+macro_rules! impl_via_many_scalar {
+    ( $( $t:ty ),* $(,)? ) => {
+        $(
+            impl ViaManyField for $t {
+                type Query = Query<List<$t>>;
+
+                fn via_field_ty(
+                    singular: Name,
+                    path: stmt::Path,
+                    terminal_owner: ModelId,
+                ) -> FieldTy {
+                    // The terminal scalar field is the path's last step, on the
+                    // model the relation chain reaches.
+                    let terminal = *path
+                        .projection
+                        .as_slice()
+                        .last()
+                        .expect("via path has at least one step");
+                    let expr_ty = stmt::Type::List(Box::new(<$t as Load>::ty()));
+                    FieldTy::Via(Via::new(
+                        terminal_owner,
+                        expr_ty,
+                        app::Cardinality::Many { singular },
+                        path,
+                        Some(terminal),
+                    ))
+                }
+
+                fn make_via_query(
+                    assoc: Association<List<$t>>,
+                    target: ModelId,
+                    terminal: usize,
+                ) -> Self::Query {
+                    // Iterate the via target's rows (the via association is
+                    // unfolded into a reachability filter during lowering) and
+                    // project the terminal field — the same shape as
+                    // `.select(Target::fields().field())`. Built like a
+                    // relation-via source query (`Query::builder(SourceModel)`)
+                    // so it lowers identically, then the returning is set to the
+                    // terminal column. `distinct` collapses duplicate terminal
+                    // values, matching the include path.
+                    let mut query = stmt::Query::builder(stmt::SourceModel {
+                        id: target,
+                        via: Some(assoc.untyped),
+                    })
+                    .build();
+                    let select = query.body.as_select_mut_unwrap();
+                    select.returning = stmt::Returning::Project(
+                        stmt::Path::field(target, terminal).into_stmt(),
+                    );
+                    select.distinct = true;
+                    Query::from_untyped(query)
+                }
+            }
+        )*
+    };
+}
+
+impl_via_many_scalar!(
+    String,
+    bool,
+    i8,
+    i16,
+    i32,
+    i64,
+    u16,
+    u32,
+    u64,
+    isize,
+    usize,
+    f32,
+    f64,
+    uuid::Uuid,
+);
+
+#[cfg(feature = "rust_decimal")]
+impl_via_many_scalar!(rust_decimal::Decimal);
+
+#[cfg(feature = "bigdecimal")]
+impl_via_many_scalar!(bigdecimal::BigDecimal);

--- a/crates/toasty/src/schema/via.rs
+++ b/crates/toasty/src/schema/via.rs
@@ -43,6 +43,15 @@ impl<E: ViaTarget> ViaManyField for Deferred<Vec<E>> {
 /// same way.
 pub type ViaMany<F> = <<F as ViaManyField>::Target as ViaTarget>::Query;
 
+/// The typed path handle a `#[has_many(via = …)]` field's accessor returns for
+/// a field of type `F` (e.g. `Vec<String>`, `Deferred<Vec<Article>>`), rooted
+/// at `Origin`.
+///
+/// Resolves to the terminal type's [`ViaTarget::Path`]: the model's chainable
+/// `ManyField` for a model terminal, `Path<Origin, List<scalar>>` for a scalar.
+/// Mirrors [`ViaMany`], which aliases the navigation query the same way.
+pub type ViaPath<F, Origin> = <<F as ViaManyField>::Target as ViaTarget>::Path<Origin>;
+
 /// A type that can be the terminal element of a `#[has_many(via = …)]`
 /// relation.
 ///

--- a/crates/toasty/src/schema/via.rs
+++ b/crates/toasty/src/schema/via.rs
@@ -1,5 +1,5 @@
 use super::{Deferred, Load};
-use crate::stmt::{Association, List, Query};
+use crate::stmt::{Association, List, Path, Query};
 
 use toasty_core::schema::Name;
 use toasty_core::schema::app::{self, FieldTy, ModelId, Via};
@@ -64,6 +64,20 @@ pub trait ViaTarget {
     /// method.
     type Query;
 
+    /// The typed path handle a `#[has_many(via = …)]` field's accessor returns,
+    /// parameterized by the origin model. Mirrors [`Model::Path`] for the
+    /// via-many case.
+    ///
+    /// A **model** terminal returns that model's chainable
+    /// [`ManyField`](crate::schema::Model::ManyField) — a `Path` wrapper that
+    /// adds field accessors, so navigation can continue *through* a via step
+    /// (e.g. `organizations.todos.title`, where `organizations.todos` is itself
+    /// a via). A **scalar** terminal returns a plain list [`Path`]: a leaf with
+    /// nothing further to chain.
+    ///
+    /// [`Model::Path`]: crate::schema::Model::Path
+    type Path<Origin>;
+
     /// Build the [`FieldTy::Via`] for a `#[has_many(via = …)]` field whose
     /// terminal element type is `Self`.
     ///
@@ -73,6 +87,13 @@ pub trait ViaTarget {
     /// chain reaches, which the path alone can't name here — so the scalar
     /// impls leave it unset and `toasty-core` fills it in while linking.
     fn via_field_ty(singular: Name, path: stmt::Path) -> FieldTy;
+
+    /// Build the [`Path`](Self::Path) handle from the typed `path` reaching this
+    /// terminal. A model terminal wraps the path in its chainable `ManyField`; a
+    /// scalar terminal is a leaf, so the path is the handle.
+    fn new_path<Origin>(path: Path<Origin, List<Self>>) -> Self::Path<Origin>
+    where
+        Self: Sized;
 
     /// Wrap a via-field association into the navigation query.
     ///
@@ -93,6 +114,12 @@ macro_rules! impl_via_many_scalar {
         $(
             impl ViaTarget for $t {
                 type Query = Query<List<$t>>;
+                type Path<Origin> = Path<Origin, List<$t>>;
+
+                fn new_path<Origin>(path: Path<Origin, List<$t>>) -> Self::Path<Origin> {
+                    // A scalar terminal is a leaf — the path is the handle.
+                    path
+                }
 
                 fn via_field_ty(singular: Name, path: stmt::Path) -> FieldTy {
                     // The terminal scalar field is the path's last step.

--- a/crates/toasty/src/schema/via.rs
+++ b/crates/toasty/src/schema/via.rs
@@ -5,6 +5,10 @@ use toasty_core::schema::Name;
 use toasty_core::schema::app::{self, FieldTy, ModelId, Via};
 use toasty_core::stmt;
 
+/// Placeholder via target for a scalar terminal, overwritten when `toasty-core`
+/// resolves the relation chain while linking. It must never reach a query.
+const UNRESOLVED_TARGET: ModelId = ModelId(usize::MAX);
+
 /// Implemented by a `#[has_many(via = …)]` field's Rust type, exposing the
 /// via's [`Target`](Self::Target) — the terminal type the path projects.
 ///
@@ -55,21 +59,20 @@ pub trait ViaTarget {
     /// terminal element type is `Self`.
     ///
     /// `path` is the fully-resolved field path (rooted at the declaring
-    /// model), including the terminal step. `terminal_owner` is the model that
-    /// owns the path's last segment: a scalar terminal uses it as the via
-    /// target, while a model terminal ignores it in favour of `Self::id()`.
-    fn via_field_ty(singular: Name, path: stmt::Path, terminal_owner: ModelId) -> FieldTy;
+    /// model), including the terminal step. The via target is `Self::id()` for
+    /// a model terminal; for a scalar terminal it is the model the relation
+    /// chain reaches, which the path alone can't name here — so the scalar
+    /// impls leave it unset and `toasty-core` fills it in while linking.
+    fn via_field_ty(singular: Name, path: stmt::Path) -> FieldTy;
 
     /// Wrap a via-field association into the navigation query.
     ///
-    /// `target` and `terminal` describe a scalar terminal (the model the
-    /// relation chain reaches and the projected field's index on it); a model
-    /// terminal ignores them.
-    fn make_via_query(
-        assoc: Association<List<Self>>,
-        target: ModelId,
-        terminal: usize,
-    ) -> Self::Query
+    /// A scalar terminal yields a query whose source model and terminal
+    /// projection are filled in during lowering ([`RewriteVia`]) from the
+    /// core-resolved schema, so neither is needed here.
+    ///
+    /// [`RewriteVia`]: ../../engine/lower/association/struct.RewriteVia.html
+    fn make_via_query(assoc: Association<List<Self>>) -> Self::Query
     where
         Self: Sized;
 }
@@ -82,21 +85,18 @@ macro_rules! impl_via_many_scalar {
             impl ViaTarget for $t {
                 type Query = Query<List<$t>>;
 
-                fn via_field_ty(
-                    singular: Name,
-                    path: stmt::Path,
-                    terminal_owner: ModelId,
-                ) -> FieldTy {
-                    // The terminal scalar field is the path's last step, on the
-                    // model the relation chain reaches.
+                fn via_field_ty(singular: Name, path: stmt::Path) -> FieldTy {
+                    // The terminal scalar field is the path's last step.
                     let terminal = *path
                         .projection
                         .as_slice()
                         .last()
                         .expect("via path has at least one step");
                     let expr_ty = stmt::Type::List(Box::new(<$t as Load>::ty()));
+                    // `target` (the model the relation chain reaches) is resolved
+                    // in core's link phase; leave a placeholder it overwrites.
                     FieldTy::Via(Via::new(
-                        terminal_owner,
+                        UNRESOLVED_TARGET,
                         expr_ty,
                         app::Cardinality::Many { singular },
                         path,
@@ -104,29 +104,18 @@ macro_rules! impl_via_many_scalar {
                     ))
                 }
 
-                fn make_via_query(
-                    assoc: Association<List<$t>>,
-                    target: ModelId,
-                    terminal: usize,
-                ) -> Self::Query {
-                    // Iterate the via target's rows (the via association is
-                    // unfolded into a reachability filter during lowering) and
-                    // project the terminal field — the same shape as
-                    // `.select(Target::fields().field())`. Built like a
-                    // relation-via source query (`Query::builder(SourceModel)`)
-                    // so it lowers identically, then the returning is set to the
-                    // terminal column. `distinct` collapses duplicate terminal
+                fn make_via_query(assoc: Association<List<$t>>) -> Self::Query {
+                    // A via-as-source query whose source model and terminal
+                    // projection RewriteVia fills in from the resolved schema
+                    // (see its scalar branch). The placeholder source id is
+                    // overwritten there. `distinct` collapses duplicate terminal
                     // values, matching the include path.
                     let mut query = stmt::Query::builder(stmt::SourceModel {
-                        id: target,
+                        id: UNRESOLVED_TARGET,
                         via: Some(assoc.untyped),
                     })
                     .build();
-                    let select = query.body.as_select_mut_unwrap();
-                    select.returning = stmt::Returning::Project(
-                        stmt::Path::field(target, terminal).into_stmt(),
-                    );
-                    select.distinct = true;
+                    query.body.as_select_mut_unwrap().distinct = true;
                     Query::from_untyped(query)
                 }
             }

--- a/crates/toasty/src/schema/via.rs
+++ b/crates/toasty/src/schema/via.rs
@@ -20,45 +20,28 @@ pub trait ViaManyField {
     /// The via's terminal type — the model or scalar the path projects.
     type Target: ViaTarget;
 
-    /// The query builder the generated navigation methods return. Forwards to
-    /// the terminal's [`ViaTarget::Query`] so the derive can name it in one hop
-    /// (`<Field as ViaManyField>::Query`) instead of projecting through both
-    /// traits.
-    type Query;
-
     /// Whether the field stores its value in a deferred load slot.
     const DEFERRED: bool;
-
-    /// Build the field's [`FieldTy::Via`]. Forwards to
-    /// [`ViaTarget::via_field_ty`] on the terminal type.
-    fn via_field_ty(singular: Name, path: stmt::Path) -> FieldTy {
-        <Self::Target as ViaTarget>::via_field_ty(singular, path)
-    }
-
-    /// Wrap a via-field association into the navigation query. Forwards to
-    /// [`ViaTarget::make_via_query`] on the terminal type.
-    fn make_via_query(assoc: Association<List<Self::Target>>) -> Self::Query;
 }
 
 impl<E: ViaTarget> ViaManyField for Vec<E> {
     type Target = E;
-    type Query = <E as ViaTarget>::Query;
     const DEFERRED: bool = false;
-
-    fn make_via_query(assoc: Association<List<E>>) -> Self::Query {
-        <E as ViaTarget>::make_via_query(assoc)
-    }
 }
 
 impl<E: ViaTarget> ViaManyField for Deferred<Vec<E>> {
     type Target = E;
-    type Query = <E as ViaTarget>::Query;
     const DEFERRED: bool = true;
-
-    fn make_via_query(assoc: Association<List<E>>) -> Self::Query {
-        <E as ViaTarget>::make_via_query(assoc)
-    }
 }
+
+/// The query builder a `#[has_many(via = …)]` navigation method returns for a
+/// field of type `F` (e.g. `Vec<String>`, `Deferred<Vec<Article>>`).
+///
+/// Resolves to the terminal type's [`ViaTarget::Query`]: `QueryMany<M>` for a
+/// model terminal, `Query<List<scalar>>` for a scalar. Mirrors
+/// [`QueryMany`](super::QueryMany), which aliases a model's query builder the
+/// same way.
+pub type ViaMany<F> = <<F as ViaManyField>::Target as ViaTarget>::Query;
 
 /// A type that can be the terminal element of a `#[has_many(via = …)]`
 /// relation.

--- a/crates/toasty/src/schema/via.rs
+++ b/crates/toasty/src/schema/via.rs
@@ -5,28 +5,28 @@ use toasty_core::schema::Name;
 use toasty_core::schema::app::{self, FieldTy, ModelId, Via};
 use toasty_core::stmt;
 
-/// Element extraction for a `#[has_many]` field's Rust type.
+/// Implemented by a `#[has_many(via = …)]` field's Rust type, exposing the
+/// via's [`Target`](Self::Target) — the terminal type the path projects.
 ///
 /// Blanket-implemented over `Vec<E>` and [`Deferred<Vec<E>>`](Deferred) for
-/// every `E`, so the derive can name a has-many field's element type — and
-/// route it through [`ViaManyField`] — without requiring `E: Model`. A single
-/// blanket impl per outer shape keeps it coherent with the per-element
-/// `ViaManyField` impls.
-pub trait ManyViaElem {
-    /// The collection's element type.
-    type Elem: ViaManyField;
+/// every `E`, so the derive can route a via field through [`ViaTarget`]
+/// without requiring `E: Model`. A single blanket impl per outer shape keeps
+/// it coherent with the per-target `ViaTarget` impls.
+pub trait ViaManyField {
+    /// The via's terminal type — the model or scalar the path projects.
+    type Target: ViaTarget;
 
     /// Whether the field stores its value in a deferred load slot.
     const DEFERRED: bool;
 }
 
-impl<E: ViaManyField> ManyViaElem for Vec<E> {
-    type Elem = E;
+impl<E: ViaTarget> ViaManyField for Vec<E> {
+    type Target = E;
     const DEFERRED: bool = false;
 }
 
-impl<E: ViaManyField> ManyViaElem for Deferred<Vec<E>> {
-    type Elem = E;
+impl<E: ViaTarget> ViaManyField for Deferred<Vec<E>> {
+    type Target = E;
     const DEFERRED: bool = true;
 }
 
@@ -46,7 +46,7 @@ impl<E: ViaManyField> ManyViaElem for Deferred<Vec<E>> {
 ///   relation-terminal via keeps its rich `QueryMany<M>` API).
 /// - This module emits an impl for each scalar primitive, setting
 ///   [`Query`](Self::Query) to the plain [`Query<List<Self>>`].
-pub trait ViaManyField {
+pub trait ViaTarget {
     /// The query builder returned by the generated has-many-via navigation
     /// method.
     type Query;
@@ -74,12 +74,12 @@ pub trait ViaManyField {
         Self: Sized;
 }
 
-/// Emit `ViaManyField` for scalar primitives. Each impl is concrete, so it
+/// Emit `ViaTarget` for scalar primitives. Each impl is concrete, so it
 /// stays disjoint from the per-model impls the derive macro generates.
 macro_rules! impl_via_many_scalar {
     ( $( $t:ty ),* $(,)? ) => {
         $(
-            impl ViaManyField for $t {
+            impl ViaTarget for $t {
                 type Query = Query<List<$t>>;
 
                 fn via_field_ty(

--- a/crates/toasty/src/schema/via.rs
+++ b/crates/toasty/src/schema/via.rs
@@ -20,18 +20,44 @@ pub trait ViaManyField {
     /// The via's terminal type — the model or scalar the path projects.
     type Target: ViaTarget;
 
+    /// The query builder the generated navigation methods return. Forwards to
+    /// the terminal's [`ViaTarget::Query`] so the derive can name it in one hop
+    /// (`<Field as ViaManyField>::Query`) instead of projecting through both
+    /// traits.
+    type Query;
+
     /// Whether the field stores its value in a deferred load slot.
     const DEFERRED: bool;
+
+    /// Build the field's [`FieldTy::Via`]. Forwards to
+    /// [`ViaTarget::via_field_ty`] on the terminal type.
+    fn via_field_ty(singular: Name, path: stmt::Path) -> FieldTy {
+        <Self::Target as ViaTarget>::via_field_ty(singular, path)
+    }
+
+    /// Wrap a via-field association into the navigation query. Forwards to
+    /// [`ViaTarget::make_via_query`] on the terminal type.
+    fn make_via_query(assoc: Association<List<Self::Target>>) -> Self::Query;
 }
 
 impl<E: ViaTarget> ViaManyField for Vec<E> {
     type Target = E;
+    type Query = <E as ViaTarget>::Query;
     const DEFERRED: bool = false;
+
+    fn make_via_query(assoc: Association<List<E>>) -> Self::Query {
+        <E as ViaTarget>::make_via_query(assoc)
+    }
 }
 
 impl<E: ViaTarget> ViaManyField for Deferred<Vec<E>> {
     type Target = E;
+    type Query = <E as ViaTarget>::Query;
     const DEFERRED: bool = true;
+
+    fn make_via_query(assoc: Association<List<E>>) -> Self::Query {
+        <E as ViaTarget>::make_via_query(assoc)
+    }
 }
 
 /// A type that can be the terminal element of a `#[has_many(via = …)]`

--- a/crates/toasty/src/schema/via.rs
+++ b/crates/toasty/src/schema/via.rs
@@ -1,25 +1,9 @@
-use super::{Deferred, Load, Model};
+use super::{Deferred, Load};
 use crate::stmt::{Association, List, Query};
 
 use toasty_core::schema::Name;
 use toasty_core::schema::app::{self, FieldTy, ModelId, Via};
 use toasty_core::stmt;
-
-/// Build the [`FieldTy::Via`] for a relation-terminal `#[has_many(via = …)]`
-/// field reaching model `M`. The per-model [`ViaManyField`] impl the derive
-/// emits delegates here so the construction (and `Box`/type plumbing) stays in
-/// this crate.
-pub fn model_via_field_ty<M: Model>(singular: Name, path: stmt::Path) -> FieldTy {
-    let target = <M as Model>::id();
-    let expr_ty = stmt::Type::List(Box::new(stmt::Type::Model(target)));
-    FieldTy::Via(Via::new(
-        target,
-        expr_ty,
-        app::Cardinality::Many { singular },
-        path,
-        None,
-    ))
-}
 
 /// Element extraction for a `#[has_many]` field's Rust type.
 ///

--- a/crates/toasty/src/stmt/association.rs
+++ b/crates/toasty/src/stmt/association.rs
@@ -39,6 +39,31 @@ impl<T> Association<T> {
             _p: PhantomData,
         }
     }
+
+    /// Construct an association from `source` following `path`, without
+    /// requiring the returning type `T` to be a model.
+    ///
+    /// Used by generated `#[has_many(via = …)]` navigation methods, whose
+    /// terminal may be a scalar (`Path<S, List<String>>`). The [`many`](Self::many) /
+    /// [`one`](Self::one) constructors bound the element on [`Model`]; this one
+    /// only bounds the *source* model `S`, so it works for both relation- and
+    /// scalar-terminal vias.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the root of `path` does not match the model id of `S`.
+    #[doc(hidden)]
+    pub fn from_source_and_path<S: Model>(source: super::Query<List<S>>, path: Path<S, T>) -> Self {
+        assert_eq!(path.untyped.root.as_model_unwrap(), S::id());
+
+        Self {
+            untyped: stmt::Association {
+                source: Box::new(source.untyped),
+                path: path.untyped,
+            },
+            _p: PhantomData,
+        }
+    }
 }
 
 impl<M: Model> Association<List<M>> {

--- a/tests/tests/ui/create_via_relation_field.stderr
+++ b/tests/tests/ui/create_via_relation_field.stderr
@@ -12,18 +12,3 @@ error[E0599]: no method named `tags` found for struct `UserCreate` in the curren
    | |        -^^^^ method not found in `UserCreate`
    | |________|
    |
-
-error[E0599]: no method named `create` found for struct `toasty::stmt::Path<T, U>` in the current scope
-  --> tests/ui/create_via_relation_field.rs:46:9
-   |
-43 |       let _ = toasty::create!(User {
-   |                               ----
-   |                               |
-   |  _____________________________method `create` is available on `&UserFields<User>`
-   | |
-44 | |         id: 1,
-45 | |         name: "Alice",
-46 | |         tags: [{ id: 1, name: "urgent" }],
-   | |        -^^^^ method not found in `toasty::stmt::Path<User, toasty::stmt::List<Tag>>`
-   | |________|
-   |

--- a/tests/tests/ui/create_via_relation_field.stderr
+++ b/tests/tests/ui/create_via_relation_field.stderr
@@ -12,3 +12,18 @@ error[E0599]: no method named `tags` found for struct `UserCreate` in the curren
    | |        -^^^^ method not found in `UserCreate`
    | |________|
    |
+
+error[E0599]: no method named `create` found for struct `toasty::stmt::Path<T, U>` in the current scope
+  --> tests/ui/create_via_relation_field.rs:46:9
+   |
+43 |       let _ = toasty::create!(User {
+   |                               ----
+   |                               |
+   |  _____________________________method `create` is available on `&UserFields<User>`
+   | |
+44 | |         id: 1,
+45 | |         name: "Alice",
+46 | |         tags: [{ id: 1, name: "urgent" }],
+   | |        -^^^^ method not found in `toasty::stmt::Path<User, toasty::stmt::List<Tag>>`
+   | |________|
+   |

--- a/tests/tests/ui/has_many_via_scalar_terminal_type_mismatch.rs
+++ b/tests/tests/ui/has_many_via_scalar_terminal_type_mismatch.rs
@@ -1,0 +1,47 @@
+// A scalar-terminal `via` whose declared element type disagrees with the type
+// the path actually reaches must be a compile error, not a runtime load
+// failure. Here the path reaches `Article::title` (a `String`) but the field is
+// declared `Vec<i64>`.
+
+#[derive(Debug, toasty::Model)]
+struct User {
+    #[key]
+    id: i64,
+
+    name: String,
+
+    #[has_many]
+    comments: toasty::Deferred<Vec<Comment>>,
+
+    #[has_many(via = comments.article.title)]
+    article_titles: toasty::Deferred<Vec<i64>>,
+}
+
+#[derive(Debug, toasty::Model)]
+struct Article {
+    #[key]
+    id: i64,
+
+    title: String,
+
+    #[has_many]
+    comments: toasty::Deferred<Vec<Comment>>,
+}
+
+#[derive(Debug, toasty::Model)]
+struct Comment {
+    #[key]
+    id: i64,
+
+    user_id: i64,
+
+    #[belongs_to(key = user_id, references = id)]
+    user: toasty::Deferred<User>,
+
+    article_id: i64,
+
+    #[belongs_to(key = article_id, references = id)]
+    article: toasty::Deferred<Article>,
+}
+
+fn main() {}

--- a/tests/tests/ui/has_many_via_scalar_terminal_type_mismatch.stderr
+++ b/tests/tests/ui/has_many_via_scalar_terminal_type_mismatch.stderr
@@ -1,0 +1,11 @@
+error[E0277]: the trait bound `toasty::stmt::Path<User, toasty::stmt::List<i64>>: From<toasty::stmt::Path<User, toasty::stmt::List<std::string::String>>>` is not satisfied
+  --> tests/ui/has_many_via_scalar_terminal_type_mismatch.rs:6:17
+   |
+ 6 | #[derive(Debug, toasty::Model)]
+   |                 ^^^^^^^^^^^^^ unsatisfied trait bound
+...
+16 |     #[has_many(via = comments.article.title)]
+   |                                       ----- required by a bound introduced by this call
+   |
+   = help: the trait `From<toasty::stmt::Path<User, toasty::stmt::List<std::string::String>>>` is not implemented for `toasty::stmt::Path<User, toasty::stmt::List<i64>>`
+   = note: required for `toasty::stmt::Path<User, toasty::stmt::List<std::string::String>>` to implement `Into<toasty::stmt::Path<User, toasty::stmt::List<i64>>>`

--- a/tests/tests/ui/has_many_via_scalar_terminal_type_mismatch.stderr
+++ b/tests/tests/ui/has_many_via_scalar_terminal_type_mismatch.stderr
@@ -1,11 +1,8 @@
 error[E0277]: the trait bound `toasty::stmt::Path<User, toasty::stmt::List<i64>>: From<toasty::stmt::Path<User, toasty::stmt::List<std::string::String>>>` is not satisfied
-  --> tests/ui/has_many_via_scalar_terminal_type_mismatch.rs:6:17
+  --> tests/ui/has_many_via_scalar_terminal_type_mismatch.rs:16:39
    |
- 6 | #[derive(Debug, toasty::Model)]
-   |                 ^^^^^^^^^^^^^ unsatisfied trait bound
-...
 16 |     #[has_many(via = comments.article.title)]
-   |                                       ----- required by a bound introduced by this call
+   |                                       ^^^^^ unsatisfied trait bound
    |
    = help: the trait `From<toasty::stmt::Path<User, toasty::stmt::List<std::string::String>>>` is not implemented for `toasty::stmt::Path<User, toasty::stmt::List<i64>>`
    = note: required for `toasty::stmt::Path<User, toasty::stmt::List<std::string::String>>` to implement `Into<toasty::stmt::Path<User, toasty::stmt::List<i64>>>`


### PR DESCRIPTION
## Summary

`#[has_many(via = todos.tags.name)] tag_names: Vec<String>` now projects a scalar field through a relation path. Previously a `via` path had to terminate in a relation reaching a model — yet the runtime already supported the equivalent `user.todos().tags().select(Tag::fields().name())`, so this exposes that as a declarative field.

Has-many via fields route through a new `ViaManyField` trait keyed on the **terminal element type**, with disjoint concrete impls so coherence holds:

- the derive emits a per-model impl → relation terminals keep their rich `QueryMany<M>` builder (no regression);
- toasty emits one impl per scalar primitive → scalar terminals yield `Query<List<scalar>>`.

This sidesteps the `M: Model` bound `RelationManyField` requires. The element type and scalar-vs-model determination stay at macro/type time — an intermediate that isn't navigable fails to chain, and the declared element type is pinned against the path's terminal (a mismatch like `Vec<i64>` over a `String` is a compile error). The scalar via's **target model** is resolved in `toasty-core` while linking, by walking the relation chain (which also rejects an embedded hop or non-scalar terminal with a clear schema error).

`app::Via` gains `terminal: Option<usize>`; the engine projects the terminal column (rather than the whole record) in both `via_join` (include/select) and `RewriteVia` (navigation). Available through `.include()`, `.select()`, the instance method (`user.tag_names()`), and the query-chain method (`User::filter(..).tag_names()`). Scalar vias yield **distinct terminal values**. SQL backends only, matching existing via support.

Deferred (not in this PR): `has_one` scalar terminals, embedded-struct terminals, and non-SQL backends.

## Type of change

- [x] Other (please explain): adds public API. The design was decided interactively rather than via a `docs/dev/design/` doc — flagging for maintainer triage (see Notes).

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy --workspace --all-features` are clean
- [x] `cargo test` passes

## Notes for reviewers

- **Distinct semantics**: a scalar via yields distinct terminal values, consistent across include / select / navigation. The alternative is mirroring `.select(field)` exactly (distinct *targets*, so duplicate values survive). Easy to flip if you'd prefer the latter.
- **Public API**: purely additive for users — the via navigation methods (instance and query-chain) work for scalar terminals and are unchanged for model terminals. The one signature change is internal: `app::Via` gained a `terminal` field and `app::Via::new` a corresponding parameter (relevant only to code constructing schema objects directly, e.g. codegen).
- No design doc was authored (went straight to implementation by request). If the public-API surface warrants one, happy to write it up.
- `create!`/`update!` already skipped via fields; reload + model registration for via now go through `Load` / the relation chain rather than `RelationManyField`.