### PR TITLE
refactor!: rename RelationManyField/RelationOneField assoc type to Target

### DIFF
--- a/crates/toasty-macros/src/model/expand.rs
+++ b/crates/toasty-macros/src/model/expand.rs
@@ -393,8 +393,8 @@ impl Expand<'_> {
         let span = field_ident.span();
 
         quote_spanned! { span=>
-            #vis fn #field_ident(&self) -> <<#ty as #field_trait>::Model as #toasty::Model>::OneField<__Origin> {
-                <<<#ty as #field_trait>::Model as #toasty::Model>::OneField<__Origin>>::from_path(
+            #vis fn #field_ident(&self) -> <<#ty as #field_trait>::Target as #toasty::Model>::OneField<__Origin> {
+                <<<#ty as #field_trait>::Target as #toasty::Model>::OneField<__Origin>>::from_path(
                     self.path().chain(
                         <#model_ident as #schema_trait>::path_field(#field_offset)
                     )

--- a/crates/toasty-macros/src/model/expand/create.rs
+++ b/crates/toasty-macros/src/model/expand/create.rs
@@ -163,7 +163,7 @@ impl Expand<'_> {
                         } else {
                             let plural = name;
                             let ty = &rel.ty;
-                            let target = quote!(<#ty as #toasty::RelationManyField>::Model);
+                            let target = quote!(<#ty as #toasty::RelationManyField>::Target);
 
                             quote! {
                                 #vis fn #plural(mut self, #plural: impl #toasty::IntoExpr<#toasty::List<#target>>) -> Self {

--- a/crates/toasty-macros/src/model/expand/fields.rs
+++ b/crates/toasty-macros/src/model/expand/fields.rs
@@ -64,8 +64,8 @@ impl Expand<'_> {
                         };
 
                         quote_spanned! { span=>
-                            #vis fn #field_ident(&self) -> <<#ty as #toasty::RelationManyField>::Model as #toasty::Model>::ManyField<__Origin> {
-                                <<<#ty as #toasty::RelationManyField>::Model as #toasty::Model>::ManyField<__Origin>>::from_path(#path)
+                            #vis fn #field_ident(&self) -> <<#ty as #toasty::RelationManyField>::Target as #toasty::Model>::ManyField<__Origin> {
+                                <<<#ty as #toasty::RelationManyField>::Target as #toasty::Model>::ManyField<__Origin>>::from_path(#path)
                             }
                         }
                     }
@@ -383,8 +383,8 @@ impl Expand<'_> {
         let span = field_ident.span();
 
         quote_spanned! { span=>
-            #vis fn #field_ident(&self) -> <<#ty as #field_trait>::Model as #toasty::Model>::ManyField<__Origin> {
-                <<<#ty as #field_trait>::Model as #toasty::Model>::ManyField<__Origin>>::from_path(
+            #vis fn #field_ident(&self) -> <<#ty as #field_trait>::Target as #toasty::Model>::ManyField<__Origin> {
+                <<<#ty as #field_trait>::Target as #toasty::Model>::ManyField<__Origin>>::from_path(
                     self.path().chain(
                         <#model_ident as #schema_trait>::path_field(#field_offset)
                     )

--- a/crates/toasty-macros/src/model/expand/query.rs
+++ b/crates/toasty-macros/src/model/expand/query.rs
@@ -329,7 +329,7 @@ impl Expand<'_> {
         let toasty = &self.toasty;
         let vis = &self.model.vis;
         let ty = &rel.ty;
-        let target = quote!(<#ty as #toasty::RelationOneField>::Model);
+        let target = quote!(<#ty as #toasty::RelationOneField>::Target);
         let model_ident = &self.model.ident;
         let field_ident = &field.name.ident;
         let field_offset = util::int(field.id);
@@ -353,7 +353,7 @@ impl Expand<'_> {
         let toasty = &self.toasty;
         let vis = &self.model.vis;
         let ty = &rel.ty;
-        let target = quote!(<#ty as #toasty::RelationManyField>::Model);
+        let target = quote!(<#ty as #toasty::RelationManyField>::Target);
         let model_ident = &self.model.ident;
         let field_ident = &field.name.ident;
         let field_offset = util::int(field.id);
@@ -374,7 +374,7 @@ impl Expand<'_> {
         let toasty = &self.toasty;
         let vis = &self.model.vis;
         let ty = &rel.ty;
-        let target = quote!(<#ty as #toasty::RelationOneField>::Model);
+        let target = quote!(<#ty as #toasty::RelationOneField>::Target);
         let model_ident = &self.model.ident;
         let field_ident = &field.name.ident;
         let field_offset = util::int(field.id);

--- a/crates/toasty-macros/src/model/expand/relation.rs
+++ b/crates/toasty-macros/src/model/expand/relation.rs
@@ -41,7 +41,7 @@ impl Expand<'_> {
         let vis = &self.model.vis;
         let field_ident = &field.name.ident;
         let ty = &rel.ty;
-        let target_ty = quote!(<#ty as #toasty::RelationOneField>::Model);
+        let target_ty = quote!(<#ty as #toasty::RelationOneField>::Target);
 
         let operands = rel.foreign_key.iter().map(|fk_field| {
             let source = &self.model.fields[fk_field.source];
@@ -106,7 +106,7 @@ impl Expand<'_> {
         let vis = &self.model.vis;
         let field_ident = &field.name.ident;
         let ty = &rel.ty;
-        let target = quote!(<#ty as #toasty::RelationManyField>::Model);
+        let target = quote!(<#ty as #toasty::RelationManyField>::Target);
 
         // A `via` relation reaches its target through a path of existing
         // relations; it has no paired `BelongsTo`, so skip the back-reference
@@ -156,7 +156,7 @@ impl Expand<'_> {
         let vis = &self.model.vis;
         let field_ident = &field.name.ident;
         let ty = &rel.ty;
-        let target = quote!(<#ty as #toasty::RelationOneField>::Model);
+        let target = quote!(<#ty as #toasty::RelationOneField>::Target);
 
         // A `via` relation reaches its target through a path of existing
         // relations; it has no paired `BelongsTo`, so skip the back-reference
@@ -269,8 +269,8 @@ impl Expand<'_> {
                 fn verify<#verify_t: Verify<#verify_a>, #verify_a>(_: &#verify_t) {
                 }
 
-                let instance = load::<<#ty as #field_trait>::Model>();
-                verify::<_, <#ty as #field_trait>::Model>(instance.#verify_pair_belongs_to_exists_for_field());
+                let instance = load::<<#ty as #field_trait>::Target>();
+                verify::<_, <#ty as #field_trait>::Target>(instance.#verify_pair_belongs_to_exists_for_field());
             }
         }
     }

--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -146,7 +146,7 @@ impl Expand<'_> {
                                     index: #source,
                                 },
                                 target: {
-                                    type __RelationTarget = <#ty as #toasty::RelationOneField>::Model;
+                                    type __RelationTarget = <#ty as #toasty::RelationOneField>::Target;
                                     <__RelationTarget as #toasty::Model>::field_name_to_id(#target)
                                 },
                             }
@@ -459,19 +459,19 @@ impl Expand<'_> {
                 FieldTy::BelongsTo(rel) => {
                     let ty = &rel.ty;
                     quote! {
-                        <<#ty as #toasty::RelationOneField>::Model as #toasty::Model>::register(model_set);
+                        <<#ty as #toasty::RelationOneField>::Target as #toasty::Model>::register(model_set);
                     }
                 }
                 FieldTy::HasMany(rel) => {
                     let ty = &rel.ty;
                     quote! {
-                        <<#ty as #toasty::RelationManyField>::Model as #toasty::Model>::register(model_set);
+                        <<#ty as #toasty::RelationManyField>::Target as #toasty::Model>::register(model_set);
                     }
                 }
                 FieldTy::HasOne(rel) => {
                     let ty = &rel.ty;
                     quote! {
-                        <<#ty as #toasty::RelationOneField>::Model as #toasty::Model>::register(model_set);
+                        <<#ty as #toasty::RelationOneField>::Target as #toasty::Model>::register(model_set);
                     }
                 }
             })
@@ -503,7 +503,7 @@ fn expand_pair(
             let name = ident.to_string();
             quote! {
                 Some({
-                    type __RelationTarget = <#target_ty as #field_trait>::Model;
+                    type __RelationTarget = <#target_ty as #field_trait>::Target;
                     <__RelationTarget as #toasty::Model>::field_name_to_id(#name)
                 })
             }

--- a/crates/toasty-macros/src/model/expand/update.rs
+++ b/crates/toasty-macros/src/model/expand/update.rs
@@ -75,7 +75,7 @@ impl Expand<'_> {
                     TokenStream::new()
                 } else {
                     let ty = &rel.ty;
-                    let target = quote!(<#ty as #toasty::RelationManyField>::Model);
+                    let target = quote!(<#ty as #toasty::RelationManyField>::Target);
 
                     quote! {
                         #vis fn #field_ident(mut self, #field_ident: impl #toasty::Assign<#toasty::List<#target>>) -> Self {

--- a/crates/toasty/src/schema/has_many.rs
+++ b/crates/toasty/src/schema/has_many.rs
@@ -5,7 +5,7 @@ use toasty_core::schema::app::{self, FieldId, FieldTy, ModelId};
 use toasty_core::stmt;
 
 impl<M: Model> RelationManyField for Vec<M> {
-    type Model = M;
+    type Target = M;
 
     const DEFERRED: bool = false;
 
@@ -23,7 +23,7 @@ impl<M: Model> RelationManyField for Vec<M> {
 }
 
 impl<M: Model> RelationManyField for Deferred<Vec<M>> {
-    type Model = M;
+    type Target = M;
 
     const DEFERRED: bool = true;
 

--- a/crates/toasty/src/schema/relation.rs
+++ b/crates/toasty/src/schema/relation.rs
@@ -13,7 +13,7 @@ use toasty_core::stmt;
 /// the trait.
 pub trait RelationManyField: Load<Output = Self> {
     /// The target model that this field references.
-    type Model: Model;
+    type Target: Model;
 
     /// Whether the field stores its value in a deferred load slot.
     const DEFERRED: bool;

--- a/crates/toasty/src/schema/relation_one.rs
+++ b/crates/toasty/src/schema/relation_one.rs
@@ -13,15 +13,15 @@ use toasty_core::stmt;
 /// shape does not satisfy the trait.
 pub trait RelationOneField: Load<Output = Self> {
     /// The target model that this field references.
-    type Model: Model;
+    type Target: Model;
 
     /// The query type produced by the relation accessor. For non-nullable
-    /// impls this is `<Model as Model>::Query<Model>`; for nullable impls it is
-    /// `<Model as Model>::Query<Option<Model>>`.
+    /// impls this is `<Target as Model>::Query<Target>`; for nullable impls it is
+    /// `<Target as Model>::Query<Option<Target>>`.
     type One;
 
     /// The expression-level type used in create/update setters. Resolves to
-    /// the unwrapped `Self::Model` for non-nullable impls and `Option<Self::Model>`
+    /// the unwrapped `Self::Target` for non-nullable impls and `Option<Self::Target>`
     /// for nullable impls.
     type Expr;
 
@@ -42,7 +42,7 @@ pub trait RelationOneField: Load<Output = Self> {
     /// singular association via [`Model::wrap_query`]) and pass it here; the
     /// association's path is preserved through the wrap so generated mutators
     /// (insert, remove, create) can read it.
-    fn make_one(query: QueryMany<Self::Model>) -> Self::One;
+    fn make_one(query: QueryMany<Self::Target>) -> Self::One;
 
     /// Build the [`FieldTy`] for a `HasOne` relation field, given an
     /// optional paired `BelongsTo` field on the target model resolved
@@ -61,7 +61,7 @@ pub trait RelationOneField: Load<Output = Self> {
 }
 
 impl<M: Model> RelationOneField for M {
-    type Model = M;
+    type Target = M;
     type One = QueryOne<M>;
     type Expr = M;
 
@@ -72,7 +72,7 @@ impl<M: Model> RelationOneField for M {
         <Self as Load>::reload(target, value)
     }
 
-    fn make_one(query: QueryMany<Self::Model>) -> Self::One {
+    fn make_one(query: QueryMany<Self::Target>) -> Self::One {
         <M as Model>::query_one(query)
     }
 
@@ -86,7 +86,7 @@ impl<M: Model> RelationOneField for M {
 }
 
 impl<M: Model> RelationOneField for Option<M> {
-    type Model = M;
+    type Target = M;
     type One = QueryOptionOne<M>;
     type Expr = Option<M>;
 
@@ -97,7 +97,7 @@ impl<M: Model> RelationOneField for Option<M> {
         <Self as Load>::reload(target, value)
     }
 
-    fn make_one(query: QueryMany<Self::Model>) -> Self::One {
+    fn make_one(query: QueryMany<Self::Target>) -> Self::One {
         <M as Model>::query_first(query)
     }
 
@@ -111,7 +111,7 @@ impl<M: Model> RelationOneField for Option<M> {
 }
 
 impl<M: Model> RelationOneField for Deferred<M> {
-    type Model = M;
+    type Target = M;
     type One = QueryOne<M>;
     type Expr = M;
 
@@ -123,7 +123,7 @@ impl<M: Model> RelationOneField for Deferred<M> {
         Ok(())
     }
 
-    fn make_one(query: QueryMany<Self::Model>) -> Self::One {
+    fn make_one(query: QueryMany<Self::Target>) -> Self::One {
         <M as Model>::query_one(query)
     }
 
@@ -137,7 +137,7 @@ impl<M: Model> RelationOneField for Deferred<M> {
 }
 
 impl<M: Model> RelationOneField for Deferred<Option<M>> {
-    type Model = M;
+    type Target = M;
     type One = QueryOptionOne<M>;
     type Expr = Option<M>;
 
@@ -149,7 +149,7 @@ impl<M: Model> RelationOneField for Deferred<Option<M>> {
         Ok(())
     }
 
-    fn make_one(query: QueryMany<Self::Model>) -> Self::One {
+    fn make_one(query: QueryMany<Self::Target>) -> Self::One {
         <M as Model>::query_first(query)
     }
 

--- a/crates/toasty/tests/relation_load.rs
+++ b/crates/toasty/tests/relation_load.rs
@@ -89,9 +89,9 @@ impl IntoExpr<Dummy> for DummyCreate {
     }
 }
 
-fn assert_has_many_field<F: RelationManyField<Model = Dummy>>() {}
-fn assert_has_one_field<F: RelationOneField<Model = Dummy>>() {}
-fn assert_belongs_to_field<F: RelationOneField<Model = Dummy>>() {}
+fn assert_has_many_field<F: RelationManyField<Target = Dummy>>() {}
+fn assert_has_one_field<F: RelationOneField<Target = Dummy>>() {}
+fn assert_belongs_to_field<F: RelationOneField<Target = Dummy>>() {}
 
 #[test]
 fn deferred_relation_field_shapes_are_supported() {


### PR DESCRIPTION
## Summary

`RelationManyField` and `RelationOneField` exposed the related model through an
associated type called `Model`. That name collided with the trait bound also
called `Model`, so `<Vec<Todo> as RelationManyField>::Model` ended up reading
awkwardly, and it didn't match `ViaManyField::Target` that #1012 introduced for
the same idea. This renames the associated type to `Target` on both traits, in
their impls, and in the macro-generated references.

Closes #1013.

## Type of change

- [x] Small / obvious change: internal cleanup, mechanical rename

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
