### PR TITLE
refactor(macros): drop dead RelationManyField::NULLABLE

### DIFF
--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -187,7 +187,8 @@ impl Expand<'_> {
                     } else {
                         let pair = expand_pair(toasty, quote!(#toasty::RelationManyField), ty, rel.pair.as_ref());
 
-                        nullable = quote!(<#ty as #toasty::RelationManyField>::NULLABLE);
+                        // A has-many collection is always present, never null.
+                        nullable = quote!(false);
                         deferred = quote!(<#ty as #toasty::RelationManyField>::DEFERRED);
                         field_ty = quote!(<#ty as #toasty::RelationManyField>::many_relation_field_ty(#singular_name, #pair, None));
                     }

--- a/crates/toasty/src/schema/relation.rs
+++ b/crates/toasty/src/schema/relation.rs
@@ -18,10 +18,6 @@ pub trait RelationManyField: Load<Output = Self> {
     /// Whether the field stores its value in a deferred load slot.
     const DEFERRED: bool;
 
-    /// A has-many is a collection; the collection itself is always present
-    /// even when empty, so a has-many field is never nullable.
-    const NULLABLE: bool = false;
-
     /// Reloads this relation field from a returned value.
     fn reload(target: &mut Self, value: stmt::Value) -> crate::Result<()>;
 


### PR DESCRIPTION
## Summary

`RelationManyField::NULLABLE` was always `false` and no impl overrode it: a
has-many collection is always present, even when empty. After #1012 split the
has-many expansion, the via branch already emitted `false` directly. This does
the same for the non-via branch and removes the constant.

Closes #1014.

## Checklist

- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
