### PR TITLE
docs: structure bug reports around observed behavior, not root cause

### DIFF
--- a/.agents/skills/issue/SKILL.md
+++ b/.agents/skills/issue/SKILL.md
@@ -28,8 +28,9 @@ Issue templates live in
 [`.github/ISSUE_TEMPLATE/`](../../../.github/ISSUE_TEMPLATE):
 
 - [`bug_report.yml`](../../../.github/ISSUE_TEMPLATE/bug_report.yml) —
-  incorrect or unexpected behavior. Requires a reproducer, the affected
-  driver(s), and the Toasty version or commit SHA.
+  incorrect or unexpected behavior. Asks what you did, what you expected,
+  and what happened instead; the affected driver(s); the Toasty version;
+  and a reproducer.
 - [`feature_proposal.yml`](../../../.github/ISSUE_TEMPLATE/feature_proposal.yml) —
   new features, public-API changes, or anything that affects driver
   implementations. Requires the problem, proposed solution,
@@ -41,11 +42,23 @@ say so explicitly rather than leaving it blank.
 
 ## Bug reports
 
-A small, self-contained reproducer is the single most useful thing in a
-bug report. A failing test in
-`crates/toasty-driver-integration-suite/src/tests/` is ideal; a
-standalone snippet works too. Include the exact error, generated SQL,
-or backtrace when relevant.
+Report what you observed, not why you think it happened. A bug report
+has five parts:
+
+- **What you did** — the query or operation you ran.
+- **What you expected** — the result you expected.
+- **What actually happened** — the error, wrong result, or panic. Quote
+  the exact message, generated SQL, or backtrace.
+- **Additional context** — affected driver, Toasty version, related
+  issues.
+- **A minimal reproducer** — a failing test in
+  `crates/toasty-driver-integration-suite/src/tests/` is ideal; a small
+  standalone snippet works too. This is the single most useful thing in
+  the report.
+
+Leave out root-cause analysis. Diagnosing the bug is the maintainer's
+job, and a guess at the cause sends triage down the wrong path. Describe
+the behavior; the reproducer shows the rest.
 
 ## Feature proposals
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,19 +5,39 @@ body:
   - type: markdown
     attributes:
       value: |
-        A small, self-contained reproducer is the single most useful thing
-        you can include.
+        Describe what you observed — what you did, what you expected, and
+        what happened instead. A small, self-contained reproducer is the
+        single most useful thing you can include.
+
+        Leave the diagnosis to maintainers. Describe what happened, not why
+        you think it happens — a guess at the cause tends to send triage
+        down the wrong path.
 
   - type: textarea
-    id: summary
+    id: what_you_did
     attributes:
-      label: Summary
-      description: What did you expect to happen, and what happened instead?
+      label: What you did
+      description: The query or operation you ran, in prose or code.
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+      description: The result you expected.
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: What actually happened
+      description: |
+        What happened instead — the error, wrong result, or panic. Quote
+        the exact message, generated SQL, or backtrace. Describe what you
+        saw, not why you think it happened.
 
   - type: textarea
     id: reproducer
     attributes:
-      label: Reproducer
+      label: Minimal reproducer
       description: |
         A minimal example that demonstrates the issue. A failing test in
         `crates/toasty-driver-integration-suite/src/tests/` is ideal; a
@@ -47,4 +67,4 @@ body:
     id: notes
     attributes:
       label: Additional context
-      description: Backtrace, generated SQL, related issues, anything else relevant.
+      description: Related issues, environment details, anything else relevant.


### PR DESCRIPTION
## Summary

Restructure the bug report issue template and the `issue` skill so reporters
describe observable behavior, not root cause.

- **Template** (`.github/ISSUE_TEMPLATE/bug_report.yml`): split the combined
  "Summary" field into **What you did**, **What you expected**, and **What
  actually happened**, and keep a dedicated **Minimal reproducer** field. The
  intro and the "what actually happened" field both ask reporters to describe
  what they saw, not why they think it happened.
- **`issue` skill** (`.agents/skills/issue/SKILL.md`): rewrite the Bug reports
  section into the same five parts and state that root-cause analysis does not
  belong in a report — a guessed cause sends triage down the wrong path.

Bug reports only; feature proposals are unchanged. Fields stay optional (guide,
not gate).

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format

## Notes for reviewers

No Rust touched — only an issue-form template and a skill doc, so `cargo
fmt`/`clippy`/`test` are unaffected.
