### PR TITLE
feat: support composite unique indices

### DIFF
--- a/crates/toasty-driver-dynamodb/src/op/create_table.rs
+++ b/crates/toasty-driver-dynamodb/src/op/create_table.rs
@@ -57,7 +57,26 @@ impl Connection {
         let mut gsis = vec![];
 
         for index in &table.indices {
-            if index.primary_key || index.unique {
+            if index.primary_key {
+                continue;
+            }
+
+            if index.unique {
+                // Unique indices are materialized as separate tables below. Each
+                // index table is keyed on a single column and enforced with an
+                // `attribute_not_exists` condition, so composite (multi-column)
+                // unique indices are not supported. Reject them here, before any
+                // table is created, rather than partway through. SQL backends
+                // support them via `CREATE UNIQUE INDEX`.
+                if index.columns.len() != 1 {
+                    return Err(toasty_core::Error::unsupported_feature(format!(
+                        "DynamoDB does not support composite unique indices; \
+                         index '{}' spans {} columns",
+                        index.name,
+                        index.columns.len()
+                    )));
+                }
+
                 continue;
             }
 
@@ -138,11 +157,9 @@ impl Connection {
             .await
             .map_err(toasty_core::Error::driver_operation_failed)?;
 
-        // Now, create separate tables for each unique index
+        // Now, create separate tables for each unique index. Composite unique
+        // indices were already rejected above, so each index has one column.
         for index in table.indices.iter().filter(|i| !i.primary_key && i.unique) {
-            // TODO: handle more than one column
-            assert_eq!(1, index.columns.len());
-
             let pk = schema.column(index.columns[0].column);
 
             self.client

--- a/crates/toasty-driver-integration-suite/src/tests/index_composite.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/index_composite.rs
@@ -613,17 +613,20 @@ pub async fn composite_index_sort_key_range_filter(t: &mut Test) -> Result<()> {
 /// `composite_unique_index_unsupported_on_dynamodb`.
 #[driver_test(requires(sql))]
 pub async fn composite_unique_index_enforced(t: &mut Test) -> Result<()> {
+    // Short model/field names keep the auto-generated index name within
+    // MySQL's 64-char identifier limit once the test harness table prefix is
+    // applied.
     #[derive(Debug, toasty::Model)]
-    #[unique(coa_id, combination_hash)]
-    struct AccountCombination {
+    #[unique(org_id, slug)]
+    struct Account {
         #[key]
         #[auto]
         id: u64,
-        coa_id: i64,
-        combination_hash: String,
+        org_id: i64,
+        slug: String,
     }
 
-    let mut db = t.setup_db(models!(AccountCombination)).await;
+    let mut db = t.setup_db(models!(Account)).await;
 
     // The one non-primary-key index must be unique and span both columns.
     let index = db.schema().db.tables[0]
@@ -634,43 +637,43 @@ pub async fn composite_unique_index_enforced(t: &mut Test) -> Result<()> {
     assert!(index.unique);
     assert_eq!(index.columns.len(), 2);
 
-    toasty::create!(AccountCombination {
-        coa_id: 1_i64,
-        combination_hash: "abc"
+    toasty::create!(Account {
+        org_id: 1_i64,
+        slug: "abc"
     })
     .exec(&mut db)
     .await?;
 
-    // The same (coa_id, combination_hash) combination is rejected.
+    // The same (org_id, slug) combination is rejected.
     assert_err!(
-        toasty::create!(AccountCombination {
-            coa_id: 1_i64,
-            combination_hash: "abc"
+        toasty::create!(Account {
+            org_id: 1_i64,
+            slug: "abc"
         })
         .exec(&mut db)
         .await
     );
 
-    // The same combination_hash under a different coa_id is allowed —
-    // uniqueness is on the combination, not either column alone.
-    toasty::create!(AccountCombination {
-        coa_id: 2_i64,
-        combination_hash: "abc"
+    // The same slug under a different org_id is allowed — uniqueness is on the
+    // combination, not either column alone.
+    toasty::create!(Account {
+        org_id: 2_i64,
+        slug: "abc"
     })
     .exec(&mut db)
     .await?;
 
-    // The same coa_id with a different combination_hash is also allowed.
-    toasty::create!(AccountCombination {
-        coa_id: 1_i64,
-        combination_hash: "xyz"
+    // The same org_id with a different slug is also allowed.
+    toasty::create!(Account {
+        org_id: 1_i64,
+        slug: "xyz"
     })
     .exec(&mut db)
     .await?;
 
     // The generated full-key getter resolves a single record.
-    let row = AccountCombination::get_by_coa_id_and_combination_hash(&mut db, 2_i64, "abc").await?;
-    assert_eq!(row.coa_id, 2);
+    let row = Account::get_by_org_id_and_slug(&mut db, 2_i64, "abc").await?;
+    assert_eq!(row.org_id, 2);
 
     Ok(())
 }
@@ -682,15 +685,15 @@ pub async fn composite_unique_index_enforced(t: &mut Test) -> Result<()> {
 #[driver_test(requires(not(sql)))]
 pub async fn composite_unique_index_unsupported_on_dynamodb(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
-    #[unique(coa_id, combination_hash)]
-    struct AccountCombination {
+    #[unique(org_id, slug)]
+    struct Account {
         #[key]
         id: String,
-        coa_id: String,
-        combination_hash: String,
+        org_id: String,
+        slug: String,
     }
 
-    let err = assert_err!(t.try_setup_db(models!(AccountCombination)).await);
+    let err = assert_err!(t.try_setup_db(models!(Account)).await);
     assert!(
         err.is_unsupported_feature(),
         "expected unsupported_feature error, got: {err}"

--- a/crates/toasty-driver-integration-suite/src/tests/index_composite.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/index_composite.rs
@@ -604,3 +604,97 @@ pub async fn composite_index_sort_key_range_filter(t: &mut Test) -> Result<()> {
 
     Ok(())
 }
+
+/// Struct-level `#[unique(field_a, field_b)]` enforces uniqueness across the
+/// combination of columns rather than each column individually (SQL-only).
+///
+/// On SQL this lowers to `CREATE UNIQUE INDEX ... (field_a, field_b)`. DynamoDB
+/// does not support composite unique indices — see
+/// `composite_unique_index_unsupported_on_dynamodb`.
+#[driver_test(requires(sql))]
+pub async fn composite_unique_index_enforced(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    #[unique(coa_id, combination_hash)]
+    struct AccountCombination {
+        #[key]
+        #[auto]
+        id: u64,
+        coa_id: i64,
+        combination_hash: String,
+    }
+
+    let mut db = t.setup_db(models!(AccountCombination)).await;
+
+    // The one non-primary-key index must be unique and span both columns.
+    let index = db.schema().db.tables[0]
+        .indices
+        .iter()
+        .find(|i| !i.primary_key)
+        .expect("composite unique index");
+    assert!(index.unique);
+    assert_eq!(index.columns.len(), 2);
+
+    toasty::create!(AccountCombination {
+        coa_id: 1_i64,
+        combination_hash: "abc"
+    })
+    .exec(&mut db)
+    .await?;
+
+    // The same (coa_id, combination_hash) combination is rejected.
+    assert_err!(
+        toasty::create!(AccountCombination {
+            coa_id: 1_i64,
+            combination_hash: "abc"
+        })
+        .exec(&mut db)
+        .await
+    );
+
+    // The same combination_hash under a different coa_id is allowed —
+    // uniqueness is on the combination, not either column alone.
+    toasty::create!(AccountCombination {
+        coa_id: 2_i64,
+        combination_hash: "abc"
+    })
+    .exec(&mut db)
+    .await?;
+
+    // The same coa_id with a different combination_hash is also allowed.
+    toasty::create!(AccountCombination {
+        coa_id: 1_i64,
+        combination_hash: "xyz"
+    })
+    .exec(&mut db)
+    .await?;
+
+    // The generated full-key getter resolves a single record.
+    let row = AccountCombination::get_by_coa_id_and_combination_hash(&mut db, 2_i64, "abc").await?;
+    assert_eq!(row.coa_id, 2);
+
+    Ok(())
+}
+
+/// DynamoDB does not support composite (multi-column) unique indices: backing a
+/// composite unique constraint would require a composite-key index table plus
+/// matching write synchronization, which is not implemented. Schema setup must
+/// surface a clean `unsupported_feature` error rather than panicking (DDB-only).
+#[driver_test(requires(not(sql)))]
+pub async fn composite_unique_index_unsupported_on_dynamodb(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    #[unique(coa_id, combination_hash)]
+    struct AccountCombination {
+        #[key]
+        id: String,
+        coa_id: String,
+        combination_hash: String,
+    }
+
+    let err = assert_err!(t.try_setup_db(models!(AccountCombination)).await);
+    assert!(
+        err.is_unsupported_feature(),
+        "expected unsupported_feature error, got: {err}"
+    );
+
+    Ok(())
+}

--- a/crates/toasty-macros/src/model/schema/key_attr.rs
+++ b/crates/toasty-macros/src/model/schema/key_attr.rs
@@ -3,6 +3,10 @@ pub(crate) struct KeyAttr {
     pub(crate) partition: Vec<syn::Ident>,
     pub(crate) local: Vec<syn::Ident>,
     pub(crate) name: Option<String>,
+
+    /// When `true`, the index enforces uniqueness. Set for `#[unique(...)]`
+    /// attributes; always `false` for `#[key(...)]` and `#[index(...)]`.
+    pub(crate) unique: bool,
 }
 
 impl KeyAttr {
@@ -137,6 +141,7 @@ impl KeyAttr {
             partition,
             local,
             name,
+            unique: false,
         })
     }
 }

--- a/crates/toasty-macros/src/model/schema/model.rs
+++ b/crates/toasty-macros/src/model/schema/model.rs
@@ -333,7 +333,7 @@ impl Model {
 
             indices.push(Index {
                 fields: index_fields,
-                unique: false,
+                unique: index_attr.unique,
                 primary_key: false,
                 name: index_attr.name.clone(),
             });

--- a/crates/toasty-macros/src/model/schema/model_attr.rs
+++ b/crates/toasty-macros/src/model/schema/model_attr.rs
@@ -35,6 +35,17 @@ impl ModelAttr {
                     Ok(index_attr) => self.indices.push(index_attr),
                     Err(e) => errs.push(e),
                 }
+            } else if attr.path().is_ident("unique") {
+                // A struct-level `#[unique(...)]` is a composite unique index. It
+                // mirrors `#[index(...)]` (simple and partition/local modes, plus
+                // `name = "..."`) but enforces uniqueness across the listed fields.
+                match KeyAttr::from_ast(attr, names) {
+                    Ok(mut index_attr) => {
+                        index_attr.unique = true;
+                        self.indices.push(index_attr);
+                    }
+                    Err(e) => errs.push(e),
+                }
             } else if attr.path().is_ident("table") {
                 if self.table.is_some() {
                     return Err(syn::Error::new_spanned(attr, "duplicate `table` attribute"));

--- a/docs/guide/src/dynamodb.md
+++ b/docs/guide/src/dynamodb.md
@@ -198,6 +198,11 @@ Two operational consequences worth knowing:
   transaction. The transaction's condition expression catches
   concurrent writers atomically.
 
+The index table is keyed on a single column, so composite unique
+constraints (`#[unique(a, b)]`) are not supported. Declaring one returns
+an `unsupported_feature` error when the schema is created. SQL backends
+support them via `CREATE UNIQUE INDEX`.
+
 See [Indexes and Unique Constraints](./indexes-and-unique-constraints.md)
 for the model-level syntax.
 

--- a/docs/guide/src/indexes-and-unique-constraints.md
+++ b/docs/guide/src/indexes-and-unique-constraints.md
@@ -366,6 +366,48 @@ keep generated names within a database's identifier-length limit.
 | Query matching | Database uses leftmost-prefix matching | All `partition` fields required; `local` fields optional left-to-right |
 | Column limits | No artificial limits | Up to 4 partition and 4 local attributes per index |
 
+## Multi-column unique constraints
+
+A struct-level `#[unique(...)]` defines a composite unique index. It takes the
+same field list as `#[index(...)]` — simple mode, named `partition`/`local`
+mode, and a `name = "..."` override — but the database enforces uniqueness
+across the combination of columns.
+
+```rust
+# use toasty::Model;
+#[derive(Debug, toasty::Model)]
+#[unique(coa_id, combination_hash)]
+struct AccountCombination {
+    #[key]
+    #[auto]
+    id: u64,
+    coa_id: i64,
+    combination_hash: String,
+}
+```
+
+On SQL databases this produces a unique index over both columns:
+
+```sql
+CREATE UNIQUE INDEX idx_account_combinations_coa_id_combination_hash
+    ON account_combinations (coa_id, combination_hash);
+```
+
+The constraint applies to the combination, not either column alone — two rows
+may share a `coa_id` or a `combination_hash`, but not both. Inserting a row that
+duplicates an existing `(coa_id, combination_hash)` pair returns an error.
+
+Toasty generates the same prefix query methods as a composite `#[index(...)]`:
+`filter_by_coa_id`, `filter_by_coa_id_and_combination_hash`, and the matching
+`get_by_*`, `update_by_*`, and `delete_by_*` methods.
+
+DynamoDB does not support composite unique constraints. Toasty backs each unique
+index with a dedicated index table guarded by an `attribute_not_exists`
+condition, and that mechanism enforces a single column. Declaring a multi-column
+`#[unique(...)]` returns an `unsupported_feature` error when the schema is
+created. A single-column `#[unique(field)]` works on DynamoDB and is equivalent
+to a field-level `#[unique]`.
+
 ## Indexing newtype fields
 
 Newtype embedded structs (single unnamed field, e.g., `struct Email(String)`)


### PR DESCRIPTION
## Summary

Implements composite unique indices (#972). A struct-level `#[unique(field_a, field_b)]` declares a unique index spanning multiple columns, mirroring `#[index(...)]` (simple and partition/local modes, plus `name = "..."`) but enforcing uniqueness across the listed fields. Previously only single-field `#[unique]` was available.

```rust
#[derive(Debug, toasty::Model)]
#[unique(coa_id, combination_hash)]
struct AccountCombination {
    #[key] #[auto] id: u64,
    coa_id: i64,
    combination_hash: String,
}
```

The `unique` flag already threaded through the schema layers, so SQL backends emit `CREATE UNIQUE INDEX (...)` with no engine changes; query-method codegen is uniqueness-agnostic and generates the usual `get_by_*` / `filter_by_*` for each index prefix.

DynamoDB backs each unique index with a dedicated single-column index table guarded by `attribute_not_exists`, which cannot enforce a composite constraint. `create_table` now rejects multi-column unique indices with `unsupported_feature` (validated before any table is created) instead of panicking on the old `assert_eq!(1, …)`. Single-column `#[unique(field)]` is unchanged there.

Closes #972

## Type of change

- [x] Other: additive feature implementing accepted request #972; mirrors the existing `#[index(...)]` attribute, documented in the user guide.

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes — SQLite full suite (1108) and DynamoDB full suite against local DDB, plus trybuild UI tests

## Notes for reviewers

- No design doc: the feature mirrors the existing `#[index(...)]` / `#[unique]` attributes and is documented in the user guide (`indexes-and-unique-constraints.md`, `dynamodb.md`). Issue #972 serves as the design.
- DynamoDB composite-unique support is deliberately deferred. The index-table mechanism (and the insert/update/delete sync) is single-column; full support would need a composite-key index table plus rewritten write synchronization. The clean `unsupported_feature` rejection keeps single-column unique working while making the gap explicit.
- New tests in `index_composite.rs`: `composite_unique_index_enforced` (SQL — duplicate combination rejected, partial overlaps allowed) and `composite_unique_index_unsupported_on_dynamodb` (DDB rejection).