### PR TITLE
feat: support Option<Embed> as a model field

### DIFF
--- a/crates/toasty-core/src/schema/builder/table.rs
+++ b/crates/toasty-core/src/schema/builder/table.rs
@@ -77,6 +77,13 @@ struct MapField<'a, 'b> {
     /// since only the active variant's columns are populated.
     in_enum_variant: bool,
 
+    /// When true, columns are created nullable regardless of the field's own
+    /// nullability. Set while processing the fields of a nullable embed
+    /// (`Option<Embed>`), since the entire embed may be absent (all columns
+    /// NULL). Propagated into nested embeds so every flattened leaf column of
+    /// an optional embed is nullable.
+    in_nullable_embed: bool,
+
     /// Base expression for the current nesting level.
     ///
     /// `None` at the top level. `Expr::Project(source_ref, proj)` at any nested
@@ -488,6 +495,15 @@ impl BuildMapping<'_> {
                         .collect::<Result<_>>()?;
                     stmt::Expr::record(exprs)
                 };
+                // A nullable embed's default-returning expression must also
+                // collapse to `Null` when the embed is absent, so an
+                // INSERT...RETURNING of a `None` echoes back `None` rather than
+                // `Some` of all-NULL fields.
+                let expr = if field.nullable {
+                    self.wrap_nullable_embed_record(s, expr)
+                } else {
+                    expr
+                };
                 s.default_returning = expr.clone();
                 Ok(expr)
             }
@@ -719,6 +735,7 @@ impl BuildMapping<'_> {
         &self,
         model: &app::EmbeddedStruct,
         mapping: &mapping::FieldStruct,
+        nullable: bool,
     ) -> Result<stmt::Expr> {
         let exprs: Vec<stmt::Expr> = model
             .fields
@@ -726,7 +743,50 @@ impl BuildMapping<'_> {
             .enumerate()
             .map(|(index, field)| self.build_table_to_model_field(field, &mapping.fields[index]))
             .collect::<Result<_>>()?;
-        Ok(stmt::Expr::record(exprs))
+        let record = stmt::Expr::record(exprs);
+
+        if nullable {
+            Ok(self.wrap_nullable_embed_record(mapping, record))
+        } else {
+            Ok(record)
+        }
+    }
+
+    /// Wraps an embedded struct's reconstructed `record` so that a row in which
+    /// every flattened column of the embed is NULL decodes to `Value::Null`
+    /// (which `Option<Embed>::load` turns into `None`), while any present row
+    /// decodes to the record. Used for nullable embeds (`Option<Embed>`).
+    ///
+    /// The sentinel is the conjunction of `IS NULL` over *every* flattened leaf
+    /// column of the embed. When every inner field is itself nullable, a `Some`
+    /// whose fields are all `None` is indistinguishable from `None` — both store
+    /// all-NULL columns and both decode to `None`. This is inherent to flattened
+    /// storage without a dedicated presence column.
+    fn wrap_nullable_embed_record(
+        &self,
+        mapping: &mapping::FieldStruct,
+        record: stmt::Expr,
+    ) -> stmt::Expr {
+        let null_tests: Vec<stmt::Expr> = mapping
+            .columns
+            .keys()
+            .map(|column_id| {
+                stmt::Expr::is_null(stmt::Expr::column(stmt::ExprColumn {
+                    nesting: 0,
+                    table: 0,
+                    column: column_id.index,
+                }))
+            })
+            .collect();
+
+        stmt::Expr::match_expr(
+            stmt::Expr::and_from_vec(null_tests),
+            vec![stmt::MatchArm {
+                pattern: stmt::Value::Bool(true),
+                expr: stmt::Expr::null(),
+            }],
+            record,
+        )
     }
 
     fn build_table_to_model_field(
@@ -753,7 +813,7 @@ impl BuildMapping<'_> {
                         let mapping = mapping
                             .as_struct()
                             .expect("embedded struct field should have struct mapping");
-                        self.build_table_to_model_field_struct(embedded, mapping)
+                        self.build_table_to_model_field_struct(embedded, mapping, field.nullable)
                     }
                     _ => unreachable!("invalid schema"),
                 }
@@ -771,6 +831,7 @@ impl<'a, 'b> MapField<'a, 'b> {
             build,
             prefix: vec![],
             in_enum_variant: false,
+            in_nullable_embed: false,
             field_base: None,
             field_expr_base: stmt::Expr::arg(0),
             inherited_auto_increment: false,
@@ -928,12 +989,38 @@ impl<'a, 'b> MapField<'a, 'b> {
         // newtypes, but `Foo { a, b: Bar(u64) }` would not propagate it
         // from any outer past the `Foo` layer.
         let single_field = embedded_struct.fields.len() == 1;
+
+        // For a nullable embed (`Option<Embed>`) the whole embed may be absent.
+        // Capture a reference to the embed field's value in the *parent* context
+        // before descending; it becomes the subject of the per-column null
+        // guard installed below.
+        let embed_field_expr = field.nullable.then(|| self.field_expr(field, field_index));
+
         let mut child = self.for_struct(field, field_index);
         if single_field {
             child.inherited_auto_increment |= field.is_auto_increment();
         } else {
             child.inherited_auto_increment = false;
         }
+
+        if let Some(embed_field_expr) = embed_field_expr {
+            // Force every flattened column nullable (the embed may be NULL) and
+            // wrap each column's lowering expression so a `None` embed encodes
+            // every column to NULL. Without the guard, projecting a column out
+            // of a `Value::Null` embed panics (`Value::entry`). Mirrors the
+            // discriminant guard installed by `for_variant`.
+            child.in_nullable_embed = true;
+            let null_guard = stmt::Expr::match_expr(
+                stmt::Expr::is_null(embed_field_expr),
+                vec![stmt::MatchArm {
+                    pattern: stmt::Value::Bool(true),
+                    expr: stmt::Expr::null(),
+                }],
+                stmt::Expr::arg(0),
+            );
+            child.field_expr_base.substitute(&[null_guard]);
+        }
+
         let nested_fields = child.map_fields(&embedded_struct.fields)?;
 
         let columns: indexmap::IndexMap<ColumnId, usize> =
@@ -1020,7 +1107,7 @@ impl<'a, 'b> MapField<'a, 'b> {
             name: self.column_name(field),
             ty: storage_ty.bridge_type(&primitive.ty),
             storage_ty,
-            nullable: field.nullable || self.in_enum_variant,
+            nullable: field.nullable || self.in_enum_variant || self.in_nullable_embed,
             primary_key: false,
             auto_increment: is_auto_increment,
             versionable: field.is_versionable(),
@@ -1101,6 +1188,7 @@ impl<'a, 'b> MapField<'a, 'b> {
             build: self.build,
             prefix,
             in_enum_variant: self.in_enum_variant,
+            in_nullable_embed: self.in_nullable_embed,
             field_base: self.field_base.clone(),
             field_expr_base: self.field_expr_base.clone(),
             inherited_auto_increment: self.inherited_auto_increment,

--- a/crates/toasty-driver-integration-suite/src/scenarios.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios.rs
@@ -1,4 +1,5 @@
 pub mod company_office_address;
+pub mod company_optional_office;
 pub mod composite_chain_relations;
 pub mod composite_fk_has_many_belongs_to;
 pub mod composite_has_many_belongs_to;
@@ -8,6 +9,7 @@ pub mod deferred_json_document;
 pub mod deferred_optional_document;
 pub mod document_deferred_metadata;
 pub mod document_metadata_deferred_notes;
+pub mod document_optional_metadata;
 pub mod fixed_item_name;
 pub mod fixed_item_name_quantity;
 pub mod has_many_belongs_to;

--- a/crates/toasty-driver-integration-suite/src/scenarios/company_optional_office.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios/company_optional_office.rs
@@ -1,0 +1,34 @@
+use crate::prelude::*;
+
+scenario! {
+    #![id(ID)]
+
+    #[derive(Debug, toasty::Model)]
+    struct Company {
+        #[key]
+        #[auto]
+        id: ID,
+
+        name: String,
+
+        // A nullable embed that itself contains a nested embed, exercising
+        // nullability propagation through every flattened leaf column.
+        headquarters: Option<Office>,
+    }
+
+    #[derive(Debug, toasty::Embed)]
+    struct Office {
+        name: String,
+        address: Address,
+    }
+
+    #[derive(Debug, toasty::Embed)]
+    struct Address {
+        street: String,
+        city: String,
+    }
+
+    async fn setup(test: &mut Test) -> toasty::Db {
+        test.setup_db(models!(Company)).await
+    }
+}

--- a/crates/toasty-driver-integration-suite/src/scenarios/document_optional_metadata.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios/document_optional_metadata.rs
@@ -1,0 +1,26 @@
+use crate::prelude::*;
+
+scenario! {
+    #![id(ID)]
+
+    #[derive(Debug, toasty::Model)]
+    struct Document {
+        #[key]
+        #[auto]
+        id: ID,
+
+        title: String,
+
+        metadata: Option<Metadata>,
+    }
+
+    #[derive(Debug, toasty::Embed)]
+    struct Metadata {
+        author: String,
+        notes: String,
+    }
+
+    async fn setup(test: &mut Test) -> toasty::Db {
+        test.setup_db(models!(Document)).await
+    }
+}

--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -35,6 +35,7 @@ pub mod embed_enum_shared_type;
 pub mod embed_enum_string_discriminant;
 pub mod embed_enum_unit;
 pub mod embed_newtype;
+pub mod embed_optional_struct;
 pub mod embed_struct;
 pub mod embed_struct_index;
 pub mod field_auto;

--- a/crates/toasty-driver-integration-suite/src/tests/deferred_embed.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/deferred_embed.rs
@@ -39,11 +39,9 @@ pub async fn deferred_embed_struct(t: &mut Test) -> Result<()> {
     Ok(())
 }
 
-// `Deferred<Option<EmbeddedType>>` is not covered here. `Option<Embed>`
-// itself isn't yet supported as a model field — the schema layer has no
-// representation for a nullable embedded type, so the column-type lowering
-// errors out with "type Model(...) is not supported by this database".
-// Tracking that gap is orthogonal to deferred fields.
+// `Deferred<Option<EmbeddedType>>` is not covered here. `Option<Embed>` is
+// supported on its own (see `embed_optional_struct`); combining it with
+// `Deferred` is a separate concern, orthogonal to deferred fields.
 
 // ---------- Deferred<T> inside an embed struct that's nested in an enum variant ----------
 //

--- a/crates/toasty-driver-integration-suite/src/tests/embed_optional_struct.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embed_optional_struct.rs
@@ -1,0 +1,232 @@
+//! `Option<EmbeddedType>` model fields: a nullable embed flattens to nullable
+//! columns and round-trips `None` (all columns NULL) ⇄ `Some(record)`.
+
+use crate::prelude::*;
+
+// ---------- create / read ----------
+
+#[driver_test(id(ID), scenario(crate::scenarios::document_optional_metadata))]
+pub async fn create_and_read_some(t: &mut Test) -> Result<()> {
+    let mut db = setup(t).await;
+
+    let created = toasty::create!(Document {
+        title: "Hello".to_string(),
+        metadata: Some(Metadata {
+            author: "Alice".to_string(),
+            notes: "Important".to_string(),
+        }),
+    })
+    .exec(&mut db)
+    .await?;
+
+    assert_struct!(created.metadata, Some(_ {
+        author: "Alice",
+        notes: "Important",
+    }));
+
+    let read = Document::get_by_id(&mut db, &created.id).await?;
+    assert_struct!(read.metadata, Some(_ {
+        author: "Alice",
+        notes: "Important",
+    }));
+
+    Ok(())
+}
+
+#[driver_test(id(ID), scenario(crate::scenarios::document_optional_metadata))]
+pub async fn create_and_read_none(t: &mut Test) -> Result<()> {
+    let mut db = setup(t).await;
+
+    // Omitting the optional embed creates it as `None`. This exercises the
+    // encoding null-guard (all columns NULL, no projection panic), the
+    // INSERT...RETURNING default (the echoed record collapses to `None`), and
+    // the SELECT decode sentinel.
+    let created = toasty::create!(Document {
+        title: "Hello".to_string(),
+    })
+    .exec(&mut db)
+    .await?;
+
+    assert!(created.metadata.is_none());
+
+    let read = Document::get_by_id(&mut db, &created.id).await?;
+    assert_eq!("Hello", read.title);
+    assert!(read.metadata.is_none());
+
+    Ok(())
+}
+
+// ---------- update (set whole field) ----------
+
+#[driver_test(id(ID), scenario(crate::scenarios::document_optional_metadata))]
+pub async fn update_some_to_none_and_back(t: &mut Test) -> Result<()> {
+    let mut db = setup(t).await;
+
+    let mut doc = toasty::create!(Document {
+        title: "Hello".to_string(),
+        metadata: Some(Metadata {
+            author: "Alice".to_string(),
+            notes: "Important".to_string(),
+        }),
+    })
+    .exec(&mut db)
+    .await?;
+
+    // Some -> None
+    doc.update().metadata(None).exec(&mut db).await?;
+    assert!(
+        Document::get_by_id(&mut db, &doc.id)
+            .await?
+            .metadata
+            .is_none()
+    );
+
+    // None -> Some
+    doc.update()
+        .metadata(Some(Metadata {
+            author: "Bob".to_string(),
+            notes: "Revised".to_string(),
+        }))
+        .exec(&mut db)
+        .await?;
+
+    assert_struct!(Document::get_by_id(&mut db, &doc.id).await?.metadata, Some(_ {
+        author: "Bob",
+        notes: "Revised",
+    }));
+
+    Ok(())
+}
+
+// ---------- filtering ----------
+
+#[driver_test(
+    id(ID),
+    scenario(crate::scenarios::document_optional_metadata),
+    requires(scan)
+)]
+pub async fn filter_is_none_and_is_some(t: &mut Test) -> Result<()> {
+    let mut db = setup(t).await;
+
+    toasty::create!(Document {
+        title: "with".to_string(),
+        metadata: Some(Metadata {
+            author: "Alice".to_string(),
+            notes: "n".to_string(),
+        }),
+    })
+    .exec(&mut db)
+    .await?;
+
+    toasty::create!(Document {
+        title: "without".to_string(),
+    })
+    .exec(&mut db)
+    .await?;
+
+    let none = Document::filter(Document::fields().metadata().is_none())
+        .exec(&mut db)
+        .await?;
+    assert_eq!(1, none.len());
+    assert_eq!("without", none[0].title);
+
+    let some = Document::filter(Document::fields().metadata().is_some())
+        .exec(&mut db)
+        .await?;
+    assert_eq!(1, some.len());
+    assert_eq!("with", some[0].title);
+
+    Ok(())
+}
+
+#[driver_test(
+    id(ID),
+    scenario(crate::scenarios::document_optional_metadata),
+    requires(scan)
+)]
+pub async fn filter_eq_whole_value(t: &mut Test) -> Result<()> {
+    let mut db = setup(t).await;
+
+    toasty::create!(Document {
+        title: "alice".to_string(),
+        metadata: Some(Metadata {
+            author: "Alice".to_string(),
+            notes: "n".to_string(),
+        }),
+    })
+    .exec(&mut db)
+    .await?;
+
+    toasty::create!(Document {
+        title: "bob".to_string(),
+        metadata: Some(Metadata {
+            author: "Bob".to_string(),
+            notes: "n".to_string(),
+        }),
+    })
+    .exec(&mut db)
+    .await?;
+
+    toasty::create!(Document {
+        title: "without".to_string(),
+    })
+    .exec(&mut db)
+    .await?;
+
+    // Whole-value equality against a present embed expands to a per-column
+    // comparison and excludes both the non-matching and the absent embed.
+    let matched = Document::filter(Document::fields().metadata().eq(Some(Metadata {
+        author: "Alice".to_string(),
+        notes: "n".to_string(),
+    })))
+    .exec(&mut db)
+    .await?;
+    assert_eq!(1, matched.len());
+    assert_eq!("alice", matched[0].title);
+
+    Ok(())
+}
+
+// ---------- nested embed under Option ----------
+//
+// `Option<Office>` where `Office` itself embeds `Address`. Confirms the forced
+// nullability and the None sentinel propagate through every flattened leaf
+// column, including those of the nested embed.
+
+#[driver_test(id(ID), scenario(crate::scenarios::company_optional_office))]
+pub async fn nested_embed_under_option(t: &mut Test) -> Result<()> {
+    let mut db = setup(t).await;
+
+    let with = toasty::create!(Company {
+        name: "Acme".to_string(),
+        headquarters: Some(Office {
+            name: "HQ".to_string(),
+            address: Address {
+                street: "1 Main".to_string(),
+                city: "Springfield".to_string(),
+            },
+        }),
+    })
+    .exec(&mut db)
+    .await?;
+
+    let without = toasty::create!(Company {
+        name: "Remote Inc".to_string(),
+    })
+    .exec(&mut db)
+    .await?;
+
+    assert_struct!(Company::get_by_id(&mut db, &with.id).await?.headquarters, Some(_ {
+        name: "HQ",
+        address: _ { street: "1 Main", city: "Springfield" },
+    }));
+
+    assert!(
+        Company::get_by_id(&mut db, &without.id)
+            .await?
+            .headquarters
+            .is_none()
+    );
+
+    Ok(())
+}

--- a/crates/toasty-sql/src/serializer/expr.rs
+++ b/crates/toasty-sql/src/serializer/expr.rs
@@ -8,7 +8,20 @@ impl ToSql for &stmt::Expr {
     fn to_sql(self, f: &mut super::Formatter<'_>) {
         match self {
             stmt::Expr::And(expr) => {
-                fmt!(f, Delimited(&expr.operands, " AND "));
+                // `AND` binds tighter than `OR`, so an `OR` operand must be
+                // parenthesized to preserve grouping — otherwise
+                // `a AND (b OR c)` would serialize as `a AND b OR c`, which
+                // SQL parses as `(a AND b) OR c`.
+                let mut sep = "";
+                for operand in &expr.operands {
+                    f.dst.push_str(sep);
+                    sep = " AND ";
+                    if matches!(operand, stmt::Expr::Or(_)) {
+                        fmt!(f, "(" operand ")");
+                    } else {
+                        fmt!(f, operand);
+                    }
+                }
             }
             stmt::Expr::BinaryOp(expr) => {
                 assert!(!expr.lhs.is_value_null());

--- a/crates/toasty/src/engine/simplify/expr_binary_op.rs
+++ b/crates/toasty/src/engine/simplify/expr_binary_op.rs
@@ -180,7 +180,7 @@ impl Simplify<'_> {
             self.visit_expr_mut(&mut term);
 
             // Prune dead branches
-            if term.is_false() || matches!(&term, Expr::Value(stmt::Value::Null)) {
+            if is_dead_filter_term(&term) {
                 continue;
             }
 
@@ -212,11 +212,28 @@ impl Simplify<'_> {
             self.visit_expr_mut(&mut term);
 
             // Prune dead branches
-            if !term.is_false() && !matches!(&term, Expr::Value(stmt::Value::Null)) {
+            if !is_dead_filter_term(&term) {
                 operands.push(term);
             }
         }
 
         Expr::or_from_vec(operands)
+    }
+}
+
+/// Returns `true` if `term` can never evaluate to `true` in a boolean filter
+/// context, so it may be dropped from an `OR` of guarded match arms.
+///
+/// Covers the constant dead values plus an `AND` carrying a `NULL` (or `false`)
+/// operand — e.g. an arm that compares the `NULL` branch of a nullable-embed
+/// sentinel (`Match(all_null, [true => null], record)`) against a value, which
+/// folds to `… AND NULL`. SQL tolerates that (it evaluates to NULL/false), but
+/// DynamoDB rejects a bare value placeholder in a `FilterExpression`, so the
+/// dead term must be pruned rather than serialized.
+fn is_dead_filter_term(term: &Expr) -> bool {
+    match term {
+        Expr::Value(stmt::Value::Null) | Expr::Value(stmt::Value::Bool(false)) => true,
+        Expr::And(and) => and.operands.iter().any(is_dead_filter_term),
+        _ => false,
     }
 }

--- a/crates/toasty/src/engine/simplify/expr_is_null.rs
+++ b/crates/toasty/src/engine/simplify/expr_is_null.rs
@@ -1,22 +1,89 @@
 use super::Simplify;
-use toasty_core::stmt;
+use toasty_core::stmt::{self, Expr, VisitMut};
 
 impl Simplify<'_> {
     /// Heavyweight `IS NULL` rewrites. Cheap canonicalization (constant
     /// folding, cast stripping) runs in `fold::expr_is_null` before this is
     /// reached.
-    pub(super) fn simplify_expr_is_null(&self, expr: &mut stmt::ExprIsNull) -> Option<stmt::Expr> {
-        let stmt::Expr::Reference(f @ stmt::ExprReference::Field { .. }) = &mut *expr.expr else {
-            return None;
-        };
+    pub(super) fn simplify_expr_is_null(&mut self, expr: &mut stmt::ExprIsNull) -> Option<Expr> {
+        match &mut *expr.expr {
+            Expr::Reference(f @ stmt::ExprReference::Field { .. }) => {
+                let field = self.cx.resolve_expr_reference(f).as_field_unwrap();
 
-        let field = self.cx.resolve_expr_reference(f).as_field_unwrap();
+                if !field.nullable() {
+                    // `is_null` on a non-nullable field evaluates to `false`.
+                    return Some(Expr::Value(stmt::Value::Bool(false)));
+                }
 
-        if !field.nullable() {
-            // `is_null` on a non-nullable field evaluates to `false`.
-            return Some(stmt::Expr::Value(stmt::Value::Bool(false)));
+                None
+            }
+            // A flattened embed reference lowers to a record of its columns; the
+            // embed is absent exactly when every column is NULL. Distribute so
+            // the predicate reduces to a conjunction of per-column `IS NULL`
+            // (the SQL serializer has no notion of "record IS NULL").
+            Expr::Record(rec) => {
+                let tests: Vec<Expr> = std::mem::take(&mut rec.fields)
+                    .into_iter()
+                    .map(Expr::is_null)
+                    .collect();
+                let mut result = Expr::and_from_vec(tests);
+                self.visit_expr_mut(&mut result);
+                Some(result)
+            }
+            // A nullable embed's field reference lowers to a `Match` sentinel
+            // (`Match(all_null, [true => null], record)`). SQL predicates can't
+            // carry a `Match`, so distribute `IS NULL` over its arms into an OR
+            // of guarded `IS NULL` terms, mirroring the binary-op match
+            // elimination. Requires a stable subject so the guards may be
+            // duplicated safely.
+            Expr::Match(m) if m.subject.is_stable() => {
+                let Expr::Match(m) = expr.expr.take() else {
+                    unreachable!()
+                };
+                Some(self.eliminate_match_in_is_null(m))
+            }
+            _ => None,
+        }
+    }
+
+    /// Distributes `IS NULL` over match arms, producing an OR of guarded
+    /// `IS NULL` terms. Each arm becomes `(subject == pattern) AND is_null(arm_expr)`,
+    /// plus an else term guarded by the negation of every arm pattern. Dead
+    /// branches (false/null) are pruned after inline simplification.
+    fn eliminate_match_in_is_null(&mut self, match_expr: stmt::ExprMatch) -> Expr {
+        let mut operands = Vec::new();
+
+        let patterns: Vec<_> = match_expr.arms.iter().map(|a| a.pattern.clone()).collect();
+
+        for arm in match_expr.arms {
+            let guard = Expr::eq((*match_expr.subject).clone(), Expr::from(arm.pattern));
+            let mut term = Expr::and_from_vec(vec![guard, Expr::is_null(arm.expr)]);
+            self.visit_expr_mut(&mut term);
+
+            if term.is_false() || matches!(&term, Expr::Value(stmt::Value::Null)) {
+                continue;
+            }
+
+            operands.push(term);
         }
 
-        None
+        {
+            let mut else_operands: Vec<Expr> = patterns
+                .into_iter()
+                .map(|pattern| {
+                    Expr::not(Expr::eq((*match_expr.subject).clone(), Expr::from(pattern)))
+                })
+                .collect();
+            else_operands.push(Expr::is_null(*match_expr.else_expr));
+
+            let mut term = Expr::and_from_vec(else_operands);
+            self.visit_expr_mut(&mut term);
+
+            if !term.is_false() && !matches!(&term, Expr::Value(stmt::Value::Null)) {
+                operands.push(term);
+            }
+        }
+
+        Expr::or_from_vec(operands)
     }
 }

--- a/crates/toasty/src/engine/simplify/tests/expr_is_null.rs
+++ b/crates/toasty/src/engine/simplify/tests/expr_is_null.rs
@@ -18,7 +18,7 @@ fn is_null_non_nullable_field() {
     let schema = test_schema_with(&[User::schema()]);
     let model = schema.app.model(User::id());
     let simplify = Simplify::new(&schema, &toasty_core::driver::Capability::SQLITE);
-    let simplify = simplify.scope(model.as_root_unwrap());
+    let mut simplify = simplify.scope(model.as_root_unwrap());
 
     // `is_null(field)` → `false` (non-nullable field)
     let mut field = ExprIsNull {


### PR DESCRIPTION
## Summary

Adds `Option<StructEmbed>` model fields (issue #800).

The issue's premise was stale: the "type `Model(...)` is not supported" error
predated #926, which made `Option<T>::field_ty` delegate to the inner type, so
`Option<Embed>` already resolved to an `Embedded` app field. What was actually
broken was that the flattened columns were `NOT NULL`, inserting `None` panicked
in the simplifier (`Project(Null, ..)` → `Value::entry` `todo!()`), and a `None`
row never decoded back to `None`.

A nullable struct embed is a two-state value (`None` = every flattened column
NULL, vs `Some(record)`) — structurally the same as the existing enum embed.
The fix reuses that machinery, so **no macro / `Field`-trait changes** are
needed (the accessor already yields `Path<_, Option<Embed>>`):

- **`core`** — `MapField.in_nullable_embed` forces every flattened leaf column
  nullable; an encode null-guard makes a `None` write all-NULL; a decode
  sentinel `Match(all-columns-NULL → null, else record)` (in `table_to_model`
  and the INSERT…RETURNING default) decodes an all-NULL row to `None`.
- **`engine`** — `IS NULL` distributes over `Record`/`Match` so
  `.is_none()`/`.is_some()` reduce to per-column predicates (neither SQL nor
  DynamoDB can carry a `Match` in a predicate).

Two latent precedence bugs the new expressions exposed are also fixed:

- **`sql`** — parenthesize `OR` operands nested inside `AND`; without it
  `a AND (b OR c)` serialized as `a AND b OR c`.
- **`engine`** — prune dead `AND(.., NULL)` match-elimination terms. SQL
  tolerated `… AND NULL`, but DynamoDB rejected the bare value placeholder in a
  `FilterExpression`.

Covers create/read `Some`+`None`, set-whole-value update, `.is_none()` /
`.is_some()`, and whole-value `.eq(Some(..))`, on SQLite, PostgreSQL, and
DynamoDB.

**Not** `Closes #800`: the issue also lists nested-field path access
(`Document::fields().metadata().author()`) as a goal. That conflicts with
nullable-scalar path typing (`Path<_, Option<U>>` carries `is_none`/`is_some`)
and would need specialization or a `Field` path-machinery redesign, so it's
deferred — along with `Option<enum embed>` and partial within-embed updates.

## Type of change

- [x] Other: implements the maintainer-authored proposed solution in #800
      (struct-embed subset; nested path access deferred).

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes — SQLite 2944, PostgreSQL 1150, DynamoDB 534, all green

## Notes for reviewers

- The design is captured in #800; no separate `docs/dev/design/` doc was added.
- The two precedence fixes are independent latent bugs, only surfaced here
  because the nullable-embed sentinel is the first expression to nest `OR`
  inside `AND` / produce an `AND(.., NULL)` filter term. Worth a close look —
  they change SQL/DDB filter serialization for any future expression of that
  shape.
- `.eq(None)` is intentionally not tested: `expr <op> null` folds to constant
  `null` for every field (pre-existing), so `.is_none()` is the idiom.
