### PR TITLE
fix(core): truncate auto-generated index names that exceed the backend limit

### DIFF
--- a/crates/toasty-core/src/driver/capability.rs
+++ b/crates/toasty-core/src/driver/capability.rs
@@ -67,6 +67,19 @@ pub struct Capability {
     /// `Integer(4)`.
     pub max_auto_increment_integer_width: Option<u8>,
 
+    /// Maximum byte length for a database identifier (table name, index name,
+    /// column name, etc.).
+    ///
+    /// When `Some(n)`, auto-generated index names that exceed `n` bytes are
+    /// truncated and a short stable hash suffix is appended so names remain
+    /// unique and deterministic across builds. User-supplied `#[index(name =
+    /// "...")]` names are left untouched.
+    ///
+    /// - MySQL: `Some(64)` — hard error on longer names
+    /// - PostgreSQL: `Some(63)` — silently truncates, risking collisions
+    /// - SQLite / DynamoDB: `None` — no enforced limit
+    pub max_identifier_length: Option<usize>,
+
     /// Whether the database supports `VARCHAR(n)` column types natively.
     ///
     /// Must be consistent with [`StorageTypes::varchar`]: when `true`,
@@ -529,6 +542,7 @@ impl Capability {
         max_auto_increment_integer_width: Some(4),
         bigdecimal_implemented: false,
         bool_key_type: true,
+        max_identifier_length: None,
 
         native_varchar: true,
 
@@ -609,6 +623,7 @@ impl Capability {
         auto_increment: true,
         max_auto_increment_integer_width: None,
         bigdecimal_implemented: false,
+        max_identifier_length: Some(63),
 
         // PostgreSQL has the `^@` prefix-match operator.
         native_starts_with: true,
@@ -667,6 +682,7 @@ impl Capability {
         auto_increment: true,
         max_auto_increment_integer_width: None,
         bigdecimal_implemented: true,
+        max_identifier_length: Some(64),
 
         // MySQL has inline ENUM('a', 'b') column types
         native_enum: true,
@@ -736,6 +752,7 @@ impl Capability {
         auto_increment: false,
         max_auto_increment_integer_width: None,
         bigdecimal_implemented: false,
+        max_identifier_length: None,
         // DynamoDB key attributes (primary key and GSI keys) only support
         // S, N, or B — BOOL is not a valid key attribute type.
         bool_key_type: false,

--- a/crates/toasty-core/src/schema/builder/table.rs
+++ b/crates/toasty-core/src/schema/builder/table.rs
@@ -373,18 +373,24 @@ impl BuildTableFromModels<'_> {
                 continue;
             }
 
-            index.name = format!("index_{}_by", self.table.name);
+            let mut name = format!("index_{}_by", self.table.name);
 
             for (i, index_column) in index.columns.iter().enumerate() {
                 let column = &self.table.columns[index_column.column.index];
 
                 if i > 0 {
-                    index.name.push_str("_and");
+                    name.push_str("_and");
                 }
 
-                index.name.push('_');
-                index.name.push_str(&column.name);
+                name.push('_');
+                name.push_str(&column.name);
             }
+
+            index.name = if let Some(limit) = self.db.max_identifier_length {
+                truncate_identifier(name, limit)
+            } else {
+                name
+            };
         }
     }
 }
@@ -1152,6 +1158,39 @@ impl<'a, 'b> MapField<'a, 'b> {
         child.field_base = Some(field_base);
         child
     }
+}
+
+/// Truncate `name` to `limit` bytes, appending a 5-character stable hash
+/// suffix (`_XXXX`) so the result is unique and deterministic across builds.
+///
+/// The hash is FNV-1a over the *full* pre-truncation name so two names that
+/// share a long prefix produce different suffixes. `DefaultHasher` is
+/// intentionally avoided — it is unstable across Rust versions and would
+/// churn migration snapshots.
+fn truncate_identifier(name: String, limit: usize) -> String {
+    if name.len() <= limit {
+        return name;
+    }
+
+    // FNV-1a 32-bit hash of the full name for a stable 4-hex-digit suffix.
+    const FNV_OFFSET: u32 = 2_166_136_261;
+    const FNV_PRIME: u32 = 16_777_619;
+    let hash = name
+        .bytes()
+        .fold(FNV_OFFSET, |acc, b| acc.wrapping_mul(FNV_PRIME) ^ b as u32);
+    let suffix = format!("_{:04x}", hash & 0xFFFF);
+
+    // Truncate at a char boundary so we never split a multi-byte character.
+    // The condition uses the char's END position so we never exceed `budget`.
+    let budget = limit.saturating_sub(suffix.len());
+    let truncated = &name[..name
+        .char_indices()
+        .take_while(|(i, c)| i + c.len_utf8() <= budget)
+        .last()
+        .map(|(i, c)| i + c.len_utf8())
+        .unwrap_or(0)];
+
+    format!("{truncated}{suffix}")
 }
 
 /// Look up an embedded model by ID, returning a descriptive error if not found.

--- a/crates/toasty-driver-integration-suite/src/tests/index_custom_name.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/index_custom_name.rs
@@ -79,6 +79,64 @@ pub async fn index_custom_name_default_unchanged(t: &mut Test) -> Result<()> {
     Ok(())
 }
 
+/// Auto-generated index names that exceed the backend's identifier limit are
+/// truncated and given a stable 5-character hash suffix (`_XXXX`). The table
+/// can still be created and the index is usable for queries.
+///
+/// The bare auto-generated name for this model is:
+/// `index_organization_memberships_by_organization_id_and_member_user_id`
+/// (69 chars), which exceeds MySQL's 64-char and PostgreSQL's 63-char limits.
+/// With the test harness table prefix it is longer still.
+#[driver_test]
+pub async fn index_long_name_is_truncated(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    #[index(organization_id, member_user_id)]
+    struct OrganizationMembership {
+        // String key avoids auto-increment, which DynamoDB does not support.
+        #[key]
+        id: String,
+        organization_id: i64,
+        member_user_id: i64,
+    }
+
+    let mut db = t.setup_db(models!(OrganizationMembership)).await;
+
+    let limit = db.capability().max_identifier_length;
+    let table = &db.schema().db.tables[0];
+    let auto_idx = table
+        .indices
+        .iter()
+        .find(|i| !i.primary_key)
+        .expect("non-PK index should exist");
+
+    if let Some(limit) = limit {
+        assert!(
+            auto_idx.name.len() <= limit,
+            "index name `{}` ({} chars) exceeds limit {}",
+            auto_idx.name,
+            auto_idx.name.len(),
+            limit
+        );
+    }
+
+    // The index must be usable regardless of name length.
+    toasty::create!(OrganizationMembership::[
+        { id: "m1", organization_id: 1_i64, member_user_id: 10_i64 },
+        { id: "m2", organization_id: 1_i64, member_user_id: 20_i64 },
+        { id: "m3", organization_id: 2_i64, member_user_id: 10_i64 },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let members: Vec<OrganizationMembership> =
+        OrganizationMembership::filter_by_organization_id(1_i64)
+            .exec(&mut db)
+            .await?;
+    assert_eq!(members.len(), 2);
+
+    Ok(())
+}
+
 /// `#[key(name = "...", ...)]` records the custom name on the primary-key
 /// index in the DB schema. SQL backends emit primary keys inline today, so
 /// this verifies the schema-internal wiring rather than DDL output.


### PR DESCRIPTION
## Summary

Fixes #1020.

`update_index_names` generates names of the form `index_<table>_by_<col>(_and_<col>)*`. For models with long-ish table and column names — especially under the test harness, which prepends a `test_{pid}_{counter}_` prefix — these names exceed MySQL's hard 64-char limit (`ERROR 1059`) and PostgreSQL's 63-char soft limit (silent truncation with latent collision risk).

**Changes:**

- Add `Capability::max_identifier_length: Option<usize>` — `Some(64)` for MySQL, `Some(63)` for PostgreSQL, `None` for SQLite and DynamoDB.
- In `update_index_names`, when a generated name exceeds the limit, truncate to `limit - 5` bytes and append `_XXXX`: four hex digits from an FNV-1a hash of the *full* pre-truncation name. The hash is stable across builds (unlike `DefaultHasher`) so migration snapshots don't churn. Two indexes that share a long prefix get different suffixes.
- User-supplied `#[index(name = "...")]` names are never touched.

**Test:** `index_long_name_is_truncated` creates the exact model from the issue reproducer (`OrganizationMembership` with a two-column composite index) and asserts the index name respects the backend limit.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

FNV-1a is inlined (~5 lines) to avoid a new dependency. Only the low 16 bits of the hash are used (`& 0xFFFF`) — that's 65 536 buckets, which is more than enough to distinguish the handful of long indexes a schema is likely to have.
