### PR TITLE
refactor(core)!: make UpdateByKey returning columns explicit

### DIFF
--- a/crates/toasty-core/src/driver/operation/update_by_key.rs
+++ b/crates/toasty-core/src/driver/operation/update_by_key.rs
@@ -1,6 +1,9 @@
 use super::Operation;
 
-use crate::{schema::db::TableId, stmt};
+use crate::{
+    schema::db::{ColumnId, TableId},
+    stmt,
+};
 
 /// Updates one or more records identified by primary key.
 ///
@@ -19,7 +22,7 @@ use crate::{schema::db::TableId, stmt};
 ///     assignments: assignments,
 ///     filter: None,
 ///     condition: None,
-///     returning: true,
+///     returning: None,
 /// };
 /// let operation: Operation = op.into();
 /// ```
@@ -43,9 +46,14 @@ pub struct UpdateByKey {
     /// than silently skipping the row.
     pub condition: Option<stmt::Expr>,
 
-    /// When `true`, the driver returns the full record for each updated row
-    /// in the [`ExecResponse`](super::super::ExecResponse).
-    pub returning: bool,
+    /// The columns to return for each updated row.
+    ///
+    /// `None` returns the affected-row count. `Some(columns)` returns one
+    /// record per updated row containing exactly these columns, in this order,
+    /// in the [`ExecResponse`](super::super::ExecResponse). The engine builds
+    /// this list explicitly, so the driver never has to infer which columns to
+    /// return from the assignments.
+    pub returning: Option<Vec<ColumnId>>,
 }
 
 impl From<UpdateByKey> for Operation {

--- a/crates/toasty-driver-dynamodb/src/op/update_by_key.rs
+++ b/crates/toasty-driver-dynamodb/src/op/update_by_key.rs
@@ -155,12 +155,11 @@ impl Connection {
 
         let mut update_expression_set = String::new();
         let mut update_expression_remove = String::new();
-        let mut ret = vec![];
-        // Indices in `ret` whose stored value is a placeholder (the appended
-        // elements, not the post-update column value). After the UpdateItem
-        // call we refresh these from the `UPDATED_NEW` response so the engine
-        // sees the actual new column value.
-        let mut refresh_after_update: Vec<(usize, &db::Column)> = vec![];
+
+        // Bound value per assigned column index. Used below to seed the
+        // returning-row placeholders; only the transact path (which can't
+        // fetch `UPDATED_NEW`) actually surfaces these seeds.
+        let mut bound_values: HashMap<usize, &stmt::Value> = HashMap::new();
 
         for (projection, assignment) in op.assignments.iter() {
             enum AssignKind {
@@ -197,19 +196,7 @@ impl Connection {
             };
 
             let column_ref = table.resolve(projection);
-
-            // `ret` carries the post-update column values back to the
-            // engine. `lower::returning::constantize_returning` inlines
-            // `Set` values at plan time, so the engine's returning
-            // projection covers only the columns that need a driver
-            // round-trip — `Append` / `Add` / `Subtract`. Skip `Set` here
-            // to keep the row shape aligned with that projection. The
-            // non-Set kinds push a placeholder then `refresh_after_update`
-            // fills in the post-update value from `UPDATED_NEW`.
-            if !matches!(kind, AssignKind::Set) {
-                refresh_after_update.push((ret.len(), column_ref));
-                ret.push(value.clone());
-            }
+            bound_values.insert(column_ref.id.index, value);
 
             let column = expr_attrs.column(column_ref).to_string();
 
@@ -283,10 +270,32 @@ impl Connection {
             write!(update_expression, " REMOVE {update_expression_remove}").unwrap();
         }
 
-        // When any assignment is relative (`Append`), the placeholder values
-        // in `ret` are not the post-update column values. Request
-        // `UPDATED_NEW` so the response carries the actual new attribute
-        // values and we can replace the placeholders below.
+        // Build the returning row from the explicit column list the engine
+        // requested — exactly these columns, in this order. The engine inlines
+        // `Set` values at plan time and injects the engine-managed `#[version]`
+        // bump outside the returning projection, so neither appears in
+        // `op.returning`; the driver no longer has to infer the row shape from
+        // the assignments. Each column is seeded with a placeholder, then
+        // refreshed below from the `UPDATED_NEW` response with its post-update
+        // value.
+        let mut ret = vec![];
+        let mut refresh_after_update: Vec<(usize, &db::Column)> = vec![];
+
+        if let Some(columns) = &op.returning {
+            for column_id in columns {
+                let column = schema.column(*column_id);
+                let placeholder = bound_values
+                    .get(&column_id.index)
+                    .map(|value| (*value).clone())
+                    .unwrap_or(stmt::Value::Null);
+                refresh_after_update.push((ret.len(), column));
+                ret.push(placeholder);
+            }
+        }
+
+        // The seeded placeholders are not the post-update column values.
+        // Request `UPDATED_NEW` so the response carries the actual new
+        // attribute values and we can replace the placeholders below.
         let needs_updated_new = !refresh_after_update.is_empty();
 
         match &unique_indices[..] {
@@ -323,7 +332,7 @@ impl Connection {
                                     cce.message.as_deref(),
                                     table,
                                     op.filter.as_ref(),
-                                    op.returning,
+                                    op.returning.is_some(),
                                 );
                             }
                             return Err(toasty_core::Error::driver_operation_failed(
@@ -389,7 +398,7 @@ impl Connection {
                                 tce.message(),
                                 table,
                                 op.filter.as_ref(),
-                                op.returning,
+                                op.returning.is_some(),
                             );
                         }
                         return Err(toasty_core::Error::driver_operation_failed(
@@ -566,7 +575,7 @@ impl Connection {
                                 cce.message.as_deref(),
                                 table,
                                 op.filter.as_ref(),
-                                op.returning,
+                                op.returning.is_some(),
                             );
                         }
                         return Err(toasty_core::Error::driver_operation_failed(
@@ -696,7 +705,7 @@ impl Connection {
                                 tce.message(),
                                 table,
                                 op.filter.as_ref(),
-                                op.returning,
+                                op.returning.is_some(),
                             );
                         }
                         return Err(toasty_core::Error::driver_operation_failed(
@@ -708,8 +717,8 @@ impl Connection {
             _ => todo!(),
         }
 
-        // If we get here, then returning should be false
-        Ok(if op.returning {
+        // If we get here, then returning should be None
+        Ok(if op.returning.is_some() {
             let values = stmt::ValueStream::from_value(stmt::Value::record_from_vec(ret));
             ExecResponse::value_stream(values)
         } else {

--- a/crates/toasty-driver-integration-suite/src/scenarios.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios.rs
@@ -50,6 +50,7 @@ pub mod user_with_age;
 pub mod user_with_email;
 pub mod user_with_status;
 pub mod user_with_zip_address;
+pub mod versioned_counter;
 pub mod versioned_item;
 pub mod versioned_user_unique_email;
 pub mod widget_mixed_types;

--- a/crates/toasty-driver-integration-suite/src/scenarios/versioned_counter.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios/versioned_counter.rs
@@ -1,0 +1,19 @@
+use crate::prelude::*;
+
+scenario! {
+    #[derive(Debug, toasty::Model)]
+    struct Counter {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+
+        value: i64,
+
+        #[version]
+        version: u64,
+    }
+
+    async fn setup(test: &mut Test) -> toasty::Db {
+        test.setup_db(models!(Counter)).await
+    }
+}

--- a/crates/toasty-driver-integration-suite/src/tests/crud_basic.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/crud_basic.rs
@@ -144,7 +144,7 @@ pub async fn crud_one_string(test: &mut Test) -> Result<()> {
             keys.len(): 1,
             assignments: #{ [1]: Assignment::Set(== "updated!")},
             filter: None,
-            returning: false,
+            returning: None,
         }));
     }
     assert_struct!(resp, { values: Rows::Count(1) });

--- a/crates/toasty-driver-integration-suite/src/tests/crud_driver_ops.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/crud_driver_ops.rs
@@ -154,7 +154,7 @@ pub async fn basic_crud(test: &mut Test) -> Result<()> {
             filter: None,
             keys: _,
             assignments: #{ [2]: Assignment::Set(== 31i32)},
-            returning: false,
+            returning: None,
         }));
     }
 

--- a/crates/toasty-driver-integration-suite/src/tests/crud_partitioned.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/crud_partitioned.rs
@@ -89,7 +89,7 @@ pub async fn update_by_partition_key(test: &mut Test) {
             keys.len(): 2,
             assignments: #{ [2]: Assignment::Set(== "updated")},
             filter: None,
-            returning: false,
+            returning: None,
         }));
 
         assert_struct!(resp, {

--- a/crates/toasty-driver-integration-suite/src/tests/embed_enum_unit.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embed_enum_unit.rs
@@ -102,7 +102,7 @@ pub async fn create_and_query_enum(t: &mut Test) -> Result<()> {
             filter: None,
             keys: _,
             assignments: #{ [2]: Assignment::Set(== 2i64)},
-            returning: false,
+            returning: None,
         }));
     }
 

--- a/crates/toasty-driver-integration-suite/src/tests/field_version.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/field_version.rs
@@ -32,6 +32,36 @@ pub async fn update_increments_version(test: &mut Test) -> Result<()> {
     Ok(())
 }
 
+/// A relative update (`increment`) on a versioned model. The post-increment
+/// value can't be computed client-side, so the driver returns it; the
+/// client-side `#[version]` bump rides along as a constant in the same
+/// returning projection. The two must not collide: the engine asks the driver
+/// for exactly the relative column, so the version value never lands in the
+/// returned row and shifts `value` out of its slot.
+#[driver_test(requires(not(sql)), scenario(crate::scenarios::versioned_counter))]
+pub async fn relative_update_increments_value_and_version(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let mut counter = toasty::create!(Counter { value: 10 }).exec(&mut db).await?;
+    assert_struct!(counter, _ { value: 10, version: 1, .. });
+
+    counter
+        .update()
+        .value(toasty::stmt::increment())
+        .exec(&mut db)
+        .await?;
+
+    // The handle is reloaded from the update's returning row: `value` is read
+    // back from the driver, `version` is bumped to 2.
+    assert_struct!(counter, _ { value: 11, version: 2, .. });
+
+    // And it is durable.
+    let reloaded = Counter::filter_by_id(counter.id).get(&mut db).await?;
+    assert_struct!(reloaded, _ { value: 11, version: 2, .. });
+
+    Ok(())
+}
+
 /// Two updates from the same stale snapshot — the second should fail with a
 /// condition-check error because the DB version has already moved to 2.
 #[driver_test(requires(not(sql)), scenario(crate::scenarios::versioned_item))]

--- a/crates/toasty/src/engine/exec/update_by_key.rs
+++ b/crates/toasty/src/engine/exec/update_by_key.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use toasty_core::{
     driver::{ExecResponse, Rows, operation},
-    schema::db::TableId,
+    schema::db::{ColumnId, TableId},
     stmt::{self, ValueStream},
 };
 
@@ -28,9 +28,9 @@ pub(crate) struct UpdateByKey {
     /// Fail the update if the condition is not met
     pub condition: Option<stmt::Expr>,
 
-    /// When `true` return the record being updated *after* the update. When
-    /// `false`, just return the count of updated rows.
-    pub returning: bool,
+    /// The columns to return for each updated row *after* the update. When
+    /// `None`, just return the count of updated rows.
+    pub returning: Option<Vec<ColumnId>>,
 }
 
 impl Exec<'_> {
@@ -45,7 +45,7 @@ impl Exec<'_> {
             .into_list_unwrap();
 
         let res = if keys.is_empty() {
-            if action.returning {
+            if action.returning.is_some() {
                 Rows::value_stream(ValueStream::default())
             } else {
                 Rows::Count(0)
@@ -57,12 +57,12 @@ impl Exec<'_> {
                 assignments: action.assignments.clone(),
                 filter: action.filter.clone(),
                 condition: action.condition.clone(),
-                returning: action.returning,
+                returning: action.returning.clone(),
             };
 
             let res = self.connection.exec(&self.engine.schema, op.into()).await?;
 
-            debug_assert_eq!(!res.values.is_count(), action.returning);
+            debug_assert_eq!(!res.values.is_count(), action.returning.is_some());
 
             res.values
         };

--- a/crates/toasty/src/engine/mir/update_by_key.rs
+++ b/crates/toasty/src/engine/mir/update_by_key.rs
@@ -1,4 +1,8 @@
-use toasty_core::{schema::db::TableId, stmt};
+use indexmap::IndexSet;
+use toasty_core::{
+    schema::db::{ColumnId, TableId},
+    stmt,
+};
 
 use crate::engine::{
     exec,
@@ -28,6 +32,10 @@ pub(crate) struct UpdateByKey {
     /// Optional condition for optimistic locking.
     pub(crate) condition: Option<stmt::Expr>,
 
+    /// The columns to return for each updated row. Empty when the update
+    /// returns only an affected-row count.
+    pub(crate) columns: IndexSet<stmt::ExprReference>,
+
     /// The return type.
     pub(crate) ty: stmt::Type,
 }
@@ -43,6 +51,28 @@ impl UpdateByKey {
         let output = var_table.register_var(node.ty().clone());
         node.var.set(Some(output));
 
+        let returning = if self.ty.is_unit() {
+            None
+        } else {
+            Some(
+                self.columns
+                    .iter()
+                    .map(|expr_reference| {
+                        let stmt::ExprReference::Column(expr_column) = expr_reference else {
+                            todo!()
+                        };
+                        debug_assert_eq!(expr_column.nesting, 0);
+                        debug_assert_eq!(expr_column.table, 0);
+
+                        ColumnId {
+                            table: self.table,
+                            index: expr_column.column,
+                        }
+                    })
+                    .collect(),
+            )
+        };
+
         exec::UpdateByKey {
             input,
             output: exec::Output {
@@ -53,7 +83,7 @@ impl UpdateByKey {
             assignments: self.assignments.clone(),
             filter: self.filter.clone(),
             condition: self.condition.clone(),
-            returning: !self.ty.is_unit(),
+            returning,
         }
     }
 }

--- a/crates/toasty/src/engine/plan/statement.rs
+++ b/crates/toasty/src/engine/plan/statement.rs
@@ -1582,6 +1582,7 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
                     assignments: update_stmt.assignments.clone(),
                     filter: index_plan.result_filter.take(),
                     condition: update_stmt.condition.expr.clone(),
+                    columns: self.load_data.select_items.extract_expr_references(),
                     ty: ty.clone(),
                 })
             }


### PR DESCRIPTION
## Summary

`UpdateByKey.returning` was a `bool`. With it set, key-value drivers had to
reverse-engineer *which* columns to return by scanning the assignments and
keeping every non-`Set` one. That only stays correct while non-`Set`
assignments line up 1:1, in order, with the engine's returning projection — an
unstated invariant the first out-of-projection relative assignment (e.g. an
injected `#[version]` bump) would break, leaking the extra column into the
returned row and shifting a user column out of its slot.

This replaces it with `Option<Vec<ColumnId>>`: the engine passes the exact
returning columns (the same `select_items` that build the return type),
mirroring `GetByKey`/`Scan`. The DynamoDB driver builds its return row from
that list instead of inferring it, so engine-managed columns can never end up
in the row. Behavior is unchanged on every currently-reachable path; this
makes the implicit invariant explicit so future features can't trip it.

Adds a `versioned_counter` scenario and a `relative_update_increments_value_and_version`
test covering a relative update on a `#[version]` model.

## Type of change

- [x] Small / obvious change — internal cleanup (behavior-preserving driver-interface refactor)

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes (SQLite suite + full DynamoDB suite)

## Notes for reviewers

- **Breaking** for driver implementors: `operation::UpdateByKey.returning` is
  now `Option<Vec<ColumnId>>` (`None` → affected count, `Some(cols)` → those
  columns per row). Only the DynamoDB driver implements `UpdateByKey`; SQL
  drivers go through `QuerySql`.
- No design doc: this preserves existing driver-observable semantics (the
  engine gets the same result) — it only changes the in-process representation
  drivers match against, replacing an inference heuristic with an explicit list.
