### PR TITLE
refactor(macros): dedupe codegen helpers in model expansion

### DIFF
--- a/crates/toasty-macros/src/model/expand/query.rs
+++ b/crates/toasty-macros/src/model/expand/query.rs
@@ -2,7 +2,7 @@ use super::{Expand, util};
 use crate::model::schema::{BelongsTo, Field, FieldTy, HasMany, HasOne};
 
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{format_ident, quote};
 
 impl Expand<'_> {
     pub(super) fn expand_query_struct(&self) -> TokenStream {
@@ -328,21 +328,33 @@ impl Expand<'_> {
             .collect()
     }
 
-    fn expand_belongs_to_method(&self, field: &Field, rel: &BelongsTo) -> TokenStream {
+    /// Shared body for the per-relation accessor methods on `Query<List<M>>`.
+    /// The three direct relation kinds emit the same `QueryMany<Target>`
+    /// accessor and differ only along two axes: which projection trait names
+    /// the target model (`RelationOneField` for the singular `belongs_to` /
+    /// `has_one`, `RelationManyField` for `has_many`) and which
+    /// `chain_or_build_*` helper threads the association. `has_many(via = …)`
+    /// takes a different shape and is handled by
+    /// [`Self::expand_has_many_via_method`].
+    fn expand_relation_query_method(
+        &self,
+        field: &Field,
+        ty: &syn::Type,
+        target_field: &str,
+        chain_builder: &str,
+    ) -> TokenStream {
         let toasty = &self.toasty;
         let vis = &self.model.vis;
-        let ty = &rel.ty;
-        let target = quote!(<#ty as #toasty::RelationOneField>::Target);
+        let target_field = format_ident!("{}", target_field);
+        let chain_builder = format_ident!("{}", chain_builder);
+        let target = quote!(<#ty as #toasty::#target_field>::Target);
         let model_ident = &self.model.ident;
         let field_ident = &field.name.ident;
         let field_offset = util::int(field.id);
 
-        // Belongs-to via the source side is always singular and may be
-        // nullable; both cases collapse to `QueryMany<Target>` here because we
-        // are starting from a list of source rows.
         quote! {
             #vis fn #field_ident(self) -> #toasty::QueryMany<#target> {
-                let assoc = #toasty::chain_or_build_many_via_one::<#model_ident, #target>(
+                let assoc = #toasty::#chain_builder::<#model_ident, #target>(
                     self.stmt,
                     #field_offset,
                     #model_ident::fields().#field_ident().into(),
@@ -350,6 +362,18 @@ impl Expand<'_> {
                 <#toasty::QueryMany<#target>>::from_assoc_many(assoc)
             }
         }
+    }
+
+    fn expand_belongs_to_method(&self, field: &Field, rel: &BelongsTo) -> TokenStream {
+        // Belongs-to via the source side is always singular and may be
+        // nullable; both cases collapse to `QueryMany<Target>` here because we
+        // are starting from a list of source rows.
+        self.expand_relation_query_method(
+            field,
+            &rel.ty,
+            "RelationOneField",
+            "chain_or_build_many_via_one",
+        )
     }
 
     /// Chained accessor for a `#[has_many(via = …)]` field. Builds an
@@ -381,45 +405,21 @@ impl Expand<'_> {
     }
 
     fn expand_has_many_method(&self, field: &Field, rel: &HasMany) -> TokenStream {
-        let toasty = &self.toasty;
-        let vis = &self.model.vis;
-        let ty = &rel.ty;
-        let target = quote!(<#ty as #toasty::RelationManyField>::Target);
-        let model_ident = &self.model.ident;
-        let field_ident = &field.name.ident;
-        let field_offset = util::int(field.id);
-
-        quote! {
-            #vis fn #field_ident(self) -> #toasty::QueryMany<#target> {
-                let assoc = #toasty::chain_or_build_many::<#model_ident, #target>(
-                    self.stmt,
-                    #field_offset,
-                    #model_ident::fields().#field_ident().into(),
-                );
-                <#toasty::QueryMany<#target>>::from_assoc_many(assoc)
-            }
-        }
+        self.expand_relation_query_method(
+            field,
+            &rel.ty,
+            "RelationManyField",
+            "chain_or_build_many",
+        )
     }
 
     fn expand_has_one_method(&self, field: &Field, rel: &HasOne) -> TokenStream {
-        let toasty = &self.toasty;
-        let vis = &self.model.vis;
-        let ty = &rel.ty;
-        let target = quote!(<#ty as #toasty::RelationOneField>::Target);
-        let model_ident = &self.model.ident;
-        let field_ident = &field.name.ident;
-        let field_offset = util::int(field.id);
-
-        quote! {
-            #vis fn #field_ident(self) -> #toasty::QueryMany<#target> {
-                let assoc = #toasty::chain_or_build_many_via_one::<#model_ident, #target>(
-                    self.stmt,
-                    #field_offset,
-                    #model_ident::fields().#field_ident().into(),
-                );
-                <#toasty::QueryMany<#target>>::from_assoc_many(assoc)
-            }
-        }
+        self.expand_relation_query_method(
+            field,
+            &rel.ty,
+            "RelationOneField",
+            "chain_or_build_many_via_one",
+        )
     }
 
     fn expand_include_method(&self, include_ty: &syn::Ident) -> Option<TokenStream> {

--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -381,17 +381,10 @@ impl Expand<'_> {
             let col_ty = field.attrs.column.as_ref().and_then(|c| c.ty.as_ref())?;
             let marker = col_ty.compat_marker(toasty)?;
 
-            // Pin the diagnostic at the field type's span so the error lands
-            // on the user's declaration, not the derive call site.
-            Some(quote_spanned! { ty.span()=>
-                const _: () = {
-                    fn _check<__T>()
-                    where
-                        __T: #toasty::storage::CompatibleWith<#marker>,
-                    {}
-                    let _ = _check::<#ty>;
-                };
-            })
+            Some(compat_check(
+                ty,
+                quote! { #toasty::storage::CompatibleWith<#marker> },
+            ))
         });
 
         quote! { #( #checks )* }
@@ -420,17 +413,10 @@ impl Expand<'_> {
                 AutoStrategy::Increment => quote! { #toasty::auto::tag::Increment },
             };
 
-            // Pin the diagnostic at the field type's span so the error lands
-            // on the user's declaration, not the derive call site.
-            Some(quote_spanned! { ty.span()=>
-                const _: () = {
-                    fn _check<__T>()
-                    where
-                        __T: #toasty::auto::AutoCompatible<#tag>,
-                    {}
-                    let _ = _check::<#ty>;
-                };
-            })
+            Some(compat_check(
+                ty,
+                quote! { #toasty::auto::AutoCompatible<#tag> },
+            ))
         });
 
         quote! { #( #checks )* }
@@ -455,12 +441,7 @@ impl Expand<'_> {
                 return None;
             };
 
-            Some(quote_spanned! { ty.span()=>
-                const _: () = {
-                    fn _check<__T: #toasty::Version>() {}
-                    let _ = _check::<#ty>;
-                };
-            })
+            Some(compat_check(ty, quote! { #toasty::Version }))
         });
 
         quote! { #( #checks )* }
@@ -513,6 +494,26 @@ impl Expand<'_> {
                 }
             })
             .collect()
+    }
+}
+
+/// Emit a span-pinned compile-time obligation that `ty` satisfies `bound`.
+///
+/// The check leans on the type checker rather than inspecting `ty`: the
+/// zero-cost `_check::<#ty>` reference forces the bound to hold. `quote_spanned`
+/// pins any resulting diagnostic at the field type's span so the error lands on
+/// the user's declaration, not the derive call site. Shared by the
+/// storage/auto/version `expand_*_compat_checks` expansions, which differ only
+/// in the `bound` they require.
+fn compat_check(ty: &syn::Type, bound: TokenStream) -> TokenStream {
+    quote_spanned! { ty.span()=>
+        const _: () = {
+            fn _check<__T>()
+            where
+                __T: #bound,
+            {}
+            let _ = _check::<#ty>;
+        };
     }
 }
 

--- a/crates/toasty-macros/src/model/schema/model.rs
+++ b/crates/toasty-macros/src/model/schema/model.rs
@@ -238,9 +238,9 @@ impl Model {
         // Build ModelKind based on whether this is embedded or root
         let kind = if is_embedded {
             ModelKind::EmbeddedStruct(ModelEmbeddedStruct {
-                field_struct_ident: struct_ident("Fields", ast),
-                field_list_struct_ident: struct_list_ident("ListFields", ast),
-                update_struct_ident: struct_ident("Update", ast),
+                field_struct_ident: suffixed_ident(&ast.ident, "Fields"),
+                field_list_struct_ident: suffixed_ident(&ast.ident, "ListFields"),
+                update_struct_ident: suffixed_ident(&ast.ident, "Update"),
                 fields_named: matches!(ast.fields, syn::Fields::Named(_)),
             })
         } else {
@@ -282,11 +282,11 @@ impl Model {
             ModelKind::Root(ModelRoot {
                 primary_key: PrimaryKey { fields: pk_fields },
                 version_field,
-                field_struct_ident: struct_ident("Fields", ast),
-                field_list_struct_ident: struct_list_ident("ListFields", ast),
-                query_struct_ident: struct_ident("Query", ast),
-                create_struct_ident: struct_ident("Create", ast),
-                update_struct_ident: struct_ident("Update", ast),
+                field_struct_ident: suffixed_ident(&ast.ident, "Fields"),
+                field_list_struct_ident: suffixed_ident(&ast.ident, "ListFields"),
+                query_struct_ident: suffixed_ident(&ast.ident, "Query"),
+                create_struct_ident: suffixed_ident(&ast.ident, "Create"),
+                update_struct_ident: suffixed_ident(&ast.ident, "Update"),
             })
         };
 
@@ -533,8 +533,8 @@ impl Model {
             ident: model_ident,
             fields: all_fields,
             kind: ModelKind::EmbeddedEnum(ModelEmbeddedEnum {
-                field_struct_ident: enum_ident("Fields", ast),
-                field_list_struct_ident: enum_list_ident("ListFields", ast),
+                field_struct_ident: suffixed_ident(&ast.ident, "Fields"),
+                field_list_struct_ident: suffixed_ident(&ast.ident, "ListFields"),
                 variants,
                 storage_strategy,
             }),
@@ -577,19 +577,9 @@ fn collect_field_indices(fields: &[Field], indices: &mut Vec<Index>) {
     }
 }
 
-fn struct_ident(suffix: &str, model: &syn::ItemStruct) -> syn::Ident {
-    syn::Ident::new(&format!("{}{}", model.ident, suffix), model.ident.span())
-}
-
-/// Generates an ident like `UserListFields` — injects the suffix after the model name.
-fn struct_list_ident(suffix: &str, model: &syn::ItemStruct) -> syn::Ident {
-    syn::Ident::new(&format!("{}{}", model.ident, suffix), model.ident.span())
-}
-
-fn enum_ident(suffix: &str, model: &syn::ItemEnum) -> syn::Ident {
-    syn::Ident::new(&format!("{}{}", model.ident, suffix), model.ident.span())
-}
-
-fn enum_list_ident(suffix: &str, model: &syn::ItemEnum) -> syn::Ident {
-    syn::Ident::new(&format!("{}{}", model.ident, suffix), model.ident.span())
+/// Append `suffix` to a model name to derive a builder ident — e.g.
+/// `(User, "ListFields") -> UserListFields` — carrying the base ident's span so
+/// diagnostics point back at the model declaration.
+fn suffixed_ident(base: &syn::Ident, suffix: &str) -> syn::Ident {
+    syn::Ident::new(&format!("{base}{suffix}"), base.span())
 }


### PR DESCRIPTION
## Summary

Internal cleanup in `toasty-macros`, found by running `similarity-rs` over
the crate. Three sets of near-identical codegen helpers collapse into shared
functions, each now a single source of truth:

- **`expand_*_compat_checks`** (storage/auto/version) shared an identical
  span-pinned `const _: () = { fn _check… }` trait obligation; extracted a
  `compat_check(ty, bound)` emitter — only the bound differs.
- **`*_ident` builders** — `struct_ident`/`struct_list_ident`/`enum_ident`/
  `enum_list_ident` (the first two byte-identical) collapse into one
  `suffixed_ident(&syn::Ident, &str)`.
- **`Query<List<M>>` relation accessors** — `belongs_to`/`has_one` were
  byte-identical; all three direct-relation expanders now share
  `expand_relation_query_method`, parameterized by target trait and chain
  builder, with thin named forwarders so the dispatch stays readable.

Generated code is byte-for-byte unchanged.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

No behavior change — the macro emits the same tokens; the macro doctests and
full SQLite suite pass. The other high-similarity clusters flagged by
`similarity-rs` (operator method families with per-method docs, `ToSql` /
`VisitMut` / `IntoExpr` dispatch tables, distinct `Parse` impls) were left
alone — their similarity is structural, and consolidating would hurt clarity.
