### PR TITLE
docs: correct starts_with case-sensitivity notes

### DIFF
--- a/docs/dev/architecture/README.md
+++ b/docs/dev/architecture/README.md
@@ -24,12 +24,11 @@ This produces two rules for query methods:
   `Capability::native_ilike`) rather than emulated.
 
 Toasty implements an operation on every backend only when it can give the
-operation identical semantics on all of them. `.starts_with()` is meant to be
+operation identical semantics on all of them. `.starts_with()` is exactly
 that: a case-sensitive prefix match has one meaning that every backend can
-express (DynamoDB's `begins_with`, a prefix match on SQL), so it is offered
-everywhere. A uniform `.ilike()` would not qualify, because the backends
-disagree on how to fold case. (The SQL lowering of `.starts_with()` is not yet
-case-sensitive on SQLite and MySQL; see issue #936.)
+express (DynamoDB's `begins_with`, PostgreSQL's `^@`, SQLite's `GLOB`, MySQL's
+`BINARY ... LIKE`), so it is offered everywhere. A uniform `.ilike()` would not
+qualify, because the backends disagree on how to fold case.
 
 ## Crates
 

--- a/docs/guide/src/filtering-with-expressions.md
+++ b/docs/guide/src/filtering-with-expressions.md
@@ -15,7 +15,7 @@ checking for null — use `Model::filter()` with field expressions.
 | [`.in_list([...])`](#membership-with-in_list) | Value in list | `IN (...)` |
 | [`.is_none()`](#null-checks) | Null check (`Option` fields) | `IS NULL` |
 | [`.is_some()`](#null-checks) | Not-null check (`Option` fields) | `IS NOT NULL` |
-| [`.starts_with(prefix)`](#starts_with) | Prefix match | `begins_with(field, prefix)` / `LIKE 'prefix%'` |
+| [`.starts_with(prefix)`](#starts_with) | Case-sensitive prefix match | `begins_with(field, prefix)` / `^@`, `GLOB`, `BINARY ... LIKE` |
 | [`.like(pattern)`](#like) | Pattern match, behavior per backend | `LIKE pattern` |
 | [`.ilike(pattern)`](#ilike) | Case-insensitive pattern match, PostgreSQL only | `ILIKE pattern` |
 | [`.and(expr)`](#combining-with-and) | Both conditions true | `AND` |
@@ -400,8 +400,17 @@ below.
 ### `starts_with`
 
 `.starts_with()` tests whether a string field starts with the given prefix. It
-works on all supported databases — SQL drivers translate it to `LIKE 'prefix%'`,
-and DynamoDB uses its native `begins_with` condition expression:
+works on all supported databases and is case-sensitive on every backend.
+DynamoDB uses its native `begins_with` condition expression; each SQL backend
+lowers to an operator that preserves case:
+
+| Backend | Operator |
+|---|---|
+| PostgreSQL | `col ^@ 'prefix'` |
+| SQLite | `col GLOB 'prefix*'` |
+| MySQL | `BINARY col LIKE 'prefix%'` |
+
+The match is exact: `.starts_with("Al")` matches `"Alice"` but not `"alice"`.
 
 ```rust
 # use toasty::Model;

--- a/docs/guide/src/mysql.md
+++ b/docs/guide/src/mysql.md
@@ -165,6 +165,11 @@ transaction.
 [`.paginate(per_page).prev(&db)`](./sorting-limits-and-pagination.md#navigating-pages)
 walks backwards from a page cursor.
 
+**Case-sensitive prefix match.** The
+[`.starts_with()`](./filtering-with-expressions.md#starts_with) filter lowers to
+`BINARY col LIKE 'prefix%'`. Casting the column to `BINARY` forces a byte
+comparison, so the match is case-sensitive regardless of the column's collation.
+
 A few things that exist on PostgreSQL are absent here:
 
 **No `ILIKE`.** MySQL has no `ILIKE` operator, so

--- a/docs/guide/src/sqlite.md
+++ b/docs/guide/src/sqlite.md
@@ -144,19 +144,21 @@ behaviors differ from the other SQL backends:
 **`LIKE` is case-insensitive for ASCII.** SQLite's `LIKE` ignores case for ASCII
 characters but is case-sensitive for non-ASCII ones. A
 [`.like("Rust")`](./filtering-with-expressions.md#like) filter also matches
-`"rust"` and `"RUST"`, but `.like("café")` does not match `"CAFÉ"`. Use `GLOB`
-(which Toasty does not currently expose) or a `CHECK` against exact bytes if you
-need case-sensitive pattern matching.
+`"rust"` and `"RUST"`, but `.like("café")` does not match `"CAFÉ"`. For a
+case-sensitive prefix match, use
+[`.starts_with()`](./filtering-with-expressions.md#starts_with), which lowers to
+`GLOB`. Toasty exposes no operator for case-sensitive matching of an arbitrary
+pattern; use a `CHECK` against exact bytes if you need one.
 
 **No `ILIKE`.** SQLite has no `ILIKE` operator, so
 [`.ilike()`](./filtering-with-expressions.md#ilike) is rejected with an
 `unsupported_feature` error. Since SQLite's `LIKE` already folds ASCII case, use
 `.like()` for case-insensitive ASCII matching.
 
-**No native prefix-match operator.**
+**Prefix match via `GLOB`.**
 [`.starts_with("abc")`](./filtering-with-expressions.md#starts_with)
-lowers to `LIKE 'abc%'`. The optimizer can use a regular index for the
-common-prefix lookup.
+lowers to `col GLOB 'abc*'`, a case-sensitive prefix match. The optimizer can
+use a regular index for the common-prefix lookup.
 
 **Scalar arrays use JSON1.** A
 [`Vec<T>` field](./field-options.md#scalar-arrays) lives in a `TEXT`


### PR DESCRIPTION
## Summary

[#983](https://github.com/tokio-rs/toasty/pull/983) made `.starts_with()` case-sensitive on every SQL backend and closed #936, but several docs still described the old case-insensitive `LIKE 'prefix%'` lowering. Closes #1008.

Each SQL backend now lowers `.starts_with()` to a case-sensitive operator:

| Backend | Operator |
|---|---|
| PostgreSQL | `col ^@ 'prefix'` |
| SQLite | `col GLOB 'prefix*'` |
| MySQL | `BINARY col LIKE 'prefix%'` |

Updated:
- `docs/dev/architecture/README.md` — removed the resolved `#936` caveat; named the actual operators.
- `docs/guide/src/filtering-with-expressions.md` — fixed the reference table and the `starts_with` section (was `LIKE 'prefix%'`).
- `docs/guide/src/sqlite.md` — `.starts_with()` lowers to `GLOB`, not `LIKE 'abc%'`; pointed the `.like()` note at `.starts_with()` for case-sensitive prefixes.
- `docs/guide/src/mysql.md` — added a prefix-match note for parity with the SQLite/PostgreSQL pages.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

Docs only — no `rust` code blocks changed, so the guide's compiled doctests are unaffected. `mdbook build` passes including the link checker.

Verified the SQLite claim empirically: a bound-parameter `col GLOB 'abc*'` uses the index (`SEARCH ... USING INDEX`), while the old `LIKE 'abc%'` did a full `SCAN` — so #983 also fixed index usage, and the "optimizer can use a regular index" note is now accurate.