### PR TITLE
feat: allow index on unit enum

### DIFF
--- a/crates/toasty-core/src/schema/builder/table.rs
+++ b/crates/toasty-core/src/schema/builder/table.rs
@@ -349,10 +349,18 @@ impl BuildTableFromModels<'_> {
             match mapping {
                 mapping::Field::Primitive(p) => return p.column,
                 mapping::Field::Enum(p) => {
-                    if p.sub_projection.is_identity() {
-                        return p.discriminant.column;
-                    }
-                    panic!("only unit enum column can be indexed")
+                    // Only unit (data-less) enums can be indexed: the
+                    // discriminant column alone represents the value.
+                    // Data-carrying enums span multiple columns and have no
+                    // single index column. The derive macro rejects this at
+                    // compile time via `IndexableField`; this assert is the
+                    // backstop for schemas built without the macro.
+                    assert!(
+                        p.variants.iter().all(|v| v.fields.is_empty()),
+                        "only unit (data-less) embedded enums can be indexed; \
+                         data-carrying enum variants span multiple columns"
+                    );
+                    return p.discriminant.column;
                 }
                 mapping::Field::Struct(s) => {
                     let embedded_struct = self.app.model(s.id).as_embedded_struct_unwrap();

--- a/crates/toasty-core/src/schema/builder/table.rs
+++ b/crates/toasty-core/src/schema/builder/table.rs
@@ -348,6 +348,12 @@ impl BuildTableFromModels<'_> {
         loop {
             match mapping {
                 mapping::Field::Primitive(p) => return p.column,
+                mapping::Field::Enum(p) => {
+                    if p.sub_projection.is_identity() {
+                        return p.discriminant.column;
+                    }
+                    panic!("only unit enum column can be indexed")
+                }
                 mapping::Field::Struct(s) => {
                     let embedded_struct = self.app.model(s.id).as_embedded_struct_unwrap();
                     assert!(

--- a/crates/toasty-driver-integration-suite/src/tests/embed_enum_index.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embed_enum_index.rs
@@ -137,3 +137,158 @@ pub async fn embedded_enum_unique_index_enforced(test: &mut Test) -> Result<()> 
 
     Ok(())
 }
+
+/// Regression test for #973: a unit (data-less) embedded enum used as a model
+/// field can be indexed. The index targets the enum's discriminant column.
+///
+/// Before the fix, building the schema panicked because the index-column
+/// resolver had no case for enum mappings.
+#[driver_test]
+pub async fn unit_enum_field_index_schema(test: &mut Test) {
+    #[derive(Debug, toasty::Embed)]
+    enum EntityType {
+        Fund,
+        Account,
+        Department,
+        Program,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    #[index(entity_type)]
+    struct Registry {
+        #[key]
+        id: String,
+        #[allow(dead_code)]
+        entity_type: EntityType,
+    }
+
+    let db = test.setup_db(models!(Registry)).await;
+    let schema = db.schema();
+
+    // The enum field is stored as a single discriminant column; the index
+    // targets that column.
+    let table = &schema.db.tables[0];
+    let entity_type_col = table
+        .columns
+        .iter()
+        .find(|c| c.name == "entity_type")
+        .expect("entity_type discriminant column should exist");
+
+    // Index 0: primary key (id). Index 1: non-unique on the discriminant column.
+    assert_struct!(table.indices, [
+        { primary_key: true },
+        { unique: false, primary_key: false, columns: [{ column: == entity_type_col.id }] },
+    ]);
+}
+
+/// Regression test for #973: queries filtering on an indexed unit enum field
+/// return the correct rows across all drivers.
+#[driver_test]
+pub async fn unit_enum_field_index_filter(test: &mut Test) -> Result<()> {
+    #[derive(Debug, PartialEq, toasty::Embed)]
+    enum EntityType {
+        Fund,
+        Account,
+        Department,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    #[index(entity_type)]
+    struct Registry {
+        #[key]
+        id: String,
+        entity_type: EntityType,
+    }
+
+    let mut db = test.setup_db(models!(Registry)).await;
+
+    toasty::create!(Registry::[
+        { id: "1", entity_type: EntityType::Fund },
+        { id: "2", entity_type: EntityType::Account },
+        { id: "3", entity_type: EntityType::Fund },
+        { id: "4", entity_type: EntityType::Department },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let mut funds = Registry::filter(Registry::fields().entity_type().eq(EntityType::Fund))
+        .exec(&mut db)
+        .await?;
+    funds.sort_by(|a, b| a.id.cmp(&b.id));
+
+    assert_struct!(funds, [{ id: "1" }, { id: "3" }]);
+
+    Ok(())
+}
+
+/// Regression test for #973: a unit embedded enum field can participate in a
+/// composite `#[unique(...)]` constraint alongside scalar fields, mirroring the
+/// `#[unique(dimension_type_id, entity_type, entity_id)]` case from the issue.
+///
+/// DynamoDB does not support composite unique indices (see
+/// `composite_unique_index_unsupported_on_dynamodb` in `index_composite`), so
+/// this is SQL-only.
+#[driver_test(requires(sql))]
+pub async fn unit_enum_composite_unique_enforced(test: &mut Test) -> Result<()> {
+    #[derive(Debug, PartialEq, toasty::Embed)]
+    enum EntityType {
+        Fund,
+        Account,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    #[unique(entity_type, entity_id)]
+    struct Registry {
+        #[key]
+        #[auto]
+        id: u64,
+        entity_type: EntityType,
+        entity_id: String,
+    }
+
+    let mut db = test.setup_db(models!(Registry)).await;
+
+    // The non-primary-key index is unique and spans both columns (the enum's
+    // discriminant column plus entity_id).
+    let index = db.schema().db.tables[0]
+        .indices
+        .iter()
+        .find(|i| !i.primary_key)
+        .expect("composite unique index");
+    assert!(index.unique);
+    assert_eq!(index.columns.len(), 2);
+
+    toasty::create!(Registry {
+        entity_type: EntityType::Fund,
+        entity_id: "x"
+    })
+    .exec(&mut db)
+    .await?;
+
+    // The same (entity_type, entity_id) combination is rejected.
+    assert_err!(
+        toasty::create!(Registry {
+            entity_type: EntityType::Fund,
+            entity_id: "x"
+        })
+        .exec(&mut db)
+        .await
+    );
+
+    // Differing in either column is allowed — uniqueness is on the combination.
+    toasty::create!(Registry {
+        entity_type: EntityType::Account,
+        entity_id: "x"
+    })
+    .exec(&mut db)
+    .await?;
+
+    toasty::create!(Registry {
+        entity_type: EntityType::Fund,
+        entity_id: "y"
+    })
+    .exec(&mut db)
+    .await?;
+
+    Ok(())
+}

--- a/crates/toasty-macros/src/model/expand.rs
+++ b/crates/toasty-macros/src/model/expand.rs
@@ -38,6 +38,7 @@ impl Expand<'_> {
         let storage_compat_checks = self.expand_storage_compat_checks();
         let auto_compat_checks = self.expand_auto_compat_checks();
         let version_compat_checks = self.expand_version_compat_checks();
+        let indexable_checks = self.expand_indexable_checks();
 
         wrap_in_const(quote! {
             #model_impls
@@ -49,6 +50,7 @@ impl Expand<'_> {
             #storage_compat_checks
             #auto_compat_checks
             #version_compat_checks
+            #indexable_checks
         })
     }
 }
@@ -89,11 +91,14 @@ pub(super) fn embedded_model(model: &Model) -> TokenStream {
     let embedded_model_impls = expand.expand_embedded_model_impls();
     let embedded_update_builder = expand.expand_embedded_update_builder();
     let storage_compat_checks = expand.expand_storage_compat_checks();
+    let indexable_checks = expand.expand_indexable_checks();
     let newtype_marker = expand.expand_embedded_newtype_marker();
+    let newtype_indexable_impl = expand.expand_embedded_indexable_impl();
     let field_list_struct_ident = &embedded.field_list_struct_ident;
 
     wrap_in_const(quote! {
         #newtype_marker
+        #newtype_indexable_impl
 
         #embedded_field_struct
         #embedded_field_list_struct
@@ -103,6 +108,7 @@ pub(super) fn embedded_model(model: &Model) -> TokenStream {
         #embedded_model_impls
 
         #storage_compat_checks
+        #indexable_checks
 
         impl #toasty::Embed for #model_ident {
             fn id() -> #toasty::core::schema::app::ModelId {
@@ -231,12 +237,24 @@ pub(super) fn embedded_enum(model: &Model) -> TokenStream {
     let enum_field_list_struct = e.expand_field_list_struct();
     let field_register_calls = e.expand_field_register_calls();
     let storage_compat_checks = e.expand_storage_compat_checks();
+    let indexable_checks = e.expand_indexable_checks();
+
+    // A unit (data-less) enum maps to a single discriminant column, so it can
+    // serve as an index column. Data-carrying enums span multiple columns and
+    // therefore do not implement `IndexableField`.
+    let indexable_impl = if model.fields.is_empty() {
+        quote! { impl #toasty::index::IndexableField for #model_ident {} }
+    } else {
+        quote! {}
+    };
 
     wrap_in_const(quote! {
         #enum_field_struct
         #enum_field_list_struct
 
         #storage_compat_checks
+        #indexable_checks
+        #indexable_impl
 
         impl #toasty::Embed for #model_ident {
             fn id() -> #toasty::core::schema::app::ModelId {
@@ -374,6 +392,37 @@ impl Expand<'_> {
                     Self(inner)
                 }
             }
+        }
+    }
+
+    /// For tuple-newtype `#[derive(Embed)]` structs, emit an `IndexableField`
+    /// impl that forwards to the inner type, so a newtype wrapping an indexable
+    /// scalar can itself serve as an index column. Multi-field and named
+    /// single-field structs are opaque wrappers and stay non-indexable.
+    ///
+    /// This is a per-type impl rather than a `NewtypeOf` blanket: a blanket
+    /// would conflict with the `Box<T>` forwarding impl in
+    /// `codegen_support::index`, because `Box` is `#[fundamental]`.
+    fn expand_embedded_indexable_impl(&self) -> TokenStream {
+        let ModelKind::EmbeddedStruct(embedded) = &self.model.kind else {
+            return quote! {};
+        };
+        if embedded.fields_named || self.model.fields.len() != 1 {
+            return quote! {};
+        }
+
+        let FieldTy::Primitive(inner_ty) = &self.model.fields[0].ty else {
+            return quote! {};
+        };
+
+        let toasty = &self.toasty;
+        let model_ident = &self.model.ident;
+
+        quote! {
+            impl #toasty::index::IndexableField for #model_ident
+            where
+                #inner_ty: #toasty::index::IndexableField,
+            {}
         }
     }
 

--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -466,6 +466,54 @@ impl Expand<'_> {
         quote! { #( #checks )* }
     }
 
+    /// Emit one obligation per field that participates in a secondary index or
+    /// unique constraint (`#[index]`, `#[unique]`, or a model-level
+    /// `#[index(...)]` / `#[unique(...)]`) that the field's Rust type implements
+    /// `codegen_support::index::IndexableField`.
+    ///
+    /// Scalars satisfy the bound directly; newtype embeds via the `NewtypeOf`
+    /// blanket; unit (data-less) enums via the impl emitted by
+    /// `#[derive(Embed)]`. Data-carrying enums and multi-field embedded structs
+    /// span multiple columns and do not implement it, so naming one in an index
+    /// is a compile error instead of a runtime panic.
+    ///
+    /// The primary key is excluded: keys are validated through their own paths.
+    pub(super) fn expand_indexable_checks(&self) -> TokenStream {
+        let toasty = &self.toasty;
+
+        let mut seen = std::collections::BTreeSet::new();
+        let checks = self
+            .model
+            .indices
+            .iter()
+            .filter(|index| !index.primary_key)
+            .flat_map(|index| index.fields.iter())
+            .filter_map(|index_field| {
+                if !seen.insert(index_field.field) {
+                    return None;
+                }
+
+                let FieldTy::Primitive(ty) = &self.model.fields[index_field.field].ty else {
+                    return None;
+                };
+
+                // Pin the diagnostic at the field type's span so the error
+                // lands on the user's declaration, not the derive call site.
+                Some(quote_spanned! { ty.span()=>
+                    const _: () = {
+                        fn _check<__T>()
+                        where
+                            __T: #toasty::index::IndexableField,
+                        {}
+                        let _ = _check::<#ty>;
+                    };
+                })
+            })
+            .collect::<Vec<_>>();
+
+        quote! { #( #checks )* }
+    }
+
     /// Generate calls to register all models reachable from this model's fields.
     ///
     /// For primitive fields, no call is emitted (the default `Field::register`

--- a/crates/toasty/src/codegen_support.rs
+++ b/crates/toasty/src/codegen_support.rs
@@ -5,6 +5,7 @@
 #![doc(hidden)]
 
 pub mod auto;
+pub mod index;
 pub mod newtype;
 pub mod storage;
 pub mod version;

--- a/crates/toasty/src/codegen_support/index.rs
+++ b/crates/toasty/src/codegen_support/index.rs
@@ -1,0 +1,91 @@
+//! Compile-time validation that a field used in an index maps to a single
+//! index column.
+//!
+//! When `#[derive(Model)]` sees a field participating in a secondary index or
+//! unique constraint (`#[index]`, `#[unique]`, or a model-level
+//! `#[index(...)]` / `#[unique(...)]`), the generated code emits a one-shot
+//! obligation that the field's Rust type implements [`IndexableField`].
+//!
+//! Scalars implement it directly; tuple-newtype embeds and unit (data-less)
+//! enums via impls emitted by `#[derive(Embed)]`. Data-carrying enums and
+//! multi-field embedded structs map to more than one column, so they do not
+//! implement it and naming one in an index is a compile error rather than a
+//! runtime panic.
+//!
+//! Mirrors the pattern in [`crate::codegen_support::storage`] and
+//! [`crate::codegen_support::auto`]: a trait carrying a
+//! `#[diagnostic::on_unimplemented]` message and concrete impls for the
+//! supported scalar types. Unlike those, newtype embeds get a per-type impl
+//! from the derive rather than a `NewtypeOf` blanket — a blanket would conflict
+//! with the `Box<T>` forwarding impl below, since `Box` is `#[fundamental]`.
+
+/// Asserts that a Rust field type can serve as a single index column.
+///
+/// Macro-generated code emits a `_check::<FieldType>()` call bounded by
+/// `IndexableField`. The Rust type checker — not the macro — resolves the field
+/// type, so type aliases and newtype embeds are handled correctly.
+#[diagnostic::on_unimplemented(
+    message = "field type `{Self}` cannot be used in an index",
+    label = "not indexable",
+    note = "only scalar fields, newtype embeds, and unit (data-less) enums can be indexed; \
+            data-carrying enums and multi-field embedded structs span multiple columns and \
+            have no single index column"
+)]
+pub trait IndexableField {}
+
+// `Option<T>` is indexable wherever `T` is. The schema tracks nullability
+// separately, so the option wrapper does not affect indexability.
+impl<T> IndexableField for Option<T> where T: IndexableField {}
+
+// Smart-pointer wrappers (used for boxed foreign keys) are transparent for
+// storage, so they are indexable wherever the pointee is.
+impl<T> IndexableField for Box<T> where T: IndexableField {}
+impl<T> IndexableField for std::rc::Rc<T> where T: IndexableField {}
+impl<T> IndexableField for std::sync::Arc<T> where T: IndexableField {}
+
+// A `Deferred<T>` field is loaded lazily but stores the same single column as
+// `T`, so it is indexable wherever `T` is.
+impl<T> IndexableField for crate::Deferred<T> where T: IndexableField {}
+
+impl IndexableField for bool {}
+
+impl IndexableField for i8 {}
+impl IndexableField for i16 {}
+impl IndexableField for i32 {}
+impl IndexableField for i64 {}
+impl IndexableField for isize {}
+
+impl IndexableField for u8 {}
+impl IndexableField for u16 {}
+impl IndexableField for u32 {}
+impl IndexableField for u64 {}
+impl IndexableField for usize {}
+
+impl IndexableField for f32 {}
+impl IndexableField for f64 {}
+
+impl IndexableField for String {}
+impl IndexableField for Vec<u8> {}
+
+impl IndexableField for uuid::Uuid {}
+
+#[cfg(feature = "rust_decimal")]
+impl IndexableField for rust_decimal::Decimal {}
+
+#[cfg(feature = "bigdecimal")]
+impl IndexableField for bigdecimal::BigDecimal {}
+
+#[cfg(feature = "jiff")]
+mod jiff_impls {
+    use super::IndexableField;
+
+    impl IndexableField for jiff::Timestamp {}
+    impl IndexableField for jiff::civil::Date {}
+    impl IndexableField for jiff::civil::Time {}
+    impl IndexableField for jiff::civil::DateTime {}
+}
+
+// Tuple-newtype embeds get a per-type `IndexableField` impl from
+// `#[derive(Embed)]` (see `expand_embedded_indexable_impl` in toasty-macros),
+// forwarding to their inner type. A `NewtypeOf` blanket would be more concise
+// but conflicts with the `Box<T>` impl above, since `Box` is `#[fundamental]`.

--- a/tests/tests/ui/index_on_data_enum.rs
+++ b/tests/tests/ui/index_on_data_enum.rs
@@ -1,0 +1,24 @@
+// A data-carrying embedded enum maps to a discriminant column plus per-variant
+// data columns, so it has no single index column. Indexing one must be rejected
+// at compile time, not panic when the schema is built. A unit (data-less) enum
+// is fine — only data variants are the problem.
+
+#[derive(Debug, toasty::Embed)]
+enum Contact {
+    #[column(variant = 1)]
+    Email { address: String },
+    #[column(variant = 2)]
+    Phone { number: String },
+}
+
+#[derive(Debug, toasty::Model)]
+struct User {
+    #[key]
+    #[auto]
+    id: uuid::Uuid,
+
+    #[index]
+    contact: Contact,
+}
+
+fn main() {}

--- a/tests/tests/ui/index_on_data_enum.stderr
+++ b/tests/tests/ui/index_on_data_enum.stderr
@@ -1,0 +1,31 @@
+error[E0277]: field type `Contact` cannot be used in an index
+  --> tests/ui/index_on_data_enum.rs:21:14
+   |
+21 |     contact: Contact,
+   |              ^^^^^^^ not indexable
+   |
+help: the trait `toasty::codegen_support::index::IndexableField` is not implemented for `Contact`
+  --> tests/ui/index_on_data_enum.rs:7:1
+   |
+ 7 | enum Contact {
+   | ^^^^^^^^^^^^
+   = note: only scalar fields, newtype embeds, and unit (data-less) enums can be indexed; data-carrying enums and multi-field embedded structs span multiple columns and have no single index column
+   = help: the following other types implement trait `toasty::codegen_support::index::IndexableField`:
+             Arc<T>
+             Box<T>
+             Deferred<T>
+             Option<T>
+             Rc<T>
+             Vec<u8>
+             bigdecimal::BigDecimal
+             bool
+           and $N others
+note: required by a bound in `_check`
+  --> tests/ui/index_on_data_enum.rs:14:17
+   |
+14 | #[derive(Debug, toasty::Model)]
+   |                 ^^^^^^^^^^^^^ required by this bound in `_check`
+...
+21 |     contact: Contact,
+   |              ------- required by a bound in this function
+   = note: this error originates in the derive macro `toasty::Model` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/tests/ui/unique_composite_on_data_enum.rs
+++ b/tests/tests/ui/unique_composite_on_data_enum.rs
@@ -1,0 +1,25 @@
+// Same restriction through a model-level composite `#[unique(...)]`: naming a
+// data-carrying embedded enum among the unique columns is a compile error.
+// This is the shape from issue #973, but with a data-carrying enum instead of a
+// unit enum.
+
+#[derive(Debug, toasty::Embed)]
+enum Contact {
+    #[column(variant = 1)]
+    Email { address: String },
+    #[column(variant = 2)]
+    Phone { number: String },
+}
+
+#[derive(Debug, toasty::Model)]
+#[unique(contact, slug)]
+struct User {
+    #[key]
+    #[auto]
+    id: uuid::Uuid,
+
+    contact: Contact,
+    slug: String,
+}
+
+fn main() {}

--- a/tests/tests/ui/unique_composite_on_data_enum.stderr
+++ b/tests/tests/ui/unique_composite_on_data_enum.stderr
@@ -1,0 +1,31 @@
+error[E0277]: field type `Contact` cannot be used in an index
+  --> tests/ui/unique_composite_on_data_enum.rs:21:14
+   |
+21 |     contact: Contact,
+   |              ^^^^^^^ not indexable
+   |
+help: the trait `toasty::codegen_support::index::IndexableField` is not implemented for `Contact`
+  --> tests/ui/unique_composite_on_data_enum.rs:7:1
+   |
+ 7 | enum Contact {
+   | ^^^^^^^^^^^^
+   = note: only scalar fields, newtype embeds, and unit (data-less) enums can be indexed; data-carrying enums and multi-field embedded structs span multiple columns and have no single index column
+   = help: the following other types implement trait `toasty::codegen_support::index::IndexableField`:
+             Arc<T>
+             Box<T>
+             Deferred<T>
+             Option<T>
+             Rc<T>
+             Vec<u8>
+             bigdecimal::BigDecimal
+             bool
+           and $N others
+note: required by a bound in `_::_::_check`
+  --> tests/ui/unique_composite_on_data_enum.rs:14:17
+   |
+14 | #[derive(Debug, toasty::Model)]
+   |                 ^^^^^^^^^^^^^ required by this bound in `_check`
+...
+21 |     contact: Contact,
+   |              ------- required by a bound in this function
+   = note: this error originates in the derive macro `toasty::Model` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
<!--
PR title uses Conventional Commits, e.g.
    feat: add upsert support
    fix: handle composite key in IN-list rewrite
See CONTRIBUTING.md for the full process.
-->

## Summary
Currently unit enums are not indexed. This PR fixes #973. It checks field's projection and decides whether it's an unit struct and returns discriminant column as an index.

## Type of change

<!-- Check one. -->

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test
- [ ] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`):
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [ ] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [ ] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers

<!-- Anything reviewers should focus on. -->
