### PR TITLE
feat: add between operator to query DSL

### DIFF
--- a/crates/toasty-core/src/stmt.rs
+++ b/crates/toasty-core/src/stmt.rs
@@ -69,6 +69,9 @@ pub use expr_all_op::ExprAllOp;
 mod expr_and;
 pub use expr_and::ExprAnd;
 
+mod expr_between;
+pub use expr_between::ExprBetween;
+
 mod expr_any;
 pub use expr_any::ExprAny;
 

--- a/crates/toasty-core/src/stmt/expr.rs
+++ b/crates/toasty-core/src/stmt/expr.rs
@@ -1,11 +1,11 @@
 use crate::stmt::{ExprExists, Input};
 
 use super::{
-    Entry, EntryMut, EntryPath, ExprAllOp, ExprAnd, ExprAny, ExprAnyOp, ExprArg, ExprBinaryOp,
-    ExprCast, ExprError, ExprFunc, ExprInList, ExprInSubquery, ExprIntersects, ExprIsNull,
-    ExprIsSuperset, ExprIsVariant, ExprLength, ExprLet, ExprLike, ExprList, ExprMap, ExprMatch,
-    ExprNot, ExprOr, ExprProject, ExprRecord, ExprStartsWith, ExprStmt, Node, Projection,
-    Substitute, Value, Visit, VisitMut, expr_reference::ExprReference,
+    Entry, EntryMut, EntryPath, ExprAllOp, ExprAnd, ExprAny, ExprAnyOp, ExprArg, ExprBetween,
+    ExprBinaryOp, ExprCast, ExprError, ExprFunc, ExprInList, ExprInSubquery, ExprIntersects,
+    ExprIsNull, ExprIsSuperset, ExprIsVariant, ExprLength, ExprLet, ExprLike, ExprList, ExprMap,
+    ExprMatch, ExprNot, ExprOr, ExprProject, ExprRecord, ExprStartsWith, ExprStmt, Node,
+    Projection, Substitute, Value, Visit, VisitMut, expr_reference::ExprReference,
 };
 use std::fmt;
 
@@ -46,6 +46,9 @@ pub enum Expr {
 
     /// `lhs <op> ANY(rhs)` predicate against an array-valued operand. See [`ExprAnyOp`].
     AnyOp(ExprAnyOp),
+
+    /// `expr BETWEEN low AND high` inclusive range test. See [`ExprBetween`].
+    Between(ExprBetween),
 
     /// Positional argument placeholder. See [`ExprArg`].
     Arg(ExprArg),
@@ -223,6 +226,8 @@ impl Expr {
             Self::Any(_) => true,
             // ANY/ALL array predicates always evaluate to true or false.
             Self::AnyOp(_) | Self::AllOp(_) => true,
+            // BETWEEN always evaluates to true or false.
+            Self::Between(_) => true,
             // Comparisons always evaluate to true or false.
             Self::BinaryOp(_) => true,
             // IS NULL checks always evaluate to true or false.
@@ -289,6 +294,11 @@ impl Expr {
             Self::Cast(expr_cast) => expr_cast.expr.is_stable(),
             Self::StartsWith(e) => e.expr.is_stable() && e.prefix.is_stable(),
             Self::Like(e) => e.expr.is_stable() && e.pattern.is_stable(),
+            Self::Between(expr_between) => {
+                expr_between.expr.is_stable()
+                    && expr_between.low.is_stable()
+                    && expr_between.high.is_stable()
+            }
             Self::BinaryOp(expr_binary) => {
                 expr_binary.lhs.is_stable() && expr_binary.rhs.is_stable()
             }
@@ -397,6 +407,11 @@ impl Expr {
             Self::Like(e) => {
                 e.expr.is_const_at_depth(map_depth) && e.pattern.is_const_at_depth(map_depth)
             }
+            Self::Between(expr_between) => {
+                expr_between.expr.is_const_at_depth(map_depth)
+                    && expr_between.low.is_const_at_depth(map_depth)
+                    && expr_between.high.is_const_at_depth(map_depth)
+            }
             Self::BinaryOp(expr_binary) => {
                 expr_binary.lhs.is_const_at_depth(map_depth)
                     && expr_binary.rhs.is_const_at_depth(map_depth)
@@ -487,6 +502,11 @@ impl Expr {
             Self::Record(expr_record) => expr_record.iter().all(|expr| expr.is_eval()),
             Self::List(expr_list) => expr_list.items.iter().all(|expr| expr.is_eval()),
             Self::Cast(expr_cast) => expr_cast.expr.is_eval(),
+            Self::Between(expr_between) => {
+                expr_between.expr.is_eval()
+                    && expr_between.low.is_eval()
+                    && expr_between.high.is_eval()
+            }
             Self::BinaryOp(expr_binary) => expr_binary.lhs.is_eval() && expr_binary.rhs.is_eval(),
             Self::And(expr_and) => expr_and.iter().all(|expr| expr.is_eval()),
             Self::Any(expr_any) => expr_any.expr.is_eval(),
@@ -665,6 +685,7 @@ impl fmt::Debug for Expr {
             Self::Any(e) => e.fmt(f),
             Self::AnyOp(e) => e.fmt(f),
             Self::Arg(e) => e.fmt(f),
+            Self::Between(e) => e.fmt(f),
             Self::BinaryOp(e) => e.fmt(f),
             Self::Cast(e) => e.fmt(f),
             Self::Default => write!(f, "Default"),

--- a/crates/toasty-core/src/stmt/expr_between.rs
+++ b/crates/toasty-core/src/stmt/expr_between.rs
@@ -1,0 +1,38 @@
+use super::Expr;
+
+/// Tests whether a value lies within an inclusive range.
+///
+/// Returns `true` if `low <= expr <= high`.
+///
+/// # Examples
+///
+/// ```text
+/// between(age, 18, 65)  // returns `true` if 18 <= age <= 65
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExprBetween {
+    /// The value being tested.
+    pub expr: Box<Expr>,
+    /// Inclusive lower bound.
+    pub low: Box<Expr>,
+    /// Inclusive upper bound.
+    pub high: Box<Expr>,
+}
+
+impl Expr {
+    /// Creates a `BETWEEN` expression: `expr BETWEEN low AND high` (inclusive).
+    pub fn between(expr: impl Into<Self>, low: impl Into<Self>, high: impl Into<Self>) -> Self {
+        ExprBetween {
+            expr: Box::new(expr.into()),
+            low: Box::new(low.into()),
+            high: Box::new(high.into()),
+        }
+        .into()
+    }
+}
+
+impl From<ExprBetween> for Expr {
+    fn from(value: ExprBetween) -> Self {
+        Self::Between(value)
+    }
+}

--- a/crates/toasty-core/src/stmt/visit.rs
+++ b/crates/toasty-core/src/stmt/visit.rs
@@ -2,8 +2,8 @@
 
 use super::{
     Assignment, Assignments, Association, Condition, Cte, Delete, Expr, ExprAllOp, ExprAnd,
-    ExprAny, ExprAnyOp, ExprArg, ExprBinaryOp, ExprCast, ExprColumn, ExprError, ExprExists,
-    ExprFunc, ExprInList, ExprInSubquery, ExprIntersects, ExprIsNull, ExprIsSuperset,
+    ExprAny, ExprAnyOp, ExprArg, ExprBetween, ExprBinaryOp, ExprCast, ExprColumn, ExprError,
+    ExprExists, ExprFunc, ExprInList, ExprInSubquery, ExprIntersects, ExprIsNull, ExprIsSuperset,
     ExprIsVariant, ExprLength, ExprLet, ExprLike, ExprList, ExprMap, ExprMatch, ExprNot, ExprOr,
     ExprProject, ExprRecord, ExprReference, ExprSet, ExprSetOp, ExprStartsWith, ExprStmt, Filter,
     FuncCount, FuncLastInsertId, Insert, InsertTarget, Join, JoinOp, Limit, LimitCursor,
@@ -110,6 +110,13 @@ pub trait Visit {
     /// The default implementation delegates to [`visit_expr_all_op`].
     fn visit_expr_all_op(&mut self, i: &ExprAllOp) {
         visit_expr_all_op(self, i);
+    }
+
+    /// Visits an [`ExprBetween`] node.
+    ///
+    /// The default implementation delegates to [`visit_expr_between`].
+    fn visit_expr_between(&mut self, i: &ExprBetween) {
+        visit_expr_between(self, i);
     }
 
     /// Visits an [`ExprBinaryOp`] node.
@@ -584,6 +591,10 @@ impl<V: Visit> Visit for &mut V {
         Visit::visit_expr_all_op(&mut **self, i);
     }
 
+    fn visit_expr_between(&mut self, i: &ExprBetween) {
+        Visit::visit_expr_between(&mut **self, i);
+    }
+
     fn visit_expr_binary_op(&mut self, i: &ExprBinaryOp) {
         Visit::visit_expr_binary_op(&mut **self, i);
     }
@@ -890,6 +901,7 @@ where
         Expr::Any(expr) => v.visit_expr_any(expr),
         Expr::AnyOp(expr) => v.visit_expr_any_op(expr),
         Expr::Arg(expr) => v.visit_expr_arg(expr),
+        Expr::Between(expr) => v.visit_expr_between(expr),
         Expr::BinaryOp(expr) => v.visit_expr_binary_op(expr),
         Expr::Cast(expr) => v.visit_expr_cast(expr),
         Expr::Default => v.visit_expr_default(),
@@ -1042,6 +1054,16 @@ where
     V: Visit + ?Sized,
 {
     // FuncLastInsertId has no fields to visit
+}
+
+/// Default traversal for [`ExprBetween`] nodes. Visits the expression, low, and high bounds.
+pub fn visit_expr_between<V>(v: &mut V, node: &ExprBetween)
+where
+    V: Visit + ?Sized,
+{
+    v.visit_expr(&node.expr);
+    v.visit_expr(&node.low);
+    v.visit_expr(&node.high);
 }
 
 /// Default traversal for [`ExprInList`] nodes. Visits the expression and list.

--- a/crates/toasty-core/src/stmt/visit_mut.rs
+++ b/crates/toasty-core/src/stmt/visit_mut.rs
@@ -2,8 +2,8 @@
 
 use super::{
     Assignment, Assignments, Association, Condition, Cte, Delete, Expr, ExprAllOp, ExprAnd,
-    ExprAny, ExprAnyOp, ExprArg, ExprBinaryOp, ExprCast, ExprColumn, ExprError, ExprExists,
-    ExprFunc, ExprInList, ExprInSubquery, ExprIntersects, ExprIsNull, ExprIsSuperset,
+    ExprAny, ExprAnyOp, ExprArg, ExprBetween, ExprBinaryOp, ExprCast, ExprColumn, ExprError,
+    ExprExists, ExprFunc, ExprInList, ExprInSubquery, ExprIntersects, ExprIsNull, ExprIsSuperset,
     ExprIsVariant, ExprLength, ExprLet, ExprLike, ExprList, ExprMap, ExprMatch, ExprNot, ExprOr,
     ExprProject, ExprRecord, ExprReference, ExprSet, ExprSetOp, ExprStartsWith, ExprStmt, Filter,
     FuncCount, FuncLastInsertId, Insert, InsertTarget, Join, JoinOp, Limit, LimitCursor,
@@ -112,6 +112,13 @@ pub trait VisitMut {
     /// The default implementation delegates to [`visit_expr_all_op_mut`].
     fn visit_expr_all_op_mut(&mut self, i: &mut ExprAllOp) {
         visit_expr_all_op_mut(self, i);
+    }
+
+    /// Visits an [`ExprBetween`] node mutably.
+    ///
+    /// The default implementation delegates to [`visit_expr_between_mut`].
+    fn visit_expr_between_mut(&mut self, i: &mut ExprBetween) {
+        visit_expr_between_mut(self, i);
     }
 
     /// Visits an [`ExprBinaryOp`] node mutably.
@@ -586,6 +593,10 @@ impl<V: VisitMut> VisitMut for &mut V {
         VisitMut::visit_expr_all_op_mut(&mut **self, i);
     }
 
+    fn visit_expr_between_mut(&mut self, i: &mut ExprBetween) {
+        VisitMut::visit_expr_between_mut(&mut **self, i);
+    }
+
     fn visit_expr_binary_op_mut(&mut self, i: &mut ExprBinaryOp) {
         VisitMut::visit_expr_binary_op_mut(&mut **self, i);
     }
@@ -892,6 +903,7 @@ where
         Expr::Any(expr) => v.visit_expr_any_mut(expr),
         Expr::AnyOp(expr) => v.visit_expr_any_op_mut(expr),
         Expr::Arg(expr) => v.visit_expr_arg_mut(expr),
+        Expr::Between(expr) => v.visit_expr_between_mut(expr),
         Expr::BinaryOp(expr) => v.visit_expr_binary_op_mut(expr),
         Expr::Cast(expr) => v.visit_expr_cast_mut(expr),
         Expr::Default => v.visit_expr_default_mut(),
@@ -1044,6 +1056,16 @@ where
     V: VisitMut + ?Sized,
 {
     // FuncLastInsertId has no fields to visit
+}
+
+/// Default mutable traversal for [`ExprBetween`] nodes. Visits the expression, low, and high bounds.
+pub fn visit_expr_between_mut<V>(v: &mut V, node: &mut ExprBetween)
+where
+    V: VisitMut + ?Sized,
+{
+    v.visit_expr_mut(&mut node.expr);
+    v.visit_expr_mut(&mut node.low);
+    v.visit_expr_mut(&mut node.high);
 }
 
 /// Default mutable traversal for [`ExprInList`] nodes. Visits the expression and the list expression.

--- a/crates/toasty-driver-dynamodb/src/lib.rs
+++ b/crates/toasty-driver-dynamodb/src/lib.rs
@@ -330,6 +330,12 @@ fn ddb_expression(
     expr: &stmt::Expr,
 ) -> String {
     match expr {
+        stmt::Expr::Between(expr_between) => {
+            let field = ddb_expression(cx, attrs, primary, &expr_between.expr);
+            let low = ddb_expression(cx, attrs, primary, &expr_between.low);
+            let high = ddb_expression(cx, attrs, primary, &expr_between.high);
+            format!("{field} BETWEEN {low} AND {high}")
+        }
         stmt::Expr::BinaryOp(expr_binary_op) => {
             let lhs = ddb_expression(cx, attrs, primary, &expr_binary_op.lhs);
             let rhs = ddb_expression(cx, attrs, primary, &expr_binary_op.rhs);

--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -45,6 +45,7 @@ pub mod field_column_type;
 pub mod field_default_and_update;
 pub mod field_version;
 pub mod field_version_newtype;
+pub mod filter_between;
 pub mod filter_ilike;
 pub mod filter_like;
 pub mod float_fields;

--- a/crates/toasty-driver-integration-suite/src/tests/filter_between.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/filter_between.rs
@@ -134,7 +134,7 @@ pub async fn filter_between_string(test: &mut Test) -> Result<()> {
 #[driver_test(requires(not(sql)))]
 pub async fn filter_between_sort_key(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
-    #[key(partition = pk, local = sk)]
+    #[key(pk, sk)]
     struct Item {
         pk: i64,
         sk: i64,

--- a/crates/toasty-driver-integration-suite/src/tests/filter_between.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/filter_between.rs
@@ -1,0 +1,210 @@
+use crate::prelude::*;
+
+/// Filters on a numeric field using `between()`, returning only rows in range.
+#[driver_test(id(ID))]
+pub async fn filter_between_numeric(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: ID,
+
+        score: i64,
+    }
+
+    let mut db = test.setup_db(models!(Item)).await;
+
+    for score in [10_i64, 20, 30, 40, 50] {
+        Item::create().score(score).exec(&mut db).await?;
+    }
+
+    let mut items: Vec<_> = Item::filter(Item::fields().score().between(20_i64, 40_i64))
+        .exec(&mut db)
+        .await?;
+
+    items.sort_by_key(|i| i.score);
+    assert_eq!(items.len(), 3);
+    assert_eq!(items[0].score, 20);
+    assert_eq!(items[1].score, 30);
+    assert_eq!(items[2].score, 40);
+
+    Ok(())
+}
+
+/// Verifies that `between()` bounds are inclusive on both ends.
+#[driver_test(id(ID))]
+pub async fn filter_between_inclusive_bounds(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: ID,
+
+        value: i64,
+    }
+
+    let mut db = test.setup_db(models!(Item)).await;
+
+    for v in [1_i64, 5, 10] {
+        Item::create().value(v).exec(&mut db).await?;
+    }
+
+    // Both boundary values (1 and 10) should be included.
+    let items: Vec<_> = Item::filter(Item::fields().value().between(1_i64, 10_i64))
+        .exec(&mut db)
+        .await?;
+    assert_eq!(items.len(), 3);
+
+    // Exact lower bound.
+    let items: Vec<_> = Item::filter(Item::fields().value().between(1_i64, 1_i64))
+        .exec(&mut db)
+        .await?;
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].value, 1);
+
+    // Exact upper bound.
+    let items: Vec<_> = Item::filter(Item::fields().value().between(10_i64, 10_i64))
+        .exec(&mut db)
+        .await?;
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].value, 10);
+
+    Ok(())
+}
+
+/// Verifies that `between()` returns nothing when the range excludes all rows.
+#[driver_test(id(ID))]
+pub async fn filter_between_empty_result(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: ID,
+
+        value: i64,
+    }
+
+    let mut db = test.setup_db(models!(Item)).await;
+
+    for v in [1_i64, 2, 3] {
+        Item::create().value(v).exec(&mut db).await?;
+    }
+
+    let items: Vec<_> = Item::filter(Item::fields().value().between(100_i64, 200_i64))
+        .exec(&mut db)
+        .await?;
+
+    assert_eq!(items.len(), 0);
+
+    Ok(())
+}
+
+/// Filters on a string field using `between()`.
+#[driver_test(id(ID))]
+pub async fn filter_between_string(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: ID,
+
+        name: String,
+    }
+
+    let mut db = test.setup_db(models!(Item)).await;
+
+    for name in ["apple", "banana", "cherry", "date", "elderberry"] {
+        Item::create().name(name).exec(&mut db).await?;
+    }
+
+    let items: Vec<_> = Item::filter(Item::fields().name().between("banana", "date"))
+        .exec(&mut db)
+        .await?;
+
+    assert_eq!(items.len(), 3);
+    assert_eq_unordered!(
+        items.iter().map(|i| i.name.as_str()),
+        ["banana", "cherry", "date"]
+    );
+
+    Ok(())
+}
+
+/// For DynamoDB: uses `between()` as a key condition on the sort key.
+#[driver_test(requires(not(sql)))]
+pub async fn filter_between_sort_key(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    #[key(partition = pk, local = sk)]
+    struct Item {
+        pk: i64,
+        sk: i64,
+    }
+
+    let mut db = test.setup_db(models!(Item)).await;
+
+    for sk in 0..10_i64 {
+        Item::create().pk(1).sk(sk).exec(&mut db).await?;
+    }
+
+    // between on the sort key (key condition expression path in DynamoDB)
+    let mut items: Vec<_> = Item::filter(
+        Item::fields()
+            .pk()
+            .eq(1_i64)
+            .and(Item::fields().sk().between(3_i64, 6_i64)),
+    )
+    .exec(&mut db)
+    .await?;
+
+    items.sort_by_key(|i| i.sk);
+    assert_eq!(items.len(), 4);
+    assert_eq!(items[0].sk, 3);
+    assert_eq!(items[1].sk, 4);
+    assert_eq!(items[2].sk, 5);
+    assert_eq!(items[3].sk, 6);
+
+    Ok(())
+}
+
+/// For DynamoDB: uses `between()` as a key condition on a GSI sort key.
+#[driver_test(requires(not(sql)))]
+pub async fn filter_between_gsi_sort_key(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    #[key(id)]
+    #[index(partition = [player_id], local = [score])]
+    struct Match {
+        id: String,
+        player_id: String,
+        score: i64,
+    }
+
+    let mut db = test.setup_db(models!(Match)).await;
+
+    toasty::create!(Match::[
+        { id: "m1", player_id: "p1", score: 10_i64 },
+        { id: "m2", player_id: "p1", score: 20_i64 },
+        { id: "m3", player_id: "p1", score: 30_i64 },
+        { id: "m4", player_id: "p1", score: 40_i64 },
+        { id: "m5", player_id: "p1", score: 50_i64 },
+        { id: "m6", player_id: "p2", score: 25_i64 },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let mut matches: Vec<Match> = Match::filter(
+        Match::fields()
+            .player_id()
+            .eq("p1")
+            .and(Match::fields().score().between(20_i64, 40_i64)),
+    )
+    .exec(&mut db)
+    .await?;
+
+    matches.sort_by_key(|m| m.score);
+    assert_eq!(matches.len(), 3);
+    assert_eq!(matches[0].score, 20);
+    assert_eq!(matches[1].score, 30);
+    assert_eq!(matches[2].score, 40);
+
+    Ok(())
+}

--- a/crates/toasty-macros/src/model/schema/key_attr.rs
+++ b/crates/toasty-macros/src/model/schema/key_attr.rs
@@ -118,8 +118,12 @@ impl KeyAttr {
         })?;
 
         if !simple_fields.is_empty() {
-            // Simple mode: all fields become partition keys
-            partition = simple_fields;
+            // Simple mode (e.g. `#[key(a, b, c)]`): first field is the partition
+            // (hash) key, rest are local (sort) keys. Matches `#[index(a, b, c)]`
+            // so the simple form is equivalent to `#[key(partition = a, local = [b, c])]`.
+            let mut iter = simple_fields.into_iter();
+            partition = iter.next().into_iter().collect();
+            local = iter.collect();
         } else {
             // Named mode: require both partition and local
             if partition.is_empty() {

--- a/crates/toasty-sql/src/serializer/expr.rs
+++ b/crates/toasty-sql/src/serializer/expr.rs
@@ -10,6 +10,9 @@ impl ToSql for &stmt::Expr {
             stmt::Expr::And(expr) => {
                 fmt!(f, Delimited(&expr.operands, " AND "));
             }
+            stmt::Expr::Between(expr) => {
+                fmt!(f, expr.expr " BETWEEN " expr.low " AND " expr.high);
+            }
             stmt::Expr::BinaryOp(expr) => {
                 assert!(!expr.lhs.is_value_null());
                 assert!(!expr.rhs.is_value_null());

--- a/crates/toasty/src/engine/fold.rs
+++ b/crates/toasty/src/engine/fold.rs
@@ -79,6 +79,7 @@ fn fold_one(i: &mut Expr) -> Option<Expr> {
         | Expr::Any(_)
         | Expr::AnyOp(_)
         | Expr::Arg(_)
+        | Expr::Between(_)
         | Expr::Default
         | Expr::Error(_)
         | Expr::Exists(_)

--- a/crates/toasty/src/engine/index/index_match.rs
+++ b/crates/toasty/src/engine/index/index_match.rs
@@ -63,6 +63,13 @@ impl<'stmt> IndexMatch<'stmt> {
                 }
                 _ => false,
             },
+            Between(e) => match &*e.expr {
+                stmt::Expr::Reference(expr_column @ stmt::ExprReference::Column(_)) => {
+                    // between is a range condition: valid on sort key, not partition key
+                    self.match_expr_binary_op_column(cx, expr_column, expr, stmt::BinaryOp::Ge)
+                }
+                _ => false,
+            },
             InList(e) => self.match_expr_in_list(cx, &e.expr, expr),
             IsNull(e) => match &*e.expr {
                 stmt::Expr::Reference(expr_column @ stmt::ExprReference::Column(_)) => {
@@ -295,7 +302,7 @@ impl<'stmt> IndexMatch<'stmt> {
         use stmt::Expr::*;
 
         match expr {
-            StartsWith(_) | InList(_) | IsNull(_) | Like(_) | Not(_) => {
+            StartsWith(_) | Between(_) | InList(_) | IsNull(_) | Like(_) | Not(_) => {
                 if self
                     .columns
                     .iter()

--- a/crates/toasty/src/engine/verify.rs
+++ b/crates/toasty/src/engine/verify.rs
@@ -206,6 +206,7 @@ impl VerifyExpr<'_, '_> {
             And(_)
             | AllOp(_)
             | AnyOp(_)
+            | Between(_)
             | BinaryOp(_)
             | Like(_)
             | InList(_)

--- a/crates/toasty/src/stmt/path.rs
+++ b/crates/toasty/src/stmt/path.rs
@@ -268,6 +268,33 @@ impl<T, U> Path<T, U> {
         self.build_filter(move |path| stmt::Expr::le(path, rhs))
     }
 
+    /// Test whether this field's value is in the inclusive range `[low, high]`.
+    ///
+    /// Generates a `BETWEEN low AND high` condition in SQL and a native
+    /// `BETWEEN` condition expression in DynamoDB.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[derive(Debug, toasty::Model)]
+    /// # struct User {
+    /// #     #[key]
+    /// #     id: i64,
+    /// #     name: String,
+    /// # }
+    /// let filter = User::fields().id().between(18_i64, 65_i64);
+    /// ```
+    pub fn between(self, low: impl IntoExpr<U>, high: impl IntoExpr<U>) -> Expr<bool> {
+        Expr {
+            untyped: stmt::Expr::between(
+                self.untyped.into_stmt(),
+                low.into_expr().untyped,
+                high.into_expr().untyped,
+            ),
+            _p: PhantomData,
+        }
+    }
+
     /// Test whether this field's value is in `rhs`.
     ///
     /// `rhs` can be any collection that implements `IntoExpr<List<U>>`, such

--- a/docs/guide/src/keys-and-auto-generation.md
+++ b/docs/guide/src/keys-and-auto-generation.md
@@ -300,8 +300,10 @@ struct Enrollment {
 }
 ```
 
-`#[key(student_id, course_id)]` on the struct is equivalent to putting `#[key]`
-on both `student_id` and `course_id`. It generates the same lookup methods:
+`#[key(student_id, course_id)]` is shorthand for
+`#[key(partition = student_id, local = course_id)]`: the first field is the
+partition (hash) key, and any remaining fields are local (sort) keys. It
+generates the same lookup methods as `#[key]` on each field:
 
 ```rust
 # use toasty::Model;
@@ -405,5 +407,5 @@ For a model with `#[key]`, Toasty generates these methods:
 |---|---|
 | `#[key]` on single field | `get_by_<field>()`, `filter_by_<field>()`, `delete_by_<field>()` |
 | `#[key]` on multiple fields | `get_by_<a>_and_<b>()`, `filter_by_<a>_and_<b>()`, `delete_by_<a>_and_<b>()` |
-| `#[key(a, b)]` on struct | Same as `#[key]` on multiple fields |
+| `#[key(a, b)]` on struct | Same generated methods as `#[key]` on multiple fields; `a` is the partition key, `b` is the local (sort) key |
 | `#[key(partition = a, local = b)]` | `get_by_<a>_and_<b>()`, `filter_by_<a>()`, `filter_by_<a>_and_<b>()`, `delete_by_<a>_and_<b>()` |


### PR DESCRIPTION
## Summary

Adds `Path::between(low, high)` for inclusive range filtering across all drivers. SQL drivers emit `field BETWEEN low AND high`; DynamoDB emits a native `BETWEEN` condition usable as both key condition and filter.

While testing, two latent bugs surfaced; both are fixed here:

- **`engine/index_match`** — `match_restriction` had no arm for the new `Between` expression, so range predicates on a sort key (table or GSI) were routed to the DynamoDB FilterExpression and rejected with `ValidationException: Filter Expression can only contain non-primary key attributes`. Added the missing arm, mirroring `StartsWith`.
- **`macros/key_attr`** — simple-form `#[key(a, b)]` put every field into `IndexScope::Partition`, while `#[index(a, b)]` made the first field partition and the rest local. The two attributes now agree: first field is the partition key, the rest are local (sort) keys. This makes `#[key(a, b)]` a real shorthand for `#[key(partition = a, local = b)]` and unblocks range queries on the second column. DynamoDB primary-key creation already used positional HASH/RANGE assignment, so existing `#[key(a, b)]` schemas don't change shape.

Integration tests cover numeric, string, boundary, empty-result, table sort-key, and GSI sort-key scenarios.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes (default SQL suite + `--features dynamodb` against local DDB)

## Notes for reviewers

The `#[key]`/`#[index]` semantics fix is a behavior change for any model using simple-form composite `#[key(a, b)]`: the second column moves from partition to local scope. DynamoDB tables don't change physically (HASH/RANGE assignment was already positional), but range queries against the second column now work where before they would silently fall back to a scan or fail. The doc table in `keys-and-auto-generation.md` is updated to call this out.