### PR TITLE
style: clean up user-facing generic names in model macros

### DIFF
--- a/crates/toasty-macros/src/model/expand/model.rs
+++ b/crates/toasty-macros/src/model/expand/model.rs
@@ -109,10 +109,10 @@ impl Expand<'_> {
                 type Create = #create_struct_ident;
                 type Update<'a> = #update_struct_ident<&'a mut Self>;
                 type UpdateQuery = #update_struct_ident;
-                type Path<Origin> = #field_struct_ident<Origin>;
+                type Path<__Origin> = #field_struct_ident<__Origin>;
                 type PrimaryKey = #primary_key_ty;
-                type ManyField<Origin> = #field_list_struct_ident<Origin>;
-                type OneField<Origin> = #field_struct_ident<Origin>;
+                type ManyField<__Origin> = #field_list_struct_ident<__Origin>;
+                type OneField<__Origin> = #field_struct_ident<__Origin>;
 
                 fn id() -> #toasty::core::schema::app::ModelId {
                     static ID: std::sync::OnceLock<#toasty::core::schema::app::ModelId> = std::sync::OnceLock::new();
@@ -129,13 +129,13 @@ impl Expand<'_> {
                     #( #field_register_calls )*
                 }
 
-                fn new_path<Origin>(path: #toasty::Path<Origin, Self>) -> Self::Path<Origin> {
+                fn new_path<__Origin>(path: #toasty::Path<__Origin, Self>) -> Self::Path<__Origin> {
                     #field_struct_ident::from_path(path)
                 }
 
-                fn new_many_field<Origin>(
-                    path: #toasty::Path<Origin, #toasty::List<Self>>,
-                ) -> #field_list_struct_ident<Origin> {
+                fn new_many_field<__Origin>(
+                    path: #toasty::Path<__Origin, #toasty::List<Self>>,
+                ) -> #field_list_struct_ident<__Origin> {
                     #field_list_struct_ident::from_path(path)
                 }
 
@@ -171,11 +171,11 @@ impl Expand<'_> {
             // through the per-primitive `ViaTarget` impls instead.
             impl #toasty::ViaTarget for #model_ident {
                 type Query = #query_struct_ident<#toasty::List<#model_ident>>;
-                type Path<Origin> = <#model_ident as #toasty::Model>::ManyField<Origin>;
+                type Path<__Origin> = <#model_ident as #toasty::Model>::ManyField<__Origin>;
 
-                fn new_path<Origin>(
-                    path: #toasty::Path<Origin, #toasty::List<#model_ident>>,
-                ) -> Self::Path<Origin> {
+                fn new_path<__Origin>(
+                    path: #toasty::Path<__Origin, #toasty::List<#model_ident>>,
+                ) -> Self::Path<__Origin> {
                     // A model terminal keeps navigating, so hand back its
                     // chainable `ManyField`.
                     <#model_ident as #toasty::Model>::new_many_field(path)

--- a/crates/toasty-macros/src/model/expand/model.rs
+++ b/crates/toasty-macros/src/model/expand/model.rs
@@ -105,14 +105,14 @@ impl Expand<'_> {
             }
 
             impl #toasty::Model for #model_ident {
-                type Query<__T> = #query_struct_ident<__T>;
+                type Query<T> = #query_struct_ident<T>;
                 type Create = #create_struct_ident;
                 type Update<'a> = #update_struct_ident<&'a mut Self>;
                 type UpdateQuery = #update_struct_ident;
-                type Path<__Origin> = #field_struct_ident<__Origin>;
+                type Path<Origin> = #field_struct_ident<Origin>;
                 type PrimaryKey = #primary_key_ty;
-                type ManyField<__Origin> = #field_list_struct_ident<__Origin>;
-                type OneField<__Origin> = #field_struct_ident<__Origin>;
+                type ManyField<Origin> = #field_list_struct_ident<Origin>;
+                type OneField<Origin> = #field_struct_ident<Origin>;
 
                 fn id() -> #toasty::core::schema::app::ModelId {
                     static ID: std::sync::OnceLock<#toasty::core::schema::app::ModelId> = std::sync::OnceLock::new();
@@ -129,13 +129,13 @@ impl Expand<'_> {
                     #( #field_register_calls )*
                 }
 
-                fn new_path<__Origin>(path: #toasty::Path<__Origin, Self>) -> Self::Path<__Origin> {
+                fn new_path<Origin>(path: #toasty::Path<Origin, Self>) -> Self::Path<Origin> {
                     #field_struct_ident::from_path(path)
                 }
 
-                fn new_many_field<__Origin>(
-                    path: #toasty::Path<__Origin, #toasty::List<Self>>,
-                ) -> #field_list_struct_ident<__Origin> {
+                fn new_many_field<Origin>(
+                    path: #toasty::Path<Origin, #toasty::List<Self>>,
+                ) -> #field_list_struct_ident<Origin> {
                     #field_list_struct_ident::from_path(path)
                 }
 
@@ -145,9 +145,9 @@ impl Expand<'_> {
                     #find_by_primary_key_body
                 }
 
-                fn wrap_query<__T>(
-                    stmt: #toasty::stmt::Query<__T>,
-                ) -> Self::Query<__T> {
+                fn wrap_query<T>(
+                    stmt: #toasty::stmt::Query<T>,
+                ) -> Self::Query<T> {
                     #query_struct_ident::from_stmt(stmt)
                 }
 
@@ -171,11 +171,11 @@ impl Expand<'_> {
             // through the per-primitive `ViaTarget` impls instead.
             impl #toasty::ViaTarget for #model_ident {
                 type Query = #query_struct_ident<#toasty::List<#model_ident>>;
-                type Path<__Origin> = <#model_ident as #toasty::Model>::ManyField<__Origin>;
+                type Path<Origin> = <#model_ident as #toasty::Model>::ManyField<Origin>;
 
-                fn new_path<__Origin>(
-                    path: #toasty::Path<__Origin, #toasty::List<#model_ident>>,
-                ) -> Self::Path<__Origin> {
+                fn new_path<Origin>(
+                    path: #toasty::Path<Origin, #toasty::List<#model_ident>>,
+                ) -> Self::Path<Origin> {
                     // A model terminal keeps navigating, so hand back its
                     // chainable `ManyField`.
                     <#model_ident as #toasty::Model>::new_many_field(path)

--- a/crates/toasty-macros/src/model/expand/query.rs
+++ b/crates/toasty-macros/src/model/expand/query.rs
@@ -21,11 +21,11 @@ impl Expand<'_> {
         let include = self.expand_include_method(&include_ty);
 
         quote! {
-            #vis struct #query_struct_ident<__T = #toasty::List<#model_ident>> {
-                stmt: #toasty::stmt::Query<__T>,
+            #vis struct #query_struct_ident<T = #toasty::List<#model_ident>> {
+                stmt: #toasty::stmt::Query<T>,
             }
 
-            impl<__T> #toasty::Clone for #query_struct_ident<__T> {
+            impl<T> #toasty::Clone for #query_struct_ident<T> {
                 fn clone(&self) -> Self {
                     Self {
                         stmt: self.stmt.clone(),
@@ -34,16 +34,16 @@ impl Expand<'_> {
             }
 
             // ----- Shared methods (all `T`) -----
-            impl<__T> #query_struct_ident<__T> {
-                #vis const fn from_stmt(stmt: #toasty::stmt::Query<__T>) -> Self {
+            impl<T> #query_struct_ident<T> {
+                #vis const fn from_stmt(stmt: #toasty::stmt::Query<T>) -> Self {
                     Self { stmt }
                 }
 
                 #include
 
-                #vis async fn exec(self, executor: &mut dyn #toasty::Executor) -> #toasty::Result<__T::Output>
+                #vis async fn exec(self, executor: &mut dyn #toasty::Executor) -> #toasty::Result<T::Output>
                 where
-                    __T: #toasty::Load,
+                    T: #toasty::Load,
                 {
                     use #toasty::IntoStatement;
                     executor.exec(self.stmt.into_statement()).await
@@ -51,9 +51,9 @@ impl Expand<'_> {
             }
 
             // ----- Shared `create` (any `T` whose query can scope an insert) -----
-            impl<__T> #query_struct_ident<__T>
+            impl<T> #query_struct_ident<T>
             where
-                #toasty::stmt::Query<__T>: #toasty::stmt::IntoScope<#model_ident>,
+                #toasty::stmt::Query<T>: #toasty::stmt::IntoScope<#model_ident>,
             {
                 #vis fn create(self) -> #create_builder_ident {
                     let mut builder = #create_builder_ident::default();
@@ -100,13 +100,13 @@ impl Expand<'_> {
                     self.stmt.count()
                 }
 
-                #vis fn select<__E, __U>(
+                #vis fn select<E, T>(
                     self,
-                    projection: __E,
-                ) -> #toasty::stmt::Query<#toasty::List<__U>>
+                    projection: E,
+                ) -> #toasty::stmt::Query<#toasty::List<T>>
                 where
-                    __E: #toasty::IntoExpr<__U>,
-                    __U: #toasty::Load,
+                    E: #toasty::IntoExpr<T>,
+                    T: #toasty::Load,
                 {
                     self.stmt.select(projection)
                 }
@@ -180,19 +180,19 @@ impl Expand<'_> {
             }
 
             // ----- IntoStatement / IntoScope -----
-            impl<__T> #toasty::IntoStatement for #query_struct_ident<__T> {
-                type Returning = __T;
+            impl<T> #toasty::IntoStatement for #query_struct_ident<T> {
+                type Returning = T;
 
-                fn into_statement(self) -> #toasty::Statement<__T> {
+                fn into_statement(self) -> #toasty::Statement<T> {
                     use #toasty::IntoStatement;
                     self.stmt.into_statement()
                 }
             }
 
-            impl<__T> #toasty::IntoStatement for &#query_struct_ident<__T> {
-                type Returning = __T;
+            impl<T> #toasty::IntoStatement for &#query_struct_ident<T> {
+                type Returning = T;
 
-                fn into_statement(self) -> #toasty::Statement<__T> {
+                fn into_statement(self) -> #toasty::Statement<T> {
                     use #toasty::IntoStatement;
                     self.stmt.clone().into_statement()
                 }
@@ -238,10 +238,10 @@ impl Expand<'_> {
             #[diagnostic::do_not_recommend]
             impl #toasty::Scope for #query_struct_ident<#toasty::List<#model_ident>> {
                 type Item = #toasty::List<#model_ident>;
-                type Path<__Origin> = #field_list_struct_ident<__Origin>;
+                type Path<Origin> = #field_list_struct_ident<Origin>;
                 type Create = #create_builder_ident;
 
-                fn new_path<__Origin>(path: #toasty::Path<__Origin, Self::Item>) -> Self::Path<__Origin> {
+                fn new_path<Origin>(path: #toasty::Path<Origin, Self::Item>) -> Self::Path<Origin> {
                     #field_list_struct_ident::from_path(path)
                 }
 
@@ -261,10 +261,10 @@ impl Expand<'_> {
             #[diagnostic::do_not_recommend]
             impl #toasty::Scope for #query_struct_ident<#model_ident> {
                 type Item = #model_ident;
-                type Path<__Origin> = #field_struct_ident<__Origin>;
+                type Path<Origin> = #field_struct_ident<Origin>;
                 type Create = #create_builder_ident;
 
-                fn new_path<__Origin>(path: #toasty::Path<__Origin, Self::Item>) -> Self::Path<__Origin> {
+                fn new_path<Origin>(path: #toasty::Path<Origin, Self::Item>) -> Self::Path<Origin> {
                     #field_struct_ident::from_path(path)
                 }
 
@@ -284,10 +284,10 @@ impl Expand<'_> {
             #[diagnostic::do_not_recommend]
             impl #toasty::Scope for #query_struct_ident<#toasty::Option<#model_ident>> {
                 type Item = #model_ident;
-                type Path<__Origin> = #field_struct_ident<__Origin>;
+                type Path<Origin> = #field_struct_ident<Origin>;
                 type Create = #create_builder_ident;
 
-                fn new_path<__Origin>(path: #toasty::Path<__Origin, Self::Item>) -> Self::Path<__Origin> {
+                fn new_path<Origin>(path: #toasty::Path<Origin, Self::Item>) -> Self::Path<Origin> {
                     #field_struct_ident::from_path(path)
                 }
 

--- a/crates/toasty-macros/src/model/expand/query.rs
+++ b/crates/toasty-macros/src/model/expand/query.rs
@@ -238,10 +238,10 @@ impl Expand<'_> {
             #[diagnostic::do_not_recommend]
             impl #toasty::Scope for #query_struct_ident<#toasty::List<#model_ident>> {
                 type Item = #toasty::List<#model_ident>;
-                type Path<Origin> = #field_list_struct_ident<Origin>;
+                type Path<__Origin> = #field_list_struct_ident<__Origin>;
                 type Create = #create_builder_ident;
 
-                fn new_path<Origin>(path: #toasty::Path<Origin, Self::Item>) -> Self::Path<Origin> {
+                fn new_path<__Origin>(path: #toasty::Path<__Origin, Self::Item>) -> Self::Path<__Origin> {
                     #field_list_struct_ident::from_path(path)
                 }
 
@@ -261,10 +261,10 @@ impl Expand<'_> {
             #[diagnostic::do_not_recommend]
             impl #toasty::Scope for #query_struct_ident<#model_ident> {
                 type Item = #model_ident;
-                type Path<Origin> = #field_struct_ident<Origin>;
+                type Path<__Origin> = #field_struct_ident<__Origin>;
                 type Create = #create_builder_ident;
 
-                fn new_path<Origin>(path: #toasty::Path<Origin, Self::Item>) -> Self::Path<Origin> {
+                fn new_path<__Origin>(path: #toasty::Path<__Origin, Self::Item>) -> Self::Path<__Origin> {
                     #field_struct_ident::from_path(path)
                 }
 
@@ -284,10 +284,10 @@ impl Expand<'_> {
             #[diagnostic::do_not_recommend]
             impl #toasty::Scope for #query_struct_ident<#toasty::Option<#model_ident>> {
                 type Item = #model_ident;
-                type Path<Origin> = #field_struct_ident<Origin>;
+                type Path<__Origin> = #field_struct_ident<__Origin>;
                 type Create = #create_builder_ident;
 
-                fn new_path<Origin>(path: #toasty::Path<Origin, Self::Item>) -> Self::Path<Origin> {
+                fn new_path<__Origin>(path: #toasty::Path<__Origin, Self::Item>) -> Self::Path<__Origin> {
                     #field_struct_ident::from_path(path)
                 }
 

--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -508,9 +508,9 @@ impl Expand<'_> {
 fn compat_check(ty: &syn::Type, bound: TokenStream) -> TokenStream {
     quote_spanned! { ty.span()=>
         const _: () = {
-            fn _check<__T>()
+            fn _check<T>()
             where
-                __T: #bound,
+                T: #bound,
             {}
             let _ = _check::<#ty>;
         };


### PR DESCRIPTION
## Summary

This PR cleans up the user-facing macro generics by removing the noisy `__` prefixes in `rustdoc` signatures and compiler error messages.

It changes generated signatures like `select<__E, __T>` to `select<E, T>`.

Let me know if I accidentally changed something that I shouldn't!

Closes #1010

Update: I realized I jumped the gun on `__Origin` and stripped its prefix without accounting for the def-site/mixed-site hygiene collision risk mentioned in the issue. I've reverted `__Origin` back to its original state to keep it safe for now. This PR now strictly targets the completely safe user-facing generics.

## Type of change

- [ x ] Small / obvious change — bug fix, docs, internal cleanup, or test
- [ ] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`):
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [ x ] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [ x ] `cargo fmt` and `cargo clippy` are clean
- [ x ] `cargo test` passes
- [ ] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [ ] Touches the `Driver` trait or driver-observable behavior → the design doc covers it