### PR TITLE
feat: implement serde serialization and deserialization for toasty::Json<T> and decode percent-encoded paths for file-backed databases(SQLite and Turso).

### DIFF
--- a/crates/toasty-driver-sqlite/Cargo.toml
+++ b/crates/toasty-driver-sqlite/Cargo.toml
@@ -23,6 +23,7 @@ serde_json.workspace = true
 tracing.workspace = true
 url.workspace = true
 uuid.workspace = true
+percent-encoding.workspace = true
 
 [lints]
 workspace = true

--- a/crates/toasty-driver-sqlite/src/lib.rs
+++ b/crates/toasty-driver-sqlite/src/lib.rs
@@ -431,3 +431,50 @@ impl Connection {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Sqlite;
+    use std::path::PathBuf;
+
+    /// The file path `Sqlite::new` resolves out of a `sqlite:` URL.
+    fn file_path(url: &str) -> PathBuf {
+        match Sqlite::new(url).unwrap() {
+            Sqlite::File(path) => path,
+            Sqlite::InMemory => panic!("expected a file-backed database for {url}"),
+        }
+    }
+
+    #[test]
+    fn new_decodes_percent_encoded_path() {
+        // `url::Url` stores the path percent-encoded: a space becomes `%20` and
+        // non-ASCII bytes become `%XX` sequences. The driver must decode it back
+        // before opening the file, otherwise it opens one whose name literally
+        // contains `%20`.
+        assert_eq!(
+            file_path("sqlite:/tmp/my db.sqlite"),
+            PathBuf::from("/tmp/my db.sqlite")
+        );
+        assert_eq!(
+            file_path("sqlite:///tmp/my%20db.sqlite"),
+            PathBuf::from("/tmp/my db.sqlite")
+        );
+        assert_eq!(
+            file_path("sqlite:/tmp/d%C3%A9j%C3%A0.db"),
+            PathBuf::from("/tmp/déjà.db")
+        );
+        // Percent-decoding, not form-decoding: a literal `+` must stay a `+`.
+        assert_eq!(
+            file_path("sqlite:/tmp/a+b.db"),
+            PathBuf::from("/tmp/a+b.db")
+        );
+    }
+
+    #[test]
+    fn new_memory_url_stays_in_memory() {
+        assert!(matches!(
+            Sqlite::new("sqlite::memory:").unwrap(),
+            Sqlite::InMemory
+        ));
+    }
+}

--- a/crates/toasty-driver-sqlite/src/lib.rs
+++ b/crates/toasty-driver-sqlite/src/lib.rs
@@ -81,7 +81,12 @@ impl Sqlite {
         if url.path() == ":memory:" {
             Ok(Self::InMemory)
         } else {
-            Ok(Self::File(PathBuf::from(url.path())))
+            Ok(Self::File(PathBuf::from(
+                percent_encoding::percent_decode(url.path().as_bytes())
+                    .decode_utf8_lossy()
+                    .to_string()
+                    .as_str(),
+            )))
         }
     }
 

--- a/crates/toasty-driver-turso/Cargo.toml
+++ b/crates/toasty-driver-turso/Cargo.toml
@@ -24,6 +24,7 @@ tracing.workspace = true
 turso.workspace = true
 url.workspace = true
 uuid.workspace = true
+percent-encoding.workspace = true
 
 [lints]
 workspace = true

--- a/crates/toasty-driver-turso/src/lib.rs
+++ b/crates/toasty-driver-turso/src/lib.rs
@@ -205,7 +205,12 @@ impl Turso {
         let path = if url.path() == ":memory:" {
             TursoPath::InMemory
         } else {
-            TursoPath::File(PathBuf::from(url.path()))
+            TursoPath::File(PathBuf::from(
+                percent_encoding::percent_decode(url.path().as_bytes())
+                    .decode_utf8_lossy()
+                    .to_string()
+                    .as_str(),
+            ))
         };
         Ok(Self::with_path(path))
     }

--- a/crates/toasty-driver-turso/src/lib.rs
+++ b/crates/toasty-driver-turso/src/lib.rs
@@ -658,3 +658,47 @@ impl toasty_core::driver::Connection for Connection {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{Turso, TursoPath};
+    use std::path::PathBuf;
+
+    /// The file path `Turso::new` resolves out of a `turso:` URL.
+    fn file_path(url: &str) -> PathBuf {
+        match Turso::new(url).unwrap().path {
+            TursoPath::File(path) => path,
+            TursoPath::InMemory => panic!("expected a file-backed database for {url}"),
+        }
+    }
+
+    #[test]
+    fn new_decodes_percent_encoded_path() {
+        // `url::Url` stores the path percent-encoded: a space becomes `%20` and
+        // non-ASCII bytes become `%XX` sequences. The driver must decode it back
+        // before opening the file, otherwise it opens one whose name literally
+        // contains `%20`.
+        assert_eq!(
+            file_path("turso:/tmp/my db.sqlite"),
+            PathBuf::from("/tmp/my db.sqlite")
+        );
+        assert_eq!(
+            file_path("turso:///tmp/my%20db.sqlite"),
+            PathBuf::from("/tmp/my db.sqlite")
+        );
+        assert_eq!(
+            file_path("turso:/tmp/d%C3%A9j%C3%A0.db"),
+            PathBuf::from("/tmp/déjà.db")
+        );
+        // Percent-decoding, not form-decoding: a literal `+` must stay a `+`.
+        assert_eq!(file_path("turso:/tmp/a+b.db"), PathBuf::from("/tmp/a+b.db"));
+    }
+
+    #[test]
+    fn new_memory_url_stays_in_memory() {
+        assert!(matches!(
+            Turso::new("turso::memory:").unwrap().path,
+            TursoPath::InMemory
+        ));
+    }
+}

--- a/crates/toasty/src/stmt/json.rs
+++ b/crates/toasty/src/stmt/json.rs
@@ -259,3 +259,27 @@ impl<T: fmt::Display> fmt::Display for Json<T> {
         self.0.fmt(f)
     }
 }
+
+impl<T> serde_core::Serialize for Json<T>
+where
+    T: serde_core::Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde_core::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de, T> serde_core::Deserialize<'de> for Json<T>
+where
+    T: serde_core::Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde_core::Deserializer<'de>,
+    {
+        T::deserialize(deserializer).map(Json)
+    }
+}


### PR DESCRIPTION
<!--
PR title uses Conventional Commits, e.g.
    feat: add upsert support
    fix: handle composite key in IN-list rewrite
See CONTRIBUTING.md for the full process.
-->

## Summary
Impl serde_core::Serialize and serde_core::Deserialize for Json<T>, so that the Serialize derive macro can be applied to model struct.
Decode percent-encoded paths for file-backed databases, so that paths that contains space or other spacial characters can be correctly handled.
## Type of change

<!-- Check one. -->

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

<!-- Anything reviewers should focus on. -->
