### PR TITLE
fix(cli): include the path in Toasty config load errors

### DIFF
--- a/crates/toasty-cli/src/config.rs
+++ b/crates/toasty-cli/src/config.rs
@@ -1,5 +1,5 @@
 use crate::migration::MigrationConfig;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
@@ -46,8 +46,17 @@ impl Config {
 
     /// Load configuration from a specific path.
     pub fn load_from(path: &Path) -> Result<Self> {
-        let contents = fs::read_to_string(path)?;
-        let config: Config = toml::from_str(&contents)?;
+        let contents = fs::read_to_string(path).with_context(|| {
+            format!(
+                "failed to read Toasty config file at `{}` — check that the file exists \
+                 at this path relative to the working directory (a common cause in Docker \
+                 multi-stage builds is forgetting to copy it into the final image)",
+                path.display()
+            )
+        })?;
+        let config: Config = toml::from_str(&contents).with_context(|| {
+            format!("failed to parse Toasty config file at `{}`", path.display())
+        })?;
         Ok(config)
     }
 
@@ -91,5 +100,19 @@ mod tests {
         let default = Config::default();
 
         assert_eq!(reparsed, default);
+    }
+
+    #[test]
+    fn load_from_missing_file_reports_path() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("Toasty.toml");
+
+        let err = Config::load_from(&path).unwrap_err();
+
+        let message = format!("{err:#}");
+        assert!(
+            message.contains(&path.display().to_string()),
+            "error message should mention the missing path: {message}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

`Config::load_from` propagated bare `io::Error`/`toml::de::Error` values
through `?`, so a missing or malformed `Toasty.toml` surfaced only as
`Error: No such file or directory (os error 2)` — with no indication of
*which* path Toasty was looking at. This is especially confusing in
contexts like multi-stage Docker builds, where forgetting to copy
`Toasty.toml` into the final image is an easy mistake to make blind.

This wraps both the read and parse steps with `anyhow::Context`, naming
the path and, for the read failure, hinting at the common Docker cause.

Closes #1032.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test
- [ ] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`):
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [ ] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [ ] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers

`Config::load`/`load_or_default` and the reporter's separate point about
production binaries not requiring `Toasty.toml` at all are left alone —
that's a behavioral question (should `load` fall back to defaults?)
beyond the scope of "the error message doesn't say which file is missing".
