### PR TITLE
feat: add set_* replace-variants to Query builder

### DIFF
--- a/crates/toasty-core/src/stmt/query.rs
+++ b/crates/toasty-core/src/stmt/query.rs
@@ -180,6 +180,15 @@ impl Query {
         self.body.as_select_mut_unwrap().add_filter(filter);
     }
 
+    /// Sets the filter for this query's `SELECT` body overwriting any existing one.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the query body is not a `SELECT`.
+    pub fn set_filter(&mut self, filter: impl Into<Filter>) {
+        self.body.as_select_mut_unwrap().filter = filter.into();
+    }
+
     /// Adds an association include path to this query's `SELECT` body.
     pub fn include(&mut self, path: impl Into<Path>) {
         match &mut self.body {

--- a/crates/toasty/src/stmt/query.rs
+++ b/crates/toasty/src/stmt/query.rs
@@ -139,6 +139,27 @@ impl<T> Query<T> {
         self
     }
 
+    /// Sets the filter, combined with AND, for this query overwriting existing ones.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[derive(Debug, toasty::Model)]
+    /// # struct User {
+    /// #     #[key]
+    /// #     id: i64,
+    /// #     name: String,
+    /// # }
+    /// use toasty::stmt::{List, Query};
+    ///
+    /// let mut q = Query::<List<User>>::all();
+    /// q.set_filter(User::fields().name().eq("Alice"));
+    /// ```
+    pub fn set_filter(&mut self, filter: Expr<bool>) -> &mut Self {
+        self.untyped.set_filter(filter);
+        self
+    }
+
     /// Eagerly load a related association when this query executes.
     ///
     /// `path` identifies the relation to include (e.g., a has-many or
@@ -200,6 +221,35 @@ impl<T> Query<T> {
             Some(existing) => existing.exprs.extend(order_by.exprs),
             None => self.untyped.order_by = Some(order_by),
         }
+        self
+    }
+
+    /// Sets the sort order for this query overwriting existing ones.
+    ///
+    /// Pass an [`OrderByExpr`](toasty_core::stmt::OrderByExpr) obtained from
+    /// [`Path::asc`] or [`Path::desc`], or a tuple of them to sort by several
+    /// fields at once. Calling `order_by` multiple times appends each
+    /// expression to the existing order, so later calls act as tie-breakers
+    /// for earlier ones.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[derive(Debug, toasty::Model)]
+    /// # struct User {
+    /// #     #[key]
+    /// #     id: i64,
+    /// #     name: String,
+    /// #     age: i64
+    /// # }
+    /// use toasty::stmt::{List, Query};
+    ///
+    /// let mut q = Query::<List<User>>::all();
+    /// q.set_order_by(User::fields().name().desc());
+    /// ```
+    pub fn set_order_by(&mut self, order_by: impl Into<stmt::OrderBy>) -> &mut Self {
+        let order_by = order_by.into();
+        self.untyped.order_by = Some(order_by);
         self
     }
 


### PR DESCRIPTION
## Summary
This adds the methods `set_order_by` and `set_filter` to the `toasty::stmt::Query` type as proposed in #902 to allow for overwriting prior `order_by` or `filter` statements without starting a new query.
Although the changes do touch a public API of the `toasty::stmt::Query` type, #902 clearly states that no design doc is required for this quite small change.

Closes #902 

## Type of change
Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior

## Notes for reviewers
This is my first contribution to toasty so if I made some mistakes regarding the contribution conduct, please point me into the right direction for future contributions :)