### PR TITLE
feat: add escape support for like expr

### DIFF
--- a/crates/toasty-core/src/stmt/expr_like.rs
+++ b/crates/toasty-core/src/stmt/expr_like.rs
@@ -50,6 +50,32 @@ impl Expr {
         }
         .into()
     }
+
+    /// Creates a `expr LIKE pattern` expression with escape character.
+    pub fn like_with_escape(expr: impl Into<Self>, pattern: impl Into<Self>, escape: char) -> Self {
+        ExprLike {
+            expr: Box::new(expr.into()),
+            pattern: Box::new(pattern.into()),
+            escape: Some(escape),
+            case_insensitive: false,
+        }
+        .into()
+    }
+
+    /// Creates a `expr ILIKE pattern` expression with escape character.
+    pub fn ilike_with_escape(
+        expr: impl Into<Self>,
+        pattern: impl Into<Self>,
+        escape: char,
+    ) -> Self {
+        ExprLike {
+            expr: Box::new(expr.into()),
+            pattern: Box::new(pattern.into()),
+            escape: Some(escape),
+            case_insensitive: true,
+        }
+        .into()
+    }
 }
 
 impl From<ExprLike> for Expr {

--- a/crates/toasty-driver-integration-suite/src/tests/filter_like.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/filter_like.rs
@@ -89,3 +89,92 @@ pub async fn like_optional_field(test: &mut Test) -> Result<()> {
 
     Ok(())
 }
+
+#[driver_test(requires(sql), scenario(crate::scenarios::fixed_item_name))]
+pub async fn like_escape_percent(t: &mut Test) -> Result<()> {
+    let mut db = setup(t).await;
+
+    toasty::create!(Item::[
+        { id: 1_i64, name: "Alice%1" },
+        { id: 2_i64, name: "AliceA1" },
+        { id: 3_i64, name: "Alice"  },
+    ])
+    .exec(&mut db)
+    .await
+    .unwrap();
+
+    let mut items: Vec<Item> = Item::filter(
+        Item::fields()
+            .name()
+            .like_with_escape("Alice\\%%".to_string(), '\\'),
+    )
+    .exec(&mut db)
+    .await?;
+
+    items.sort_by(|a, b| a.name.cmp(&b.name));
+
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].name, "Alice%1");
+
+    Ok(())
+}
+
+#[driver_test(requires(sql), scenario(crate::scenarios::fixed_item_name))]
+pub async fn like_escape_underscore(t: &mut Test) -> Result<()> {
+    let mut db = setup(t).await;
+
+    toasty::create!(Item::[
+        { id: 1_i64, name: "foo_bar" },
+        { id: 2_i64, name: "fooXbar" },
+        { id: 3_i64, name: "foobar"  },
+    ])
+    .exec(&mut db)
+    .await
+    .unwrap();
+
+    let mut items: Vec<Item> = Item::filter(
+        Item::fields()
+            .name()
+            .like_with_escape("foo\\_bar".to_string(), '\\'),
+    )
+    .exec(&mut db)
+    .await?;
+
+    items.sort_by(|a, b| a.name.cmp(&b.name));
+
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].name, "foo_bar");
+
+    Ok(())
+}
+
+#[driver_test(requires(sql), scenario(crate::scenarios::fixed_item_name))]
+pub async fn like_escape_keeps_wildcards(t: &mut Test) -> Result<()> {
+    let mut db = setup(t).await;
+
+    toasty::create!(Item::[
+        { id: 1_i64, name: "Alice%1" },
+        { id: 2_i64, name: "Alice%2" },
+        { id: 3_i64, name: "AliceA1" },
+        { id: 4_i64, name: "Bob"     },
+    ])
+    .exec(&mut db)
+    .await
+    .unwrap();
+
+    let mut items: Vec<Item> = Item::filter(
+        Item::fields()
+            .name()
+            .like_with_escape("Alice\\%%".to_string(), '\\'),
+    )
+    .exec(&mut db)
+    .await?;
+
+    items.sort_by(|a, b| a.name.cmp(&b.name));
+
+    assert_eq!(items.len(), 2);
+    assert_eq!(items[0].name, "Alice%1");
+    assert_eq!(items[1].name, "Alice%2");
+
+    Ok(())
+}

--- a/crates/toasty-sql/src/serializer/expr.rs
+++ b/crates/toasty-sql/src/serializer/expr.rs
@@ -119,7 +119,12 @@ impl ToSql for &stmt::Expr {
                     };
                 fmt!(f, expr.expr op expr.pattern);
                 if let Some(escape) = expr.escape {
-                    let escape = &stmt::Value::String(escape.to_string());
+                    let escape = if f.serializer.is_mysql() && escape == '\\' {
+                        stmt::Value::String("\\\\".to_string())
+                    } else {
+                        stmt::Value::String(escape.to_string())
+                    };
+                    let escape = &escape;
                     fmt!(f, " ESCAPE " escape);
                 }
             }

--- a/crates/toasty/src/stmt/path.rs
+++ b/crates/toasty/src/stmt/path.rs
@@ -656,6 +656,112 @@ where
             _p: PhantomData,
         }
     }
+
+    /// Test whether this string field matches a SQL `LIKE` pattern using an
+    /// explicit escape character.
+    ///
+    /// Available on any string-valued field, including `String`,
+    /// `Option<String>`, and other wrappers whose `Field::Inner` is `String`.
+    ///
+    /// The caller is responsible for constructing the `LIKE` pattern. Toasty does
+    /// not escape `pattern` automatically. Any `%` or `_` characters that are not
+    /// escaped by `escape` are treated as SQL `LIKE` wildcards:
+    ///
+    /// - `%` matches any sequence of characters.
+    /// - `_` matches any single character.
+    /// - `escape` followed by `%`, `_`, or `escape` matches that character
+    ///   literally.
+    ///
+    /// This is useful when the pattern needs to match literal `%` or `_`
+    /// characters. For example, with `escape` set to `'\\'`, the pattern
+    /// `"Alice\\%%"` matches strings beginning with the literal text `"Alice%"`.
+    /// The first `%` is escaped and matched literally; the second `%` remains a
+    /// wildcard.
+    ///
+    /// Not supported by the DynamoDB driver. Use [`starts_with`](Self::starts_with)
+    /// instead when targeting DynamoDB.
+    ///
+    /// `.like_with_escape()` is a pass-through to the database's own `LIKE`
+    /// operator with an `ESCAPE` clause. Case sensitivity differs by backend:
+    /// case-sensitive on PostgreSQL, case-insensitive for ASCII on SQLite, and
+    /// collation-dependent on MySQL. For a case-insensitive match on PostgreSQL,
+    /// use [`ilike`](Self::ilike).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[derive(Debug, toasty::Model)]
+    /// # struct User {
+    /// #     #[key]
+    /// #     id: i64,
+    /// #     name: String,
+    /// #     nickname: Option<String>,
+    /// # }
+    /// // Match names starting with "Al".
+    /// let filter = User::fields().name().like_with_escape("Al%".to_string(), '\\');
+    ///
+    /// // Match names starting with the literal text "Alice%".
+    /// let filter = User::fields().name().like_with_escape("Alice\\%%".to_string(), '\\');
+    ///
+    /// // Also works on nullable string fields.
+    /// let filter = User::fields().nickname().like_with_escape("Al%".to_string(), '\\');
+    /// ```
+    pub fn like_with_escape(self, pattern: impl IntoExpr<String>, escape: char) -> Expr<bool> {
+        let pattern = pattern.into_expr().untyped;
+        self.build_filter(move |path| stmt::Expr::like_with_escape(path, pattern, escape))
+    }
+
+    /// Test whether this string field matches a case-insensitive SQL `LIKE`
+    /// pattern using an explicit escape character.
+    ///
+    /// This is the escaped variant of [`ilike`](Self::ilike). It maps to
+    /// PostgreSQL's `ILIKE ... ESCAPE ...` syntax.
+    ///
+    /// PostgreSQL is the only supported backend with a native `ILIKE`, so
+    /// `.ilike_with_escape()` works only there. Toasty does not emulate it: on
+    /// MySQL, SQLite, and DynamoDB the query is rejected with an
+    /// unsupported-feature error.
+    ///
+    /// The caller is responsible for constructing the `ILIKE` pattern. Toasty does
+    /// not escape `pattern` automatically. Any `%` or `_` characters that are not
+    /// escaped by `escape` are treated as SQL pattern wildcards:
+    ///
+    /// - `%` matches any sequence of characters.
+    /// - `_` matches any single character.
+    /// - `escape` followed by `%`, `_`, or `escape` matches that character
+    ///   literally.
+    ///
+    /// This is useful when the pattern needs to match literal `%` or `_`
+    /// characters while still matching case-insensitively. For example, with
+    /// `escape` set to `'\\'`, the pattern `"Alice\\%%"` matches strings beginning
+    /// with the literal text `"Alice%"`, ignoring case. It can match `"Alice%1"`,
+    /// `"ALICE%1"`, or `"alice%foo"`, but not `"AliceA1"`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[derive(Debug, toasty::Model)]
+    /// # struct User {
+    /// #     #[key]
+    /// #     id: i64,
+    /// #     name: String,
+    /// # }
+    /// // Match names starting with "al", ignoring case.
+    /// let filter = User::fields().name().ilike_with_escape("al%".to_string(), '\\');
+    ///
+    /// // Match names starting with the literal text "alice%", ignoring case.
+    /// let filter = User::fields().name().ilike_with_escape("alice\\%%".to_string(), '\\');
+    /// ```
+    pub fn ilike_with_escape(self, pattern: impl IntoExpr<String>, escape: char) -> Expr<bool> {
+        Expr {
+            untyped: stmt::Expr::ilike_with_escape(
+                self.untyped.into_stmt(),
+                pattern.into_expr().untyped,
+                escape,
+            ),
+            _p: PhantomData,
+        }
+    }
 }
 
 impl<T, U> Clone for Path<T, U> {


### PR DESCRIPTION
## Summary

Expose the existing `ESCAPE` clause support for `LIKE` / `ILIKE` through the
public query DSL.

`ExprLike` already carries an `escape: Option<char>` field and `toasty-sql`
already serializes it as `LIKE ... ESCAPE ...`, but there was no way to set it
from user code. This adds:

- `Expr::like_with_escape()` / `Expr::ilike_with_escape()` constructors in
  `toasty-core`
- `.like_with_escape(pattern, escape)` / `.ilike_with_escape(pattern, escape)`
  on string-valued field paths in the `toasty` DSL

Both are pass-throughs to the backend's native operator, following the design
philosophy for `.like()` / `.ilike()`: `like_with_escape` works on all SQL
backends with backend-native case sensitivity; `ilike_with_escape` is
PostgreSQL-only and rejected elsewhere with `unsupported_feature`. Toasty does
not escape the pattern automatically — the caller constructs it, and the escape
character makes `%` / `_` matchable as literals.

## Type of change

- [x] Other (please explain): public-API extension mirroring the existing
      `.like()` / `.ilike()` methods; no new driver-layer behavior, the AST
      field and SQL serialization already existed.

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- Touches a public API, but follows the established `.like()` / `.ilike()`
  pass-through pattern, which has no design doc; the `Driver` trait and
  driver-observable behavior are unchanged.

## Notes for reviewers

- Integration tests cover escaping `%`, escaping `_`, and that unescaped
  wildcards in the same pattern still act as wildcards
  (`crates/toasty-driver-integration-suite/src/tests/filter_like.rs`). They are
  gated with `requires(sql)` since DynamoDB has no `LIKE`.
- There is currently no test exercising `ilike_with_escape` against PostgreSQL.