### PR TITLE
test(tests): cover Query set_filter and set_order_by replace-variants

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/crud_query.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/crud_query.rs
@@ -244,6 +244,30 @@ pub async fn query_local_key_cmp(test: &mut Test) -> Result<()> {
 }
 
 #[driver_test(id(ID), scenario(crate::scenarios::user_with_age))]
+pub async fn set_filter_overwrites(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    toasty::create!(User::[
+        { name: "Alice", age: 30 },
+        { name: "Bob", age: 20 },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    // `set_filter` replaces the existing filter rather than AND-combining it.
+    // If it combined, `name = "Alice" AND name = "Bob"` would match nothing.
+    use toasty::stmt::{List, Query};
+    let mut q = Query::<List<User>>::all().filter(User::fields().name().eq("Alice"));
+    q.set_filter(User::fields().name().eq("Bob"));
+
+    let users = q.exec(&mut db).await?;
+
+    assert_eq!(1, users.len());
+    assert_eq!("Bob", users[0].name);
+    Ok(())
+}
+
+#[driver_test(id(ID), scenario(crate::scenarios::user_with_age))]
 pub async fn query_or_basic(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
     let _name_column = db.schema().table_for(User::id()).columns[1].id;

--- a/crates/toasty-driver-integration-suite/src/tests/crud_sort_limit.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/crud_sort_limit.rs
@@ -263,6 +263,32 @@ pub async fn order_by_multiple_columns_composes(t: &mut Test) -> Result<()> {
 }
 
 #[driver_test(id(ID), scenario(crate::scenarios::user_with_age), requires(sql))]
+pub async fn set_order_by_overwrites(t: &mut Test) -> Result<()> {
+    let mut db = setup(t).await;
+
+    toasty::create!(User::[
+        { name: "Alice", age: 30 },
+        { name: "Bob",   age: 20 },
+        { name: "Carol", age: 40 },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    // `set_order_by` replaces the existing sort rather than appending to it.
+    // Overwriting an ascending sort with a descending one must produce a
+    // descending result, not an asc-then-desc tie-break.
+    use toasty::stmt::{List, Query};
+    let mut q = Query::<List<User>>::all().order_by(User::fields().age().asc());
+    q.set_order_by(User::fields().age().desc());
+
+    let users = q.exec(&mut db).await?;
+
+    let ages: Vec<i64> = users.iter().map(|u| u.age).collect();
+    assert_eq!(ages, [40, 30, 20]);
+    Ok(())
+}
+
+#[driver_test(id(ID), scenario(crate::scenarios::user_with_age), requires(sql))]
 pub async fn order_by_tuple(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 


### PR DESCRIPTION
Exercise the overwrite semantics added in #1037: set_filter replaces the
existing filter instead of AND-combining, and set_order_by replaces the
existing sort instead of appending.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015DVfxy1stZnkHTHjUiw2xz