### PR TITLE
fix(engine,dynamodb): make multi-key delete and update consistent

### DIFF
--- a/crates/toasty-driver-dynamodb/src/op/delete_by_key.rs
+++ b/crates/toasty-driver-dynamodb/src/op/delete_by_key.rs
@@ -43,134 +43,84 @@ impl Connection {
         }
 
         if unique_indices.is_empty() {
-            if op.keys.len() == 1 {
-                let key = &op.keys[0];
+            // The engine shreds multi-key deletes into one op per key, so a
+            // non-unique-index delete always carries exactly one key.
+            let [key] = &op.keys[..] else {
+                panic!("expected exactly 1 key, got {}", op.keys.len());
+            };
 
-                let mut req = self
-                    .client
-                    .delete_item()
-                    .table_name(&table.name)
-                    .set_key(Some(ddb_key(table, key)))
-                    .set_expression_attribute_names(if condition_expression.is_some() {
-                        Some(expr_attrs.attr_names)
-                    } else {
-                        None
-                    })
-                    .set_expression_attribute_values(if condition_expression.is_some() {
-                        Some(expr_attrs.attr_values)
-                    } else {
-                        None
-                    })
-                    .set_condition_expression(condition_expression);
+            let mut req = self
+                .client
+                .delete_item()
+                .table_name(&table.name)
+                .set_key(Some(ddb_key(table, key)))
+                .set_expression_attribute_names(if condition_expression.is_some() {
+                    Some(expr_attrs.attr_names)
+                } else {
+                    None
+                })
+                .set_expression_attribute_values(if condition_expression.is_some() {
+                    Some(expr_attrs.attr_values)
+                } else {
+                    None
+                })
+                .set_condition_expression(condition_expression);
 
-                if has_condition || filter_expr.is_some() {
-                    req = req.return_values_on_condition_check_failure(
-                        ReturnValuesOnConditionCheckFailure::AllOld,
-                    );
-                }
+            if has_condition || filter_expr.is_some() {
+                req = req.return_values_on_condition_check_failure(
+                    ReturnValuesOnConditionCheckFailure::AllOld,
+                );
+            }
 
-                let res = req.send().await;
+            let res = req.send().await;
 
-                if let Err(SdkError::ServiceError(e)) = res {
-                    if let DeleteItemError::ConditionalCheckFailedException(cce) = e.err() {
-                        if !has_condition {
-                            // Pure filter failure → count 0
-                            return Ok(ExecResponse::count(0));
-                        }
-
-                        if let Some(filter) = filter_expr {
-                            // Both filter and condition set — check if filter matched
-                            if let Some(old_item) = cce.item() {
-                                let record =
-                                    item_to_record(old_item, table.columns.iter()).unwrap();
-                                use toasty_core::stmt;
-                                struct RecordInput<'a>(&'a stmt::ValueRecord);
-                                impl stmt::Input for RecordInput<'_> {
-                                    fn resolve_ref(
-                                        &mut self,
-                                        expr_reference: &stmt::ExprReference,
-                                        projection: &stmt::Projection,
-                                    ) -> Option<stmt::Expr> {
-                                        match expr_reference {
-                                            stmt::ExprReference::Column(col) => Some(
-                                                self.0.fields[col.column]
-                                                    .entry(projection)
-                                                    .to_expr(),
-                                            ),
-                                            _ => None,
-                                        }
-                                    }
-                                }
-                                if !filter.eval_bool(RecordInput(&record)).unwrap_or(false) {
-                                    return Ok(ExecResponse::count(0));
-                                }
-                            } else {
-                                // Record gone — filter trivially didn't match
-                                return Ok(ExecResponse::count(0));
-                            }
-                        }
-
-                        return Err(toasty_core::Error::condition_failed(
-                            "DynamoDB conditional check failed",
-                        ));
+            if let Err(SdkError::ServiceError(e)) = res {
+                if let DeleteItemError::ConditionalCheckFailedException(cce) = e.err() {
+                    if !has_condition {
+                        // Pure filter failure → count 0
+                        return Ok(ExecResponse::count(0));
                     }
 
-                    return Err(toasty_core::Error::driver_operation_failed(
-                        SdkError::ServiceError(e),
+                    if let Some(filter) = filter_expr {
+                        // Both filter and condition set — check if filter matched
+                        if let Some(old_item) = cce.item() {
+                            let record = item_to_record(old_item, table.columns.iter()).unwrap();
+                            use toasty_core::stmt;
+                            struct RecordInput<'a>(&'a stmt::ValueRecord);
+                            impl stmt::Input for RecordInput<'_> {
+                                fn resolve_ref(
+                                    &mut self,
+                                    expr_reference: &stmt::ExprReference,
+                                    projection: &stmt::Projection,
+                                ) -> Option<stmt::Expr> {
+                                    match expr_reference {
+                                        stmt::ExprReference::Column(col) => Some(
+                                            self.0.fields[col.column].entry(projection).to_expr(),
+                                        ),
+                                        _ => None,
+                                    }
+                                }
+                            }
+                            if !filter.eval_bool(RecordInput(&record)).unwrap_or(false) {
+                                return Ok(ExecResponse::count(0));
+                            }
+                        } else {
+                            // Record gone — filter trivially didn't match
+                            return Ok(ExecResponse::count(0));
+                        }
+                    }
+
+                    return Err(toasty_core::Error::condition_failed(
+                        "DynamoDB conditional check failed",
                     ));
                 }
 
-                return Ok(ExecResponse::count(1));
-            } else {
-                let mut transact_items = vec![];
-
-                for key in &op.keys {
-                    transact_items.push(
-                        TransactWriteItem::builder()
-                            .delete(
-                                Delete::builder()
-                                    .table_name(&table.name)
-                                    .set_key(Some(ddb_key(table, key)))
-                                    .set_expression_attribute_names(
-                                        if condition_expression.is_some() {
-                                            Some(expr_attrs.attr_names.clone())
-                                        } else {
-                                            None
-                                        },
-                                    )
-                                    .set_expression_attribute_values(
-                                        if condition_expression.is_some() {
-                                            Some(expr_attrs.attr_values.clone())
-                                        } else {
-                                            None
-                                        },
-                                    )
-                                    .set_condition_expression(condition_expression.clone())
-                                    .build()
-                                    .unwrap(),
-                            )
-                            .build(),
-                    );
-                }
-
-                let res = self
-                    .client
-                    .transact_write_items()
-                    .set_transact_items(Some(transact_items))
-                    .send()
-                    .await;
-
-                if let Err(SdkError::ServiceError(e)) = res {
-                    if has_condition {
-                        return Err(toasty_core::Error::condition_failed(
-                            "DynamoDB conditional check failed",
-                        ));
-                    }
-                    todo!("err={:#?}", e);
-                }
-
-                return Ok(ExecResponse::count(op.keys.len() as _));
+                return Err(toasty_core::Error::driver_operation_failed(
+                    SdkError::ServiceError(e),
+                ));
             }
+
+            return Ok(ExecResponse::count(1));
         }
 
         let [key] = &op.keys[..] else {

--- a/crates/toasty-driver-dynamodb/src/op/update_by_key.rs
+++ b/crates/toasty-driver-dynamodb/src/op/update_by_key.rs
@@ -300,102 +300,39 @@ impl Connection {
 
         match &unique_indices[..] {
             [] => {
-                if op.keys.len() == 1 {
-                    let key = &op.keys[0];
+                // The engine shreds multi-key updates into one op per key, so a
+                // non-unique-index update always carries exactly one key.
+                let [key] = &op.keys[..] else {
+                    panic!("expected exactly 1 key, got {}", op.keys.len());
+                };
 
-                    let res = self
-                        .client
-                        .update_item()
-                        .table_name(&table.name)
-                        .set_key(Some(ddb_key(table, key)))
-                        .set_update_expression(Some(update_expression))
-                        .set_expression_attribute_names(Some(expr_attrs.attr_names))
-                        .set_expression_attribute_values(if !expr_attrs.attr_values.is_empty() {
-                            Some(expr_attrs.attr_values)
-                        } else {
-                            None
-                        })
-                        .set_condition_expression(filter_expression)
-                        .return_values_on_condition_check_failure(
-                            ReturnValuesOnConditionCheckFailure::AllOld,
-                        )
-                        .set_return_values(needs_updated_new.then_some(ReturnValue::UpdatedNew))
-                        .send()
-                        .await;
+                let res = self
+                    .client
+                    .update_item()
+                    .table_name(&table.name)
+                    .set_key(Some(ddb_key(table, key)))
+                    .set_update_expression(Some(update_expression))
+                    .set_expression_attribute_names(Some(expr_attrs.attr_names))
+                    .set_expression_attribute_values(if !expr_attrs.attr_values.is_empty() {
+                        Some(expr_attrs.attr_values)
+                    } else {
+                        None
+                    })
+                    .set_condition_expression(filter_expression)
+                    .return_values_on_condition_check_failure(
+                        ReturnValuesOnConditionCheckFailure::AllOld,
+                    )
+                    .set_return_values(needs_updated_new.then_some(ReturnValue::UpdatedNew))
+                    .send()
+                    .await;
 
-                    let output = match res {
-                        Ok(output) => output,
-                        Err(SdkError::ServiceError(e)) => {
-                            if let UpdateItemError::ConditionalCheckFailedException(cce) = e.err() {
-                                return on_update_item_condition_failed(
-                                    cce.item(),
-                                    cce.message.as_deref(),
-                                    table,
-                                    op.filter.as_ref(),
-                                    op.returning.is_some(),
-                                );
-                            }
-                            return Err(toasty_core::Error::driver_operation_failed(
-                                SdkError::ServiceError(e),
-                            ));
-                        }
-                        Err(other) => {
-                            return Err(toasty_core::Error::driver_operation_failed(other));
-                        }
-                    };
-
-                    if needs_updated_new && let Some(attrs) = output.attributes() {
-                        for (idx, column) in &refresh_after_update {
-                            if let Some(attr) = attrs.get(&column.name) {
-                                ret[*idx] = Value::from_ddb(&column.ty, attr).into_inner();
-                            }
-                        }
-                    }
-                } else {
-                    let mut transact_items = vec![];
-
-                    for key in &op.keys {
-                        transact_items.push(
-                            TransactWriteItem::builder()
-                                .update(
-                                    Update::builder()
-                                        .table_name(&table.name)
-                                        .set_key(Some(ddb_key(table, key)))
-                                        .set_update_expression(Some(update_expression.clone()))
-                                        .set_expression_attribute_names(Some(
-                                            expr_attrs.attr_names.clone(),
-                                        ))
-                                        .set_expression_attribute_values(
-                                            if !expr_attrs.attr_values.is_empty() {
-                                                Some(expr_attrs.attr_values.clone())
-                                            } else {
-                                                None
-                                            },
-                                        )
-                                        .set_condition_expression(filter_expression.clone())
-                                        .return_values_on_condition_check_failure(
-                                            ReturnValuesOnConditionCheckFailure::AllOld,
-                                        )
-                                        .build()
-                                        .unwrap(),
-                                )
-                                .build(),
-                        );
-                    }
-
-                    let res = self
-                        .client
-                        .transact_write_items()
-                        .set_transact_items(Some(transact_items))
-                        .send()
-                        .await;
-
-                    if let Err(SdkError::ServiceError(e)) = res {
-                        if let TransactWriteItemsError::TransactionCanceledException(tce) = e.err()
-                        {
-                            return on_transaction_cancelled(
-                                tce.cancellation_reasons(),
-                                tce.message(),
+                let output = match res {
+                    Ok(output) => output,
+                    Err(SdkError::ServiceError(e)) => {
+                        if let UpdateItemError::ConditionalCheckFailedException(cce) = e.err() {
+                            return on_update_item_condition_failed(
+                                cce.item(),
+                                cce.message.as_deref(),
                                 table,
                                 op.filter.as_ref(),
                                 op.returning.is_some(),
@@ -404,6 +341,17 @@ impl Connection {
                         return Err(toasty_core::Error::driver_operation_failed(
                             SdkError::ServiceError(e),
                         ));
+                    }
+                    Err(other) => {
+                        return Err(toasty_core::Error::driver_operation_failed(other));
+                    }
+                };
+
+                if needs_updated_new && let Some(attrs) = output.attributes() {
+                    for (idx, column) in &refresh_after_update {
+                        if let Some(attr) = attrs.get(&column.name) {
+                            ret[*idx] = Value::from_ddb(&column.ty, attr).into_inner();
+                        }
                     }
                 }
             }

--- a/crates/toasty-driver-integration-suite/src/tests/crud_partitioned.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/crud_partitioned.rs
@@ -71,8 +71,9 @@ pub async fn update_by_partition_key(test: &mut Test) {
             values: Rows::Count(_),
         });
     } else {
-        // NoSQL: first a QueryPk to collect all matching PKs, then UpdateByKey
-        // for every matched record.
+        // NoSQL: first a QueryPk to collect all matching PKs, then one
+        // single-key UpdateByKey per matched record (the engine shreds
+        // multi-key updates so each key is adjudicated independently).
         let (op, _) = test.log().pop();
 
         assert_struct!(op, Operation::QueryPk({
@@ -81,20 +82,22 @@ pub async fn update_by_partition_key(test: &mut Test) {
             filter: None,
         }));
 
-        let (op, resp) = test.log().pop();
-
         // Column index 2 = title (id=0, user_id=1, title=2).
-        assert_struct!(op, Operation::UpdateByKey({
-            table: == todo_table_id,
-            keys.len(): 2,
-            assignments: #{ [2]: Assignment::Set(== "updated")},
-            filter: None,
-            returning: None,
-        }));
+        for _ in 0..2 {
+            let (op, resp) = test.log().pop();
 
-        assert_struct!(resp, {
-            values: Rows::Count(2),
-        });
+            assert_struct!(op, Operation::UpdateByKey({
+                table: == todo_table_id,
+                keys.len(): 1,
+                assignments: #{ [2]: Assignment::Set(== "updated")},
+                filter: None,
+                returning: None,
+            }));
+
+            assert_struct!(resp, {
+                values: Rows::Count(1),
+            });
+        }
     }
 
     assert!(test.log().is_empty(), "log should be empty after update");

--- a/crates/toasty-driver-integration-suite/src/tests/dynamodb_update_batch_filter.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/dynamodb_update_batch_filter.rs
@@ -3,13 +3,14 @@
 //! When a compound filter is applied to an update (e.g. secondary-index column
 //! AND non-indexed column), the planner routes it through `UpdateByKey` with
 //! `keys` populated from a `FindPkByIndex` scan and `filter` set to the
-//! non-indexed predicate.  With multiple keys the driver uses
-//! `transact_write_items`; if any item fails the filter condition DynamoDB
-//! returns `TransactionCanceledException`.
+//! non-indexed predicate.  The engine shreds the multi-key update into one
+//! single-key `UpdateByKey` op per key, so each key's filter is adjudicated
+//! independently — matching SQL's per-row semantics.  These updates are not
+//! atomic.
 //!
-//! Before the fix the driver hit `todo!()` on that error.  These tests verify
-//! the corrected semantics: filter miss → count 0 (no panic), no miss → all
-//! items updated.
+//! These tests verify the per-row semantics: every key matching → all updated,
+//! no key matching → none updated, and a partial match → only the matching
+//! subset is updated.
 
 use crate::prelude::*;
 
@@ -51,9 +52,63 @@ pub async fn batch_update_filter_all_match(t: &mut Test) -> Result<()> {
     Ok(())
 }
 
-/// No items match the filter — the transact_write_items call is cancelled with
-/// ConditionalCheckFailed for every item.  The driver must return count 0 rather
-/// than panicking.
+/// A subset of items match the filter — only the matching keys are updated;
+/// the rest are left untouched.  A single `transact_write_items` could not
+/// express this (any condition failure cancels the whole transaction), so this
+/// is the case that shredding fixes.
+#[driver_test(requires(not(sql)), scenario(crate::scenarios::tagged_item))]
+pub async fn batch_update_filter_partial_match(t: &mut Test) -> Result<()> {
+    let mut db = setup(t).await;
+
+    toasty::create!(Item {
+        tag: "batch",
+        status: "active",
+        name: "alpha"
+    })
+    .exec(&mut db)
+    .await?;
+    toasty::create!(Item {
+        tag: "batch",
+        status: "inactive",
+        name: "beta"
+    })
+    .exec(&mut db)
+    .await?;
+    toasty::create!(Item {
+        tag: "batch",
+        status: "active",
+        name: "gamma"
+    })
+    .exec(&mut db)
+    .await?;
+
+    // alpha and gamma match (status == active); beta does not.
+    Item::filter(
+        Item::fields()
+            .tag()
+            .eq("batch")
+            .and(Item::fields().status().eq("active")),
+    )
+    .update()
+    .name("updated")
+    .exec(&mut db)
+    .await?;
+
+    let items: Vec<Item> = Item::filter_by_tag("batch").exec(&mut db).await?;
+    assert_eq!(3, items.len());
+    for item in &items {
+        if item.status == "active" {
+            assert_eq!(item.name, "updated");
+        } else {
+            assert_eq!(item.name, "beta");
+        }
+    }
+
+    Ok(())
+}
+
+/// No items match the filter — every key's filter misses, so nothing is
+/// updated and the call returns count 0.
 #[driver_test(requires(not(sql)), scenario(crate::scenarios::tagged_item))]
 pub async fn batch_update_filter_no_match(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;

--- a/crates/toasty/src/engine/exec/update_by_key.rs
+++ b/crates/toasty/src/engine/exec/update_by_key.rs
@@ -48,27 +48,22 @@ impl Exec<'_> {
         // filter is adjudicated independently — matching SQL's per-row
         // semantics, and mirroring how delete fans out. These updates are not
         // atomic.
-        let res = if action.returning.is_some() {
-            let mut rows = vec![];
+        let mut total_count = 0u64;
+        let mut rows = vec![];
 
-            for key in keys {
-                let res = self.exec_update_one(action, key).await?;
-
-                debug_assert!(!res.is_count());
-                rows.extend(res.into_value_stream().collect().await?);
+        for key in keys {
+            match self.exec_update_one(action, key).await? {
+                Rows::Count(n) => total_count += n,
+                other => rows.extend(other.into_value_stream().collect().await?),
             }
+        }
 
+        // The output shape is a property of the action, not the results: with
+        // zero keys there is nothing to match on, yet a `returning` update must
+        // still yield an (empty) stream rather than a count.
+        let res = if action.returning.is_some() {
             Rows::value_stream(ValueStream::from_vec(rows))
         } else {
-            let mut total_count = 0u64;
-
-            for key in keys {
-                match self.exec_update_one(action, key).await? {
-                    Rows::Count(n) => total_count += n,
-                    _ => panic!("expected Count from UpdateByKey"),
-                }
-            }
-
             Rows::Count(total_count)
         };
 

--- a/crates/toasty/src/engine/exec/update_by_key.rs
+++ b/crates/toasty/src/engine/exec/update_by_key.rs
@@ -44,27 +44,32 @@ impl Exec<'_> {
             .await?
             .into_list_unwrap();
 
-        let res = if keys.is_empty() {
-            if action.returning.is_some() {
-                Rows::value_stream(ValueStream::default())
-            } else {
-                Rows::Count(0)
+        // Shred a multi-key update into one single-key op per key so each key's
+        // filter is adjudicated independently — matching SQL's per-row
+        // semantics, and mirroring how delete fans out. These updates are not
+        // atomic.
+        let res = if action.returning.is_some() {
+            let mut rows = vec![];
+
+            for key in keys {
+                let res = self.exec_update_one(action, key).await?;
+
+                debug_assert!(!res.is_count());
+                rows.extend(res.into_value_stream().collect().await?);
             }
+
+            Rows::value_stream(ValueStream::from_vec(rows))
         } else {
-            let op = operation::UpdateByKey {
-                table: action.table,
-                keys,
-                assignments: action.assignments.clone(),
-                filter: action.filter.clone(),
-                condition: action.condition.clone(),
-                returning: action.returning.clone(),
-            };
+            let mut total_count = 0u64;
 
-            let res = self.connection.exec(&self.engine.schema, op.into()).await?;
+            for key in keys {
+                match self.exec_update_one(action, key).await? {
+                    Rows::Count(n) => total_count += n,
+                    _ => panic!("expected Count from UpdateByKey"),
+                }
+            }
 
-            debug_assert_eq!(!res.values.is_count(), action.returning.is_some());
-
-            res.values
+            Rows::Count(total_count)
         };
 
         self.vars.store(
@@ -74,6 +79,24 @@ impl Exec<'_> {
         );
 
         Ok(())
+    }
+
+    /// Execute a single-key `UpdateByKey` op for one resolved key.
+    async fn exec_update_one(&mut self, action: &UpdateByKey, key: stmt::Value) -> Result<Rows> {
+        let op = operation::UpdateByKey {
+            table: action.table,
+            keys: vec![key],
+            assignments: action.assignments.clone(),
+            filter: action.filter.clone(),
+            condition: action.condition.clone(),
+            returning: action.returning.clone(),
+        };
+
+        let res = self.connection.exec(&self.engine.schema, op.into()).await?;
+
+        debug_assert_eq!(!res.values.is_count(), action.returning.is_some());
+
+        Ok(res.values)
     }
 }
 


### PR DESCRIPTION
## Summary

Multi-key `delete` and `update` on DynamoDB made opposite trade-offs at the transaction boundary:

- **delete** shredded into one `DeleteItem` per key — not atomic.
- **update** sent one `transact_write_items` — atomic, but a filtered update whose subset matched cancelled the whole transaction and updated nothing. It could never update the matching subset the way SQL does.

This shreds both. The engine now fans a multi-key update out into one single-key `UpdateByKey` op per key, mirroring delete, so each key's filter is adjudicated independently and a partial match updates exactly the matching rows. `returning` is preserved by concatenating the per-key rows.

The result is a single easy-to-document contract: multi-key writes are uniformly **non-atomic** on DynamoDB. Atomicity is a deliberate follow-up that will reintroduce it uniformly via the atomic-batches `TransactWrite` work, rather than through these divergent per-operation transact paths.

Also removes the now-unreachable multi-key `transact_write_items` branches from both drivers (the delete branch carried a `todo!()` panic). The single-key and unique-index paths are unchanged.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes (SQLite + core; DynamoDB suite run locally against DynamoDB Local)

## Notes for reviewers

Driver-observable behavior changes, but no design doc is added: this aligns delete and update on the existing per-row semantics and removes the lossy filtered-update path — a consistency cleanup, not new public API. The atomic-batches feature that reintroduces atomicity will carry its own design doc.

New test `dynamodb_update_batch_filter::batch_update_filter_partial_match` covers the previously-lossy case (was written test-first and confirmed to fail before the fix). `crud_partitioned::update_by_partition_key` was updated to expect the shredded op sequence.