### PR TITLE
docs: reference the runnable examples from the guide and add an examples README

### DIFF
--- a/docs/guide/src/batch-operations.md
+++ b/docs/guide/src/batch-operations.md
@@ -236,3 +236,7 @@ Both can insert multiple records, but they differ:
 
 Use `create_many()` when inserting multiple records of the same model. Use
 `batch()` when combining different operations or models.
+
+> **Runnable example:** [`store-operations`] runs transactions, savepoints, batches, query-based updates and deletes, and raw SQL.
+
+[`store-operations`]: https://github.com/tokio-rs/toasty/tree/main/examples/store-operations

--- a/docs/guide/src/belongs-to.md
+++ b/docs/guide/src/belongs-to.md
@@ -317,3 +317,7 @@ For a `Post` model with `#[belongs_to] user: Deferred<User>`, Toasty generates:
 | `toasty::create!(Post { user: &user })` | Create builder | Sets the foreign key from a parent reference |
 | `toasty::create!(Post { user_id: id })` | Create builder | Sets the foreign key directly |
 | `Post::fields().user()` | Field path | Used with `.include()` for preloading |
+
+> **Runnable example:** [`forum-relationships`] loads and traverses relations — `has_one`, preloading with `.include()`, `via` relations, and association filters.
+
+[`forum-relationships`]: https://github.com/tokio-rs/toasty/tree/main/examples/forum-relationships

--- a/docs/guide/src/creating-records.md
+++ b/docs/guide/src/creating-records.md
@@ -346,6 +346,9 @@ let (user, todo) = toasty::create!((
 .await?;
 ```
 
+> **Runnable example:** [`store-operations`] runs transactions, savepoints, batches, query-based updates and deletes, and raw SQL.
+
+
 ### Dynamic batches with `toasty::batch()`
 
 When the number of records is determined at runtime, collect create builders
@@ -418,3 +421,8 @@ The create builder's setter methods accept flexible input types through the
 `&String`. For numeric fields, you can pass the value directly or by reference.
 See [Defining Models — What types can you pass to setters?](./defining-models.md#what-types-can-you-pass-to-setters)
 for details.
+
+> **Runnable example:** [`quickstart-blog`] walks the full create → query → update → delete cycle over a `has_many`/`belongs_to` relationship.
+
+[`quickstart-blog`]: https://github.com/tokio-rs/toasty/tree/main/examples/quickstart-blog
+[`store-operations`]: https://github.com/tokio-rs/toasty/tree/main/examples/store-operations

--- a/docs/guide/src/database-setup.md
+++ b/docs/guide/src/database-setup.md
@@ -146,3 +146,7 @@ let mut db = toasty::Db::builder()
     .connect("sqlite::memory:")
     .await?;
 ```
+
+> **Runnable example:** [`service-ops`] lays out a lib + binaries project with connection pooling, tracing, and the `toasty-cli` migration workflow.
+
+[`service-ops`]: https://github.com/tokio-rs/toasty/tree/main/examples/service-ops

--- a/docs/guide/src/deferred-fields.md
+++ b/docs/guide/src/deferred-fields.md
@@ -358,3 +358,7 @@ argument to `create!`, just like any other non-nullable field —
 Deferred fields are supported on every driver. SQL backends shorten the
 `SELECT` column list; DynamoDB shortens the `ProjectionExpression`.
 Drivers do not need a capability flag for this feature.
+
+> **Runnable example:** [`cms-article-fields`] covers field options — defaults, auto timestamps, `Json<T>`, a queryable `Vec<scalar>`, and deferred columns.
+
+[`cms-article-fields`]: https://github.com/tokio-rs/toasty/tree/main/examples/cms-article-fields

--- a/docs/guide/src/defining-models.md
+++ b/docs/guide/src/defining-models.md
@@ -65,6 +65,9 @@ Enable feature flags in your `Cargo.toml`:
 toasty = { version = "{{toasty_version}}", features = ["sqlite", "jiff"] }
 ```
 
+> **Runnable example:** [`crm-embedded`] flattens embedded structs and enums, keys a model with a newtype, and patches embedded fields.
+
+
 ## Optional fields
 
 Wrap a field in `Option<T>` to make it nullable. An `Option<T>` field maps to a
@@ -134,6 +137,9 @@ struct User {
 ```
 
 This maps to a table named `people` instead of the default `users`.
+
+> **Runnable example:** [`cms-article-fields`] covers field options — defaults, auto timestamps, `Json<T>`, a queryable `Vec<scalar>`, and deferred columns.
+
 
 ## What gets generated
 
@@ -286,3 +292,9 @@ pass the value in whatever form you have it.
 
 Additional methods are generated when you add attributes like `#[key]`,
 `#[unique]`, and `#[index]`. The next chapters cover these.
+
+> **Runnable example:** [`quickstart-blog`] walks the full create → query → update → delete cycle over a `has_many`/`belongs_to` relationship.
+
+[`quickstart-blog`]: https://github.com/tokio-rs/toasty/tree/main/examples/quickstart-blog
+[`crm-embedded`]: https://github.com/tokio-rs/toasty/tree/main/examples/crm-embedded
+[`cms-article-fields`]: https://github.com/tokio-rs/toasty/tree/main/examples/cms-article-fields

--- a/docs/guide/src/deleting-records.md
+++ b/docs/guide/src/deleting-records.md
@@ -120,3 +120,7 @@ For a model with `#[key]` on `id` and `#[unique]` on `email`, Toasty generates:
   given email. Executes immediately.
 - Any query builder's `.delete()` method — converts the query into a delete
   statement.
+
+> **Runnable example:** [`store-operations`] runs transactions, savepoints, batches, query-based updates and deletes, and raw SQL.
+
+[`store-operations`]: https://github.com/tokio-rs/toasty/tree/main/examples/store-operations

--- a/docs/guide/src/embedded-types.md
+++ b/docs/guide/src/embedded-types.md
@@ -496,3 +496,7 @@ on `contact_country`. The same rules from
 
 Indexes on data-carrying enum variant fields work the same way. The index is
 created on the nullable column for that variant's field.
+
+> **Runnable example:** [`crm-embedded`] flattens embedded structs and enums, keys a model with a newtype, and patches embedded fields.
+
+[`crm-embedded`]: https://github.com/tokio-rs/toasty/tree/main/examples/crm-embedded

--- a/docs/guide/src/field-options.md
+++ b/docs/guide/src/field-options.md
@@ -487,3 +487,7 @@ the JSON literal `"null"` instead.
 
 See [Concurrency Control](./concurrency-control.md) for the `#[version]`
 attribute.
+
+> **Runnable example:** [`cms-article-fields`] covers field options — defaults, auto timestamps, `Json<T>`, a queryable `Vec<scalar>`, and deferred columns.
+
+[`cms-article-fields`]: https://github.com/tokio-rs/toasty/tree/main/examples/cms-article-fields

--- a/docs/guide/src/filtering-with-expressions.md
+++ b/docs/guide/src/filtering-with-expressions.md
@@ -630,3 +630,9 @@ let users = User::filter(
 user with no todos matches `todos().all(...)` for any filter. This
 mirrors Rust's `[].iter().all(...)` semantics.
 
+> **Runnable example:** [`forum-relationships`] loads and traverses relations — `has_one`, preloading with `.include()`, `via` relations, and association filters.
+
+> **Runnable example:** [`product-search`] builds filter expressions, sorts, cursor-paginates, and projects columns.
+
+[`product-search`]: https://github.com/tokio-rs/toasty/tree/main/examples/product-search
+[`forum-relationships`]: https://github.com/tokio-rs/toasty/tree/main/examples/forum-relationships

--- a/docs/guide/src/getting-started.md
+++ b/docs/guide/src/getting-started.md
@@ -127,3 +127,10 @@ connection URLs, and supported databases.
 `db.push_schema()` creates all tables and indexes defined by your models. See
 [Migrations and Schema Management](./schema-management.md) for more on managing
 your database schema.
+
+> **Runnable example:** [`service-ops`] lays out a lib + binaries project with connection pooling, tracing, and the `toasty-cli` migration workflow.
+
+> **Runnable example:** [`quickstart-blog`] walks the full create → query → update → delete cycle over a `has_many`/`belongs_to` relationship.
+
+[`quickstart-blog`]: https://github.com/tokio-rs/toasty/tree/main/examples/quickstart-blog
+[`service-ops`]: https://github.com/tokio-rs/toasty/tree/main/examples/service-ops

--- a/docs/guide/src/has-many.md
+++ b/docs/guide/src/has-many.md
@@ -383,6 +383,9 @@ Preload a `via` relation with `.include()` to avoid the N+1 — see
 projecting a `via` relation is supported on SQL backends; both are not yet
 available on DynamoDB.
 
+> **Runnable example:** [`forum-relationships`] loads and traverses relations — `has_one`, preloading with `.include()`, `via` relations, and association filters.
+
+
 ## What gets generated
 
 For a `User` model with `#[has_many] posts: Deferred<Vec<Post>>`, Toasty generates:
@@ -411,3 +414,8 @@ For a `User` model with `#[has_many] posts: Deferred<Vec<Post>>`, Toasty generat
 |---|---|
 | `User::fields().posts()` | Field path for preloading and filtering |
 | `User::fields().posts().any(expr)` | Filter parents by child conditions |
+
+> **Runnable example:** [`quickstart-blog`] walks the full create → query → update → delete cycle over a `has_many`/`belongs_to` relationship.
+
+[`quickstart-blog`]: https://github.com/tokio-rs/toasty/tree/main/examples/quickstart-blog
+[`forum-relationships`]: https://github.com/tokio-rs/toasty/tree/main/examples/forum-relationships

--- a/docs/guide/src/has-one.md
+++ b/docs/guide/src/has-one.md
@@ -400,3 +400,7 @@ generates:
 | `user.update().profile(...)` | Update builder | Replace or associate a profile |
 | `user.update().profile(None)` | Update builder | Disassociate the profile |
 | `User::fields().profile()` | Field path | Used with `.include()` for preloading |
+
+> **Runnable example:** [`forum-relationships`] loads and traverses relations — `has_one`, preloading with `.include()`, `via` relations, and association filters.
+
+[`forum-relationships`]: https://github.com/tokio-rs/toasty/tree/main/examples/forum-relationships

--- a/docs/guide/src/indexes-and-unique-constraints.md
+++ b/docs/guide/src/indexes-and-unique-constraints.md
@@ -366,6 +366,9 @@ keep generated names within a database's identifier-length limit.
 | Query matching | Database uses leftmost-prefix matching | All `partition` fields required; `local` fields optional left-to-right |
 | Column limits | No artificial limits | Up to 4 partition and 4 local attributes per index |
 
+> **Runnable example:** [`product-search`] builds filter expressions, sorts, cursor-paginates, and projects columns.
+
+
 ## Multi-column unique constraints
 
 A struct-level `#[unique(...)]` defines a composite unique index. It takes the
@@ -479,3 +482,8 @@ These methods follow the same patterns as key-generated methods. See
 [Updating Records](./updating-records.md), and
 [Deleting Records](./deleting-records.md) for details on terminal methods and
 builders.
+
+> **Runnable example:** [`quickstart-blog`] walks the full create → query → update → delete cycle over a `has_many`/`belongs_to` relationship.
+
+[`quickstart-blog`]: https://github.com/tokio-rs/toasty/tree/main/examples/quickstart-blog
+[`product-search`]: https://github.com/tokio-rs/toasty/tree/main/examples/product-search

--- a/docs/guide/src/introduction.md
+++ b/docs/guide/src/introduction.md
@@ -64,3 +64,7 @@ transactions.
 - **[Transactions](./transactions.md)** — atomic operations
 - **[Database Setup](./database-setup.md)** — connection URLs, table creation, and supported databases
 - **[Migrations and Schema Management](./schema-management.md)** — create and reset database tables
+
+> **Runnable example:** [`quickstart-blog`] walks the full create → query → update → delete cycle over a `has_many`/`belongs_to` relationship.
+
+[`quickstart-blog`]: https://github.com/tokio-rs/toasty/tree/main/examples/quickstart-blog

--- a/docs/guide/src/keys-and-auto-generation.md
+++ b/docs/guide/src/keys-and-auto-generation.md
@@ -125,6 +125,9 @@ struct User {
 }
 ```
 
+> **Runnable example:** [`crm-embedded`] flattens embedded structs and enums, keys a model with a newtype, and patches embedded fields.
+
+
 ## Auto-generated values
 
 The `#[auto]` attribute tells Toasty to generate the field's value
@@ -399,6 +402,9 @@ let todos = Todo::filter_by_user_id(&1)
 # }
 ```
 
+> **Runnable example:** [`store-operations`] runs transactions, savepoints, batches, query-based updates and deletes, and raw SQL.
+
+
 ## What gets generated
 
 For a model with `#[key]`, Toasty generates these methods:
@@ -409,3 +415,9 @@ For a model with `#[key]`, Toasty generates these methods:
 | `#[key]` on multiple fields | `get_by_<a>_and_<b>()`, `filter_by_<a>_and_<b>()`, `delete_by_<a>_and_<b>()` |
 | `#[key(a, b)]` on struct | Same generated methods as `#[key]` on multiple fields; `a` is the partition key, `b` is the local (sort) key |
 | `#[key(partition = a, local = b)]` | `get_by_<a>_and_<b>()`, `filter_by_<a>()`, `filter_by_<a>_and_<b>()`, `delete_by_<a>_and_<b>()` |
+
+> **Runnable example:** [`quickstart-blog`] walks the full create → query → update → delete cycle over a `has_many`/`belongs_to` relationship.
+
+[`quickstart-blog`]: https://github.com/tokio-rs/toasty/tree/main/examples/quickstart-blog
+[`crm-embedded`]: https://github.com/tokio-rs/toasty/tree/main/examples/crm-embedded
+[`store-operations`]: https://github.com/tokio-rs/toasty/tree/main/examples/store-operations

--- a/docs/guide/src/preloading-associations.md
+++ b/docs/guide/src/preloading-associations.md
@@ -368,3 +368,7 @@ for user in &users {
 | `model.relation` | Access an eager `Vec<T>`, `T`, or `Option<T>` relation field |
 | `model.relation.try_get()` | Non-panicking access; returns `None` if not preloaded |
 | `model.relation.is_unloaded()` | Check whether a `Deferred<_>` relation was preloaded |
+
+> **Runnable example:** [`forum-relationships`] loads and traverses relations — `has_one`, preloading with `.include()`, `via` relations, and association filters.
+
+[`forum-relationships`]: https://github.com/tokio-rs/toasty/tree/main/examples/forum-relationships

--- a/docs/guide/src/querying-records.md
+++ b/docs/guide/src/querying-records.md
@@ -30,6 +30,9 @@ The method name matches the key field name. A model with `#[key] code: String`
 generates `get_by_code()`. Composite keys generate combined names like
 `get_by_student_id_and_course_id()`.
 
+> **Runnable example:** [`quickstart-blog`] walks the full create → query → update → delete cycle over a `has_many`/`belongs_to` relationship.
+
+
 ## Get all records
 
 `<YourModel>::all()` returns a query for all records of that model.
@@ -325,3 +328,8 @@ Query builders support these terminal methods:
 | `.exec(&mut db)` | `Result<Vec<User>>` |
 | `.first().exec(&mut db)` | `Result<Option<User>>` |
 | `.get(&mut db)` | `Result<User>` |
+
+> **Runnable example:** [`product-search`] builds filter expressions, sorts, cursor-paginates, and projects columns.
+
+[`product-search`]: https://github.com/tokio-rs/toasty/tree/main/examples/product-search
+[`quickstart-blog`]: https://github.com/tokio-rs/toasty/tree/main/examples/quickstart-blog

--- a/docs/guide/src/raw-sql.md
+++ b/docs/guide/src/raw-sql.md
@@ -162,3 +162,7 @@ tx.commit().await?;
 
 Nested transactions work the same way as they do for query builders: raw SQL
 executed through the nested transaction is part of that savepoint.
+
+> **Runnable example:** [`store-operations`] runs transactions, savepoints, batches, query-based updates and deletes, and raw SQL.
+
+[`store-operations`]: https://github.com/tokio-rs/toasty/tree/main/examples/store-operations

--- a/docs/guide/src/relationships.md
+++ b/docs/guide/src/relationships.md
@@ -312,3 +312,7 @@ querying, creating, and updating:
   child, replace and unset behavior
 - [**Preloading Associations**](./preloading-associations.md) — avoiding extra
   queries by loading relations upfront with `.include()`
+
+> **Runnable example:** [`forum-relationships`] loads and traverses relations — `has_one`, preloading with `.include()`, `via` relations, and association filters.
+
+[`forum-relationships`]: https://github.com/tokio-rs/toasty/tree/main/examples/forum-relationships

--- a/docs/guide/src/schema-management.md
+++ b/docs/guide/src/schema-management.md
@@ -250,3 +250,7 @@ A common development cycle looks like this:
 For early development when the schema changes frequently, `push_schema` is
 simpler. Switch to migrations when your database has data you want to preserve
 across schema changes.
+
+> **Runnable example:** [`service-ops`] lays out a lib + binaries project with connection pooling, tracing, and the `toasty-cli` migration workflow.
+
+[`service-ops`]: https://github.com/tokio-rs/toasty/tree/main/examples/service-ops

--- a/docs/guide/src/sorting-limits-and-pagination.md
+++ b/docs/guide/src/sorting-limits-and-pagination.md
@@ -367,3 +367,7 @@ Methods available on `Page`:
 | `.items` | `Vec<M>` | The records in this page |
 | `.len()` | `usize` | Number of items (via `Deref` to slice) |
 | `.iter()` | iterator | Iterate items (via `Deref` to slice) |
+
+> **Runnable example:** [`product-search`] builds filter expressions, sorts, cursor-paginates, and projects columns.
+
+[`product-search`]: https://github.com/tokio-rs/toasty/tree/main/examples/product-search

--- a/docs/guide/src/sqlite.md
+++ b/docs/guide/src/sqlite.md
@@ -264,3 +264,7 @@ The pool sizing knobs from
 [Database Setup](./database-setup.md#connection-pool) still apply for
 file-backed databases. In-memory mode pins the pool to a single
 connection regardless of `max_pool_size`.
+
+> **Runnable example:** [`quickstart-blog`] is the simplest of the examples; like all of them it runs on in-memory SQLite by default.
+
+[`quickstart-blog`]: https://github.com/tokio-rs/toasty/tree/main/examples/quickstart-blog

--- a/docs/guide/src/tracing.md
+++ b/docs/guide/src/tracing.md
@@ -117,3 +117,7 @@ events for each item operation it performs (`getting single item`,
 `querying primary key`, `batch inserting items`, and so on) with the
 table name, index name, and item counts. Enable them with
 `RUST_LOG=toasty_driver_dynamodb=trace`.
+
+> **Runnable example:** [`service-ops`] lays out a lib + binaries project with connection pooling, tracing, and the `toasty-cli` migration workflow.
+
+[`service-ops`]: https://github.com/tokio-rs/toasty/tree/main/examples/service-ops

--- a/docs/guide/src/transactions.md
+++ b/docs/guide/src/transactions.md
@@ -260,3 +260,7 @@ PostgreSQL and MySQL accept only `Default` and `Deferred`; calling
 they diverge on Turso under [`concurrent_writes()`](./turso.md#concurrent-writes):
 `Default` issues `BEGIN CONCURRENT` (MVCC) and `Deferred` is the way to opt
 out and request classic locking on a single transaction.
+
+> **Runnable example:** [`store-operations`] runs transactions, savepoints, batches, query-based updates and deletes, and raw SQL.
+
+[`store-operations`]: https://github.com/tokio-rs/toasty/tree/main/examples/store-operations

--- a/docs/guide/src/updating-records.md
+++ b/docs/guide/src/updating-records.md
@@ -231,6 +231,9 @@ toasty::update!(doc {
 .exec(&mut db).await?;
 ```
 
+> **Runnable example:** [`crm-embedded`] flattens embedded structs and enums, keys a model with a newtype, and patches embedded fields.
+
+
 ## Inserting has-many children
 
 A bracket-of-braces literal on a [has-many](./has-many.md) field
@@ -310,6 +313,9 @@ toasty::update!(User::filter_by_id(user_id) { name: "Bob" })
 Scoped queries like `user.todos().filter_by_done(false)` are query
 builders too. The query runs as part of the `UPDATE` statement; no
 records are loaded first.
+
+> **Runnable example:** [`store-operations`] runs transactions, savepoints, batches, query-based updates and deletes, and raw SQL.
+
 
 ## Update by indexed field
 
@@ -425,3 +431,9 @@ the derive generates:
 
 The update builder has a setter for each field. The `UPDATE`
 statement includes only the fields you set.
+
+> **Runnable example:** [`cms-article-fields`] covers field options — defaults, auto timestamps, `Json<T>`, a queryable `Vec<scalar>`, and deferred columns.
+
+[`cms-article-fields`]: https://github.com/tokio-rs/toasty/tree/main/examples/cms-article-fields
+[`crm-embedded`]: https://github.com/tokio-rs/toasty/tree/main/examples/crm-embedded
+[`store-operations`]: https://github.com/tokio-rs/toasty/tree/main/examples/store-operations

--- a/docs/guide/src/vec-scalar-fields.md
+++ b/docs/guide/src/vec-scalar-fields.md
@@ -354,3 +354,7 @@ The element-removal builders are narrower:
 they lower to `array_remove` and array slicing. On the other drivers
 they return an error. See the per-database pages for the storage and
 operator details specific to each backend.
+
+> **Runnable example:** [`cms-article-fields`] covers field options — defaults, auto timestamps, `Json<T>`, a queryable `Vec<scalar>`, and deferred columns.
+
+[`cms-article-fields`]: https://github.com/tokio-rs/toasty/tree/main/examples/cms-article-fields

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,60 @@
+# Toasty Examples
+
+Each example is a self-contained program that demonstrates a set of Toasty
+features in a realistic scenario. Start with `quickstart-blog`, then read
+whichever example covers what you need. The [user guide](../docs/guide) links to
+these examples for runnable versions of what it describes.
+
+## Contents
+
+| Example | What it covers |
+| --- | --- |
+| [quickstart-blog](quickstart-blog) | Defining models and keys, and the create/read/update/delete loop over a `has_many`/`belongs_to` relationship. Start here. |
+| [forum-relationships](forum-relationships) | `has_one`, traversing a relationship in both directions, preloading with `.include()` to avoid N+1 queries, multi-step `via` relations, and association filters. |
+| [product-search](product-search) | Reading data: filter expressions, sorting, `limit`/`offset`, cursor pagination, column projection, and a composite index. |
+| [cms-article-fields](cms-article-fields) | Field options: create and update defaults, auto timestamps, `Json<T>`, a queryable `Vec<scalar>`, deferred columns, and custom table/column names. |
+| [crm-embedded](crm-embedded) | Embedded value types: flattened structs, tagged-union enums, newtype keys, and partial embed updates with `stmt::patch`. |
+| [store-operations](store-operations) | Writes: interactive transactions, savepoints, batch inserts, query-based update and delete, and raw SQL. |
+| [service-ops](service-ops) | Project layout: shared models in a library, an application binary, and a migration CLI built from `toasty-cli`. |
+
+## Running an example
+
+Every example runs against an in-memory SQLite database by default, so no setup
+is required:
+
+```sh
+cargo run -p example-quickstart-blog
+```
+
+Each program prints what it does as it runs.
+
+### Running against PostgreSQL or MySQL
+
+The examples read the connection URL from `TOASTY_CONNECTION_URL` and fall back
+to `sqlite::memory:`. To run one against another SQL backend, set the URL and
+enable the matching driver feature (`sqlite` is the default; `postgresql` and
+`mysql` are also available):
+
+```sh
+TOASTY_CONNECTION_URL=postgresql://user:pass@localhost/mydb \
+  cargo run -p example-product-search --features postgresql
+```
+
+### service-ops
+
+`service-ops` has two binaries. `cargo run -p example-service-ops` runs the
+`server` binary (the default). The migration CLI is a separate binary; run it
+from the example's directory so it finds `Toasty.toml`:
+
+```sh
+cd examples/service-ops
+
+# Generate a migration after editing the models in src/lib.rs:
+cargo run --bin migrate -- migration generate --name <name>
+
+# Apply pending migrations to a persistent database:
+TOASTY_CONNECTION_URL=sqlite:./service.db cargo run --bin migrate -- migration apply
+```
+
+Each example's `src/main.rs` (or `src/lib.rs`) opens with a comment describing
+what it teaches.


### PR DESCRIPTION
## Summary

Wire the runnable examples into the docs, in two parts:

- **`examples/README.md`** — a table of contents mapping each example to the features it
  covers, plus how to run them (in-memory SQLite by default, another SQL backend via
  `TOASTY_CONNECTION_URL`, and the `service-ops` migration CLI).
- **Guide cross-references** — a "Runnable example" note on each guide page whose topic an
  example demonstrates: a blockquote with a reference-style link to the example's directory.
  39 notes across 27 pages — one per page (keyed to the example that owns the page's topic)
  plus section-level notes where a different example owns a subsection.

`concurrency-control.md` and the backend-specific pages (`postgresql`/`mysql`/`turso`/`dynamodb`)
are intentionally left unlinked — no current example covers them.

## Type of change

- [x] Small / obvious change — docs

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `mdbook build` passes — html backend and `linkcheck2` are clean

(`cargo fmt`/`clippy`/`test` and the design-doc items are omitted: this is a docs-only change
with no Rust code.)

## Notes for reviewers

- Note format is a blockquote + reference-style link to the example on GitHub, so it works in
  both the rendered book and GitHub source view. Rendered as
  `<a href=".../examples/X"><code>X</code></a>` (verified in the built HTML).
- The page → example mapping came from a cross-reference inventory of the whole guide; each
  page's "home" example is the one that centers on that page's topic.
