### PR TITLE
feat: share columns across enum variants via #[column("name")]

### DIFF
--- a/crates/toasty-core/src/schema/builder/table.rs
+++ b/crates/toasty-core/src/schema/builder/table.rs
@@ -52,6 +52,26 @@ struct BuildMapping<'a> {
     lowering_columns: Vec<ColumnId>,
     model_to_table: Vec<stmt::Expr>,
     table_to_model: Vec<stmt::Expr>,
+    /// Column-sharing registry, active only while mapping the variant fields of
+    /// an embedded enum. Maps a flattened column name to the column an earlier
+    /// variant already created for it, so a later variant field with the same
+    /// column name shares that column instead of producing a duplicate. `None`
+    /// outside an enum's variant mapping. Saved and restored around each enum so
+    /// sharing is scoped to a single enum's variants (and never leaks across
+    /// nested enums).
+    shared_columns: Option<std::collections::HashMap<String, SharedColumn>>,
+}
+
+/// A column created by an earlier enum variant that later variants may reuse.
+#[derive(Clone)]
+struct SharedColumn {
+    column: ColumnId,
+    /// Index into `model_to_table` of the column's encode expression. Later
+    /// variants merge their discriminant-guarded arm into this `Match`.
+    lowering: usize,
+    /// App type of the field that first created the column. Reused fields must
+    /// match it exactly so the column needs no per-variant casting.
+    ty: stmt::Type,
 }
 
 /// Per-level state for the recursive `map_field*` methods.
@@ -203,6 +223,7 @@ impl BuildTableFromModels<'_> {
             lowering_columns: vec![],
             model_to_table: vec![],
             table_to_model: vec![],
+            shared_columns: None,
         }
         .build_mapping(root)?;
 
@@ -703,6 +724,29 @@ impl BuildMapping<'_> {
         lowering_index
     }
 
+    /// Merges a later variant field's encode into the shared column's existing
+    /// encode at `lowering`, so one column encodes every contributing variant.
+    ///
+    /// Both encodes are produced by [`MapField::for_variant`], so each is a
+    /// discriminant-guarded `Match` (optionally wrapped in a `Cast`) whose arm
+    /// fires only for that variant. Appending `new_encode`'s arm to the existing
+    /// `Match` yields `match disc { d1 => v1, d2 => v2, .. } else null` — exactly
+    /// the per-variant dispatch a shared column needs.
+    fn merge_shared_encode(&mut self, lowering: usize, new_encode: stmt::Expr) -> Result<()> {
+        let new_arms = into_match_arms(new_encode).ok_or_else(|| {
+            Error::invalid_schema(
+                "shared enum column encode is not a discriminant match expression",
+            )
+        })?;
+        let existing = match_arms_mut(&mut self.model_to_table[lowering]).ok_or_else(|| {
+            Error::invalid_schema(
+                "shared enum column encode is not a discriminant match expression",
+            )
+        })?;
+        existing.extend(new_arms);
+        Ok(())
+    }
+
     fn encode_column(
         &self,
         column_id: ColumnId,
@@ -855,9 +899,7 @@ impl<'a, 'b> MapField<'a, 'b> {
 
     fn map_field(&mut self, index: usize, field: &app::Field) -> Result<mapping::Field> {
         match &field.ty {
-            app::FieldTy::Primitive(primitive) => {
-                Ok(self.map_field_primitive(index, field, primitive))
-            }
+            app::FieldTy::Primitive(primitive) => self.map_field_primitive(index, field, primitive),
             app::FieldTy::Embedded(embedded) => {
                 let target = lookup_embedded_model(self.build.app, embedded.target, field)?;
 
@@ -882,26 +924,71 @@ impl<'a, 'b> MapField<'a, 'b> {
     }
 
     /// Creates the column and builds the mapping for a primitive field in one step.
+    ///
+    /// When column sharing is active (i.e. mapping enum variant fields) and an
+    /// earlier variant already created a column with the same flattened name,
+    /// this reuses that column — merging the field's discriminant-guarded encode
+    /// into the shared column's `Match` — instead of creating a duplicate.
     fn map_field_primitive(
         &mut self,
         field_index: usize,
         field: &app::Field,
         primitive: &app::FieldPrimitive,
-    ) -> mapping::Field {
-        let column_id = self.create_column(field, primitive);
+    ) -> Result<mapping::Field> {
         let expr = self.field_expr(field, field_index);
-        let lowering_index = self.build.push_lowering(column_id, &primitive.ty, expr);
+        let column_name = self.column_name(field);
+
+        let shared = self
+            .build
+            .shared_columns
+            .as_ref()
+            .and_then(|columns| columns.get(&column_name).cloned());
+
+        let (column_id, lowering_index) = if let Some(shared) = shared {
+            // A shared column needs no per-variant casting, so the contributing
+            // fields must have identical types. Width or kind mismatches (e.g.
+            // `i32` vs `i64`, or `String` vs `i64`) are rejected here rather
+            // than silently coerced.
+            if shared.ty != primitive.ty {
+                return Err(Error::invalid_schema(format!(
+                    "enum variant fields mapped to the shared column `{column_name}` \
+                     have incompatible types ({:?} and {:?}); fields sharing a column \
+                     must have the same type",
+                    shared.ty, primitive.ty,
+                )));
+            }
+
+            self.build.merge_shared_encode(shared.lowering, expr)?;
+            (shared.column, shared.lowering)
+        } else {
+            let column_id = self.create_column(field, primitive);
+            let lowering_index = self.build.push_lowering(column_id, &primitive.ty, expr);
+
+            if let Some(columns) = self.build.shared_columns.as_mut() {
+                columns.insert(
+                    column_name,
+                    SharedColumn {
+                        column: column_id,
+                        lowering: lowering_index,
+                        ty: primitive.ty.clone(),
+                    },
+                );
+            }
+
+            (column_id, lowering_index)
+        };
+
         let bit = self.build.next_bit();
         let sub_projection = self.sub_projection(field_index);
         let column_expr = self.build.map_table_column_to_model(column_id, primitive);
 
-        mapping::Field::Primitive(mapping::FieldPrimitive {
+        Ok(mapping::Field::Primitive(mapping::FieldPrimitive {
             column: column_id,
             lowering: lowering_index,
             field_mask: stmt::PathFieldSet::from_iter([bit]),
             sub_projection,
             column_expr,
-        })
+        }))
     }
 
     /// Creates the discriminant and variant-field columns, then builds the
@@ -934,7 +1021,15 @@ impl<'a, 'b> MapField<'a, 'b> {
 
         let disc_proj = stmt::Expr::project(field_expr.clone(), stmt::Projection::single(0));
 
-        let variants = embedded_enum
+        // Activate a fresh column-sharing registry for this enum's variant
+        // fields. A nested enum installs (and restores) its own, so sharing
+        // never crosses enum boundaries. Restored after the variants are mapped.
+        let saved_shared = self
+            .build
+            .shared_columns
+            .replace(std::collections::HashMap::new());
+
+        let variants: Result<Vec<mapping::EnumVariant>> = embedded_enum
             .variants
             .iter()
             .enumerate()
@@ -957,7 +1052,10 @@ impl<'a, 'b> MapField<'a, 'b> {
                     fields,
                 })
             })
-            .collect::<Result<_>>()?;
+            .collect();
+
+        self.build.shared_columns = saved_shared;
+        let variants = variants?;
 
         let field_mask = stmt::PathFieldSet::from_iter([bit]);
 
@@ -1406,6 +1504,29 @@ impl<'a, 'b> MapField<'a, 'b> {
     fn for_nullable_struct(&mut self, field: &app::Field, field_index: usize) -> MapField<'_, 'b> {
         let guard = self.presence_guard(field, field_index, stmt::Expr::arg(0));
         self.for_guarded_embed(field, field_index, guard)
+    }
+}
+
+/// Returns a mutable reference to the arms of a discriminant-guarded encode,
+/// peeling a `Cast` wrapper if present. Used to merge a later variant field's
+/// arm into a shared column's existing `Match`.
+fn match_arms_mut(expr: &mut stmt::Expr) -> Option<&mut Vec<stmt::MatchArm>> {
+    match expr {
+        stmt::Expr::Match(m) => Some(&mut m.arms),
+        stmt::Expr::Cast(c) => match_arms_mut(&mut c.expr),
+        _ => None,
+    }
+}
+
+/// Consumes a discriminant-guarded encode, returning its arms (peeling a `Cast`
+/// wrapper if present). The subject and `else` branch are dropped: they are
+/// identical across the variants sharing a column, so the existing `Match`
+/// retains them.
+fn into_match_arms(expr: stmt::Expr) -> Option<Vec<stmt::MatchArm>> {
+    match expr {
+        stmt::Expr::Match(m) => Some(m.arms),
+        stmt::Expr::Cast(c) => into_match_arms(*c.expr),
+        _ => None,
     }
 }
 

--- a/crates/toasty-core/src/schema/builder/table.rs
+++ b/crates/toasty-core/src/schema/builder/table.rs
@@ -72,6 +72,10 @@ struct SharedColumn {
     /// App type of the field that first created the column. Reused fields must
     /// match it exactly so the column needs no per-variant casting.
     ty: stmt::Type,
+    /// Discriminant of the variant that created the column. Reuse is only sound
+    /// across *different* variants; a field in the same variant reaching the same
+    /// column is an invalid mapping (both would be active for one discriminant).
+    variant_discriminant: Option<stmt::Value>,
 }
 
 /// Per-level state for the recursive `map_field*` methods.
@@ -123,6 +127,12 @@ struct MapField<'a, 'b> {
     /// column. ORed into the column's flag at creation time so an outer or
     /// inner declaration both take effect.
     inherited_auto_increment: bool,
+
+    /// Discriminant of the enum variant currently being mapped, set by
+    /// [`Self::for_variant`] and inherited by nested embeds within the variant.
+    /// `None` outside an enum variant. Used to distinguish a sound cross-variant
+    /// column share from an invalid same-variant collision.
+    variant_discriminant: Option<stmt::Value>,
 }
 
 impl BuildSchema<'_> {
@@ -886,6 +896,7 @@ impl<'a, 'b> MapField<'a, 'b> {
             field_base: None,
             field_expr_base: stmt::Expr::arg(0),
             inherited_auto_increment: false,
+            variant_discriminant: None,
         }
     }
 
@@ -945,6 +956,24 @@ impl<'a, 'b> MapField<'a, 'b> {
             .and_then(|columns| columns.get(&column_name).cloned());
 
         let (column_id, lowering_index) = if let Some(shared) = shared {
+            // Reuse is only sound across *different* variants — the merged encode
+            // dispatches on the discriminant, and at most one variant is active
+            // per row. Two fields in the *same* variant reaching one column would
+            // append a second arm under the same discriminant, so the encode
+            // would silently keep only the first and both fields would decode from
+            // the one column. Reject that invalid mapping. The `Embed` derive
+            // catches it at compile time; this is the backstop for schemas built
+            // without the macro.
+            if shared.variant_discriminant.is_some()
+                && shared.variant_discriminant == self.variant_discriminant
+            {
+                return Err(Error::invalid_schema(format!(
+                    "two fields in the same enum variant map to the column \
+                     `{column_name}`; a column can be shared only across different \
+                     variants",
+                )));
+            }
+
             // A shared column needs no per-variant casting, so the contributing
             // fields must have identical types. The `Embed` derive rejects a
             // mismatch at compile time via `SameColumnType`; this is the
@@ -973,6 +1002,7 @@ impl<'a, 'b> MapField<'a, 'b> {
                         column: column_id,
                         lowering: lowering_index,
                         ty: primitive.ty.clone(),
+                        variant_discriminant: self.variant_discriminant.clone(),
                     },
                 );
             }
@@ -1407,6 +1437,9 @@ impl<'a, 'b> MapField<'a, 'b> {
             field_base: self.field_base.clone(),
             field_expr_base: self.field_expr_base.clone(),
             inherited_auto_increment: self.inherited_auto_increment,
+            // A nested embed stays within its enclosing variant, so it inherits
+            // the variant discriminant; `for_variant` overrides it per variant.
+            variant_discriminant: self.variant_discriminant.clone(),
         }
     }
 
@@ -1455,7 +1488,9 @@ impl<'a, 'b> MapField<'a, 'b> {
             }],
             stmt::Expr::null(),
         );
-        self.for_guarded_embed(field, field_index, guard)
+        let mut child = self.for_guarded_embed(field, field_index, guard);
+        child.variant_discriminant = Some(discriminant.clone());
+        child
     }
 
     /// Creates a child `MapField` for recursing into an embedded struct field.

--- a/crates/toasty-core/src/schema/builder/table.rs
+++ b/crates/toasty-core/src/schema/builder/table.rs
@@ -946,9 +946,11 @@ impl<'a, 'b> MapField<'a, 'b> {
 
         let (column_id, lowering_index) = if let Some(shared) = shared {
             // A shared column needs no per-variant casting, so the contributing
-            // fields must have identical types. Width or kind mismatches (e.g.
-            // `i32` vs `i64`, or `String` vs `i64`) are rejected here rather
-            // than silently coerced.
+            // fields must have identical types. The `Embed` derive rejects a
+            // mismatch at compile time via `SameColumnType`; this is the
+            // backstop for schemas built without the macro. Width or kind
+            // mismatches (e.g. `i32` vs `i64`, or `String` vs `i64`) are
+            // rejected here rather than silently coerced.
             if shared.ty != primitive.ty {
                 return Err(Error::invalid_schema(format!(
                     "enum variant fields mapped to the shared column `{column_name}` \

--- a/crates/toasty-driver-integration-suite/src/scenarios.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios.rs
@@ -1,4 +1,5 @@
 pub mod account_optional_contact_status;
+pub mod character_creature;
 pub mod company_office_address;
 pub mod composite_chain_relations;
 pub mod composite_fk_has_many_belongs_to;

--- a/crates/toasty-driver-integration-suite/src/scenarios/character_creature.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios/character_creature.rs
@@ -1,0 +1,37 @@
+use crate::prelude::*;
+
+scenario! {
+    #[derive(Debug, toasty::Model)]
+    #[allow(dead_code)]
+    struct Character {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+
+        creature: Creature,
+    }
+
+    // Both variants carry a `name`, mapped to the same `#[column("name")]`.
+    // The two variant fields coalesce into a single shared, nullable
+    // `creature_name` column; each variant keeps its own distinct column for
+    // its variant-specific attribute (`creature_profession` / `creature_species`).
+    #[derive(Debug, PartialEq, toasty::Embed)]
+    enum Creature {
+        #[column(variant = 1)]
+        Human {
+            #[column("name")]
+            name: String,
+            profession: String,
+        },
+        #[column(variant = 2)]
+        Animal {
+            #[column("name")]
+            name: String,
+            species: String,
+        },
+    }
+
+    async fn setup(test: &mut Test) -> toasty::Db {
+        test.setup_db(models!(Character)).await
+    }
+}

--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -32,6 +32,7 @@ pub mod embed_enum_filter_variant_field;
 pub mod embed_enum_index;
 pub mod embed_enum_native_ops;
 pub mod embed_enum_optional;
+pub mod embed_enum_shared_column;
 pub mod embed_enum_shared_type;
 pub mod embed_enum_string_discriminant;
 pub mod embed_enum_unit;

--- a/crates/toasty-driver-integration-suite/src/tests/embed_enum_shared_column.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embed_enum_shared_column.rs
@@ -1,0 +1,238 @@
+use crate::prelude::*;
+
+/// A field given the same `#[column("name")]` in two variants coalesces into a
+/// single shared, nullable column rather than producing one column per variant.
+/// The table therefore has exactly one `creature_name` column alongside each
+/// variant's own distinct column.
+#[driver_test(scenario(crate::scenarios::character_creature))]
+pub async fn shared_column_db_schema(t: &mut Test) {
+    let db = setup(t).await;
+    let schema = db.schema();
+
+    assert_struct!(schema.db.tables, [
+        {
+            name: =~ r"characters$",
+            columns: [
+                { name: "id" },
+                { name: "creature", nullable: false },
+                // Shared by both Human and Animal — present exactly once.
+                { name: "creature_name", nullable: true },
+                { name: "creature_profession", nullable: true },
+                { name: "creature_species", nullable: true },
+            ],
+        },
+    ]);
+}
+
+/// The `#[column("name")]` override surfaces in the app schema as the field's
+/// storage name; both variants' `name` fields carry the same storage name,
+/// which is what drives the column coalescing.
+#[driver_test(scenario(crate::scenarios::character_creature))]
+pub async fn shared_column_schema_fields(t: &mut Test) {
+    let db = setup(t).await;
+    let schema = db.schema();
+
+    let creature = &schema.app.models[&Creature::id()];
+    assert_struct!(creature, toasty::schema::app::Model::EmbeddedEnum({
+        fields: [
+            { name.app: Some("name"), name.storage: Some("name") },
+            { name.app: Some("profession") },
+            { name.app: Some("name"), name.storage: Some("name") },
+            { name.app: Some("species") },
+        ],
+    }));
+}
+
+/// Both variants write and read the shared column, while their variant-specific
+/// columns round-trip independently.
+#[driver_test(scenario(crate::scenarios::character_creature))]
+pub async fn shared_column_roundtrip(t: &mut Test) -> Result<()> {
+    let mut db = setup(t).await;
+
+    let human = Character::create()
+        .creature(Creature::Human {
+            name: "Alice".to_string(),
+            profession: "engineer".to_string(),
+        })
+        .exec(&mut db)
+        .await?;
+
+    let animal = Character::create()
+        .creature(Creature::Animal {
+            name: "Rex".to_string(),
+            species: "dog".to_string(),
+        })
+        .exec(&mut db)
+        .await?;
+
+    assert_eq!(
+        Character::get_by_id(&mut db, &human.id).await?.creature,
+        Creature::Human {
+            name: "Alice".to_string(),
+            profession: "engineer".to_string(),
+        }
+    );
+    assert_eq!(
+        Character::get_by_id(&mut db, &animal.id).await?.creature,
+        Creature::Animal {
+            name: "Rex".to_string(),
+            species: "dog".to_string(),
+        }
+    );
+
+    Ok(())
+}
+
+/// Updating the whole enum field — including switching variants — re-encodes the
+/// shared column correctly. The merged per-variant encode must select the arm
+/// matching the *new* discriminant, so the shared column follows the value into
+/// its new variant while the old variant's column is cleared to NULL.
+#[driver_test(scenario(crate::scenarios::character_creature))]
+pub async fn shared_column_update(t: &mut Test) -> Result<()> {
+    let mut db = setup(t).await;
+
+    let mut character = Character::create()
+        .creature(Creature::Human {
+            name: "Bob".to_string(),
+            profession: "builder".to_string(),
+        })
+        .exec(&mut db)
+        .await?;
+
+    // Update within the same variant: only the shared column and the Human
+    // column change.
+    character
+        .update()
+        .creature(Creature::Human {
+            name: "Bobby".to_string(),
+            profession: "architect".to_string(),
+        })
+        .exec(&mut db)
+        .await?;
+
+    assert_eq!(
+        Character::get_by_id(&mut db, &character.id).await?.creature,
+        Creature::Human {
+            name: "Bobby".to_string(),
+            profession: "architect".to_string(),
+        }
+    );
+
+    // Switch variant: the shared `creature_name` column now holds the Animal's
+    // name, the Human column is cleared, and the Animal column is populated.
+    character
+        .update()
+        .creature(Creature::Animal {
+            name: "Whiskers".to_string(),
+            species: "cat".to_string(),
+        })
+        .exec(&mut db)
+        .await?;
+
+    assert_eq!(
+        Character::get_by_id(&mut db, &character.id).await?.creature,
+        Creature::Animal {
+            name: "Whiskers".to_string(),
+            species: "cat".to_string(),
+        }
+    );
+
+    Ok(())
+}
+
+/// Fields coalesced onto one shared column must have identical types. Giving
+/// two variants the same `#[column("v")]` but incompatible field types is
+/// rejected when the schema is built rather than silently coerced.
+#[driver_test]
+pub async fn shared_column_type_mismatch_rejected(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Embed)]
+    #[allow(dead_code)]
+    enum Value {
+        #[column(variant = 1)]
+        Text {
+            #[column("v")]
+            text: String,
+        },
+        #[column(variant = 2)]
+        Number {
+            #[column("v")]
+            number: i64,
+        },
+    }
+
+    #[derive(Debug, toasty::Model)]
+    #[allow(dead_code)]
+    struct Record {
+        #[key]
+        id: String,
+        value: Value,
+    }
+
+    let result = t.try_setup_db(models!(Record)).await;
+
+    let err = result
+        .err()
+        .expect("incompatible shared-column types should be rejected");
+    assert!(
+        err.to_string().contains("incompatible"),
+        "unexpected error: {err}"
+    );
+
+    Ok(())
+}
+
+/// Both variants store their `name` in the same physical `creature_name`
+/// column. A variant-rooted filter on that column keeps its implicit variant
+/// gate, so `human().name().eq("Bob")` matches only Human rows even though an
+/// Animal stores the same value in the same column — the discriminant
+/// disambiguates the shared column per variant.
+#[driver_test(requires(scan), scenario(crate::scenarios::character_creature))]
+pub async fn shared_column_variant_gated_filter(t: &mut Test) -> Result<()> {
+    let mut db = setup(t).await;
+
+    for (name, profession) in [("Bob", "builder"), ("Alice", "artist")] {
+        Character::create()
+            .creature(Creature::Human {
+                name: name.to_string(),
+                profession: profession.to_string(),
+            })
+            .exec(&mut db)
+            .await?;
+    }
+
+    for (name, species) in [("Bob", "dog"), ("Rex", "cat")] {
+        Character::create()
+            .creature(Creature::Animal {
+                name: name.to_string(),
+                species: species.to_string(),
+            })
+            .exec(&mut db)
+            .await?;
+    }
+
+    // "Bob" lives in `creature_name` for both a Human and an Animal. The gate on
+    // the Human-rooted filter must read that shared column yet exclude the
+    // Animal that shares its value.
+    let human_bobs = Character::filter(Character::fields().creature().human().name().eq("Bob"))
+        .exec(&mut db)
+        .await?;
+    assert_eq!(human_bobs.len(), 1);
+    assert!(matches!(human_bobs[0].creature, Creature::Human { .. }));
+
+    // The same shared column, gated to the Animal variant, finds the Animal
+    // "Bob" — proving the one column genuinely holds both variants' names.
+    let animal_bobs = Character::filter(Character::fields().creature().animal().name().eq("Bob"))
+        .exec(&mut db)
+        .await?;
+    assert_eq!(animal_bobs.len(), 1);
+    assert!(matches!(animal_bobs[0].creature, Creature::Animal { .. }));
+
+    // A name only one variant uses still resolves correctly through the gate.
+    let humans_named_alice =
+        Character::filter(Character::fields().creature().human().name().eq("Alice"))
+            .exec(&mut db)
+            .await?;
+    assert_eq!(humans_named_alice.len(), 1);
+
+    Ok(())
+}

--- a/crates/toasty-driver-integration-suite/src/tests/embed_enum_shared_column.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embed_enum_shared_column.rs
@@ -140,46 +140,9 @@ pub async fn shared_column_update(t: &mut Test) -> Result<()> {
     Ok(())
 }
 
-/// Fields coalesced onto one shared column must have identical types. Giving
-/// two variants the same `#[column("v")]` but incompatible field types is
-/// rejected when the schema is built rather than silently coerced.
-#[driver_test]
-pub async fn shared_column_type_mismatch_rejected(t: &mut Test) -> Result<()> {
-    #[derive(Debug, toasty::Embed)]
-    #[allow(dead_code)]
-    enum Value {
-        #[column(variant = 1)]
-        Text {
-            #[column("v")]
-            text: String,
-        },
-        #[column(variant = 2)]
-        Number {
-            #[column("v")]
-            number: i64,
-        },
-    }
-
-    #[derive(Debug, toasty::Model)]
-    #[allow(dead_code)]
-    struct Record {
-        #[key]
-        id: String,
-        value: Value,
-    }
-
-    let result = t.try_setup_db(models!(Record)).await;
-
-    let err = result
-        .err()
-        .expect("incompatible shared-column types should be rejected");
-    assert!(
-        err.to_string().contains("incompatible"),
-        "unexpected error: {err}"
-    );
-
-    Ok(())
-}
+// Mismatched shared-column types are rejected at compile time by the
+// `SameColumnType` obligation the `Embed` derive emits; see the trybuild case
+// `tests/ui/enum_shared_column_type_mismatch.rs`.
 
 /// Both variants store their `name` in the same physical `creature_name`
 /// column. A variant-rooted filter on that column keeps its implicit variant

--- a/crates/toasty-macros/src/model/expand.rs
+++ b/crates/toasty-macros/src/model/expand.rs
@@ -237,6 +237,7 @@ pub(super) fn embedded_enum(model: &Model) -> TokenStream {
     let enum_field_list_struct = e.expand_field_list_struct();
     let field_register_calls = e.expand_field_register_calls();
     let storage_compat_checks = e.expand_storage_compat_checks();
+    let shared_column_checks = e.expand_shared_column_checks();
     let indexable_checks = e.expand_indexable_checks();
 
     // A unit (data-less) enum maps to a single discriminant column, so it can
@@ -253,6 +254,7 @@ pub(super) fn embedded_enum(model: &Model) -> TokenStream {
         #enum_field_list_struct
 
         #storage_compat_checks
+        #shared_column_checks
         #indexable_checks
         #indexable_impl
 

--- a/crates/toasty-macros/src/model/expand/embedded_enum.rs
+++ b/crates/toasty-macros/src/model/expand/embedded_enum.rs
@@ -298,6 +298,19 @@ impl Expand<'_> {
             .map(|field| {
                 let index = util::int(field.id);
                 let app_name = field.name.as_str();
+                // A `#[column("name")]` on a variant field overrides its
+                // database column name. When two variants give a field the same
+                // column name, the schema builder coalesces them into one shared
+                // column (see `BuildMapping::map_field_primitive`).
+                let storage_name = match field
+                    .attrs
+                    .column
+                    .as_ref()
+                    .and_then(|column| column.name.as_ref())
+                {
+                    Some(name) => quote! { Some(#name.to_string()) },
+                    None => quote! { None },
+                };
                 let ty = primitive_ty_unwrap(field);
                 let variant_index = field.variant.expect("enum field must have variant");
                 let variant_idx = util::int(variant_index);
@@ -309,7 +322,7 @@ impl Expand<'_> {
                         },
                         name: #toasty::core::schema::app::FieldName {
                             app: Some(#app_name.to_string()),
-                            storage: None,
+                            storage: #storage_name,
                         },
                         ty: <#ty as #toasty::Field>::field_ty(None),
                         nullable: <#ty as #toasty::Field>::NULLABLE,

--- a/crates/toasty-macros/src/model/expand/embedded_enum.rs
+++ b/crates/toasty-macros/src/model/expand/embedded_enum.rs
@@ -2,7 +2,8 @@ use super::{Expand, schema, util};
 use crate::model::schema::{EnumStorageStrategy, FieldTy, VariantValue};
 
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{quote, quote_spanned};
+use syn::spanned::Spanned;
 
 impl Expand<'_> {
     /// Returns fields belonging to a specific variant index.
@@ -339,6 +340,66 @@ impl Expand<'_> {
                 }
             })
             .collect()
+    }
+
+    /// Emits a compile-time obligation that every group of variant fields
+    /// sharing a column via `#[column("name")]` agrees on its Rust type.
+    ///
+    /// Two variants that give a field the same `#[column("name")]` coalesce into
+    /// one shared column, which can hold only one storage type. Rather than defer
+    /// a mismatch to a schema-build error, emit a `SameColumnType` bound between
+    /// each shared field's type and the first in its group; unequal types fail to
+    /// compile with a message pinned to the offending field.
+    ///
+    /// Only fields with an explicit `#[column("name")]` are grouped. A field
+    /// without one is not necessarily single-column (an embedded struct flattens
+    /// to several columns named after its own fields), so predicting a collision
+    /// from the field name alone would reject legitimate schemas. Those cases
+    /// fall back to the schema-build check.
+    pub(super) fn expand_shared_column_checks(&self) -> TokenStream {
+        let toasty = &self.toasty;
+
+        // Group variant fields by their explicit column name, preserving
+        // declaration order within each group.
+        let mut groups: Vec<(String, Vec<&crate::model::schema::Field>)> = Vec::new();
+        for field in &self.model.fields {
+            let Some(name) = field
+                .attrs
+                .column
+                .as_ref()
+                .and_then(|column| column.name.as_ref())
+                .map(|name| name.value())
+            else {
+                continue;
+            };
+
+            match groups.iter_mut().find(|(existing, _)| *existing == name) {
+                Some((_, fields)) => fields.push(field),
+                None => groups.push((name, vec![field])),
+            }
+        }
+
+        let checks = groups
+            .iter()
+            .filter(|(_, fields)| fields.len() > 1)
+            .flat_map(|(_, fields)| {
+                let first = primitive_ty_unwrap(fields[0]);
+                fields[1..].iter().map(move |field| {
+                    let ty = primitive_ty_unwrap(field);
+                    quote_spanned! { ty.span()=>
+                        const _: () = {
+                            fn check<A, B>()
+                            where
+                                A: #toasty::shared_column::SameColumnType<B>,
+                            {
+                            }
+                            let _ = check::<#ty, #first>;
+                        };
+                    }
+                })
+            });
+
+        quote! { #( #checks )* }
     }
 
     /// Generates the full `impl Load for Enum { ... }` block, adapting

--- a/crates/toasty-macros/src/model/expand/embedded_enum.rs
+++ b/crates/toasty-macros/src/model/expand/embedded_enum.rs
@@ -342,14 +342,19 @@ impl Expand<'_> {
             .collect()
     }
 
-    /// Emits a compile-time obligation that every group of variant fields
-    /// sharing a column via `#[column("name")]` agrees on its Rust type.
+    /// Emits compile-time checks for variant fields that share a column via
+    /// `#[column("name")]`.
     ///
     /// Two variants that give a field the same `#[column("name")]` coalesce into
-    /// one shared column, which can hold only one storage type. Rather than defer
-    /// a mismatch to a schema-build error, emit a `SameColumnType` bound between
-    /// each shared field's type and the first in its group; unequal types fail to
-    /// compile with a message pinned to the offending field.
+    /// one shared column, which can hold only one storage type. This emits two
+    /// obligations rather than deferring to a schema-build error:
+    ///
+    /// - **Same-variant collision:** two fields in the *same* variant mapped to
+    ///   one column is invalid — both are active for one discriminant, so the
+    ///   column can't hold both. Emit a `compile_error!` pinned to the second.
+    /// - **Type agreement:** across variants, every shared field must have the
+    ///   same type. Emit a `SameColumnType` bound between each field's type and
+    ///   the first in its group; unequal types fail to compile.
     ///
     /// Only fields with an explicit `#[column("name")]` are grouped. A field
     /// without one is not necessarily single-column (an embedded struct flattens
@@ -379,25 +384,54 @@ impl Expand<'_> {
             }
         }
 
-        let checks = groups
-            .iter()
-            .filter(|(_, fields)| fields.len() > 1)
-            .flat_map(|(_, fields)| {
-                let first = primitive_ty_unwrap(fields[0]);
-                fields[1..].iter().map(move |field| {
-                    let ty = primitive_ty_unwrap(field);
-                    quote_spanned! { ty.span()=>
-                        const _: () = {
-                            fn check<A, B>()
-                            where
-                                A: #toasty::shared_column::SameColumnType<B>,
-                            {
-                            }
-                            let _ = check::<#ty, #first>;
-                        };
-                    }
-                })
-            });
+        let mut checks = Vec::new();
+        for (name, fields) in groups.iter().filter(|(_, fields)| fields.len() > 1) {
+            // Reject a second field in the same variant landing on this column.
+            let mut seen_variants = Vec::new();
+            let mut same_variant = false;
+            for field in fields {
+                let variant = field
+                    .variant
+                    .expect("enum variant field must have a variant");
+                if seen_variants.contains(&variant) {
+                    let ident = &field.name.ident;
+                    checks.push(
+                        syn::Error::new_spanned(
+                            ident,
+                            format!(
+                                "two fields in the same variant map to column `{name}`; \
+                                 a column can be shared only across different variants"
+                            ),
+                        )
+                        .to_compile_error(),
+                    );
+                    same_variant = true;
+                } else {
+                    seen_variants.push(variant);
+                }
+            }
+
+            // A malformed group can't be meaningfully type-checked; the
+            // collision error above is the actionable one.
+            if same_variant {
+                continue;
+            }
+
+            let first = primitive_ty_unwrap(fields[0]);
+            for field in &fields[1..] {
+                let ty = primitive_ty_unwrap(field);
+                checks.push(quote_spanned! { ty.span()=>
+                    const _: () = {
+                        fn check<A, B>()
+                        where
+                            A: #toasty::shared_column::SameColumnType<B>,
+                        {
+                        }
+                        let _ = check::<#ty, #first>;
+                    };
+                });
+            }
+        }
 
         quote! { #( #checks )* }
     }

--- a/crates/toasty-macros/src/model/expand/fields.rs
+++ b/crates/toasty-macros/src/model/expand/fields.rs
@@ -159,12 +159,20 @@ impl Expand<'_> {
         let model_ident = &self.model.ident;
         let is_root = matches!(self.model.kind, ModelKind::Root(_));
 
-        // Generate methods that return list field paths
+        // Generate methods that return list field paths.
+        //
+        // An embedded enum flattens every variant's fields into one list, so two
+        // variants may declare the same field name — e.g. a column shared across
+        // variants via `#[column("name")]`. Emit each accessor name only once to
+        // avoid duplicate method definitions. Root models and embedded structs
+        // can never have duplicate field names, so this dedup is a no-op there.
+        let mut seen_names = std::collections::HashSet::new();
         let methods = self
             .model
             .fields
             .iter()
             .enumerate()
+            .filter(move |(_, field)| seen_names.insert(field.name.as_str().to_string()))
             .map(move |(offset, field)| {
                 let field_ident = &field.name.ident;
                 let field_offset = util::int(offset);

--- a/crates/toasty/src/codegen_support.rs
+++ b/crates/toasty/src/codegen_support.rs
@@ -7,6 +7,7 @@
 pub mod auto;
 pub mod index;
 pub mod newtype;
+pub mod shared_column;
 pub mod storage;
 pub mod version;
 pub mod via;

--- a/crates/toasty/src/codegen_support/shared_column.rs
+++ b/crates/toasty/src/codegen_support/shared_column.rs
@@ -1,0 +1,28 @@
+//! Compile-time validation that enum variant fields sharing a column agree on
+//! their type.
+//!
+//! When two `#[derive(Embed)]` enum variants map a field to the same column —
+//! by giving them the same `#[column("...")]` name, or by declaring same-named
+//! fields — the generated code emits a [`SameColumnType`] obligation between the
+//! two field types. The trait is implemented only reflexively, so the obligation
+//! holds exactly when the two types are identical; otherwise the
+//! `#[diagnostic::on_unimplemented]` message points the user at the mismatch.
+//!
+//! The schema builder enforces the same rule at runtime as a backstop for
+//! schemas built without the derive macro.
+
+/// Asserts that two enum variant fields mapped to the same column have the same
+/// Rust type.
+///
+/// Implemented only reflexively (`impl<T> SameColumnType<T> for T`), so
+/// `A: SameColumnType<B>` holds iff `A` and `B` are the same type. Macro-
+/// generated code emits a `_check::<A, B>()` bounded by this trait for each pair
+/// of fields that land on one shared column.
+#[diagnostic::on_unimplemented(
+    message = "enum variant fields mapped to the same column must have the same type",
+    label = "`{Self}` does not match `{Other}`, the type another variant maps to this column",
+    note = "give both variants' fields the same type, or use distinct `#[column(\"...\")]` names so they map to separate columns"
+)]
+pub trait SameColumnType<Other> {}
+
+impl<T> SameColumnType<T> for T {}

--- a/tests/tests/ui/enum_shared_column_same_variant.rs
+++ b/tests/tests/ui/enum_shared_column_same_variant.rs
@@ -1,0 +1,16 @@
+// Two fields in the same variant map to the same `#[column("x")]`. A column can
+// be shared only across different variants (at most one is active per row), so a
+// same-variant collision is an invalid mapping and must be rejected.
+
+#[derive(Debug, toasty::Embed)]
+enum Value {
+    #[column(variant = 1)]
+    A {
+        #[column("x")]
+        left: String,
+        #[column("x")]
+        right: String,
+    },
+}
+
+fn main() {}

--- a/tests/tests/ui/enum_shared_column_same_variant.stderr
+++ b/tests/tests/ui/enum_shared_column_same_variant.stderr
@@ -1,0 +1,5 @@
+error: two fields in the same variant map to column `x`; a column can be shared only across different variants
+  --> tests/ui/enum_shared_column_same_variant.rs:12:9
+   |
+12 |         right: String,
+   |         ^^^^^

--- a/tests/tests/ui/enum_shared_column_type_mismatch.rs
+++ b/tests/tests/ui/enum_shared_column_type_mismatch.rs
@@ -1,0 +1,19 @@
+// Two variants map a field to the same `#[column("value")]` but with different
+// types. A shared column has a single storage type, so the `SameColumnType`
+// obligation must reject the mismatch.
+
+#[derive(Debug, toasty::Embed)]
+enum Value {
+    #[column(variant = 1)]
+    Text {
+        #[column("value")]
+        text: String,
+    },
+    #[column(variant = 2)]
+    Number {
+        #[column("value")]
+        number: i64,
+    },
+}
+
+fn main() {}

--- a/tests/tests/ui/enum_shared_column_type_mismatch.stderr
+++ b/tests/tests/ui/enum_shared_column_type_mismatch.stderr
@@ -1,0 +1,17 @@
+error[E0277]: enum variant fields mapped to the same column must have the same type
+  --> tests/ui/enum_shared_column_type_mismatch.rs:15:17
+   |
+15 |         number: i64,
+   |                 ^^^ `i64` does not match `std::string::String`, the type another variant maps to this column
+   |
+   = help: the trait `toasty::codegen_support::shared_column::SameColumnType<std::string::String>` is not implemented for `i64`
+   = note: give both variants' fields the same type, or use distinct `#[column("...")]` names so they map to separate columns
+note: required by a bound in `check`
+  --> tests/ui/enum_shared_column_type_mismatch.rs:5:17
+   |
+ 5 | #[derive(Debug, toasty::Embed)]
+   |                 ^^^^^^^^^^^^^ required by this bound in `check`
+...
+15 |         number: i64,
+   |                 --- required by a bound in this function
+   = note: this error originates in the derive macro `toasty::Embed` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
## Summary

Implements the "shared columns across variants" extension from the [enums and embedded structs design doc](https://github.com/tokio-rs/toasty/blob/main/docs/dev/design/enums-and-embedded-structs.md) (issue #280).

Giving a field in two or more `#[derive(Embed)]` enum variants the same `#[column("name")]` coalesces them into one nullable column instead of one column per variant — deduping storage and letting the shared attribute be queried across variants:

```rust
#[derive(toasty::Embed)]
enum Creature {
    #[column(variant = 1)]
    Human  { #[column("name")] name: String, profession: String },
    #[column(variant = 2)]
    Animal { #[column("name")] name: String, species: String },
}
// columns: creature (disc), creature_name (shared), creature_profession, creature_species
```

The schema builder reuses a variant column when a later variant maps a field to the same flattened name, merging each variant's discriminant-guarded encode into one `Match` so the column dispatches per variant on write. Decode already reads the shared column in each variant arm.

Fields sharing a column must have the same type. A mismatch now fails to compile via a `SameColumnType` obligation the `Embed` derive emits, pinned to the offending field; the runtime schema-build check stays as a backstop for schemas built without the macro.

Two supporting fixes fall out: the `Embed` macro now threads `#[column("name")]` on variant fields (previously ignored), and the list-field accessor codegen deduplicates by name so two variants sharing a field name no longer emit a duplicate method.

## Type of change

- [x] Implements a previously accepted design — [`docs/dev/design/enums-and-embedded-structs.md`](https://github.com/tokio-rs/toasty/blob/main/docs/dev/design/enums-and-embedded-structs.md), the "Shared columns across variants" section (this PR does not touch the doc's other two extensions, tuple variants and `stmt::patch`)

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → the design doc describes the behavior
- [x] Touches driver-observable behavior (column layout) → the design doc's "Driver integration" section covers it (no new `Operation` variants; drivers see the same per-column shape)

## Notes for reviewers

- Two commits: storage/coalescing (core + macro), then the compile-time type check.
- Cross-variant querying works today via per-variant gated filters (`creature().human().name().eq(..)`, with the implicit variant gate). The doc's dedicated `creature().name()` accessor is not implemented here. An `OR` of two variant-gated predicates hits a pre-existing simplifier/serializer limitation, filed as #1061 — reproducible on distinct-column variants too, so it's independent of this change.
- The compile-time check groups explicit `#[column("name")]` fields only: a field without one may flatten to several columns (an embedded struct), so predicting a collision from the field name would false-positive on legitimate schemas.
- DynamoDB wasn't exercised locally; the feature reuses existing per-column encoding, so the column shape drivers see is unchanged.
