### PR TITLE
feat(engine,sql): support #[version] optimistic concurrency on SQL drivers

### DIFF
--- a/crates/toasty-core/src/stmt/cx.rs
+++ b/crates/toasty-core/src/stmt/cx.rs
@@ -387,6 +387,11 @@ impl<'a, T: Resolve> ExprContext<'a, T> {
                 ExprSet::Select(body) => cx.infer_returning_ty(&body.returning, args, stmt.single),
                 ExprSet::SetOp(_body) => todo!(),
                 ExprSet::Update(_body) => todo!(),
+                ExprSet::Delete(body) => body
+                    .returning
+                    .as_ref()
+                    .map(|returning| cx.infer_returning_ty(returning, args, stmt.single))
+                    .unwrap_or(Type::Unit),
                 ExprSet::Values(_body) => todo!(),
                 ExprSet::Insert(body) => body
                     .returning
@@ -810,6 +815,7 @@ impl<'a, T: Resolve> IntoExprTarget<'a, T> for &'a ExprSet {
             ExprSet::Select(select) => select.into_expr_target(schema),
             ExprSet::SetOp(_) => todo!(),
             ExprSet::Update(update) => update.into_expr_target(schema),
+            ExprSet::Delete(delete) => delete.into_expr_target(schema),
             ExprSet::Values(_) => ExprTarget::Free,
             ExprSet::Insert(insert) => insert.into_expr_target(schema),
         }

--- a/crates/toasty-core/src/stmt/expr_set.rs
+++ b/crates/toasty-core/src/stmt/expr_set.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use super::{Expr, ExprSetOp, Insert, Select, SourceModel, Update, Values};
+use super::{Delete, Expr, ExprSetOp, Insert, Select, SourceModel, Update, Values};
 use crate::schema::db::TableId;
 
 /// A set of rows produced by a query, set operation, or explicit values.
@@ -24,6 +24,9 @@ pub enum ExprSet {
 
     /// An update expression.
     Update(Box<Update>),
+
+    /// A delete expression (used as a data-modifying CTE for conditional deletes).
+    Delete(Box<Delete>),
 
     /// Explicitly listed values (as expressions).
     Values(Values),
@@ -121,6 +124,7 @@ impl ExprSet {
                 .iter()
                 .all(|operand| operand.is_const()),
             ExprSet::Update(..) => false,
+            ExprSet::Delete(..) => false,
             ExprSet::Values(values) => values.is_const(),
             ExprSet::Insert(..) => false,
         }
@@ -133,6 +137,7 @@ impl fmt::Debug for ExprSet {
             Self::Select(e) => e.fmt(f),
             Self::SetOp(e) => e.fmt(f),
             Self::Update(e) => e.fmt(f),
+            Self::Delete(e) => e.fmt(f),
             Self::Values(e) => e.fmt(f),
             Self::Insert(e) => e.fmt(f),
         }
@@ -154,6 +159,12 @@ impl From<Select> for ExprSet {
 impl From<Update> for ExprSet {
     fn from(value: Update) -> Self {
         Self::Update(Box::new(value))
+    }
+}
+
+impl From<Delete> for ExprSet {
+    fn from(value: Delete) -> Self {
+        Self::Delete(Box::new(value))
     }
 }
 

--- a/crates/toasty-core/src/stmt/visit.rs
+++ b/crates/toasty-core/src/stmt/visit.rs
@@ -1226,6 +1226,7 @@ where
         ExprSet::Select(expr) => v.visit_stmt_select(expr),
         ExprSet::SetOp(expr) => v.visit_expr_set_op(expr),
         ExprSet::Update(expr) => v.visit_stmt_update(expr),
+        ExprSet::Delete(expr) => v.visit_stmt_delete(expr),
         ExprSet::Values(expr) => v.visit_values(expr),
         ExprSet::Insert(expr) => v.visit_stmt_insert(expr),
     }

--- a/crates/toasty-core/src/stmt/visit_mut.rs
+++ b/crates/toasty-core/src/stmt/visit_mut.rs
@@ -1228,6 +1228,7 @@ where
         ExprSet::Select(expr) => v.visit_stmt_select_mut(expr),
         ExprSet::SetOp(expr) => v.visit_expr_set_op_mut(expr),
         ExprSet::Update(expr) => v.visit_stmt_update_mut(expr),
+        ExprSet::Delete(expr) => v.visit_stmt_delete_mut(expr),
         ExprSet::Values(expr) => v.visit_values_mut(expr),
         ExprSet::Insert(expr) => v.visit_stmt_insert_mut(expr),
     }

--- a/crates/toasty-driver-integration-suite/src/tests/field_version.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/field_version.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 
 /// A newly created record starts with version == 1.
-#[driver_test(requires(not(sql)), scenario(crate::scenarios::versioned_item))]
+#[driver_test(scenario(crate::scenarios::versioned_item))]
 pub async fn create_initializes_version(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -14,7 +14,7 @@ pub async fn create_initializes_version(test: &mut Test) -> Result<()> {
 }
 
 /// Updating a record increments the version.
-#[driver_test(requires(not(sql)), scenario(crate::scenarios::versioned_item))]
+#[driver_test(scenario(crate::scenarios::versioned_item))]
 pub async fn update_increments_version(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -38,7 +38,7 @@ pub async fn update_increments_version(test: &mut Test) -> Result<()> {
 /// returning projection. The two must not collide: the engine asks the driver
 /// for exactly the relative column, so the version value never lands in the
 /// returned row and shifts `value` out of its slot.
-#[driver_test(requires(not(sql)), scenario(crate::scenarios::versioned_counter))]
+#[driver_test(scenario(crate::scenarios::versioned_counter))]
 pub async fn relative_update_increments_value_and_version(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -64,7 +64,7 @@ pub async fn relative_update_increments_value_and_version(test: &mut Test) -> Re
 
 /// Two updates from the same stale snapshot — the second should fail with a
 /// condition-check error because the DB version has already moved to 2.
-#[driver_test(requires(not(sql)), scenario(crate::scenarios::versioned_item))]
+#[driver_test(scenario(crate::scenarios::versioned_item))]
 pub async fn stale_update_fails(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -93,7 +93,7 @@ pub async fn stale_update_fails(test: &mut Test) -> Result<()> {
 
 /// Creating the same primary key twice should fail because of the
 /// attribute_not_exists condition on the version column.
-#[driver_test(requires(not(sql)), scenario(crate::scenarios::versioned_item))]
+#[driver_test(scenario(crate::scenarios::versioned_item))]
 pub async fn duplicate_create_fails(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -118,7 +118,7 @@ pub async fn duplicate_create_fails(test: &mut Test) -> Result<()> {
 
 /// Batch-creating multiple versioned items should initialize all versions to 1,
 /// and a duplicate within the batch should fail.
-#[driver_test(requires(not(sql)), scenario(crate::scenarios::versioned_item))]
+#[driver_test(scenario(crate::scenarios::versioned_item))]
 pub async fn batch_insert_checks_version(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -156,7 +156,7 @@ pub async fn batch_insert_checks_version(test: &mut Test) -> Result<()> {
 /// Unlike an instance update there is no per-row OCC guard — a query-based
 /// update is atomic at the database level — but the version still advances so
 /// concurrent stale writers are detected.
-#[driver_test(requires(not(sql)), scenario(crate::scenarios::versioned_item))]
+#[driver_test(scenario(crate::scenarios::versioned_item))]
 pub async fn query_update_increments_version(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -181,7 +181,7 @@ pub async fn query_update_increments_version(test: &mut Test) -> Result<()> {
 /// A query-based update bumps the version, so a concurrent instance update from
 /// a snapshot taken *before* the query update fails its OCC check rather than
 /// silently clobbering the query update's write.
-#[driver_test(requires(not(sql)), scenario(crate::scenarios::versioned_item))]
+#[driver_test(scenario(crate::scenarios::versioned_item))]
 pub async fn query_update_invalidates_stale_instance(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -222,7 +222,7 @@ pub async fn query_update_invalidates_stale_instance(test: &mut Test) -> Result<
 /// The increment is applied atomically to every matched row, so each row's
 /// version advances independently. Verifies the multi-key transact path applies
 /// all assignments and bumps each version.
-#[driver_test(requires(not(sql)), scenario(crate::scenarios::tagged_item))]
+#[driver_test(scenario(crate::scenarios::tagged_item))]
 pub async fn query_update_multi_key_works(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -255,10 +255,7 @@ pub async fn query_update_multi_key_works(test: &mut Test) -> Result<()> {
 /// Query-based update through the unique-index path (path 3) increments the
 /// version. The version is a non-unique column, so it rides along in the main
 /// update expression alongside the unique-index surgery.
-#[driver_test(
-    requires(not(sql)),
-    scenario(crate::scenarios::versioned_user_unique_email)
-)]
+#[driver_test(scenario(crate::scenarios::versioned_user_unique_email))]
 pub async fn query_update_unique_index_increments_version(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -284,10 +281,7 @@ pub async fn query_update_unique_index_increments_version(test: &mut Test) -> Re
 
 /// Updating a record through the unique-index path (path 3) increments the
 /// version when the unique column changes.
-#[driver_test(
-    requires(not(sql)),
-    scenario(crate::scenarios::versioned_user_unique_email)
-)]
+#[driver_test(scenario(crate::scenarios::versioned_user_unique_email))]
 pub async fn unique_index_update_increments_version(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -315,10 +309,7 @@ pub async fn unique_index_update_increments_version(test: &mut Test) -> Result<(
 
 /// Stale update on a model with a unique index: the second update from a stale
 /// snapshot should fail.
-#[driver_test(
-    requires(not(sql)),
-    scenario(crate::scenarios::versioned_user_unique_email)
-)]
+#[driver_test(scenario(crate::scenarios::versioned_user_unique_email))]
 pub async fn unique_index_stale_update_fails(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -359,7 +350,7 @@ pub async fn unique_index_stale_update_fails(test: &mut Test) -> Result<()> {
 /// returning column list; the engine-injected version bump is kept *out* of
 /// that list. The driver returns exactly the requested columns, so the version
 /// value never lands in the returned row and shifts `value` out of its slot.
-#[driver_test(requires(not(sql)), scenario(crate::scenarios::versioned_counter))]
+#[driver_test(scenario(crate::scenarios::versioned_counter))]
 pub async fn query_relative_update_increments_value_and_version(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -379,7 +370,7 @@ pub async fn query_relative_update_increments_value_and_version(test: &mut Test)
 }
 
 /// Deleting a record checks the version — a fresh handle succeeds.
-#[driver_test(requires(not(sql)), scenario(crate::scenarios::versioned_item))]
+#[driver_test(scenario(crate::scenarios::versioned_item))]
 pub async fn delete_checks_version(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
@@ -399,7 +390,7 @@ pub async fn delete_checks_version(test: &mut Test) -> Result<()> {
 }
 
 /// Deleting from a stale snapshot (wrong version) should fail.
-#[driver_test(requires(not(sql)), scenario(crate::scenarios::versioned_item))]
+#[driver_test(scenario(crate::scenarios::versioned_item))]
 pub async fn stale_delete_fails(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 

--- a/crates/toasty-driver-integration-suite/src/tests/field_version.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/field_version.rs
@@ -91,8 +91,9 @@ pub async fn stale_update_fails(test: &mut Test) -> Result<()> {
     Ok(())
 }
 
-/// Creating the same primary key twice should fail because of the
-/// attribute_not_exists condition on the version column.
+/// Creating the same primary key twice should fail. On DynamoDB the insert
+/// carries an attribute_not_exists condition on the version column; on SQL
+/// backends the primary-key constraint rejects the duplicate.
 #[driver_test(scenario(crate::scenarios::versioned_item))]
 pub async fn duplicate_create_fails(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
@@ -216,12 +217,13 @@ pub async fn query_update_invalidates_stale_instance(test: &mut Test) -> Result<
     Ok(())
 }
 
-/// Query-based update on a versioned model: exercises update_by_key path 2
-/// (no unique index, N keys via transact_write_items on DDB).
+/// Query-based update on a versioned model matching multiple rows. On DynamoDB
+/// this exercises update_by_key path 2 (no unique index, N keys via
+/// transact_write_items); on SQL backends it is a single multi-row UPDATE.
 ///
 /// The increment is applied atomically to every matched row, so each row's
-/// version advances independently. Verifies the multi-key transact path applies
-/// all assignments and bumps each version.
+/// version advances independently. Verifies the multi-row path applies all
+/// assignments and bumps each version.
 #[driver_test(scenario(crate::scenarios::tagged_item))]
 pub async fn query_update_multi_key_works(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
@@ -385,6 +387,93 @@ pub async fn delete_checks_version(test: &mut Test) -> Result<()> {
     // Item should be gone — get() should return not-found
     let after_delete = Item::filter_by_id(id).get(&mut db).await;
     assert!(after_delete.is_err(), "item should have been deleted");
+
+    Ok(())
+}
+
+/// An instance update whose row has been deleted fails instead of silently
+/// succeeding. SQL backends raise `record_not_found`.
+#[driver_test(scenario(crate::scenarios::versioned_item))]
+pub async fn update_after_delete_fails(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let mut item = toasty::create!(Item { name: "hello" })
+        .exec(&mut db)
+        .await?;
+
+    // Delete the row out from under the instance.
+    Item::filter_by_id(item.id).delete().exec(&mut db).await?;
+
+    let result: Result<()> = item.update().name("stale").exec(&mut db).await;
+    let err = assert_err!(result);
+    if test.capability().sql {
+        assert!(
+            err.is_record_not_found(),
+            "expected record_not_found, got {err:?}"
+        );
+    }
+
+    Ok(())
+}
+
+/// The read-back variant of `update_after_delete_fails`: a relative update
+/// (`increment`) carries a `RETURNING`, so the conditional write goes through
+/// the row-returning path. With the row deleted there is nothing to return —
+/// the update fails rather than reloading the instance from a phantom row.
+#[driver_test(scenario(crate::scenarios::versioned_counter))]
+pub async fn relative_update_after_delete_fails(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let mut counter = toasty::create!(Counter { value: 10 }).exec(&mut db).await?;
+
+    Counter::filter_by_id(counter.id)
+        .delete()
+        .exec(&mut db)
+        .await?;
+
+    let result: Result<()> = counter
+        .update()
+        .value(toasty::stmt::increment())
+        .exec(&mut db)
+        .await;
+    let err = assert_err!(result);
+    if test.capability().sql {
+        assert!(
+            err.is_record_not_found(),
+            "expected record_not_found, got {err:?}"
+        );
+    }
+
+    Ok(())
+}
+
+/// A conditional write binding a value whose database type cannot be inferred
+/// from the value alone (`f64`). Exercises bind-param type refinement through
+/// both SQL conditional-write plans (regression: the PostgreSQL CTE plan left
+/// `f64` assignment params untyped and panicked).
+#[driver_test]
+pub async fn update_with_float_field_works(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Gauge {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+
+        value: f64,
+
+        #[version]
+        version: u64,
+    }
+
+    let mut db = test.setup_db(models!(Gauge)).await;
+
+    let mut gauge = toasty::create!(Gauge { value: 1.5 }).exec(&mut db).await?;
+
+    gauge.update().value(2.5).exec(&mut db).await?;
+    assert_struct!(gauge, _ { value: 2.5, version: 2, .. });
+
+    let reloaded = Gauge::filter_by_id(gauge.id).get(&mut db).await?;
+    assert_struct!(reloaded, _ { value: 2.5, version: 2, .. });
 
     Ok(())
 }

--- a/crates/toasty-sql/src/serializer/statement.rs
+++ b/crates/toasty-sql/src/serializer/statement.rs
@@ -346,7 +346,7 @@ impl ToSql for &stmt::Insert {
         let returning = self
             .returning
             .as_ref()
-            .map(|returning| ("RETURNING ", returning));
+            .map(|returning| (" RETURNING ", returning));
 
         if returning.is_some() && f.serializer.is_mysql() {
             panic!(

--- a/crates/toasty-sql/src/serializer/statement.rs
+++ b/crates/toasty-sql/src/serializer/statement.rs
@@ -265,9 +265,10 @@ impl ToSql for &stmt::Delete {
     fn to_sql(self, f: &mut super::Formatter<'_>) {
         assert!(self.returning.is_none());
 
-        // Conditions never reach the serializer: a conditional DELETE is
-        // rewritten into a read-modify-write plan that strips the condition and
-        // checks it against a count probe (see `plan_conditional_sql_query_as_rmw`).
+        // Conditions never reach the serializer: the planner rewrites a
+        // conditional DELETE into a CTE or read-modify-write plan (see
+        // `plan_conditional_sql_query_as_*`), stripping the condition and
+        // folding its check into a filter predicate.
         debug_assert!(
             self.condition.is_none(),
             "SQL DELETE condition should have been lowered by the planner; condition={:#?}",

--- a/crates/toasty-sql/src/serializer/statement.rs
+++ b/crates/toasty-sql/src/serializer/statement.rs
@@ -427,6 +427,7 @@ impl ToSql for &stmt::ExprSet {
             stmt::ExprSet::Select(expr) => expr.to_sql(f),
             stmt::ExprSet::Values(expr) => expr.to_sql(f),
             stmt::ExprSet::Update(expr) => expr.to_sql(f),
+            stmt::ExprSet::Delete(expr) => expr.to_sql(f),
             _ => todo!("self={self:?}"),
         }
     }

--- a/crates/toasty-sql/src/serializer/statement.rs
+++ b/crates/toasty-sql/src/serializer/statement.rs
@@ -265,6 +265,15 @@ impl ToSql for &stmt::Delete {
     fn to_sql(self, f: &mut super::Formatter<'_>) {
         assert!(self.returning.is_none());
 
+        // Conditions never reach the serializer: a conditional DELETE is
+        // rewritten into a read-modify-write plan that strips the condition and
+        // checks it against a count probe (see `plan_conditional_sql_query_as_rmw`).
+        debug_assert!(
+            self.condition.is_none(),
+            "SQL DELETE condition should have been lowered by the planner; condition={:#?}",
+            self.condition
+        );
+
         // Create a new expression scope to serialize the statement
         let mut f = f.scope(self);
         f.alias = true;
@@ -445,16 +454,17 @@ impl ToSql for &stmt::Returning {
     fn to_sql(self, f: &mut super::Formatter<'_>) {
         match self {
             stmt::Returning::Project(stmt::Expr::Record(expr_record)) => {
+                // Alias every projected field positionally (`AS column1`, ...).
+                // A nested SELECT/RETURNING referenced from an outer query (e.g.
+                // a data-modifying CTE joined for its returned rows) is read by
+                // that alias — `ColumnAlias` — so a bare column reference must
+                // carry it too, not just computed expressions. Drivers read
+                // top-level results positionally, so the alias is harmless there.
                 let fields = expr_record
                     .fields
                     .iter()
                     .enumerate()
-                    .map(|(i, expr)| match expr {
-                        stmt::Expr::Reference(stmt::ExprReference::Column { .. }) => {
-                            (expr, None, None)
-                        }
-                        _ => (expr, Some(" AS "), Some(ColumnAlias(i))),
-                    });
+                    .map(|(i, expr)| (expr, Some(" AS "), Some(ColumnAlias(i))));
 
                 fmt!(f, Comma(fields));
             }
@@ -641,9 +651,14 @@ impl ToSql for &stmt::Update {
             );
         }
 
-        assert!(
+        // Conditions never reach the serializer: the planner rewrites a
+        // conditional UPDATE into a CTE or read-modify-write plan (see
+        // `plan_conditional_sql_query_as_*`), stripping the condition and
+        // folding its check into a filter predicate.
+        debug_assert!(
             self.condition.is_none(),
-            "SQL does not support update conditions"
+            "SQL UPDATE condition should have been lowered by the planner; condition={:#?}",
+            self.condition
         );
 
         fmt!(&mut f, "UPDATE " self.target " SET " assignments self.filter returning);

--- a/crates/toasty-sql/tests/serialize_dml.rs
+++ b/crates/toasty-sql/tests/serialize_dml.rs
@@ -189,12 +189,18 @@ fn insert_basic_values() {
 fn insert_with_returning() {
     let schema = users_schema();
     let returning = Some(Returning::Project(Expr::record([col(0, 0)])));
-    expect![[r#"INSERT INTO "users" ("id", "name") VALUES (1, 'a')RETURNING "id";"#]].assert_eq(
-        &render(Flavor::Sqlite, &schema, insert_basic(returning.clone())),
-    );
-    expect![[r#"INSERT INTO "users" ("id", "name") VALUES (1, 'a')RETURNING "id";"#]].assert_eq(
-        &render(Flavor::Postgresql, &schema, insert_basic(returning)),
-    );
+    expect![[r#"INSERT INTO "users" ("id", "name") VALUES (1, 'a')RETURNING "id" AS column1;"#]]
+        .assert_eq(&render(
+            Flavor::Sqlite,
+            &schema,
+            insert_basic(returning.clone()),
+        ));
+    expect![[r#"INSERT INTO "users" ("id", "name") VALUES (1, 'a')RETURNING "id" AS column1;"#]]
+        .assert_eq(&render(
+            Flavor::Postgresql,
+            &schema,
+            insert_basic(returning),
+        ));
 }
 
 #[test]
@@ -253,18 +259,22 @@ fn update_with_where() {
 fn update_with_returning() {
     let schema = users_schema();
     let returning = Some(Returning::Project(Expr::record([col(0, 0)])));
-    expect![[r#"UPDATE "users" AS tbl_0_0 SET "name" = 'b' WHERE "id" = 1 RETURNING "id";"#]]
-        .assert_eq(&render(
-            Flavor::Sqlite,
-            &schema,
-            update_stmt(true, returning.clone()),
-        ));
-    expect![[r#"UPDATE "users" AS tbl_0_0 SET "name" = 'b' WHERE "id" = 1 RETURNING "id";"#]]
-        .assert_eq(&render(
-            Flavor::Postgresql,
-            &schema,
-            update_stmt(true, returning),
-        ));
+    expect![[
+        r#"UPDATE "users" AS tbl_0_0 SET "name" = 'b' WHERE "id" = 1 RETURNING "id" AS column1;"#
+    ]]
+    .assert_eq(&render(
+        Flavor::Sqlite,
+        &schema,
+        update_stmt(true, returning.clone()),
+    ));
+    expect![[
+        r#"UPDATE "users" AS tbl_0_0 SET "name" = 'b' WHERE "id" = 1 RETURNING "id" AS column1;"#
+    ]]
+    .assert_eq(&render(
+        Flavor::Postgresql,
+        &schema,
+        update_stmt(true, returning),
+    ));
 }
 
 #[test]

--- a/crates/toasty-sql/tests/serialize_dml.rs
+++ b/crates/toasty-sql/tests/serialize_dml.rs
@@ -189,13 +189,13 @@ fn insert_basic_values() {
 fn insert_with_returning() {
     let schema = users_schema();
     let returning = Some(Returning::Project(Expr::record([col(0, 0)])));
-    expect![[r#"INSERT INTO "users" ("id", "name") VALUES (1, 'a')RETURNING "id" AS column1;"#]]
+    expect![[r#"INSERT INTO "users" ("id", "name") VALUES (1, 'a') RETURNING "id" AS column1;"#]]
         .assert_eq(&render(
             Flavor::Sqlite,
             &schema,
             insert_basic(returning.clone()),
         ));
-    expect![[r#"INSERT INTO "users" ("id", "name") VALUES (1, 'a')RETURNING "id" AS column1;"#]]
+    expect![[r#"INSERT INTO "users" ("id", "name") VALUES (1, 'a') RETURNING "id" AS column1;"#]]
         .assert_eq(&render(
             Flavor::Postgresql,
             &schema,

--- a/crates/toasty-sql/tests/serialize_joins.rs
+++ b/crates/toasty-sql/tests/serialize_joins.rs
@@ -113,7 +113,7 @@ fn left_join_renders_left_join_with_on_clause() {
     };
 
     let on = Expr::eq(col(1, 1), col(0, 0));
-    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 LEFT JOIN "posts" AS tbl_0_1 ON tbl_0_1."user_id" = tbl_0_0."id";"#]].assert_eq(&render_sqlite(&schema, select_with_join(JoinOp::Left(on))));
+    expect![[r#"SELECT tbl_0_0."id" AS column1 FROM "users" AS tbl_0_0 LEFT JOIN "posts" AS tbl_0_1 ON tbl_0_1."user_id" = tbl_0_0."id";"#]].assert_eq(&render_sqlite(&schema, select_with_join(JoinOp::Left(on))));
 }
 
 #[test]
@@ -126,7 +126,7 @@ fn inner_join_renders_inner_join_with_on_clause() {
     };
 
     let on = Expr::eq(col(1, 1), col(0, 0));
-    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 INNER JOIN "posts" AS tbl_0_1 ON tbl_0_1."user_id" = tbl_0_0."id";"#]].assert_eq(&render_sqlite(&schema, select_with_join(JoinOp::Inner(on))));
+    expect![[r#"SELECT tbl_0_0."id" AS column1 FROM "users" AS tbl_0_0 INNER JOIN "posts" AS tbl_0_1 ON tbl_0_1."user_id" = tbl_0_0."id";"#]].assert_eq(&render_sqlite(&schema, select_with_join(JoinOp::Inner(on))));
 }
 
 /// Multi-step join: `users LEFT JOIN posts ON ... LEFT JOIN comments ON ...`.
@@ -169,7 +169,7 @@ fn multi_step_left_join_chain() {
         distinct: false,
     };
     let stmt = stmt::Statement::Query(stmt::Query::builder(select).build());
-    expect![[r#"SELECT tbl_0_0."id", tbl_0_1."id", tbl_0_2."id" FROM "users" AS tbl_0_0 LEFT JOIN "posts" AS tbl_0_1 ON tbl_0_1."user_id" = tbl_0_0."id" LEFT JOIN "comments" AS tbl_0_2 ON tbl_0_2."post_id" = tbl_0_1."id";"#]].assert_eq(&render_sqlite(&schema, stmt));
+    expect![[r#"SELECT tbl_0_0."id" AS column1, tbl_0_1."id" AS column2, tbl_0_2."id" AS column3 FROM "users" AS tbl_0_0 LEFT JOIN "posts" AS tbl_0_1 ON tbl_0_1."user_id" = tbl_0_0."id" LEFT JOIN "comments" AS tbl_0_2 ON tbl_0_2."post_id" = tbl_0_1."id";"#]].assert_eq(&render_sqlite(&schema, stmt));
 }
 
 /// Mixed-kind chain: `users INNER JOIN posts ON ... LEFT JOIN comments ON ...`.
@@ -212,5 +212,5 @@ fn mixed_inner_then_left_join() {
         distinct: false,
     };
     let stmt = stmt::Statement::Query(stmt::Query::builder(select).build());
-    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 INNER JOIN "posts" AS tbl_0_1 ON tbl_0_1."user_id" = tbl_0_0."id" LEFT JOIN "comments" AS tbl_0_2 ON tbl_0_2."post_id" = tbl_0_1."id";"#]].assert_eq(&render_sqlite(&schema, stmt));
+    expect![[r#"SELECT tbl_0_0."id" AS column1 FROM "users" AS tbl_0_0 INNER JOIN "posts" AS tbl_0_1 ON tbl_0_1."user_id" = tbl_0_0."id" LEFT JOIN "comments" AS tbl_0_2 ON tbl_0_2."post_id" = tbl_0_1."id";"#]].assert_eq(&render_sqlite(&schema, stmt));
 }

--- a/crates/toasty-sql/tests/serialize_select.rs
+++ b/crates/toasty-sql/tests/serialize_select.rs
@@ -134,19 +134,19 @@ fn make_query(
 fn select_basic() {
     let schema = users_schema();
     let stmt = make_query(Filter::ALL, None, None, vec![]);
-    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0;"#]].assert_eq(&render(
+    expect![[r#"SELECT tbl_0_0."id" AS column1 FROM "users" AS tbl_0_0;"#]].assert_eq(&render(
         Flavor::Sqlite,
         &schema,
         stmt,
     ));
     let stmt = make_query(Filter::ALL, None, None, vec![]);
-    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0;"#]].assert_eq(&render(
+    expect![[r#"SELECT tbl_0_0."id" AS column1 FROM "users" AS tbl_0_0;"#]].assert_eq(&render(
         Flavor::Postgresql,
         &schema,
         stmt,
     ));
     let stmt = make_query(Filter::ALL, None, None, vec![]);
-    expect!["SELECT tbl_0_0.`id` FROM `users` AS tbl_0_0;"].assert_eq(&render(
+    expect!["SELECT tbl_0_0.`id` AS column_0 FROM `users` AS tbl_0_0;"].assert_eq(&render(
         Flavor::Mysql,
         &schema,
         stmt,
@@ -167,21 +167,12 @@ fn select_distinct() {
         };
         stmt::Statement::Query(stmt::Query::builder(select).build())
     };
-    expect![[r#"SELECT DISTINCT tbl_0_0."id" FROM "users" AS tbl_0_0;"#]].assert_eq(&render(
-        Flavor::Sqlite,
-        &schema,
-        distinct_query(),
-    ));
-    expect![[r#"SELECT DISTINCT tbl_0_0."id" FROM "users" AS tbl_0_0;"#]].assert_eq(&render(
-        Flavor::Postgresql,
-        &schema,
-        distinct_query(),
-    ));
-    expect!["SELECT DISTINCT tbl_0_0.`id` FROM `users` AS tbl_0_0;"].assert_eq(&render(
-        Flavor::Mysql,
-        &schema,
-        distinct_query(),
-    ));
+    expect![[r#"SELECT DISTINCT tbl_0_0."id" AS column1 FROM "users" AS tbl_0_0;"#]]
+        .assert_eq(&render(Flavor::Sqlite, &schema, distinct_query()));
+    expect![[r#"SELECT DISTINCT tbl_0_0."id" AS column1 FROM "users" AS tbl_0_0;"#]]
+        .assert_eq(&render(Flavor::Postgresql, &schema, distinct_query()));
+    expect!["SELECT DISTINCT tbl_0_0.`id` AS column_0 FROM `users` AS tbl_0_0;"]
+        .assert_eq(&render(Flavor::Mysql, &schema, distinct_query()));
 }
 
 #[test]
@@ -189,15 +180,15 @@ fn select_with_where() {
     let schema = users_schema();
     let filter = Filter::from(Expr::eq(col(0, 0), Expr::from(1i64)));
     let stmt = make_query(filter, None, None, vec![]);
-    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 WHERE tbl_0_0."id" = 1;"#]]
+    expect![[r#"SELECT tbl_0_0."id" AS column1 FROM "users" AS tbl_0_0 WHERE tbl_0_0."id" = 1;"#]]
         .assert_eq(&render(Flavor::Sqlite, &schema, stmt));
     let filter = Filter::from(Expr::eq(col(0, 0), Expr::from(1i64)));
     let stmt = make_query(filter, None, None, vec![]);
-    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 WHERE tbl_0_0."id" = 1;"#]]
+    expect![[r#"SELECT tbl_0_0."id" AS column1 FROM "users" AS tbl_0_0 WHERE tbl_0_0."id" = 1;"#]]
         .assert_eq(&render(Flavor::Postgresql, &schema, stmt));
     let filter = Filter::from(Expr::eq(col(0, 0), Expr::from(1i64)));
     let stmt = make_query(filter, None, None, vec![]);
-    expect!["SELECT tbl_0_0.`id` FROM `users` AS tbl_0_0 WHERE tbl_0_0.`id` = 1;"]
+    expect!["SELECT tbl_0_0.`id` AS column_0 FROM `users` AS tbl_0_0 WHERE tbl_0_0.`id` = 1;"]
         .assert_eq(&render(Flavor::Mysql, &schema, stmt));
 }
 
@@ -209,7 +200,7 @@ fn select_with_and_filter() {
         Expr::eq(col(0, 1), Expr::from("foo")),
     ));
     let stmt = make_query(filter, None, None, vec![]);
-    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 WHERE tbl_0_0."id" = 1 AND tbl_0_0."name" = 'foo';"#]].assert_eq(&render(Flavor::Sqlite, &schema, stmt));
+    expect![[r#"SELECT tbl_0_0."id" AS column1 FROM "users" AS tbl_0_0 WHERE tbl_0_0."id" = 1 AND tbl_0_0."name" = 'foo';"#]].assert_eq(&render(Flavor::Sqlite, &schema, stmt));
 }
 
 #[test]
@@ -220,9 +211,7 @@ fn select_with_or_filter() {
         Expr::eq(col(0, 0), Expr::from(2i64)),
     ));
     let stmt = make_query(filter, None, None, vec![]);
-    expect![[
-        r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 WHERE tbl_0_0."id" = 1 OR tbl_0_0."id" = 2;"#
-    ]]
+    expect![[r#"SELECT tbl_0_0."id" AS column1 FROM "users" AS tbl_0_0 WHERE tbl_0_0."id" = 1 OR tbl_0_0."id" = 2;"#]]
     .assert_eq(&render(Flavor::Sqlite, &schema, stmt));
 }
 
@@ -236,8 +225,10 @@ fn select_with_order_by_asc() {
         }],
     };
     let stmt = make_query(Filter::ALL, Some(order_by), None, vec![]);
-    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 ORDER BY tbl_0_0."id" ASC;"#]]
-        .assert_eq(&render(Flavor::Sqlite, &schema, stmt));
+    expect![[
+        r#"SELECT tbl_0_0."id" AS column1 FROM "users" AS tbl_0_0 ORDER BY tbl_0_0."id" ASC;"#
+    ]]
+    .assert_eq(&render(Flavor::Sqlite, &schema, stmt));
 }
 
 #[test]
@@ -250,8 +241,10 @@ fn select_with_order_by_desc() {
         }],
     };
     let stmt = make_query(Filter::ALL, Some(order_by), None, vec![]);
-    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 ORDER BY tbl_0_0."id" DESC;"#]]
-        .assert_eq(&render(Flavor::Sqlite, &schema, stmt));
+    expect![[
+        r#"SELECT tbl_0_0."id" AS column1 FROM "users" AS tbl_0_0 ORDER BY tbl_0_0."id" DESC;"#
+    ]]
+    .assert_eq(&render(Flavor::Sqlite, &schema, stmt));
 }
 
 #[test]
@@ -270,7 +263,7 @@ fn select_with_order_by_multiple_columns() {
         ],
     };
     let stmt = make_query(Filter::ALL, Some(order_by), None, vec![]);
-    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 ORDER BY tbl_0_0."name" ASC, tbl_0_0."id" DESC;"#]].assert_eq(&render(Flavor::Sqlite, &schema, stmt));
+    expect![[r#"SELECT tbl_0_0."id" AS column1 FROM "users" AS tbl_0_0 ORDER BY tbl_0_0."name" ASC, tbl_0_0."id" DESC;"#]].assert_eq(&render(Flavor::Sqlite, &schema, stmt));
 }
 
 #[test]
@@ -281,11 +274,8 @@ fn select_with_limit() {
         offset: None,
     });
     let stmt = make_query(Filter::ALL, None, Some(limit), vec![]);
-    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 LIMIT 10;"#]].assert_eq(&render(
-        Flavor::Sqlite,
-        &schema,
-        stmt,
-    ));
+    expect![[r#"SELECT tbl_0_0."id" AS column1 FROM "users" AS tbl_0_0 LIMIT 10;"#]]
+        .assert_eq(&render(Flavor::Sqlite, &schema, stmt));
 }
 
 #[test]
@@ -296,7 +286,7 @@ fn select_with_limit_and_offset() {
         offset: Some(Expr::from(20i64)),
     });
     let stmt = make_query(Filter::ALL, None, Some(limit), vec![]);
-    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 LIMIT 10 OFFSET 20;"#]]
+    expect![[r#"SELECT tbl_0_0."id" AS column1 FROM "users" AS tbl_0_0 LIMIT 10 OFFSET 20;"#]]
         .assert_eq(&render(Flavor::Sqlite, &schema, stmt));
 }
 
@@ -306,23 +296,14 @@ fn select_with_for_update() {
     // SQLite has no row-level locks, but the serializer renders `FOR UPDATE`
     // unconditionally — verify that for all three flavors.
     let stmt = make_query(Filter::ALL, None, None, vec![Lock::Update]);
-    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 FOR UPDATE;"#]].assert_eq(&render(
-        Flavor::Sqlite,
-        &schema,
-        stmt,
-    ));
+    expect![[r#"SELECT tbl_0_0."id" AS column1 FROM "users" AS tbl_0_0 FOR UPDATE;"#]]
+        .assert_eq(&render(Flavor::Sqlite, &schema, stmt));
     let stmt = make_query(Filter::ALL, None, None, vec![Lock::Update]);
-    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 FOR UPDATE;"#]].assert_eq(&render(
-        Flavor::Postgresql,
-        &schema,
-        stmt,
-    ));
+    expect![[r#"SELECT tbl_0_0."id" AS column1 FROM "users" AS tbl_0_0 FOR UPDATE;"#]]
+        .assert_eq(&render(Flavor::Postgresql, &schema, stmt));
     let stmt = make_query(Filter::ALL, None, None, vec![Lock::Update]);
-    expect!["SELECT tbl_0_0.`id` FROM `users` AS tbl_0_0 FOR UPDATE;"].assert_eq(&render(
-        Flavor::Mysql,
-        &schema,
-        stmt,
-    ));
+    expect!["SELECT tbl_0_0.`id` AS column_0 FROM `users` AS tbl_0_0 FOR UPDATE;"]
+        .assert_eq(&render(Flavor::Mysql, &schema, stmt));
 }
 
 #[test]
@@ -331,21 +312,12 @@ fn select_with_for_share() {
     // As with `FOR UPDATE`, the serializer renders `FOR SHARE` unconditionally
     // across flavors; database compatibility is enforced at execution, not here.
     let stmt = make_query(Filter::ALL, None, None, vec![Lock::Share]);
-    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 FOR SHARE;"#]].assert_eq(&render(
-        Flavor::Sqlite,
-        &schema,
-        stmt,
-    ));
+    expect![[r#"SELECT tbl_0_0."id" AS column1 FROM "users" AS tbl_0_0 FOR SHARE;"#]]
+        .assert_eq(&render(Flavor::Sqlite, &schema, stmt));
     let stmt = make_query(Filter::ALL, None, None, vec![Lock::Share]);
-    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 FOR SHARE;"#]].assert_eq(&render(
-        Flavor::Postgresql,
-        &schema,
-        stmt,
-    ));
+    expect![[r#"SELECT tbl_0_0."id" AS column1 FROM "users" AS tbl_0_0 FOR SHARE;"#]]
+        .assert_eq(&render(Flavor::Postgresql, &schema, stmt));
     let stmt = make_query(Filter::ALL, None, None, vec![Lock::Share]);
-    expect!["SELECT tbl_0_0.`id` FROM `users` AS tbl_0_0 FOR SHARE;"].assert_eq(&render(
-        Flavor::Mysql,
-        &schema,
-        stmt,
-    ));
+    expect!["SELECT tbl_0_0.`id` AS column_0 FROM `users` AS tbl_0_0 FOR SHARE;"]
+        .assert_eq(&render(Flavor::Mysql, &schema, stmt));
 }

--- a/crates/toasty-sql/tests/serialize_subqueries.rs
+++ b/crates/toasty-sql/tests/serialize_subqueries.rs
@@ -221,7 +221,7 @@ fn select_with_single_cte() {
             .build(),
     );
 
-    expect![[r#"WITH cte_0_0 as (SELECT tbl_1_0."id" FROM "users" AS tbl_1_0) SELECT tbl_0_0.column1 FROM cte_0_0 AS tbl_0_0;"#]].assert_eq(&render_sqlite(&schema, stmt));
+    expect![[r#"WITH cte_0_0 as (SELECT tbl_1_0."id" AS column1 FROM "users" AS tbl_1_0) SELECT tbl_0_0.column1 AS column1 FROM cte_0_0 AS tbl_0_0;"#]].assert_eq(&render_sqlite(&schema, stmt));
 }
 
 #[test]
@@ -259,7 +259,7 @@ fn select_with_multiple_ctes() {
             .build(),
     );
 
-    expect![[r#"WITH cte_0_0 as (SELECT tbl_1_0."id" FROM "users" AS tbl_1_0), cte_0_1 as (SELECT tbl_1_0."id" FROM "users" AS tbl_1_0) SELECT tbl_0_0.column1 FROM cte_0_0 AS tbl_0_0;"#]].assert_eq(&render_sqlite(&schema, stmt));
+    expect![[r#"WITH cte_0_0 as (SELECT tbl_1_0."id" AS column1 FROM "users" AS tbl_1_0), cte_0_1 as (SELECT tbl_1_0."id" AS column1 FROM "users" AS tbl_1_0) SELECT tbl_0_0.column1 AS column1 FROM cte_0_0 AS tbl_0_0;"#]].assert_eq(&render_sqlite(&schema, stmt));
 }
 
 // -----------------------------------------------------------------------------
@@ -289,9 +289,7 @@ fn select_from_derived_subquery() {
     };
     let stmt = stmt::Statement::Query(stmt::Query::builder(outer_select).build());
 
-    expect![[
-        r#"SELECT tbl_0_0.column1 FROM (SELECT tbl_1_0."id" FROM "users" AS tbl_1_0) AS tbl_0_0;"#
-    ]]
+    expect![[r#"SELECT tbl_0_0.column1 AS column1 FROM (SELECT tbl_1_0."id" AS column1 FROM "users" AS tbl_1_0) AS tbl_0_0;"#]]
     .assert_eq(&render_sqlite(&schema, stmt));
 }
 
@@ -321,11 +319,11 @@ fn expr_exists_subquery() {
     let schema = users_schema();
     let exists = Expr::exists(select_id_from_users());
 
-    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 WHERE EXISTS (SELECT tbl_1_0."id" FROM "users" AS tbl_1_0);"#]].assert_eq(&render_postgresql(
+    expect![[r#"SELECT tbl_0_0."id" AS column1 FROM "users" AS tbl_0_0 WHERE EXISTS (SELECT tbl_1_0."id" AS column1 FROM "users" AS tbl_1_0);"#]].assert_eq(&render_postgresql(
         &schema,
         select_users_with_filter(exists.clone()),
     ));
-    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 WHERE EXISTS (SELECT tbl_1_0."id" FROM "users" AS tbl_1_0);"#]].assert_eq(&render_sqlite(&schema, select_users_with_filter(exists)));
+    expect![[r#"SELECT tbl_0_0."id" AS column1 FROM "users" AS tbl_0_0 WHERE EXISTS (SELECT tbl_1_0."id" AS column1 FROM "users" AS tbl_1_0);"#]].assert_eq(&render_sqlite(&schema, select_users_with_filter(exists)));
 }
 
 #[test]
@@ -335,11 +333,11 @@ fn expr_not_exists_subquery() {
     // as `NOT (EXISTS (...))`.
     let not_exists = Expr::not_exists(select_id_from_users());
 
-    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 WHERE NOT (EXISTS (SELECT tbl_1_0."id" FROM "users" AS tbl_1_0));"#]].assert_eq(&render_postgresql(
+    expect![[r#"SELECT tbl_0_0."id" AS column1 FROM "users" AS tbl_0_0 WHERE NOT (EXISTS (SELECT tbl_1_0."id" AS column1 FROM "users" AS tbl_1_0));"#]].assert_eq(&render_postgresql(
         &schema,
         select_users_with_filter(not_exists.clone()),
     ));
-    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 WHERE NOT (EXISTS (SELECT tbl_1_0."id" FROM "users" AS tbl_1_0));"#]].assert_eq(&render_sqlite(
+    expect![[r#"SELECT tbl_0_0."id" AS column1 FROM "users" AS tbl_0_0 WHERE NOT (EXISTS (SELECT tbl_1_0."id" AS column1 FROM "users" AS tbl_1_0));"#]].assert_eq(&render_sqlite(
         &schema,
         select_users_with_filter(not_exists),
     ));
@@ -354,9 +352,9 @@ fn expr_in_subquery() {
     let schema = users_schema();
     let in_sub = Expr::in_subquery(col(0, 0), select_id_from_users());
 
-    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 WHERE tbl_0_0."id" IN (SELECT tbl_0_0."id" FROM "users" AS tbl_0_0);"#]].assert_eq(&render_postgresql(
+    expect![[r#"SELECT tbl_0_0."id" AS column1 FROM "users" AS tbl_0_0 WHERE tbl_0_0."id" IN (SELECT tbl_0_0."id" AS column1 FROM "users" AS tbl_0_0);"#]].assert_eq(&render_postgresql(
         &schema,
         select_users_with_filter(in_sub.clone()),
     ));
-    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0 WHERE tbl_0_0."id" IN (SELECT tbl_0_0."id" FROM "users" AS tbl_0_0);"#]].assert_eq(&render_sqlite(&schema, select_users_with_filter(in_sub)));
+    expect![[r#"SELECT tbl_0_0."id" AS column1 FROM "users" AS tbl_0_0 WHERE tbl_0_0."id" IN (SELECT tbl_0_0."id" AS column1 FROM "users" AS tbl_0_0);"#]].assert_eq(&render_sqlite(&schema, select_users_with_filter(in_sub)));
 }

--- a/crates/toasty-sql/tests/serialize_values_idents.rs
+++ b/crates/toasty-sql/tests/serialize_values_idents.rs
@@ -178,7 +178,7 @@ fn ident_quoting_postgresql_double_quote() {
     let stmt = select_id_from_users();
     let sql = Serializer::postgresql(&schema).serialize(&SqlStatement::from(stmt));
 
-    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0;"#]].assert_eq(&sql);
+    expect![[r#"SELECT tbl_0_0."id" AS column1 FROM "users" AS tbl_0_0;"#]].assert_eq(&sql);
 }
 
 #[test]
@@ -187,7 +187,7 @@ fn ident_quoting_sqlite_double_quote() {
     let stmt = select_id_from_users();
     let sql = Serializer::sqlite(&schema).serialize(&SqlStatement::from(stmt));
 
-    expect![[r#"SELECT tbl_0_0."id" FROM "users" AS tbl_0_0;"#]].assert_eq(&sql);
+    expect![[r#"SELECT tbl_0_0."id" AS column1 FROM "users" AS tbl_0_0;"#]].assert_eq(&sql);
 }
 
 #[test]
@@ -196,7 +196,7 @@ fn ident_quoting_mysql_backtick() {
     let stmt = select_id_from_users();
     let sql = Serializer::mysql(&schema).serialize(&SqlStatement::from(stmt));
 
-    expect!["SELECT tbl_0_0.`id` FROM `users` AS tbl_0_0;"].assert_eq(&sql);
+    expect!["SELECT tbl_0_0.`id` AS column_0 FROM `users` AS tbl_0_0;"].assert_eq(&sql);
 }
 
 // -----------------------------------------------------------------------------
@@ -281,13 +281,13 @@ fn column_alias_format_per_flavor() {
     let sql_stmt = SqlStatement::from(stmt);
 
     let pg = Serializer::postgresql(&schema).serialize(&sql_stmt);
-    expect![[r#"WITH cte_0_0 as (SELECT tbl_1_0."id" FROM "users" AS tbl_1_0) SELECT tbl_0_0.column1 FROM cte_0_0 AS tbl_0_0;"#]].assert_eq(&pg);
+    expect![[r#"WITH cte_0_0 as (SELECT tbl_1_0."id" AS column1 FROM "users" AS tbl_1_0) SELECT tbl_0_0.column1 AS column1 FROM cte_0_0 AS tbl_0_0;"#]].assert_eq(&pg);
 
     let sqlite = Serializer::sqlite(&schema).serialize(&sql_stmt);
-    expect![[r#"WITH cte_0_0 as (SELECT tbl_1_0."id" FROM "users" AS tbl_1_0) SELECT tbl_0_0.column1 FROM cte_0_0 AS tbl_0_0;"#]].assert_eq(&sqlite);
+    expect![[r#"WITH cte_0_0 as (SELECT tbl_1_0."id" AS column1 FROM "users" AS tbl_1_0) SELECT tbl_0_0.column1 AS column1 FROM cte_0_0 AS tbl_0_0;"#]].assert_eq(&sqlite);
 
     let mysql = Serializer::mysql(&schema).serialize(&sql_stmt);
-    expect!["WITH cte_0_0 as (SELECT tbl_1_0.`id` FROM `users` AS tbl_1_0) SELECT tbl_0_0.column_0 FROM cte_0_0 AS tbl_0_0;"].assert_eq(&mysql);
+    expect!["WITH cte_0_0 as (SELECT tbl_1_0.`id` AS column_0 FROM `users` AS tbl_1_0) SELECT tbl_0_0.column_0 AS column_0 FROM cte_0_0 AS tbl_0_0;"].assert_eq(&mysql);
 }
 
 // -----------------------------------------------------------------------------

--- a/crates/toasty/src/engine/exec.rs
+++ b/crates/toasty/src/engine/exec.rs
@@ -8,7 +8,9 @@ mod eval;
 pub(crate) use eval::Eval;
 
 mod exec_statement;
-pub(crate) use exec_statement::{ExecStatement, ExecStatementOutput, PaginationConfig};
+pub(crate) use exec_statement::{
+    ConditionalOutput, ExecStatement, ExecStatementOutput, PaginationConfig,
+};
 
 mod filter;
 pub(crate) use filter::Filter;

--- a/crates/toasty/src/engine/exec/exec_statement.rs
+++ b/crates/toasty/src/engine/exec/exec_statement.rs
@@ -17,7 +17,7 @@ use crate::{
 /// CTE statement) prefixes its result with two probe columns: the number of
 /// rows matching the filter and, of those, the number satisfying the condition.
 /// The write applied only when the two agree; a mismatch is a condition
-/// failure.
+/// failure, and zero matched rows means the record no longer exists.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ConditionalOutput {
     /// Not a conditional write. Output is passed through unchanged.
@@ -210,46 +210,48 @@ impl Exec<'_> {
                         .await?;
                 }
             }
-            ConditionalOutput::Count => {
+            ConditionalOutput::Count | ConditionalOutput::Returning => {
                 let rows = collect_conditional_probe(res.values).await?;
                 let (matched, conditioned) = conditional_probe_counts(&rows[0])?;
-                if matched != conditioned {
-                    return Err(toasty_core::Error::condition_failed(
-                        "write condition did not match",
+
+                // A conditional write targets a row the caller holds an
+                // instance of: zero matched rows means it has since been
+                // deleted.
+                if matched == 0 {
+                    return Err(toasty_core::Error::record_not_found(
+                        "conditional write matched no rows",
                     ));
                 }
-                res.values = Rows::Count(matched as u64);
-            }
-            ConditionalOutput::Returning => {
-                let rows = collect_conditional_probe(res.values).await?;
-                let (matched, conditioned) = conditional_probe_counts(&rows[0])?;
                 if matched != conditioned {
                     return Err(toasty_core::Error::condition_failed(
                         "write condition did not match",
                     ));
                 }
 
-                // When nothing matched, the LEFT JOIN yields a single
-                // NULL-padded row; drop it. Otherwise every row is a real
-                // changed row — strip the two leading probe columns.
-                let changed = if matched == 0 {
-                    vec![]
-                } else {
-                    rows.into_iter()
-                        .map(|row| {
-                            let stmt::Value::Record(record) = row else {
-                                return Err(toasty_core::Error::invalid_result(
-                                    "conditional write expected Record",
-                                ));
-                            };
-                            Ok(stmt::Value::record_from_vec(
-                                record.fields.into_iter().skip(2).collect(),
-                            ))
-                        })
-                        .collect::<Result<Vec<_>>>()?
+                res.values = match action.conditional {
+                    ConditionalOutput::Count => Rows::Count(matched as u64),
+                    _ => {
+                        // The probe locked the matched rows, so the write
+                        // applied to exactly those rows and every result row is
+                        // a real changed row — strip the two leading probe
+                        // columns.
+                        let changed = rows
+                            .into_iter()
+                            .map(|row| {
+                                let stmt::Value::Record(record) = row else {
+                                    return Err(toasty_core::Error::invalid_result(
+                                        "conditional write expected Record",
+                                    ));
+                                };
+                                Ok(stmt::Value::record_from_vec(
+                                    record.fields.into_iter().skip(2).collect(),
+                                ))
+                            })
+                            .collect::<Result<Vec<_>>>()?;
+
+                        Rows::value_stream(changed)
+                    }
                 };
-
-                res.values = Rows::value_stream(changed);
             }
         }
 

--- a/crates/toasty/src/engine/exec/exec_statement.rs
+++ b/crates/toasty/src/engine/exec/exec_statement.rs
@@ -11,6 +11,27 @@ use crate::{
     },
 };
 
+/// How to interpret a statement's output rows.
+///
+/// A conditional write (the SQL `#[version]` / OCC path compiled as a single
+/// CTE statement) prefixes its result with two probe columns: the number of
+/// rows matching the filter and, of those, the number satisfying the condition.
+/// The write applied only when the two agree; a mismatch is a condition
+/// failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ConditionalOutput {
+    /// Not a conditional write. Output is passed through unchanged.
+    None,
+
+    /// Conditional write with no `RETURNING`. The two probe columns are the
+    /// only output; the action reports the matched-row count.
+    Count,
+
+    /// Conditional write with a `RETURNING`. The two probe columns are followed
+    /// by the changed rows' columns, which become the action's output.
+    Returning,
+}
+
 /// Configuration for pagination at the execution level.
 #[derive(Debug, Clone)]
 pub(crate) struct PaginationConfig {
@@ -45,7 +66,7 @@ struct MySQLInsertReturning {
 /// statements are not atomic relative to concurrent writers — see #881 for
 /// the broader design discussion.
 #[derive(Debug)]
-struct MySQLUpdateReturning {
+pub(super) struct MySQLUpdateReturning {
     /// The `SELECT` statement that returns the post-update values. Carries
     /// the same filter as the original `UPDATE` plus the projected
     /// returning expression.
@@ -63,8 +84,8 @@ pub(crate) struct ExecStatement {
     /// The query to execute. This may require input to generate the query.
     pub stmt: stmt::Statement,
 
-    /// When true, the statement is a conditional update without any returning.
-    pub conditional_update_with_no_returning: bool,
+    /// How to interpret this statement's output. See [`ConditionalOutput`].
+    pub conditional: ConditionalOutput,
 
     /// Pagination configuration (None if not paginated)
     pub pagination: Option<PaginationConfig>,
@@ -117,7 +138,7 @@ impl Exec<'_> {
             && let stmt::ExprSet::Values(values) = &query.body
             && values.is_empty()
         {
-            assert!(!action.conditional_update_with_no_returning);
+            assert_eq!(action.conditional, ConditionalOutput::None);
 
             let rows = if action.output.ty.is_some() {
                 Rows::Stream(stmt::ValueStream::default())
@@ -145,58 +166,91 @@ impl Exec<'_> {
         let op = operation::QuerySql {
             stmt,
             params,
-            ret: if action.conditional_update_with_no_returning {
-                Some(vec![stmt::Type::I64, stmt::Type::I64])
-            } else if mysql_insert_returning.is_some() {
-                // For MySQL INSERT with RETURNING, we don't send RETURNING to the database
-                // (it doesn't support it). The driver will fetch auto-increment IDs using LAST_INSERT_ID().
-                None
-            } else if mysql_update_returning.is_some() {
-                // The UPDATE has had its RETURNING stripped; the driver runs
-                // a plain UPDATE that returns no rows. The follow-up SELECT
-                // below produces the returning values.
-                None
-            } else {
-                action.output.ty.clone()
+            ret: match action.conditional {
+                // A conditional write prefixes its result with two `I64` probe
+                // counts; the `Returning` variant follows them with the changed
+                // rows' columns.
+                ConditionalOutput::Count => Some(vec![stmt::Type::I64, stmt::Type::I64]),
+                ConditionalOutput::Returning => {
+                    let mut tys = vec![stmt::Type::I64, stmt::Type::I64];
+                    tys.extend(
+                        action
+                            .output
+                            .ty
+                            .clone()
+                            .expect("conditional write with RETURNING has output columns"),
+                    );
+                    Some(tys)
+                }
+                ConditionalOutput::None if mysql_insert_returning.is_some() => {
+                    // For MySQL INSERT with RETURNING, we don't send RETURNING to the database
+                    // (it doesn't support it). The driver will fetch auto-increment IDs using LAST_INSERT_ID().
+                    None
+                }
+                ConditionalOutput::None if mysql_update_returning.is_some() => {
+                    // The UPDATE has had its RETURNING stripped; the driver runs
+                    // a plain UPDATE that returns no rows. The follow-up SELECT
+                    // below produces the returning values.
+                    None
+                }
+                ConditionalOutput::None => action.output.ty.clone(),
             },
             last_insert_id_hack: mysql_insert_returning.as_ref().map(|info| info.num_rows),
         };
 
         let mut res = self.connection.exec(&self.engine.schema, op.into()).await?;
 
-        if action.conditional_update_with_no_returning {
-            let Rows::Stream(rows) = res.values else {
-                return Err(toasty_core::Error::invalid_result(format!(
-                    "conditional update expected Stream, got {:?}",
-                    res.values
-                )));
-            };
-
-            let rows = rows.collect().await?;
-            assert_eq!(rows.len(), 1);
-
-            let stmt::Value::Record(record) = &rows[0] else {
-                return Err(toasty_core::Error::invalid_result(format!(
-                    "conditional update expected Record, got {:?}",
-                    rows[0]
-                )));
-            };
-
-            assert_eq!(record.len(), 2);
-
-            if record[0] != record[1] {
-                return Err(toasty_core::Error::condition_failed(
-                    "update condition did not match",
-                ));
+        match action.conditional {
+            ConditionalOutput::None => {
+                if let Some(mysql_info) = mysql_insert_returning {
+                    res.values = mysql_info.reconstruct_returning(res.values).await?;
+                } else if let Some(mysql_update) = mysql_update_returning {
+                    res = self
+                        .run_mysql_update_returning_select(mysql_update, action.output.ty.clone())
+                        .await?;
+                }
             }
+            ConditionalOutput::Count => {
+                let rows = collect_conditional_probe(res.values).await?;
+                let (matched, conditioned) = conditional_probe_counts(&rows[0])?;
+                if matched != conditioned {
+                    return Err(toasty_core::Error::condition_failed(
+                        "write condition did not match",
+                    ));
+                }
+                res.values = Rows::Count(matched as u64);
+            }
+            ConditionalOutput::Returning => {
+                let rows = collect_conditional_probe(res.values).await?;
+                let (matched, conditioned) = conditional_probe_counts(&rows[0])?;
+                if matched != conditioned {
+                    return Err(toasty_core::Error::condition_failed(
+                        "write condition did not match",
+                    ));
+                }
 
-            res.values = Rows::Count(record[0].to_u64_unwrap());
-        } else if let Some(mysql_info) = mysql_insert_returning {
-            res.values = mysql_info.reconstruct_returning(res.values).await?;
-        } else if let Some(mysql_update) = mysql_update_returning {
-            res = self
-                .run_mysql_update_returning_select(mysql_update, action.output.ty.clone())
-                .await?;
+                // When nothing matched, the LEFT JOIN yields a single
+                // NULL-padded row; drop it. Otherwise every row is a real
+                // changed row — strip the two leading probe columns.
+                let changed = if matched == 0 {
+                    vec![]
+                } else {
+                    rows.into_iter()
+                        .map(|row| {
+                            let stmt::Value::Record(record) = row else {
+                                return Err(toasty_core::Error::invalid_result(
+                                    "conditional write expected Record",
+                                ));
+                            };
+                            Ok(stmt::Value::record_from_vec(
+                                record.fields.into_iter().skip(2).collect(),
+                            ))
+                        })
+                        .collect::<Result<Vec<_>>>()?
+                };
+
+                res.values = Rows::value_stream(changed);
+            }
         }
 
         // Apply pagination if configured
@@ -266,7 +320,7 @@ impl Exec<'_> {
     /// SQLite) or when the statement is not an UPDATE with a returning
     /// project. The two-statement path is not atomic relative to concurrent
     /// writers — see #881.
-    fn process_stmt_update_with_returning_on_mysql(
+    pub(super) fn process_stmt_update_with_returning_on_mysql(
         &self,
         stmt: &mut stmt::Statement,
     ) -> Option<MySQLUpdateReturning> {
@@ -300,7 +354,7 @@ impl Exec<'_> {
     /// Runs the follow-up `SELECT` for a MySQL UPDATE with stripped
     /// `RETURNING`. The driver receives a plain query whose result rows
     /// take the place of the original RETURNING output.
-    async fn run_mysql_update_returning_select(
+    pub(super) async fn run_mysql_update_returning_select(
         &mut self,
         mysql_update: MySQLUpdateReturning,
         ret_ty: Option<Vec<stmt::Type>>,
@@ -407,6 +461,44 @@ impl Exec<'_> {
             returning_expr,
             auto_column_type,
         })
+    }
+}
+
+/// Collects a conditional write's result rows. The probe (a `COUNT` aggregate)
+/// always yields at least one row, so an empty result is a driver bug.
+async fn collect_conditional_probe(rows: Rows) -> Result<Vec<stmt::Value>> {
+    let Rows::Stream(rows) = rows else {
+        return Err(toasty_core::Error::invalid_result(format!(
+            "conditional write expected Stream, got {rows:?}"
+        )));
+    };
+
+    let rows = rows.collect().await?;
+    if rows.is_empty() {
+        return Err(toasty_core::Error::invalid_result(
+            "conditional write probe returned no rows",
+        ));
+    }
+
+    Ok(rows)
+}
+
+/// Reads the two leading probe counts (`matched`, `conditioned`) from a
+/// conditional write's result row.
+fn conditional_probe_counts(row: &stmt::Value) -> Result<(i64, i64)> {
+    let stmt::Value::Record(record) = row else {
+        return Err(toasty_core::Error::invalid_result(format!(
+            "conditional write expected Record, got {row:?}"
+        )));
+    };
+
+    match (record.fields.first(), record.fields.get(1)) {
+        (Some(stmt::Value::I64(matched)), Some(stmt::Value::I64(conditioned))) => {
+            Ok((*matched, *conditioned))
+        }
+        _ => Err(toasty_core::Error::invalid_result(format!(
+            "conditional write probe columns are not I64; row={row:?}"
+        ))),
     }
 }
 

--- a/crates/toasty/src/engine/exec/rmw.rs
+++ b/crates/toasty/src/engine/exec/rmw.rs
@@ -7,7 +7,7 @@ use toasty_core::{
         ExecResponse, Rows,
         operation::{self, Transaction},
     },
-    stmt::{self, ValueStream},
+    stmt,
 };
 
 #[derive(Debug)]
@@ -16,7 +16,11 @@ pub(crate) struct ReadModifyWrite {
     pub input: Vec<VarId>,
 
     /// How to handle output
-    pub output: Option<Output>,
+    pub output: Output,
+
+    /// Column types of the write's `RETURNING` rows, or `None` when the write
+    /// has no returning (it then reports only a row count).
+    pub output_ty: Option<Vec<stmt::Type>>,
 
     /// Read statement
     pub read: stmt::Query,
@@ -55,33 +59,42 @@ impl Exec<'_> {
             .exec(&self.engine.schema, begin.into())
             .await?;
 
-        if let Err(e) = self.rmw_exec(action).await {
-            // Best effort: ignore rollback errors so the original error is returned
-            let _ = self
-                .connection
-                .exec(&self.engine.schema, rollback.into())
-                .await;
-            return Err(e);
-        }
+        let rows = match self.rmw_exec(action).await {
+            Ok(rows) => rows,
+            Err(e) => {
+                // Best effort: ignore rollback errors so the original error is returned
+                let _ = self
+                    .connection
+                    .exec(&self.engine.schema, rollback.into())
+                    .await;
+                return Err(e);
+            }
+        };
 
         self.connection
             .exec(&self.engine.schema, commit.into())
             .await?;
 
-        if let Some(output) = &action.output {
-            let rows = Rows::value_stream(ValueStream::default());
-            self.vars
-                .store(output.var, output.num_uses, ExecResponse::from_rows(rows));
-        }
+        self.vars.store(
+            action.output.var,
+            action.output.num_uses,
+            ExecResponse::from_rows(rows),
+        );
 
         Ok(())
     }
 
-    /// Execute the core read-then-write logic, returning an error on either a
-    /// DB failure or a condition mismatch. Rollback (savepoint or transaction)
-    /// is handled by the caller.
-    async fn rmw_exec(&mut self, action: &ReadModifyWrite) -> Result<()> {
-        let ty = Some(vec![stmt::Type::I64, stmt::Type::I64]);
+    /// Execute the core read-then-write logic, returning the write's output
+    /// rows on success. Errors on a DB failure or a condition mismatch;
+    /// rollback (savepoint or transaction) is handled by the caller.
+    ///
+    /// The returned [`Rows`] mirrors what the equivalent unconditional write
+    /// would produce: a `Count` when the write has no `RETURNING`, or a
+    /// buffered row stream when it does. Rows are buffered before the caller
+    /// commits so nothing is tied to the open transaction.
+    async fn rmw_exec(&mut self, action: &ReadModifyWrite) -> Result<Rows> {
+        // The probe projects the condition once per matched row.
+        let ty = Some(vec![stmt::Type::Bool]);
 
         let mut read_stmt: stmt::Statement = action.read.clone().into();
         let read_params = if self.engine.capability().sql {
@@ -110,25 +123,45 @@ impl Exec<'_> {
             ));
         };
 
+        // `matched` counts rows passing the filter; `satisfied` counts those
+        // that also meet the condition. The write is safe to apply only when the
+        // two agree — otherwise some matched row was concurrently advanced.
         let rows = rows.collect().await?;
-        assert_eq!(rows.len(), 1);
+        let matched = rows.len() as u64;
+        let mut satisfied = 0;
+        for row in &rows {
+            let stmt::Value::Record(record) = row else {
+                return Err(toasty_core::Error::invalid_result(
+                    "conditional write probe expected Record",
+                ));
+            };
+            match record.fields.first() {
+                Some(stmt::Value::Bool(true)) => satisfied += 1,
+                Some(stmt::Value::Bool(false)) | Some(stmt::Value::Null) => {}
+                other => {
+                    return Err(toasty_core::Error::invalid_result(format!(
+                        "conditional write probe expected Bool, got {other:?}"
+                    )));
+                }
+            }
+        }
 
-        let stmt::Value::Record(record) = &rows[0] else {
-            return Err(toasty_core::Error::invalid_result("expected Record value"));
-        };
-        assert_eq!(record.len(), 2);
-
-        let stmt::Value::I64(count) = record[0] else {
-            return Err(toasty_core::Error::invalid_result("expected I64 value"));
-        };
-
-        if record[0] != record[1] {
+        if matched != satisfied {
             return Err(toasty_core::Error::condition_failed(
-                "update condition did not match",
+                "write condition did not match",
             ));
         }
 
+        let count = matched;
         let mut write_stmt = action.write.clone();
+
+        // MySQL lacks `RETURNING` on `UPDATE`; strip the returning into a
+        // follow-up `SELECT` that runs inside this same transaction. After this,
+        // `write_stmt` carries a native `RETURNING` only on backends that
+        // support it (SQLite, PostgreSQL).
+        let mysql_update = self.process_stmt_update_with_returning_on_mysql(&mut write_stmt);
+        let native_returning = write_stmt.returning().is_some();
+
         let write_params = if self.engine.capability().sql {
             self.engine.extract_params(&mut write_stmt)
         } else {
@@ -142,12 +175,34 @@ impl Exec<'_> {
                 operation::QuerySql {
                     stmt: write_stmt,
                     params: write_params,
-                    ret: None,
+                    ret: if native_returning {
+                        action.output_ty.clone()
+                    } else {
+                        None
+                    },
                     last_insert_id_hack: None,
                 }
                 .into(),
             )
             .await?;
+
+        if let Some(mysql_update) = mysql_update {
+            // The UPDATE ran without RETURNING; the captured SELECT produces the
+            // post-update returning values.
+            let mut res = self
+                .run_mysql_update_returning_select(mysql_update, action.output_ty.clone())
+                .await?;
+            res.values.buffer().await?;
+            return Ok(res.values);
+        }
+
+        if native_returning {
+            // Buffer the returned rows before the caller commits so the stream
+            // is not tied to the open transaction.
+            let mut values = res.values;
+            values.buffer().await?;
+            return Ok(values);
+        }
 
         let Rows::Count(actual) = res.values else {
             return Err(toasty_core::Error::invalid_result(
@@ -155,9 +210,9 @@ impl Exec<'_> {
             ));
         };
 
-        assert_eq!(actual, count as u64);
+        assert_eq!(actual, count);
 
-        Ok(())
+        Ok(Rows::Count(actual))
     }
 }
 

--- a/crates/toasty/src/engine/exec/rmw.rs
+++ b/crates/toasty/src/engine/exec/rmw.rs
@@ -146,6 +146,14 @@ impl Exec<'_> {
             }
         }
 
+        // A conditional write targets a row the caller holds an instance of:
+        // zero matched rows means it has since been deleted.
+        if matched == 0 {
+            return Err(toasty_core::Error::record_not_found(
+                "conditional write matched no rows",
+            ));
+        }
+
         if matched != satisfied {
             return Err(toasty_core::Error::condition_failed(
                 "write condition did not match",
@@ -210,7 +218,15 @@ impl Exec<'_> {
             ));
         };
 
-        assert_eq!(actual, count);
+        // The write is supposed to touch exactly the probed rows. On backends
+        // whose probe cannot lock (`select_for_update` is false), a concurrent
+        // writer may change the matched set between the probe and the write —
+        // surface a retryable conflict; the caller rolls back.
+        if actual != count {
+            return Err(toasty_core::Error::condition_failed(format!(
+                "write applied to {actual} rows but the probe matched {count}"
+            )));
+        }
 
         Ok(Rows::Count(actual))
     }

--- a/crates/toasty/src/engine/extract_params.rs
+++ b/crates/toasty/src/engine/extract_params.rs
@@ -582,6 +582,15 @@ fn refine_query(query: &stmt::Query, cx: &Cx<'_>, params: &mut [Param]) {
                 synthesize(row, &cx, params);
             }
         }
+        // Data-modifying CTE bodies (a conditional write compiled to a CTE):
+        // the write's assignments and filter carry params that need the same
+        // column-driven refinement as a top-level UPDATE/DELETE.
+        stmt::ExprSet::Update(update) => {
+            refine_update(update, &cx, cx.schema(), params);
+        }
+        stmt::ExprSet::Delete(delete) => {
+            refine_filter(&delete.filter, &cx, params);
+        }
         _ => {}
     }
 

--- a/crates/toasty/src/engine/mir.rs
+++ b/crates/toasty/src/engine/mir.rs
@@ -51,3 +51,20 @@ pub(crate) use store::{NodeId, Store};
 
 mod update_by_key;
 pub(crate) use update_by_key::UpdateByKey;
+
+use toasty_core::stmt;
+
+/// Extracts the per-row column types from a node's return type. A node
+/// returning rows has type `List<Record<...>>` — the record field types tell
+/// the driver how to decode each row. `Unit` means the node returns only a row
+/// count, so there are no column types.
+pub(crate) fn row_field_types(ty: &stmt::Type) -> Option<Vec<stmt::Type>> {
+    match ty {
+        stmt::Type::List(rows) => match &**rows {
+            stmt::Type::Record(fields) => Some(fields.clone()),
+            _ => todo!("row_field_types: ty={ty:#?}"),
+        },
+        stmt::Type::Unit => None,
+        _ => todo!("row_field_types: ty={ty:#?}"),
+    }
+}

--- a/crates/toasty/src/engine/mir/exec_statement.rs
+++ b/crates/toasty/src/engine/mir/exec_statement.rs
@@ -21,8 +21,10 @@ pub(crate) struct ExecStatement {
     /// The return type of this operation.
     pub(crate) ty: stmt::Type,
 
-    /// When `true`, this is a conditional update that returns status, not rows.
-    pub(crate) conditional_update_with_no_returning: bool,
+    /// How this statement's output is interpreted. For a conditional write the
+    /// statement's leading two columns are probe counts checked against each
+    /// other; see [`exec::ConditionalOutput`].
+    pub(crate) conditional: exec::ConditionalOutput,
 
     /// Pagination configuration (None if not paginated)
     pub(crate) pagination: Option<exec::PaginationConfig>,
@@ -77,7 +79,7 @@ impl ExecStatement {
                 },
             },
             stmt: self.stmt.clone(),
-            conditional_update_with_no_returning: self.conditional_update_with_no_returning,
+            conditional: self.conditional,
             pagination: self.pagination.clone(),
         }
     }

--- a/crates/toasty/src/engine/mir/exec_statement.rs
+++ b/crates/toasty/src/engine/mir/exec_statement.rs
@@ -56,18 +56,7 @@ impl ExecStatement {
         let var = var_table.register_var(self.ty.clone());
         node.var.set(Some(var));
 
-        let output_ty = match &self.ty {
-            stmt::Type::List(ty_rows) => {
-                let ty_fields = match &**ty_rows {
-                    stmt::Type::Record(ty_fields) => ty_fields.clone(),
-                    _ => todo!("ty={:#?}; node={node:#?}", self.ty),
-                };
-
-                Some(ty_fields)
-            }
-            stmt::Type::Unit => None,
-            _ => todo!("ty={:#?}", self.ty),
-        };
+        let output_ty = mir::row_field_types(&self.ty);
 
         exec::ExecStatement {
             input: input_vars,

--- a/crates/toasty/src/engine/mir/read_modify_write.rs
+++ b/crates/toasty/src/engine/mir/read_modify_write.rs
@@ -44,17 +44,9 @@ impl ReadModifyWrite {
         node.var.set(Some(var));
 
         // When the write carries a `RETURNING`, the node's type is
-        // `List<Record>`; the record field types tell the driver how to decode
-        // the returned rows. Without a `RETURNING` the type is `Unit` and the
-        // write reports only a row count.
-        let output_ty = match &self.ty {
-            stmt::Type::List(item) => match &**item {
-                stmt::Type::Record(fields) => Some(fields.clone()),
-                _ => todo!("rmw output ty={:#?}", self.ty),
-            },
-            stmt::Type::Unit => None,
-            _ => todo!("rmw output ty={:#?}", self.ty),
-        };
+        // `List<Record>`; without one the type is `Unit` and the write reports
+        // only a row count.
+        let output_ty = mir::row_field_types(&self.ty);
 
         exec::ReadModifyWrite {
             input,

--- a/crates/toasty/src/engine/mir/read_modify_write.rs
+++ b/crates/toasty/src/engine/mir/read_modify_write.rs
@@ -40,15 +40,29 @@ impl ReadModifyWrite {
             .map(|input| logical_plan[input].var.get().unwrap())
             .collect();
 
-        // A hack since rmw doesn't support output yet
-        let var = var_table.register_var(stmt::Type::list(stmt::Type::Unit));
+        let var = var_table.register_var(self.ty.clone());
+        node.var.set(Some(var));
+
+        // When the write carries a `RETURNING`, the node's type is
+        // `List<Record>`; the record field types tell the driver how to decode
+        // the returned rows. Without a `RETURNING` the type is `Unit` and the
+        // write reports only a row count.
+        let output_ty = match &self.ty {
+            stmt::Type::List(item) => match &**item {
+                stmt::Type::Record(fields) => Some(fields.clone()),
+                _ => todo!("rmw output ty={:#?}", self.ty),
+            },
+            stmt::Type::Unit => None,
+            _ => todo!("rmw output ty={:#?}", self.ty),
+        };
 
         exec::ReadModifyWrite {
             input,
-            output: Some(exec::Output {
+            output: exec::Output {
                 var,
                 num_uses: node.num_uses.get(),
-            }),
+            },
+            output_ty,
             read: self.read.clone(),
             write: self.write.clone(),
         }

--- a/crates/toasty/src/engine/plan/statement.rs
+++ b/crates/toasty/src/engine/plan/statement.rs
@@ -90,7 +90,7 @@
 use std::mem;
 
 use indexmap::{IndexMap, IndexSet};
-use toasty_core::stmt::{self, Condition, visit_mut};
+use toasty_core::stmt::{self, visit_mut};
 
 use toasty_core::driver::operation::Pagination;
 
@@ -834,20 +834,30 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
         let pagination_config = pagination_info.map(|info| self.build_extract_cursor(info, &ty));
 
         let node = if stmt.condition().is_some() {
-            if let stmt::Statement::Update(stmt) = stmt {
-                assert!(stmt.returning.is_none(), "TODO: stmt={stmt:#?}");
+            // A conditional UPDATE or DELETE (e.g. an OCC `#[version]` check).
+            // The condition is checked against the current rows and the write
+            // only applies when it holds; a mismatch surfaces as an error. Two
+            // strategies, chosen by capability: a single CTE statement
+            // (PostgreSQL) or a read-modify-write transaction (SQLite, MySQL).
+            debug_assert!(
+                stmt.is_update() || stmt.is_delete(),
+                "only UPDATE and DELETE carry conditions; stmt={stmt:#?}"
+            );
 
-                if self.planner.engine.capability().cte_with_update {
-                    mir::Operation::ExecStatement(Box::new(
-                        self.plan_conditional_sql_query_as_cte(stmt, ty),
-                    ))
-                } else {
-                    mir::Operation::ReadModifyWrite(Box::new(
-                        self.plan_conditional_sql_query_as_rmw(stmt, ty),
-                    ))
-                }
+            // A conditional UPDATE compiles to a single CTE statement on
+            // backends that support data-modifying CTEs (PostgreSQL). A DELETE
+            // cannot: the statement AST has no DELETE-in-CTE form, so it always
+            // uses the read-modify-write transaction, which every SQL backend
+            // supports (PostgreSQL locks the probed rows via `SELECT ... FOR
+            // UPDATE`).
+            if stmt.is_update() && self.planner.engine.capability().cte_with_update {
+                mir::Operation::ExecStatement(Box::new(
+                    self.plan_conditional_sql_query_as_cte(stmt, ty),
+                ))
             } else {
-                todo!("stmt={stmt:#?}");
+                mir::Operation::ReadModifyWrite(Box::new(
+                    self.plan_conditional_sql_query_as_rmw(stmt, ty),
+                ))
             }
         } else {
             debug_assert!(
@@ -863,7 +873,7 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
                 inputs: mem::take(&mut self.load_data.inputs),
                 stmt,
                 ty,
-                conditional_update_with_no_returning: false,
+                conditional: exec::ConditionalOutput::None,
                 pagination: pagination_config.clone(),
             }))
         };
@@ -1027,207 +1037,203 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
 
     fn plan_conditional_sql_query_as_cte(
         &mut self,
-        stmt: stmt::Update,
+        stmt: stmt::Statement,
         ty: stmt::Type,
     ) -> mir::ExecStatement {
-        let Some(condition) = stmt.condition.expr else {
-            panic!("conditional update without condition");
+        let (condition, filter, source, write) = self.conditional_write_parts(stmt);
+
+        // Only UPDATE reaches the CTE path; DELETE cannot be nested in a CTE and
+        // is routed to read-modify-write by the caller.
+        let stmt::Statement::Update(mut write) = write else {
+            unreachable!("only UPDATE compiles to a CTE; write={write:#?}");
         };
 
-        let Some(filter) = stmt.filter.expr else {
-            panic!("conditional update without filter");
+        // `found`: the probe. Counts rows matching the filter and, of those,
+        // how many satisfy the OCC condition.
+        let found = stmt::Cte {
+            query: stmt::Query::builder(stmt::Select {
+                source,
+                filter: stmt::Filter::new(filter.clone()),
+                returning: stmt::Returning::Project(conditional_probe_projection(condition)),
+                distinct: false,
+            })
+            .build(),
         };
 
-        let stmt::UpdateTarget::Table(target) = stmt.target.clone() else {
-            panic!("conditional update without table");
-        };
-
-        let mut ctes = vec![];
-
-        // Select from update table without the update condition.
-        ctes.push(stmt::Cte {
-            query: stmt::Query::builder(target)
-                .filter(filter.clone())
-                .returning_project(stmt::Expr::record_from_vec(vec![
-                    stmt::Expr::count_star(),
-                    stmt::FuncCount {
-                        arg: None,
-                        filter: Some(Box::new(condition)),
-                    }
-                    .into(),
-                ]))
-                .build(),
-        });
-
-        let returning_len = match &stmt.returning {
-            Some(stmt::Returning::Project(expr)) => {
-                let stmt::Expr::Record(expr_record) = expr else {
-                    panic!("returning must be a record");
-                };
-
-                expr_record.fields.len()
+        // `changed`: the write. It applies only when the probe's two counts
+        // agree, expressed as a scalar subquery over `found` ANDed onto the
+        // filter. `found` sits two scopes out from here (subquery → CTE body →
+        // WITH).
+        let counts_agree = stmt::Expr::stmt(stmt::Select {
+            source: stmt::TableRef::Cte {
+                nesting: 2,
+                index: 0,
             }
-            Some(_) => todo!(),
+            .into(),
+            filter: true.into(),
+            returning: stmt::Returning::Project(stmt::Expr::record_from_vec(vec![stmt::Expr::eq(
+                stmt::ExprColumn {
+                    nesting: 0,
+                    table: 0,
+                    column: 0,
+                },
+                stmt::ExprColumn {
+                    nesting: 0,
+                    table: 0,
+                    column: 1,
+                },
+            )])),
+            distinct: false,
+        });
+        write.filter = stmt::Filter::new(stmt::Expr::and(filter, counts_agree));
+
+        // A `RETURNING` on the write (e.g. a relative `value = value + 1` read
+        // back) means the caller wants the changed rows; otherwise the write
+        // just reports how many rows it touched.
+        let returning_len = match &write.returning {
+            Some(stmt::Returning::Project(stmt::Expr::Record(record))) => record.fields.len(),
+            Some(returning) => todo!("unexpected conditional update returning={returning:#?}"),
             None => 0,
         };
 
-        // The update statement. The update condition is expressed using the select above
-        ctes.push(stmt::Cte {
-            query: stmt::Query::new(stmt::Update {
-                target: stmt.target,
-                assignments: stmt.assignments,
-                filter: stmt::Filter::new(stmt::Expr::and(
-                    filter,
-                    // SELECT found.count(*) = found.count(CONDITION) FROM found
-                    stmt::Expr::stmt(stmt::Select {
-                        source: stmt::TableRef::Cte {
-                            nesting: 2,
+        let changed = stmt::Cte {
+            query: stmt::Query::new(write),
+        };
+
+        let outer = if returning_len == 0 {
+            // No columns to read back: select just the two probe counts. The
+            // `changed` CTE is data-modifying, so PostgreSQL runs it even though
+            // the outer query does not reference it.
+            stmt::Query::builder(stmt::Select {
+                source: stmt::TableRef::Cte {
+                    nesting: 0,
+                    index: 0,
+                }
+                .into(),
+                filter: stmt::Filter::new(true),
+                returning: stmt::Returning::Project(stmt::Expr::record_from_vec(vec![
+                    cte_column(0, 0),
+                    cte_column(0, 1),
+                ])),
+                distinct: false,
+            })
+        } else {
+            // Read the probe counts alongside the changed rows. `found` yields
+            // exactly one row, so the LEFT JOIN repeats the counts across every
+            // changed row (and yields a single NULL-padded row when nothing
+            // changed).
+            let mut columns = vec![cte_column(0, 0), cte_column(0, 1)];
+            for i in 0..returning_len {
+                columns.push(cte_column(1, i));
+            }
+
+            stmt::Query::builder(stmt::Select {
+                source: stmt::Source::table_with_joins(
+                    vec![
+                        stmt::TableRef::Cte {
+                            nesting: 0,
                             index: 0,
-                        }
-                        .into(),
-                        filter: true.into(),
-                        returning: stmt::Returning::Project(stmt::Expr::record_from_vec(vec![
-                            stmt::Expr::eq(
-                                stmt::ExprColumn {
-                                    nesting: 0,
-                                    table: 0,
-                                    column: 0,
-                                },
-                                stmt::ExprColumn {
-                                    nesting: 0,
-                                    table: 0,
-                                    column: 1,
-                                },
-                            ),
-                        ])),
-                        distinct: false,
-                    }),
-                )),
-                condition: Condition::default(),
-                returning: Some(
-                    stmt.returning
-                        // TODO: hax
-                        .unwrap_or_else(|| {
-                            stmt::Returning::Project(stmt::Expr::record_from_vec(vec![
-                                stmt::Expr::from("hello"),
-                            ]))
-                        }),
+                        },
+                        stmt::TableRef::Cte {
+                            nesting: 0,
+                            index: 1,
+                        },
+                    ],
+                    stmt::TableWithJoins {
+                        relation: stmt::TableFactor::Table(stmt::SourceTableId(0)),
+                        joins: vec![stmt::Join {
+                            table: stmt::SourceTableId(1),
+                            constraint: stmt::JoinOp::Left(stmt::Expr::from(true)),
+                        }],
+                    },
                 ),
-            }),
-        });
+                filter: stmt::Filter::new(true),
+                returning: stmt::Returning::Project(stmt::Expr::record_from_vec(columns)),
+                distinct: false,
+            })
+        };
 
-        let mut columns = vec![
-            stmt::Expr::column(stmt::ExprColumn {
-                nesting: 0,
-                table: 0,
-                column: 0,
-            }),
-            stmt::Expr::column(stmt::ExprColumn {
-                nesting: 0,
-                table: 0,
-                column: 1,
-            }),
-        ];
-
-        for i in 0..returning_len {
-            columns.push(stmt::Expr::column(stmt::ExprColumn {
-                nesting: 0,
-                table: 1,
-                column: i,
-            }));
-        }
-
-        let stmt = stmt::Query::builder(stmt::Select {
-            source: stmt::Source::table_with_joins(
-                vec![
-                    stmt::TableRef::Cte {
-                        nesting: 0,
-                        index: 0,
-                    },
-                    stmt::TableRef::Cte {
-                        nesting: 0,
-                        index: 1,
-                    },
-                ],
-                stmt::TableWithJoins {
-                    relation: stmt::TableFactor::Table(stmt::SourceTableId(0)),
-                    joins: vec![stmt::Join {
-                        table: stmt::SourceTableId(1),
-                        constraint: stmt::JoinOp::Left(stmt::Expr::from(true)),
-                    }],
-                },
-            ),
-            filter: stmt::Filter::new(true),
-            returning: stmt::Returning::Project(stmt::Expr::record_from_vec(columns)),
-            distinct: false,
-        })
-        .with(ctes)
-        .build()
-        .into();
+        let stmt = outer.with(vec![found, changed]).build().into();
 
         mir::ExecStatement {
             inputs: mem::take(&mut self.load_data.inputs),
             stmt,
             ty,
-            conditional_update_with_no_returning: true,
+            conditional: if returning_len == 0 {
+                exec::ConditionalOutput::Count
+            } else {
+                exec::ConditionalOutput::Returning
+            },
             pagination: None,
         }
     }
 
     fn plan_conditional_sql_query_as_rmw(
         &mut self,
-        stmt: stmt::Update,
+        stmt: stmt::Statement,
         ty: stmt::Type,
     ) -> mir::ReadModifyWrite {
-        // For now, no returning supported
-        assert!(stmt.returning.is_none(), "TODO: support returning");
+        let (condition, filter, source, write) = self.conditional_write_parts(stmt);
 
-        let Some(condition) = stmt.condition.expr else {
-            panic!("conditional update without condition");
-        };
-
-        let Some(filter) = stmt.filter.expr else {
-            panic!("conditional update without filter");
-        };
-
-        let stmt::UpdateTarget::Table(target) = stmt.target.clone() else {
-            panic!("conditional update without table");
-        };
-
-        // Neither SQLite nor MySQL support CTE with update. We should transform
-        // the conditional update into a transaction with checks between.
-
-        let read = stmt::Query::builder(target)
-            .filter(filter.clone())
-            .returning_project(stmt::Expr::record_from_vec(vec![
-                stmt::Expr::count_star(),
-                stmt::FuncCount {
-                    arg: None,
-                    filter: Some(Box::new(condition)),
-                }
-                .into(),
-            ]))
-            .locks(if self.planner.engine.capability().select_for_update {
-                vec![stmt::Lock::Update]
-            } else {
-                vec![]
-            })
-            .build();
-
-        let write = stmt::Update {
-            target: stmt.target,
-            assignments: stmt.assignments,
+        // A conditional write on a backend without data-modifying CTEs (SQLite,
+        // MySQL) — or any conditional DELETE — becomes a transaction: first
+        // probe the matched rows, then apply the write (filter only, no
+        // condition) when every matched row satisfies the condition.
+        //
+        // The probe evaluates the condition per matched row (`SELECT
+        // <condition> FROM t WHERE <filter>`) rather than as an aggregate: a
+        // per-row projection can carry `FOR UPDATE` to lock the rows against a
+        // concurrent writer, whereas `SELECT count(*) ... FOR UPDATE` is
+        // rejected by PostgreSQL. The engine derives the matched and satisfied
+        // counts from the returned rows.
+        let read = stmt::Query::builder(stmt::Select {
+            source,
             filter: stmt::Filter::new(filter),
-            condition: stmt::Condition::default(),
-            returning: None,
-        };
+            returning: stmt::Returning::Project(stmt::Expr::record_from_vec(vec![condition])),
+            distinct: false,
+        })
+        .locks(if self.planner.engine.capability().select_for_update {
+            vec![stmt::Lock::Update]
+        } else {
+            vec![]
+        })
+        .build();
 
         mir::ReadModifyWrite {
             inputs: mem::take(&mut self.load_data.inputs),
             read,
-            write: write.into(),
+            write,
             ty,
         }
+    }
+
+    /// Decompose a conditional UPDATE/DELETE into the parts both SQL
+    /// conditional-write strategies need: the OCC condition, the row filter, a
+    /// SELECT source over the target table (for the count probe), and the bare
+    /// write statement with its condition stripped. The filter and any
+    /// `RETURNING` stay on the write.
+    fn conditional_write_parts(
+        &self,
+        mut stmt: stmt::Statement,
+    ) -> (stmt::Expr, stmt::Expr, stmt::Source, stmt::Statement) {
+        let condition = stmt
+            .condition_mut_unwrap()
+            .expr
+            .take()
+            .expect("conditional write without condition");
+
+        let filter = stmt
+            .filter()
+            .and_then(|filter| filter.expr.clone())
+            .expect("conditional write without filter");
+
+        let source = match &stmt {
+            stmt::Statement::Update(update) => stmt::Source::table(update.target.as_table_unwrap()),
+            stmt::Statement::Delete(delete) => delete.from.clone(),
+            _ => unreachable!("conditional write is UPDATE or DELETE; stmt={stmt:#?}"),
+        };
+
+        (condition, filter, source, stmt)
     }
 
     // ===== NoSQL execution =====
@@ -1843,6 +1849,31 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
     fn stmt(&self) -> &stmt::Statement {
         self.stmt_info.stmt.as_deref().unwrap()
     }
+}
+
+/// A reference to column `column` of CTE `table` in the outer query's `FROM`
+/// (both at zero nesting).
+fn cte_column(table: usize, column: usize) -> stmt::Expr {
+    stmt::Expr::column(stmt::ExprColumn {
+        nesting: 0,
+        table,
+        column,
+    })
+}
+
+/// The probe projection shared by both SQL conditional-write strategies:
+/// `[count(*), count(*) FILTER (WHERE <condition>)]`. The first column counts
+/// rows matching the filter; the second counts those that also satisfy the OCC
+/// condition. The write is safe to apply exactly when the two agree.
+fn conditional_probe_projection(condition: stmt::Expr) -> stmt::Expr {
+    stmt::Expr::record_from_vec(vec![
+        stmt::Expr::count_star(),
+        stmt::FuncCount {
+            arg: None,
+            filter: Some(Box::new(condition)),
+        }
+        .into(),
+    ])
 }
 
 /// Extract limit/pagination bounds from a query statement for use with

--- a/crates/toasty/src/engine/plan/statement.rs
+++ b/crates/toasty/src/engine/plan/statement.rs
@@ -1041,26 +1041,49 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
     ) -> mir::ExecStatement {
         let (condition, filter, source, mut write) = self.conditional_write_parts(stmt);
 
-        // `found`: the probe. Counts rows matching the filter and, of those,
-        // how many satisfy the OCC condition.
+        // `found`: the probe. Projects the OCC condition once per row matching
+        // the filter, locking those rows (`FOR UPDATE`) so the condition is
+        // evaluated against the latest committed row version and the rows
+        // cannot change before the write applies. Without the lock, a stale
+        // writer blocking on a concurrent committed update would pass the
+        // write's re-check (the probe is already materialized from the old
+        // snapshot and the write's own filter is key-only) and silently
+        // overwrite the newer row — the lost update `#[version]` exists to
+        // prevent.
         let found = stmt::Cte {
-            query: stmt::Query::builder(stmt::Select {
+            query: conditional_probe_query(
+                condition,
+                filter.clone(),
                 source,
-                filter: stmt::Filter::new(filter.clone()),
-                returning: stmt::Returning::Project(conditional_probe_projection(condition)),
+                self.planner.engine.capability().select_for_update,
+            ),
+        };
+
+        // `counts`: aggregates the probe rows into `[matched, conditioned]`.
+        // Kept separate from `found` because a locking SELECT cannot carry
+        // aggregates. `found` sits one scope out (CTE body → WITH).
+        let counts = stmt::Cte {
+            query: stmt::Query::builder(stmt::Select {
+                source: stmt::TableRef::Cte {
+                    nesting: 1,
+                    index: 0,
+                }
+                .into(),
+                filter: stmt::Filter::new(true),
+                returning: stmt::Returning::Project(conditional_probe_projection(cte_column(0, 0))),
                 distinct: false,
             })
             .build(),
         };
 
         // `changed`: the write. It applies only when the probe's two counts
-        // agree, expressed as a scalar subquery over `found` ANDed onto the
-        // filter. `found` sits two scopes out from here (subquery → CTE body →
+        // agree, expressed as a scalar subquery over `counts` ANDed onto the
+        // filter. `counts` sits two scopes out from here (subquery → CTE body →
         // WITH).
         let counts_agree = stmt::Expr::stmt(stmt::Select {
             source: stmt::TableRef::Cte {
                 nesting: 2,
-                index: 0,
+                index: 1,
             }
             .into(),
             filter: true.into(),
@@ -1114,7 +1137,7 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
             stmt::Query::builder(stmt::Select {
                 source: stmt::TableRef::Cte {
                     nesting: 0,
-                    index: 0,
+                    index: 1,
                 }
                 .into(),
                 filter: stmt::Filter::new(true),
@@ -1125,7 +1148,7 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
                 distinct: false,
             })
         } else {
-            // Read the probe counts alongside the changed rows. `found` yields
+            // Read the probe counts alongside the changed rows. `counts` yields
             // exactly one row, so the LEFT JOIN repeats the counts across every
             // changed row (and yields a single NULL-padded row when nothing
             // changed).
@@ -1139,11 +1162,11 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
                     vec![
                         stmt::TableRef::Cte {
                             nesting: 0,
-                            index: 0,
+                            index: 1,
                         },
                         stmt::TableRef::Cte {
                             nesting: 0,
-                            index: 1,
+                            index: 2,
                         },
                     ],
                     stmt::TableWithJoins {
@@ -1160,7 +1183,7 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
             })
         };
 
-        let stmt = outer.with(vec![found, changed]).build().into();
+        let stmt = outer.with(vec![found, counts, changed]).build().into();
 
         mir::ExecStatement {
             inputs: mem::take(&mut self.load_data.inputs),
@@ -1185,26 +1208,14 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
         // A conditional write on a backend without data-modifying CTEs (SQLite,
         // MySQL) becomes a transaction: first probe the matched rows, then apply
         // the write (filter only, no condition) when every matched row satisfies
-        // the condition.
-        //
-        // The probe evaluates the condition per matched row (`SELECT
-        // <condition> FROM t WHERE <filter>`) rather than as an aggregate: a
-        // per-row projection can carry `FOR UPDATE` to lock exactly those rows
-        // against a concurrent writer, while `SELECT count(*) ... FOR UPDATE` is
-        // not universally accepted. The engine derives the matched and satisfied
-        // counts from the returned rows.
-        let read = stmt::Query::builder(stmt::Select {
+        // the condition. The engine derives the matched and satisfied counts
+        // from the probe's per-row results.
+        let read = conditional_probe_query(
+            condition,
+            filter,
             source,
-            filter: stmt::Filter::new(filter),
-            returning: stmt::Returning::Project(stmt::Expr::record_from_vec(vec![condition])),
-            distinct: false,
-        })
-        .locks(if self.planner.engine.capability().select_for_update {
-            vec![stmt::Lock::Update]
-        } else {
-            vec![]
-        })
-        .build();
+            self.planner.engine.capability().select_for_update,
+        );
 
         mir::ReadModifyWrite {
             inputs: mem::take(&mut self.load_data.inputs),
@@ -1868,10 +1879,40 @@ fn cte_column(table: usize, column: usize) -> stmt::Expr {
     })
 }
 
-/// The probe projection shared by both SQL conditional-write strategies:
-/// `[count(*), count(*) FILTER (WHERE <condition>)]`. The first column counts
-/// rows matching the filter; the second counts those that also satisfy the OCC
-/// condition. The write is safe to apply exactly when the two agree.
+/// The probe query shared by both SQL conditional-write strategies:
+/// `SELECT <condition> FROM <source> WHERE <filter> [FOR UPDATE]`.
+///
+/// The condition is projected once per matched row rather than as an
+/// aggregate: a per-row projection can carry `FOR UPDATE` while `SELECT
+/// count(*) ... FOR UPDATE` is rejected. Locking the matched rows makes the
+/// probe authoritative — the condition is evaluated against the latest
+/// committed row version and the rows cannot change before the write applies.
+fn conditional_probe_query(
+    condition: stmt::Expr,
+    filter: stmt::Expr,
+    source: stmt::Source,
+    lock: bool,
+) -> stmt::Query {
+    stmt::Query::builder(stmt::Select {
+        source,
+        filter: stmt::Filter::new(filter),
+        returning: stmt::Returning::Project(stmt::Expr::record_from_vec(vec![condition])),
+        distinct: false,
+    })
+    .locks(if lock {
+        vec![stmt::Lock::Update]
+    } else {
+        vec![]
+    })
+    .build()
+}
+
+/// The aggregate projection over the probe's per-row results:
+/// `[count(*), count(*) FILTER (WHERE <ok>)]`. The first column counts rows
+/// matching the filter; the second counts those that also satisfy the OCC
+/// condition. The write is safe to apply exactly when the two agree. Used by
+/// the CTE strategy's `counts` CTE; the read-modify-write strategy derives the
+/// same counts client-side.
 fn conditional_probe_projection(condition: stmt::Expr) -> stmt::Expr {
     stmt::Expr::record_from_vec(vec![
         stmt::Expr::count_star(),

--- a/crates/toasty/src/engine/plan/statement.rs
+++ b/crates/toasty/src/engine/plan/statement.rs
@@ -844,13 +844,12 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
                 "only UPDATE and DELETE carry conditions; stmt={stmt:#?}"
             );
 
-            // A conditional UPDATE compiles to a single CTE statement on
-            // backends that support data-modifying CTEs (PostgreSQL). A DELETE
-            // cannot: the statement AST has no DELETE-in-CTE form, so it always
-            // uses the read-modify-write transaction, which every SQL backend
-            // supports (PostgreSQL locks the probed rows via `SELECT ... FOR
-            // UPDATE`).
-            if stmt.is_update() && self.planner.engine.capability().cte_with_update {
+            // A conditional UPDATE or DELETE compiles to a single CTE statement
+            // on backends that support data-modifying CTEs (PostgreSQL);
+            // elsewhere it becomes a read-modify-write transaction (which every
+            // SQL backend supports, locking the probed rows via `SELECT ... FOR
+            // UPDATE` where available).
+            if self.planner.engine.capability().cte_with_update {
                 mir::Operation::ExecStatement(Box::new(
                     self.plan_conditional_sql_query_as_cte(stmt, ty),
                 ))
@@ -1040,13 +1039,7 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
         stmt: stmt::Statement,
         ty: stmt::Type,
     ) -> mir::ExecStatement {
-        let (condition, filter, source, write) = self.conditional_write_parts(stmt);
-
-        // Only UPDATE reaches the CTE path; DELETE cannot be nested in a CTE and
-        // is routed to read-modify-write by the caller.
-        let stmt::Statement::Update(mut write) = write else {
-            unreachable!("only UPDATE compiles to a CTE; write={write:#?}");
-        };
+        let (condition, filter, source, mut write) = self.conditional_write_parts(stmt);
 
         // `found`: the probe. Counts rows matching the filter and, of those,
         // how many satisfy the OCC condition.
@@ -1085,19 +1078,33 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
             )])),
             distinct: false,
         });
-        write.filter = stmt::Filter::new(stmt::Expr::and(filter, counts_agree));
+        // The write applies only when the two counts agree — AND that guard
+        // onto the write's filter.
+        let guarded_filter = stmt::Filter::new(stmt::Expr::and(filter, counts_agree));
+        match &mut write {
+            stmt::Statement::Update(update) => update.filter = guarded_filter,
+            stmt::Statement::Delete(delete) => delete.filter = guarded_filter,
+            _ => unreachable!("conditional write is UPDATE or DELETE; write={write:#?}"),
+        }
 
         // A `RETURNING` on the write (e.g. a relative `value = value + 1` read
         // back) means the caller wants the changed rows; otherwise the write
-        // just reports how many rows it touched.
-        let returning_len = match &write.returning {
+        // just reports how many rows it touched. Only an UPDATE reads columns
+        // back — a DELETE never has a returning.
+        let returning_len = match write.returning() {
             Some(stmt::Returning::Project(stmt::Expr::Record(record))) => record.fields.len(),
-            Some(returning) => todo!("unexpected conditional update returning={returning:#?}"),
+            Some(returning) => todo!("unexpected conditional write returning={returning:#?}"),
             None => 0,
         };
 
+        // `changed`: the write, wrapped as a data-modifying CTE body.
+        let changed_body: stmt::ExprSet = match write {
+            stmt::Statement::Update(update) => update.into(),
+            stmt::Statement::Delete(delete) => delete.into(),
+            _ => unreachable!("conditional write is UPDATE or DELETE"),
+        };
         let changed = stmt::Cte {
-            query: stmt::Query::new(write),
+            query: stmt::Query::new(changed_body),
         };
 
         let outer = if returning_len == 0 {
@@ -1176,15 +1183,15 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
         let (condition, filter, source, write) = self.conditional_write_parts(stmt);
 
         // A conditional write on a backend without data-modifying CTEs (SQLite,
-        // MySQL) — or any conditional DELETE — becomes a transaction: first
-        // probe the matched rows, then apply the write (filter only, no
-        // condition) when every matched row satisfies the condition.
+        // MySQL) becomes a transaction: first probe the matched rows, then apply
+        // the write (filter only, no condition) when every matched row satisfies
+        // the condition.
         //
         // The probe evaluates the condition per matched row (`SELECT
         // <condition> FROM t WHERE <filter>`) rather than as an aggregate: a
-        // per-row projection can carry `FOR UPDATE` to lock the rows against a
-        // concurrent writer, whereas `SELECT count(*) ... FOR UPDATE` is
-        // rejected by PostgreSQL. The engine derives the matched and satisfied
+        // per-row projection can carry `FOR UPDATE` to lock exactly those rows
+        // against a concurrent writer, while `SELECT count(*) ... FOR UPDATE` is
+        // not universally accepted. The engine derives the matched and satisfied
         // counts from the returned rows.
         let read = stmt::Query::builder(stmt::Select {
             source,

--- a/docs/dev/design/field-version.md
+++ b/docs/dev/design/field-version.md
@@ -333,27 +333,35 @@ present → condition failed → `condition_failed`.
 SQL drivers consume the same `condition` through two conditional-write
 strategies, chosen per-capability. Both apply to `UPDATE` and `DELETE`:
 
-1. **CTE plan** (PostgreSQL). Compiles to a single statement with two
-   CTEs: a `found` `SELECT` that counts matching rows and rows matching
-   both the filter and the condition, and a `changed` `UPDATE`/`DELETE`
-   whose filter is `original_filter AND (matched = conditioned)`. The
-   outer query reads the counts (and, when an update reads columns back,
-   the changed rows). A count mismatch raises `condition_failed`. A
+1. **CTE plan** (PostgreSQL). Compiles to a single statement with three
+   CTEs: a `found` `SELECT` that projects the condition once per matching
+   row and locks those rows with `FOR UPDATE`, a `counts` aggregate over
+   `found` producing `[matched, conditioned]`, and a `changed`
+   `UPDATE`/`DELETE` whose filter is `original_filter AND (matched =
+   conditioned)`. The outer query reads the counts (and, when an update
+   reads columns back, the changed rows). Locking the probed rows makes
+   the condition authoritative under READ COMMITTED: `FOR UPDATE`
+   evaluates it against the latest committed row version, and the rows
+   cannot change before the write applies. A count mismatch raises
+   `condition_failed`; zero matched rows raise `record_not_found`. A
    data-modifying `DELETE` sits in the CTE via the `ExprSet::Delete`
    statement variant.
 
 2. **Read-modify-write plan** (SQLite, MySQL). Opens a transaction, probes
-   the target rows with `SELECT <condition> FROM … WHERE <filter>` — one
-   boolean per matched row, carrying `FOR UPDATE` where the backend
-   supports it so the rows are locked — then applies the write (filter
-   only, no condition) when every matched row satisfied the condition. A
-   mismatch raises `condition_failed` and rolls back.
+   the target rows with the same per-row `SELECT <condition> FROM … WHERE
+   <filter>` query, then applies the write (filter only, no condition)
+   when every matched row satisfied the condition. A mismatch raises
+   `condition_failed` and rolls back; zero matched rows raise
+   `record_not_found`.
 
-The read-modify-write probe reads the condition per matched row rather
-than as an aggregate count so it can carry `FOR UPDATE` and lock exactly
+Both strategies read the condition per matched row rather than as an
+aggregate count so the probe can carry `FOR UPDATE` and lock exactly
 those rows — `SELECT count(*) … FOR UPDATE` is not universally accepted
-(PostgreSQL rejects it outright). The engine derives the matched and
-satisfied counts from the returned rows.
+(PostgreSQL rejects it outright). The counts come from the `counts` CTE
+on the CTE plan and from the returned rows on the read-modify-write
+plan. `FOR UPDATE` is emitted where the backend supports it
+(`Capability::select_for_update`); SQLite serializes writers at the
+database level instead.
 
 The SQL `UPDATE` and `DELETE` serializers assert `condition.is_none()`:
 the planner strips the condition and folds its check into a filter

--- a/docs/dev/design/field-version.md
+++ b/docs/dev/design/field-version.md
@@ -330,32 +330,36 @@ present → condition failed → `condition_failed`.
 
 ### SQL
 
-SQL drivers consume the same `condition` through the existing conditional-
-update plans. Two strategies, chosen per-backend based on capability:
+SQL drivers consume the same `condition` through two conditional-write
+strategies, chosen per-statement and per-capability:
 
-1. **CTE plan** (PostgreSQL). Compiles to a single statement with two
-   CTEs: a `SELECT` that counts matching rows and rows matching both the
-   filter and the condition, followed by an `UPDATE` / `DELETE` whose
-   filter is `original_filter AND (matched_count = conditioned_count)`.
-   The planner inspects the CTE counts to decide between `Ok`,
-   `record_not_found`, and `condition_failed`.
+1. **CTE plan** (PostgreSQL, `UPDATE` only). Compiles to a single
+   statement with two CTEs: a `found` `SELECT` that counts matching rows
+   and rows matching both the filter and the condition, and a `changed`
+   `UPDATE` whose filter is `original_filter AND (matched = conditioned)`.
+   The outer query reads the counts (and, when the update reads columns
+   back, the changed rows). A count mismatch raises `condition_failed`.
 
-2. **Read-modify-write plan** (SQLite, MySQL). Opens a transaction, issues
-   `SELECT … FOR UPDATE` (or the backend's best equivalent) returning the
-   matched and conditioned counts, then issues the `UPDATE` / `DELETE`
-   with the filter only if the counts permit. The engine raises the same
-   three-way outcome from the counts.
+2. **Read-modify-write plan** (SQLite and MySQL `UPDATE`s; every backend's
+   `DELETE`). Opens a transaction, probes the target rows with `SELECT
+   <condition> FROM … WHERE <filter>` — one boolean per matched row,
+   carrying `FOR UPDATE` where the backend supports it so the rows are
+   locked — then applies the write (filter only, no condition) when every
+   matched row satisfied the condition. A mismatch raises `condition_failed`
+   and rolls back.
 
-The update path already goes through `plan_conditional_sql_query_as_cte`
-and `plan_conditional_sql_query_as_rmw`. The delete path reuses the same
-two planners — this is where the SQL work for `#[version]` concentrates,
-since conditional delete is new.
+A conditional `DELETE` always takes the read-modify-write path, even on
+PostgreSQL: the statement AST has no form for a `DELETE` nested in a CTE.
 
-The SQL serializer currently asserts `update.condition.is_none()` — a
-leftover from before the conditional-update plans were introduced. Both
-the update and delete serializers leave conditions to the planner, which
-rewrites them into filter predicates before the statement reaches the
-serializer. No SQL dialect receives a `CONDITION` clause.
+The probe reads the condition per row rather than as an aggregate because
+`SELECT count(*) … FOR UPDATE` is rejected by PostgreSQL; a per-row
+projection can still lock the rows. The engine derives the matched and
+satisfied counts from the returned rows.
+
+The SQL `UPDATE` and `DELETE` serializers assert `condition.is_none()`:
+the planner strips the condition and folds its check into a filter
+predicate before the statement reaches the serializer, so no SQL dialect
+receives a `CONDITION` clause.
 
 ### Expression-valued assignments
 

--- a/docs/dev/design/field-version.md
+++ b/docs/dev/design/field-version.md
@@ -331,29 +331,28 @@ present → condition failed → `condition_failed`.
 ### SQL
 
 SQL drivers consume the same `condition` through two conditional-write
-strategies, chosen per-statement and per-capability:
+strategies, chosen per-capability. Both apply to `UPDATE` and `DELETE`:
 
-1. **CTE plan** (PostgreSQL, `UPDATE` only). Compiles to a single
-   statement with two CTEs: a `found` `SELECT` that counts matching rows
-   and rows matching both the filter and the condition, and a `changed`
-   `UPDATE` whose filter is `original_filter AND (matched = conditioned)`.
-   The outer query reads the counts (and, when the update reads columns
-   back, the changed rows). A count mismatch raises `condition_failed`.
+1. **CTE plan** (PostgreSQL). Compiles to a single statement with two
+   CTEs: a `found` `SELECT` that counts matching rows and rows matching
+   both the filter and the condition, and a `changed` `UPDATE`/`DELETE`
+   whose filter is `original_filter AND (matched = conditioned)`. The
+   outer query reads the counts (and, when an update reads columns back,
+   the changed rows). A count mismatch raises `condition_failed`. A
+   data-modifying `DELETE` sits in the CTE via the `ExprSet::Delete`
+   statement variant.
 
-2. **Read-modify-write plan** (SQLite and MySQL `UPDATE`s; every backend's
-   `DELETE`). Opens a transaction, probes the target rows with `SELECT
-   <condition> FROM … WHERE <filter>` — one boolean per matched row,
-   carrying `FOR UPDATE` where the backend supports it so the rows are
-   locked — then applies the write (filter only, no condition) when every
-   matched row satisfied the condition. A mismatch raises `condition_failed`
-   and rolls back.
+2. **Read-modify-write plan** (SQLite, MySQL). Opens a transaction, probes
+   the target rows with `SELECT <condition> FROM … WHERE <filter>` — one
+   boolean per matched row, carrying `FOR UPDATE` where the backend
+   supports it so the rows are locked — then applies the write (filter
+   only, no condition) when every matched row satisfied the condition. A
+   mismatch raises `condition_failed` and rolls back.
 
-A conditional `DELETE` always takes the read-modify-write path, even on
-PostgreSQL: the statement AST has no form for a `DELETE` nested in a CTE.
-
-The probe reads the condition per row rather than as an aggregate because
-`SELECT count(*) … FOR UPDATE` is rejected by PostgreSQL; a per-row
-projection can still lock the rows. The engine derives the matched and
+The read-modify-write probe reads the condition per matched row rather
+than as an aggregate count so it can carry `FOR UPDATE` and lock exactly
+those rows — `SELECT count(*) … FOR UPDATE` is not universally accepted
+(PostgreSQL rejects it outright). The engine derives the matched and
 satisfied counts from the returned rows.
 
 The SQL `UPDATE` and `DELETE` serializers assert `condition.is_none()`:

--- a/docs/guide/src/concurrency-control.md
+++ b/docs/guide/src/concurrency-control.md
@@ -79,5 +79,17 @@ Only instance updates and instance deletes *check* the version and fail on
 conflict. Query-based updates increment the version but apply unconditionally —
 they never fail on a version mismatch.
 
-> **Note:** `#[version]` is supported by the DynamoDB driver only. SQL drivers
-> do not yet implement OCC.
+## Driver support
+
+`#[version]` works on every driver: DynamoDB, SQLite, PostgreSQL, and MySQL. How
+Toasty applies the version check varies by backend, but the behavior is the
+same everywhere:
+
+- DynamoDB conditions the write on the version value in a single request.
+- PostgreSQL bundles the check and the update into one statement.
+- SQLite and MySQL run the check and the write inside a transaction, reading the
+  current version (locking the row where the database supports it) before
+  applying the write.
+
+A conflicting write returns `Error::condition_failed`; recover by reloading the
+record and retrying.

--- a/docs/guide/src/concurrency-control.md
+++ b/docs/guide/src/concurrency-control.md
@@ -92,4 +92,5 @@ same everywhere:
   applying the write.
 
 A conflicting write returns `Error::condition_failed`; recover by reloading the
-record and retrying.
+record and retrying. If the record has been deleted since it was loaded, the
+write returns `Error::record_not_found` instead.


### PR DESCRIPTION
## Summary

`#[version]` optimistic concurrency worked only on DynamoDB — every test in `field_version.rs` was gated `requires(not(sql))`. This implements the SQL conditional-write path so `#[version]` works on SQLite, PostgreSQL, and MySQL too.

- **Read-modify-write** (SQLite, MySQL) now returns the write's rows, so an instance update reloads its changed fields — including relative updates, via the existing MySQL `UPDATE`→`SELECT` `RETURNING` workaround. The probe projects the condition per matched row (`SELECT <condition> … FOR UPDATE`) instead of an aggregate count, so it can lock exactly the matched rows (`SELECT count(*) … FOR UPDATE` is not universally accepted).
- **CTE plan** (PostgreSQL) compiles a conditional `UPDATE` *or* `DELETE` to a single statement: a `found` probe CTE plus a data-modifying `changed` CTE guarded by `matched = conditioned`. A new `ExprSet::Delete` AST variant lets a `DELETE` be a CTE body, so conditional delete is one round-trip instead of a transaction — matching how conditional `UPDATE` already compiled.
- The SQL serializer now aliases every projected column positionally (`AS column1`, …), fixing a latent bug where CTE/subquery/derived-table column references (`tbl.column1`) resolved against unaliased inner columns. The `UPDATE`/`DELETE` condition assertions become debug asserts — the planner folds the condition into a filter before the statement reaches the serializer. Also fixes a missing space in `INSERT … VALUES (…) RETURNING`.

Closes #933.

## Type of change

- [x] Implements a previously accepted design: [`docs/dev/design/field-version.md`](https://github.com/tokio-rs/toasty/blob/version-for-all/docs/dev/design/field-version.md)

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [x] Touches driver-observable behavior → the design doc covers it

## Notes for reviewers

- Validated on all four backends: `field_version` 15/15 each; full suites with 0 failures (SQLite 1171, PostgreSQL 1202, MySQL 1180, DynamoDB).
- The serializer change updated several serialization snapshots. The pre-change SQL for CTEs/subqueries referenced `column1` against unaliased inner columns — invalid SQL the serialization-only tests never executed against a database.
- `ExprSet::Delete` is a new statement-AST variant. Its blast radius mirrors the existing `ExprSet::Update`: six exhaustive-match sites in `toasty-core` (visitors, `ExprContext`, `is_const`/`Debug`) plus the SQL `ExprSet` serializer arm.
- A missing-row instance write raises `condition_failed` rather than distinguishing `record_not_found`, matching current DynamoDB behavior (that distinction is implemented on no driver today).
