### PR TITLE
fix: prune unreachable enum-decode branch in OR'd variant filters

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/embed_enum_filter_variant_field.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embed_enum_filter_variant_field.rs
@@ -140,6 +140,58 @@ pub async fn filter_variant_field_with_partition_key(t: &mut Test) -> Result<()>
     Ok(())
 }
 
+/// OR of two variant-rooted field predicates — one per variant. Each predicate
+/// on its own works; only the `OR` used to panic in the SQL serializer with
+/// "unexpected enum discriminant" (issue #1061).
+#[driver_test(requires(scan))]
+pub async fn cross_variant_or(t: &mut Test) -> Result<()> {
+    #[derive(Debug, PartialEq, toasty::Embed)]
+    enum Contact {
+        #[column(variant = 1)]
+        Email { address: String },
+        #[column(variant = 2)]
+        Phone { number: String },
+    }
+
+    #[derive(Debug, toasty::Model)]
+    #[allow(dead_code)]
+    struct User {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+        contact: Contact,
+    }
+
+    let mut db = t.setup_db(models!(User)).await;
+
+    User::create()
+        .contact(Contact::Email {
+            address: "x".to_string(),
+        })
+        .exec(&mut db)
+        .await?;
+    User::create()
+        .contact(Contact::Phone {
+            number: "x".to_string(),
+        })
+        .exec(&mut db)
+        .await?;
+
+    let rows = User::filter(
+        User::fields()
+            .contact()
+            .email()
+            .address()
+            .eq("x")
+            .or(User::fields().contact().phone().number().eq("x")),
+    )
+    .exec(&mut db)
+    .await?;
+
+    assert_eq!(rows.len(), 2);
+    Ok(())
+}
+
 /// Filtering directly via a variant-rooted path comparison (no `matches`
 /// closure). The implicit gate on filter methods means
 /// `email().address().eq("x")` is equivalent to

--- a/crates/toasty-driver-integration-suite/src/tests/embed_enum_shared_column.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embed_enum_shared_column.rs
@@ -199,3 +199,52 @@ pub async fn shared_column_variant_gated_filter(t: &mut Test) -> Result<()> {
 
     Ok(())
 }
+
+/// OR-ing the two variant-gated predicates on the shared `creature_name` column
+/// is the natural way to query a single shared column across variants: "any
+/// creature named Bob, regardless of variant". This used to panic in the SQL
+/// serializer (issue #1061) because factoring lifted the shared predicate out
+/// from under its variant gates, exposing the decode's unreachable `Error` else
+/// branch.
+#[driver_test(requires(scan), scenario(crate::scenarios::character_creature))]
+pub async fn shared_column_cross_variant_or(t: &mut Test) -> Result<()> {
+    let mut db = setup(t).await;
+
+    Character::create()
+        .creature(Creature::Human {
+            name: "Bob".to_string(),
+            profession: "builder".to_string(),
+        })
+        .exec(&mut db)
+        .await?;
+    Character::create()
+        .creature(Creature::Animal {
+            name: "Bob".to_string(),
+            species: "dog".to_string(),
+        })
+        .exec(&mut db)
+        .await?;
+    Character::create()
+        .creature(Creature::Animal {
+            name: "Rex".to_string(),
+            species: "cat".to_string(),
+        })
+        .exec(&mut db)
+        .await?;
+
+    // Both a Human "Bob" and an Animal "Bob" live in the shared column; the
+    // cross-variant OR finds both while excluding "Rex".
+    let bobs = Character::filter(
+        Character::fields()
+            .creature()
+            .human()
+            .name()
+            .eq("Bob")
+            .or(Character::fields().creature().animal().name().eq("Bob")),
+    )
+    .exec(&mut db)
+    .await?;
+    assert_eq!(bobs.len(), 2);
+
+    Ok(())
+}

--- a/crates/toasty-sql/src/serializer/expr.rs
+++ b/crates/toasty-sql/src/serializer/expr.rs
@@ -8,7 +8,7 @@ impl ToSql for &stmt::Expr {
     fn to_sql(self, f: &mut super::Formatter<'_>) {
         match self {
             stmt::Expr::And(expr) => {
-                fmt!(f, Delimited(&expr.operands, " AND "));
+                fmt!(f, Delimited(expr.operands.iter().map(AndOperand), " AND "));
             }
             stmt::Expr::Between(expr) => {
                 fmt!(f, expr.expr " BETWEEN " expr.low " AND " expr.high);
@@ -209,6 +209,25 @@ impl ToSql for &stmt::Expr {
                 Flavor::Sqlite => fmt!(f, "NULL"),
             },
             _ => todo!("expr={:#?}", self),
+        }
+    }
+}
+
+/// A single operand of an `AND` chain.
+///
+/// `OR` binds looser than `AND` in SQL, so an `Or` operand must be
+/// parenthesized: `a AND (b OR c)` would otherwise serialize as
+/// `a AND b OR c`, which parses as `(a AND b) OR c` and silently changes the
+/// query's meaning. Operands of other kinds bind at least as tightly as `AND`
+/// (comparisons, `IS NULL`, `NOT (..)`, nested `AND`), so they need no parens.
+struct AndOperand<'a>(&'a stmt::Expr);
+
+impl ToSql for AndOperand<'_> {
+    fn to_sql(self, f: &mut super::Formatter<'_>) {
+        if matches!(self.0, stmt::Expr::Or(_)) {
+            fmt!(f, "(" self.0 ")");
+        } else {
+            fmt!(f, self.0);
         }
     }
 }

--- a/crates/toasty-sql/tests/serialize_expressions.rs
+++ b/crates/toasty-sql/tests/serialize_expressions.rs
@@ -97,6 +97,47 @@ fn or_chain_joins_operands_with_or_keyword() {
     expect!["VALUES ($1 = $2 OR $3 = $4 OR $5 = $6);"].assert_eq(&render_pg(expr));
 }
 
+/// An `OR` nested inside an `AND` must be parenthesized: `OR` binds looser than
+/// `AND`, so `a AND (b OR c)` would otherwise serialize to `a AND b OR c`, which
+/// SQL parses as `(a AND b) OR c` — a different query (issue #1061).
+#[test]
+fn and_parenthesizes_nested_or_operand() {
+    let expr: Expr = ExprAnd {
+        operands: vec![
+            Expr::eq(Expr::arg(0), Expr::arg(1)),
+            ExprOr {
+                operands: vec![
+                    Expr::eq(Expr::arg(2), Expr::arg(3)),
+                    Expr::eq(Expr::arg(4), Expr::arg(5)),
+                ],
+            }
+            .into(),
+        ],
+    }
+    .into();
+    expect!["VALUES ($1 = $2 AND ($3 = $4 OR $5 = $6));"].assert_eq(&render_pg(expr));
+}
+
+/// The mirror case needs no parens: `AND` binds tighter than `OR`, so
+/// `(a AND b) OR c` renders correctly without them.
+#[test]
+fn or_does_not_parenthesize_nested_and_operand() {
+    let expr: Expr = ExprOr {
+        operands: vec![
+            ExprAnd {
+                operands: vec![
+                    Expr::eq(Expr::arg(0), Expr::arg(1)),
+                    Expr::eq(Expr::arg(2), Expr::arg(3)),
+                ],
+            }
+            .into(),
+            Expr::eq(Expr::arg(4), Expr::arg(5)),
+        ],
+    }
+    .into();
+    expect!["VALUES ($1 = $2 AND $3 = $4 OR $5 = $6);"].assert_eq(&render_pg(expr));
+}
+
 // ---------- LIKE family ----------
 
 #[test]

--- a/crates/toasty/src/engine/simplify/expr_binary_op.rs
+++ b/crates/toasty/src/engine/simplify/expr_binary_op.rs
@@ -221,19 +221,55 @@ impl Simplify<'_> {
     }
 }
 
-/// A distributed-comparison term is dead — it can never be `true`, so it
-/// contributes nothing to the surrounding `OR` — when it is `false`, a bare
-/// `NULL`, or an `AND` with a `NULL` conjunct. The last case arises when an arm
-/// compares against a decode `Match`'s `null` else branch (e.g.
-/// `eq(option_embed, Some(..))` evaluated against a `None` row): `x AND NULL`
-/// never holds in three-valued filter logic, and DynamoDB rejects the bare
-/// value placeholder the `NULL` would otherwise serialize to.
+/// Returns `true` when a distributed-comparison term can never be `true`, so it
+/// adds nothing to the surrounding `OR` and can be dropped.
+///
+/// Three shapes qualify:
+///
+/// 1. The term is `false` or a bare `NULL`.
+///
+/// 2. The term is an `AND` with a `NULL` conjunct, such as `x AND NULL`. This
+///    comes from comparing against a decode `Match`'s `null` else branch — for
+///    example `eq(option_embed, Some(..))` on a `None` row. `x AND NULL` never
+///    holds in three-valued logic, and DynamoDB rejects the bare `NULL`
+///    placeholder it would otherwise serialize to.
+///
+/// 3. The term compares against an `Expr::Error`, the placeholder a total enum
+///    decode puts in its unreachable else branch. For a two-variant enum,
+///    distributing `field == "x"` over the decode produces a term like
+///    `disc != 1 AND disc != 2 AND Error == "x"`. A surrounding variant gate
+///    usually contradicts the `disc != k` guards and folds this away, but
+///    factoring a shared predicate out from under its gates removes that gate
+///    (issue #1061). Since `Error` marks a branch that never runs, the
+///    comparison can never hold. Dropping the term also keeps `Error` out of
+///    the SQL serializer, which cannot render it.
 fn is_dead_filter_term(term: &Expr) -> bool {
     if term.is_unsatisfiable() {
+        return true;
+    }
+    if contains_error(term) {
         return true;
     }
     matches!(
         term,
         Expr::And(and) if and.operands.iter().any(Expr::is_value_null)
     )
+}
+
+/// Returns `true` if `expr` contains an `Expr::Error` node anywhere in its
+/// subtree — the unreachable-branch placeholder produced by enum decode.
+fn contains_error(expr: &Expr) -> bool {
+    use toasty_core::stmt::Visit;
+
+    struct FindError(bool);
+
+    impl Visit for FindError {
+        fn visit_expr_error(&mut self, _: &stmt::ExprError) {
+            self.0 = true;
+        }
+    }
+
+    let mut find = FindError(false);
+    find.visit_expr(expr);
+    find.0
 }


### PR DESCRIPTION
## Summary

Fixes a panic when OR-ing two variant-rooted field predicates on an embedded
enum, e.g. `email().address().eq("x").or(phone().number().eq("x"))`.

The pre-lower simplifier factors the shared comparison out from under its
variant gates:

```
(IsVariant(Email) AND P) OR (IsVariant(Phone) AND P)  →  P AND (IsVariant(Email) OR IsVariant(Phone))
```

The variant-covering OR collapses to `true`, leaving bare `P`. Once lowered,
`P`'s enum-decode `Match` has an unreachable `else` filled with `Expr::Error`,
and — with the variant gate now gone — nothing prunes it, so `Error == "x"`
reached the SQL serializer and panicked with "unexpected enum discriminant".

Two changes:

1. **engine** — a match-elimination filter term that compares against an
   unreachable `Expr::Error` is now treated as dead and pruned. The branch can
   never execute, so the term can never be satisfied.
2. **sql** — fixing (1) surfaced a latent, enum-independent serializer
   precedence bug: `AND(x, OR(a, b))` rendered as `x AND a OR b`, which SQL
   parses as `(x AND a) OR b` (wrong results, reproducible with a plain
   `a AND (b OR c)` filter). An `Or` operand nested in an `And` is now
   parenthesized.

Closes #1061

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

The serializer fix is the higher-risk part: it changes rendering for any
`AND` containing a nested `OR`. Existing OR-of-ANDs output is unchanged (AND
binds tighter, so it never needed parens). Covered by two new unit tests in
`serialize_expressions.rs` plus integration tests `cross_variant_or` (distinct
per-variant columns) and `shared_column_cross_variant_or` (the shared-column
case from the issue, where the precedence bug actually changed results).
