### PR TITLE
fix(engine): avoid panic when updating a mixed enum to a unit variant

### DIFF
--- a/crates/toasty-core/src/stmt/expr.rs
+++ b/crates/toasty-core/src/stmt/expr.rs
@@ -554,20 +554,23 @@ impl Expr {
     /// Navigates into a nested record or list expression by `path` and returns
     /// a read-only [`Entry`] reference.
     ///
-    /// Returns `None` if the path cannot be followed (e.g., the expression is
-    /// not a record or list at the expected depth).
+    /// Returns `None` if the path cannot be followed: the expression is not a
+    /// record or list at the expected depth, or a step indexes past the end of
+    /// a record or list.
     #[track_caller]
     pub fn entry(&self, path: impl EntryPath) -> Option<Entry<'_>> {
         let mut ret = Entry::Expr(self);
 
         for step in path.step_iter() {
             ret = match ret {
-                Entry::Expr(Self::Record(expr)) => Entry::Expr(&expr[step]),
-                Entry::Expr(Self::List(expr)) => Entry::Expr(&expr.items[step]),
+                Entry::Expr(Self::Record(expr)) => Entry::Expr(expr.get(step)?),
+                Entry::Expr(Self::List(expr)) => Entry::Expr(expr.items.get(step)?),
                 Entry::Value(Value::Record(record))
-                | Entry::Expr(Self::Value(Value::Record(record))) => Entry::Value(&record[step]),
+                | Entry::Expr(Self::Value(Value::Record(record))) => {
+                    Entry::Value(record.get(step)?)
+                }
                 Entry::Value(Value::List(items)) | Entry::Expr(Self::Value(Value::List(items))) => {
-                    Entry::Value(&items[step])
+                    Entry::Value(items.get(step)?)
                 }
                 _ => return None,
             }

--- a/crates/toasty-driver-integration-suite/src/tests/embed_enum_data.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embed_enum_data.rs
@@ -188,6 +188,97 @@ pub async fn mixed_enum_roundtrip(t: &mut Test) -> Result<()> {
     Ok(())
 }
 
+/// Updating a mixed enum field from a data-carrying variant to a unit variant
+/// (and back) round-trips correctly. Regression test for #1068: the unit
+/// variant's value record is narrower than the data variant's data column
+/// expects, which used to panic while lowering the update.
+#[driver_test(scenario(crate::scenarios::task_with_status))]
+pub async fn mixed_enum_update_data_to_unit_variant(t: &mut Test) -> Result<()> {
+    let mut db = setup(t).await;
+
+    let mut task = toasty::create!(Task {
+        title: "task",
+        status: Status::Failed {
+            reason: "boom".to_string(),
+        },
+    })
+    .exec(&mut db)
+    .await?;
+
+    // Data variant -> unit variant (the reported panic).
+    task.update().status(Status::Pending).exec(&mut db).await?;
+    assert_eq!(
+        Task::get_by_id(&mut db, &task.id).await?.status,
+        Status::Pending
+    );
+
+    // Unit variant -> data variant, to confirm the reverse still works.
+    task.update()
+        .status(Status::Failed {
+            reason: "again".to_string(),
+        })
+        .exec(&mut db)
+        .await?;
+    assert_eq!(
+        Task::get_by_id(&mut db, &task.id).await?.status,
+        Status::Failed {
+            reason: "again".to_string()
+        }
+    );
+
+    Ok(())
+}
+
+/// Updating a data-carrying enum between variants with *different field counts*
+/// round-trips. The narrower variant's value record is shorter than the wider
+/// variant's data columns expect, exercising the same out-of-bounds projection
+/// path as #1068 without any unit variant involved.
+#[driver_test]
+pub async fn enum_update_between_variants_of_different_width(test: &mut Test) -> Result<()> {
+    #[derive(Debug, PartialEq, toasty::Embed)]
+    enum Event {
+        #[column(variant = 1)]
+        Login { user: String },
+        #[column(variant = 2)]
+        Purchase { item: String, amount: i64 },
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Log {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+        event: Event,
+    }
+
+    let mut db = test.setup_db(models!(Log)).await;
+
+    let mut log = toasty::create!(Log {
+        event: Event::Purchase {
+            item: "book".to_string(),
+            amount: 42,
+        },
+    })
+    .exec(&mut db)
+    .await?;
+
+    // Wider variant -> narrower variant.
+    log.update()
+        .event(Event::Login {
+            user: "alice".to_string(),
+        })
+        .exec(&mut db)
+        .await?;
+    assert_eq!(
+        Log::get_by_id(&mut db, &log.id).await?.event,
+        Event::Login {
+            user: "alice".to_string()
+        }
+    );
+
+    Ok(())
+}
+
 /// Tests that UUID fields inside data-carrying enum variants round-trip correctly.
 /// UUID is a non-trivial primitive that requires type casting on some databases.
 #[driver_test]

--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -1935,7 +1935,20 @@ impl stmt::Input for AssignmentInput<'_> {
         if expr_projection.as_slice() == remaining_steps {
             Some(self.value.clone())
         } else {
-            self.value.entry(expr_projection).map(|e| e.to_expr())
+            // The column's encode template projects into variant-field
+            // positions of the assignment value. When a mixed enum is updated
+            // to a unit (or otherwise shorter) variant, the value record is
+            // narrower than a sibling variant's column expects, so the
+            // projection falls out of bounds and `entry` returns `None`. Those
+            // references live inside a discriminant-guarded match arm that is
+            // unreachable for this value, so resolving them to `null` is safe —
+            // the simplifier drops the dead arm.
+            Some(
+                self.value
+                    .entry(expr_projection)
+                    .map(|e| e.to_expr())
+                    .unwrap_or_else(stmt::Expr::null),
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1068. Updating an embedded enum field to a unit (or otherwise narrower) variant panicked while lowering the update:

```
index out of bounds: the len is 1 but the index is 1
```

A data-carrying enum stores a discriminant column plus one nullable column per variant field. Each data column's encode template is a discriminant-guarded match that projects into the assignment value at a fixed record position, e.g. for `reason`:

```
match project(value, [0]) { 2 => project(value, [1]) } else null
```

The update path resolves those projections eagerly by indexing into the value. Assigning `Status::Pending` yields a record of just `[discriminant]`, so projecting `[1]` for `reason` runs off the end and panics. (Create avoids this: it substitutes the whole value and lets the simplifier fold the dead arm first.) The same out-of-bounds path is hit updating between any two data variants with different field counts, not only unit variants.

The out-of-bounds reference lives inside a discriminant-guarded match arm that is unreachable for the new value, so it is resolved to `null` and the simplifier drops the dead arm. `Expr::entry` now returns `None` for an out-of-bounds step (via `.get()`) instead of panicking, matching its documented contract.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

Two regression tests in `embed_enum_data.rs`: the reported data→unit case (both directions) and the generalized data→narrower-data case. The `Expr::entry` bounds-check is the one shared change with callers outside this path; all its non-test callers already handle `None` (`?`, `if let Some`, or valid-row projections that never go out of bounds).