### PR TITLE
perf(core)!: derive default table names at compile time

### DIFF
--- a/.agents/scheduled_tasks.lock
+++ b/.agents/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"02609ab0-da0e-4acb-abe2-f26f88b96533","pid":14715,"procStart":"Fri Jul  3 15:22:50 2026","acquiredAt":1783099650815}

--- a/.agents/scheduled_tasks.lock
+++ b/.agents/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"02609ab0-da0e-4acb-abe2-f26f88b96533","pid":14715,"procStart":"Fri Jul  3 15:22:50 2026","acquiredAt":1783099650815}

--- a/crates/toasty-core/Cargo.toml
+++ b/crates/toasty-core/Cargo.toml
@@ -24,7 +24,6 @@ rust_decimal = { workspace = true, optional = true }
 bigdecimal = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 heck.workspace = true
-pluralizer.workspace = true
 tokio-stream.workspace = true
 uuid.workspace = true
 

--- a/crates/toasty-core/src/schema/app/model.rs
+++ b/crates/toasty-core/src/schema/app/model.rs
@@ -156,9 +156,11 @@ pub struct ModelRoot {
     /// The primary key definition. Root models always have a primary key.
     pub primary_key: PrimaryKey,
 
-    /// Optional explicit table name. When `None`, a name is derived from the
-    /// model name.
-    pub table_name: Option<String>,
+    /// The table this model maps to, before any builder-level prefix is
+    /// applied. Always set by the caller constructing the schema: `#[derive(Model)]`
+    /// derives the default (snake_case + pluralized) name at compile time, or
+    /// uses the explicit `#[table = "..."]` override.
+    pub table_name: String,
 
     /// Secondary indices defined on this model.
     pub indices: Vec<Index>,

--- a/crates/toasty-core/src/schema/builder/table.rs
+++ b/crates/toasty-core/src/schema/builder/table.rs
@@ -2,7 +2,6 @@ use super::BuildSchema;
 use crate::{
     Error, Result, driver,
     schema::{
-        Name,
         app::{self, Model, ModelId, ModelRoot},
         db::{self, ColumnId, IndexId, Table, TableId},
         mapping::{self, Mapping, TableToModel},
@@ -137,22 +136,14 @@ struct MapField<'a, 'b> {
 
 impl BuildSchema<'_> {
     pub(super) fn build_table_stub_for_model(&mut self, model: &ModelRoot) -> TableId {
-        if let Some(table_name) = model.table_name.as_ref() {
-            let table_name = self.prefix_table_name(table_name);
+        let table_name = self.prefix_table_name(&model.table_name);
 
-            if !self.table_lookup.contains_key(&table_name) {
-                let id = self.register_table(&table_name);
-                self.tables.push(Table::new(id, table_name.clone()));
-            }
-
-            *self.table_lookup.get(&table_name).unwrap()
-        } else {
-            let name = self.table_name_from_model(&model.name);
-            let id = self.register_table(&name);
-
-            self.tables.push(Table::new(id, name));
-            id
+        if !self.table_lookup.contains_key(&table_name) {
+            let id = self.register_table(&table_name);
+            self.tables.push(Table::new(id, table_name.clone()));
         }
+
+        *self.table_lookup.get(&table_name).unwrap()
     }
 
     pub(super) fn build_tables_from_models(
@@ -191,11 +182,6 @@ impl BuildSchema<'_> {
         let id = TableId(self.table_lookup.len());
         self.table_lookup.insert(name.as_ref().to_string(), id);
         id
-    }
-
-    fn table_name_from_model(&self, model_name: &Name) -> String {
-        let base = pluralizer::pluralize(&model_name.snake_case(), 2, false);
-        self.prefix_table_name(&base)
     }
 
     fn prefix_table_name(&self, name: &str) -> String {

--- a/crates/toasty-core/tests/schema_missing_model.rs
+++ b/crates/toasty-core/tests/schema_missing_model.rs
@@ -40,7 +40,7 @@ fn make_root_model(id: ModelId, name: &str, extra_fields: Vec<Field>) -> Model {
                 index: 0,
             },
         },
-        table_name: None,
+        table_name: name.to_string(),
         indices: vec![],
         version_field: None,
     })

--- a/crates/toasty-core/tests/schema_resolve_field.rs
+++ b/crates/toasty-core/tests/schema_resolve_field.rs
@@ -177,7 +177,7 @@ fn schema() -> Schema {
                 index: 0,
             },
         },
-        table_name: None,
+        table_name: "users".to_string(),
         indices: vec![],
         version_field: None,
     });

--- a/crates/toasty-core/tests/schema_verify_version_field.rs
+++ b/crates/toasty-core/tests/schema_verify_version_field.rs
@@ -44,7 +44,7 @@ fn build_model(fields: Vec<Field>, version_field: Option<FieldId>) -> Model {
             fields: vec![id.field(0)],
             index: pk_index_id,
         },
-        table_name: None,
+        table_name: "things".to_string(),
         indices: vec![Index {
             id: pk_index_id,
             name: None,

--- a/crates/toasty-core/tests/stmt_infer_expr_reference_ty.rs
+++ b/crates/toasty-core/tests/stmt_infer_expr_reference_ty.rs
@@ -101,7 +101,7 @@ fn model_root(id: usize, field_types: &[(Type, &str)]) -> ModelRoot {
                 index: 0,
             },
         },
-        table_name: None,
+        table_name: "t".to_string(),
         indices: vec![],
         version_field: None,
     }

--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -353,12 +353,16 @@ impl Expand<'_> {
     }
 
     fn expand_table_name(&self) -> TokenStream {
-        if let Some(table_name) = &self.model.table {
-            let table_name = table_name.value();
-            quote! { Some(#table_name.to_string()) }
-        } else {
-            quote! { None }
-        }
+        let table_name = match &self.model.table {
+            Some(table_name) => table_name.value(),
+            // Derive the default table name at compile time so building the
+            // schema at runtime never pays the cost of the `pluralizer` crate's
+            // lazy regex compilation: snake_case the model name, then pluralize.
+            // The table-name prefix, if any, is applied at runtime by the builder.
+            None => pluralizer::pluralize(&self.model.name.snake_case, 2, false),
+        };
+
+        quote! { #table_name.to_string() }
     }
 }
 


### PR DESCRIPTION
## Summary

Building a schema at runtime pluralized each model's default table name with the
`pluralizer` crate, whose inflection rules are lazily-compiled regexes. The first
`Db` build in a process paid the full regex-compilation cost — a one-time CPU
spike visible in profiles that adds to serverless cold-start latency, even for
models that never set `#[table = "..."]`.

`#[derive(Model)]` now pluralizes at macro-expansion time and always populates
`ModelRoot::table_name`, so the runtime builder just applies the table prefix (if
any) to the given name. The `pluralizer` dependency is dropped from `toasty-core`
and stays a compile-time-only dependency of `toasty-macros`. Derived names are
byte-for-byte unchanged (same snake_case + pluralize on the same input).

`ModelRoot::table_name` changes from `Option<String>` to `String`: the builder no
longer derives a name, so the caller constructing the schema must supply it.

Closes #1054

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

`ModelRoot::table_name: Option<String>` → `String` is a breaking change to the
`toasty-core` public API (flagged `BREAKING CHANGE` in the commit). The only
in-tree constructors of `ModelRoot` outside the macro are a handful of
`toasty-core` unit tests, updated here to pass explicit names.
