### PR TITLE
fix(macros): let update! value expressions read the target's fields

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/crud_update_macro.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/crud_update_macro.rs
@@ -205,6 +205,53 @@ pub async fn update_macro_method_shorthand_clear(test: &mut Test) -> Result<()> 
     Ok(())
 }
 
+/// Value expressions may read the target instance's own fields inline
+/// (issue #1073). The macro evaluates values before `.update()` borrows
+/// the target, so `active: !user.active` compiles.
+#[driver_test(id(ID), scenario(crate::scenarios::user_with_active))]
+pub async fn update_macro_value_reads_target_field(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let mut user = toasty::create!(User {
+        name: "Carl",
+        age: 30,
+        active: false,
+    })
+    .exec(&mut db)
+    .await?;
+
+    toasty::update!(user {
+        active: !user.active,
+        age: user.age + 1,
+    })
+    .exec(&mut db)
+    .await?;
+
+    assert_struct!(user, _ { active: true, age: 31, .. });
+
+    let reloaded = User::get_by_id(&mut db, &user.id).await?;
+    assert_struct!(reloaded, _ { active: true, age: 31, .. });
+
+    Ok(())
+}
+
+/// Method-shorthand arguments may also read the target instance's own
+/// fields inline (issue #1073).
+#[driver_test(id(ID), scenario(crate::scenarios::two_models))]
+pub async fn update_macro_method_shorthand_reads_target_field(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let mut user = User::create().name("carl").exec(&mut db).await?;
+
+    toasty::update!(user { name.set(user.name.to_uppercase()) })
+        .exec(&mut db)
+        .await?;
+
+    assert_eq!(user.name, "CARL");
+
+    Ok(())
+}
+
 /// Update through a query builder target — no instance required.
 #[driver_test(id(ID), scenario(crate::scenarios::two_models))]
 pub async fn update_macro_query_target(test: &mut Test) -> Result<()> {

--- a/crates/toasty-macros/src/lib.rs
+++ b/crates/toasty-macros/src/lib.rs
@@ -1947,6 +1947,23 @@ pub fn create(input: TokenStream) -> TokenStream {
 /// `user.update()`, which auto-borrows `&mut user` the same way the
 /// chain form does. `user` stays owned after the macro returns.
 ///
+/// Value expressions are evaluated before the target is borrowed, so
+/// they may read the target's own fields:
+///
+/// ```no_run
+/// # #[derive(toasty::Model)]
+/// # struct Todo {
+/// #     #[key]
+/// #     #[auto]
+/// #     id: i64,
+/// #     done: bool,
+/// # }
+/// # async fn example(mut db: toasty::Db, mut todo: Todo) -> toasty::Result<()> {
+/// toasty::update!(todo { done: !todo.done }).exec(&mut db).await?;
+/// # Ok(())
+/// # }
+/// ```
+///
 /// # Field shapes
 ///
 /// ## Explicit

--- a/crates/toasty-macros/src/update/expand.rs
+++ b/crates/toasty-macros/src/update/expand.rs
@@ -1,11 +1,49 @@
 use super::parse::{FieldEntry, FieldSet, FieldValue, UpdateItem};
 
 use proc_macro2::TokenStream;
-use quote::{quote, quote_spanned};
+use quote::{format_ident, quote, quote_spanned};
 use syn::spanned::Spanned;
+
+/// Collects user-supplied value expressions so they can be evaluated
+/// before the target's `.update()` call.
+///
+/// Instance targets borrow `&mut target` for the whole builder chain, so
+/// a value expression that reads the target (`done: !todo.done`) would
+/// hit E0503 if evaluated inside the chain. Hoisting evaluates every
+/// value first, while the target is still unborrowed.
+///
+/// The values are evaluated as a `match` scrutinee tuple rather than
+/// `let` bindings: temporaries created in a scrutinee live for the whole
+/// `match`, so expressions that borrow from temporaries
+/// (`name: s.to_uppercase().as_str()`) keep compiling exactly as they
+/// did when they were evaluated inline in the chain. Tuple evaluation is
+/// left-to-right, preserving field-order evaluation.
+#[derive(Default)]
+struct Hoist {
+    exprs: Vec<TokenStream>,
+    idents: Vec<syn::Ident>,
+}
+
+impl Hoist {
+    /// Register `expr` for pre-evaluation and return the `__value_N`
+    /// ident that will be bound to it. Both carry the expression's span
+    /// so type errors point at the user's code.
+    fn hoist(&mut self, expr: &syn::Expr) -> TokenStream {
+        let span = expr.span();
+        let ident = format_ident!("__value_{}", self.idents.len(), span = span);
+        self.exprs.push(quote_spanned! { span=> #expr });
+        self.idents.push(ident.clone());
+        quote!(#ident)
+    }
+}
 
 /// Top-level entry point. Expand an `update!` invocation into the
 /// equivalent update-builder method chain.
+///
+/// Field value expressions are evaluated first, as a `match` scrutinee,
+/// before the target expression is borrowed. This lets values read the
+/// target (`update!(todo { done: !todo.done })`) without tripping over
+/// the `&mut` borrow the builder chain holds.
 ///
 /// The target expression is evaluated once at `.update()`, not at
 /// some earlier `let` binding. This is what lets instance updates use
@@ -27,29 +65,41 @@ pub(crate) fn expand(item: &UpdateItem) -> TokenStream {
     let target_span = target.span();
 
     let fields_path = quote!(__fields);
-    let field_calls = expand_field_set(&item.fields, &fields_path);
+    let mut hoist = Hoist::default();
+    let field_calls = expand_field_set(&item.fields, &fields_path, &mut hoist);
 
+    let value_exprs = &hoist.exprs;
+    let value_idents = &hoist.idents;
+
+    // Trailing commas keep the tuple shape valid for zero and one
+    // hoisted values.
     quote_spanned! { target_span=>
-        {
-            let __update = #target.update();
+        match ( #( #value_exprs, )* ) {
+            ( #( #value_idents, )* ) => {
+                let __update = #target.update();
 
-            // Fields path used for embedded-patch path construction.
-            // `unused_variables` is silenced because the update may
-            // have only top-level scalar entries that don't need it.
-            #[allow(unused_variables)]
-            let #fields_path = __update.__macro_fields_root();
+                // Fields path used for embedded-patch path construction.
+                // `unused_variables` is silenced because the update may
+                // have only top-level scalar entries that don't need it.
+                #[allow(unused_variables)]
+                let #fields_path = __update.__macro_fields_root();
 
-            __update #(#field_calls)*
+                __update #(#field_calls)*
+            }
         }
     }
 }
 
 /// Expand a [`FieldSet`] into a list of method calls.
-fn expand_field_set(fields: &FieldSet, parent_path: &TokenStream) -> Vec<TokenStream> {
+fn expand_field_set(
+    fields: &FieldSet,
+    parent_path: &TokenStream,
+    hoist: &mut Hoist,
+) -> Vec<TokenStream> {
     fields
         .0
         .iter()
-        .map(|entry| expand_field_entry(entry, parent_path))
+        .map(|entry| expand_field_entry(entry, parent_path, hoist))
         .collect()
 }
 
@@ -58,22 +108,28 @@ fn expand_field_set(fields: &FieldSet, parent_path: &TokenStream) -> Vec<TokenSt
 /// `parent_path` is the fields-path expression for the parent type
 /// (e.g. `__target_fields` at the top level, or
 /// `parent_path.embedded_field()` for a nested embedded entry).
-fn expand_field_entry(entry: &FieldEntry, parent_path: &TokenStream) -> TokenStream {
+fn expand_field_entry(
+    entry: &FieldEntry,
+    parent_path: &TokenStream,
+    hoist: &mut Hoist,
+) -> TokenStream {
     let name = &entry.name;
     let span = name.span();
 
     match &entry.value {
         FieldValue::Expr(expr) => {
-            quote_spanned! { span=> .#name(#expr) }
+            let value = hoist.hoist(expr);
+            quote_spanned! { span=> .#name(#value) }
         }
         FieldValue::Method { combinator, args } => {
-            quote_spanned! { span=> .#name(toasty::stmt::#combinator(#args)) }
+            let args = hoist_args(args, hoist);
+            quote_spanned! { span=> .#name(toasty::stmt::#combinator(#(#args),*)) }
         }
         FieldValue::Single(sub_fields) => {
             // Embedded partial update — expand into
             // `stmt::apply([stmt::patch(<sub_root>.sub(), val), ...])`.
             let nested_path = quote_spanned! { span=> #parent_path.#name() };
-            let patches = expand_patch_entries(sub_fields, &nested_path);
+            let patches = expand_patch_entries(sub_fields, &nested_path, hoist);
             quote_spanned! { span=>
                 .#name(toasty::stmt::apply([ #( #patches ),* ]))
             }
@@ -108,25 +164,29 @@ fn expand_field_entry(entry: &FieldEntry, parent_path: &TokenStream) -> TokenStr
             let nested_path = quote_spanned! { span=> #parent_path.#name() };
 
             if any_builder {
-                let entries = items
+                let entries: Vec<_> = items
                     .iter()
-                    .map(|item| expand_has_many_list_item(item, &nested_path, span));
+                    .map(|item| expand_has_many_list_item(item, &nested_path, span, hoist))
+                    .collect();
                 quote_spanned! { span=>
                     .#name(toasty::stmt::apply([ #( #entries ),* ]))
                 }
             } else {
-                let entries = items.iter().map(|item| match item {
-                    FieldValue::Expr(e) => quote!(#e),
-                    // Nested `[ [...] ]` is rejected by the macro.
-                    FieldValue::List(_) => quote_spanned! { span=>
-                        compile_error!("nested lists are not supported in update!")
-                    },
-                    // Single/Method don't appear here because the
-                    // any_builder check above routed us to the other
-                    // branch when a Single was present, and Method only
-                    // appears as a top-level entry shape.
-                    FieldValue::Single(_) | FieldValue::Method { .. } => unreachable!(),
-                });
+                let entries: Vec<_> = items
+                    .iter()
+                    .map(|item| match item {
+                        FieldValue::Expr(e) => hoist.hoist(e),
+                        // Nested `[ [...] ]` is rejected by the macro.
+                        FieldValue::List(_) => quote_spanned! { span=>
+                            compile_error!("nested lists are not supported in update!")
+                        },
+                        // Single/Method don't appear here because the
+                        // any_builder check above routed us to the other
+                        // branch when a Single was present, and Method only
+                        // appears as a top-level entry shape.
+                        FieldValue::Single(_) | FieldValue::Method { .. } => unreachable!(),
+                    })
+                    .collect();
                 quote_spanned! { span=>
                     .#name([ #( #entries ),* ])
                 }
@@ -135,18 +195,34 @@ fn expand_field_entry(entry: &FieldEntry, parent_path: &TokenStream) -> TokenStr
     }
 }
 
+/// Hoist each argument of a method-shorthand call.
+fn hoist_args(
+    args: &syn::punctuated::Punctuated<syn::Expr, syn::Token![,]>,
+    hoist: &mut Hoist,
+) -> Vec<TokenStream> {
+    args.iter().map(|arg| hoist.hoist(arg)).collect()
+}
+
 /// Expand each entry of an embedded brace block into a
 /// `stmt::patch(<rooted>.sub_field(), value)` invocation.
-fn expand_patch_entries(fields: &FieldSet, parent_path: &TokenStream) -> Vec<TokenStream> {
+fn expand_patch_entries(
+    fields: &FieldSet,
+    parent_path: &TokenStream,
+    hoist: &mut Hoist,
+) -> Vec<TokenStream> {
     fields
         .0
         .iter()
-        .map(|entry| expand_patch_entry(entry, parent_path))
+        .map(|entry| expand_patch_entry(entry, parent_path, hoist))
         .collect()
 }
 
 /// Expand a single sub-entry of an embedded brace block.
-fn expand_patch_entry(entry: &FieldEntry, parent_path: &TokenStream) -> TokenStream {
+fn expand_patch_entry(
+    entry: &FieldEntry,
+    parent_path: &TokenStream,
+    hoist: &mut Hoist,
+) -> TokenStream {
     let name = &entry.name;
     let span = name.span();
 
@@ -156,22 +232,24 @@ fn expand_patch_entry(entry: &FieldEntry, parent_path: &TokenStream) -> TokenStr
 
     match &entry.value {
         FieldValue::Expr(expr) => {
+            let value = hoist.hoist(expr);
             quote_spanned! { span=>
-                toasty::stmt::patch(#rooted.#name(), #expr)
+                toasty::stmt::patch(#rooted.#name(), #value)
             }
         }
         FieldValue::Method { combinator, args } => {
+            let args = hoist_args(args, hoist);
             quote_spanned! { span=>
                 toasty::stmt::patch(
                     #rooted.#name(),
-                    toasty::stmt::#combinator(#args),
+                    toasty::stmt::#combinator(#(#args),*),
                 )
             }
         }
         FieldValue::Single(sub_fields) => {
             // Nested embedded patch — recurse.
             let nested_path = quote_spanned! { span=> #parent_path.#name() };
-            let inner_patches = expand_patch_entries(sub_fields, &nested_path);
+            let inner_patches = expand_patch_entries(sub_fields, &nested_path, hoist);
             quote_spanned! { span=>
                 toasty::stmt::patch(
                     #rooted.#name(),
@@ -196,18 +274,19 @@ fn expand_has_many_list_item(
     item: &FieldValue,
     parent_path: &TokenStream,
     span: proc_macro2::Span,
+    hoist: &mut Hoist,
 ) -> TokenStream {
     match item {
         FieldValue::Single(fields) => {
             // Build a child create builder via the field-list struct's
             // `.create()` method. A typo in any setter name surfaces as
             // a "no method named …" error at the macro call site.
-            let setters = expand_create_setters(fields);
+            let setters = expand_create_setters(fields, hoist);
             quote_spanned! { span=>
                 toasty::stmt::insert(#parent_path.create() #(#setters)*)
             }
         }
-        FieldValue::Expr(e) => quote!(#e),
+        FieldValue::Expr(e) => hoist.hoist(e),
         FieldValue::List(_) => quote_spanned! { span=>
             compile_error!("nested lists are not supported in update!")
         },
@@ -221,7 +300,7 @@ fn expand_has_many_list_item(
 /// `expand_field_entry`, but limited to entries that have a
 /// counterpart on a create builder. Deeper nesting inside a has-many
 /// list item is rejected for v1.
-fn expand_create_setters(fields: &FieldSet) -> Vec<TokenStream> {
+fn expand_create_setters(fields: &FieldSet, hoist: &mut Hoist) -> Vec<TokenStream> {
     fields
         .0
         .iter()
@@ -229,9 +308,13 @@ fn expand_create_setters(fields: &FieldSet) -> Vec<TokenStream> {
             let name = &entry.name;
             let span = name.span();
             match &entry.value {
-                FieldValue::Expr(expr) => quote_spanned! { span=> .#name(#expr) },
+                FieldValue::Expr(expr) => {
+                    let value = hoist.hoist(expr);
+                    quote_spanned! { span=> .#name(#value) }
+                }
                 FieldValue::Method { combinator, args } => {
-                    quote_spanned! { span=> .#name(toasty::stmt::#combinator(#args)) }
+                    let args = hoist_args(args, hoist);
+                    quote_spanned! { span=> .#name(toasty::stmt::#combinator(#(#args),*)) }
                 }
                 FieldValue::Single(_) | FieldValue::List(_) => quote_spanned! { span=>
                     .#name(compile_error!(

--- a/tests/tests/ui/update_macro_invalid_field.rs
+++ b/tests/tests/ui/update_macro_invalid_field.rs
@@ -1,0 +1,17 @@
+#[derive(Debug, toasty::Model)]
+struct User {
+    #[key]
+    #[auto]
+    id: i64,
+    name: String,
+}
+
+fn main() {
+    let mut user = User {
+        id: 1,
+        name: "Alice".to_string(),
+    };
+
+    // `nonexistent` is not a field on User; the error should point at `nonexistent`
+    let _ = toasty::update!(user { nonexistent: "value" });
+}

--- a/tests/tests/ui/update_macro_invalid_field.stderr
+++ b/tests/tests/ui/update_macro_invalid_field.stderr
@@ -1,0 +1,8 @@
+error[E0599]: no method named `nonexistent` found for struct `UserUpdate<__toasty_T>` in the current scope
+  --> tests/ui/update_macro_invalid_field.rs:16:36
+   |
+ 1 | #[derive(Debug, toasty::Model)]
+   |                 ------------- method `nonexistent` not found for this struct
+...
+16 |     let _ = toasty::update!(user { nonexistent: "value" });
+   |                                    ^^^^^^^^^^^ method not found in `UserUpdate<&mut User>`

--- a/tests/tests/ui/update_macro_shorthand_arg_type_mismatch.rs
+++ b/tests/tests/ui/update_macro_shorthand_arg_type_mismatch.rs
@@ -1,0 +1,19 @@
+#[derive(Debug, toasty::Model)]
+struct User {
+    #[key]
+    #[auto]
+    id: i64,
+    name: String,
+}
+
+fn main() {
+    let mut user = User {
+        id: 1,
+        name: "Alice".to_string(),
+    };
+
+    // `name` is a String field; the type error should point at `false`,
+    // even though the macro hoists the shorthand argument out of the
+    // builder chain.
+    let _ = toasty::update!(user { name.set(false) });
+}

--- a/tests/tests/ui/update_macro_shorthand_arg_type_mismatch.stderr
+++ b/tests/tests/ui/update_macro_shorthand_arg_type_mismatch.stderr
@@ -1,0 +1,30 @@
+error[E0277]: the trait bound `bool: IntoExpr<std::string::String>` is not satisfied
+  --> tests/ui/update_macro_shorthand_arg_type_mismatch.rs:18:45
+   |
+18 |     let _ = toasty::update!(user { name.set(false) });
+   |                                    -------- ^^^^^ the trait `IntoExpr<std::string::String>` is not implemented for `bool`
+   |                                    |
+   |                                    required by a bound introduced by this call
+   |
+help: the trait `IntoExpr<std::string::String>` is not implemented for `bool`
+      but trait `IntoExpr<bool>` is implemented for it
+  --> $WORKSPACE/crates/toasty/src/stmt/into_expr.rs
+   |
+   |               impl IntoExpr<$t> for $t {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^
+...
+   | / impl_into_expr_for_copy! {
+   | |     Bool(bool);
+   | |     I8(i8);
+   | |     I16(i16);
+...  |
+   | |     Uuid(uuid::Uuid);
+   | | }
+   | |_- in this macro invocation
+   = help: for that trait implementation, expected `bool`, found `std::string::String`
+note: required by a bound in `set`
+  --> $WORKSPACE/crates/toasty/src/stmt/assignment.rs
+   |
+   | pub fn set<T>(expr: impl IntoExpr<T>) -> Assignment<T> {
+   |                          ^^^^^^^^^^^ required by this bound in `set`
+   = note: this error originates in the macro `impl_into_expr_for_copy` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/tests/ui/update_macro_value_type_mismatch.rs
+++ b/tests/tests/ui/update_macro_value_type_mismatch.rs
@@ -1,0 +1,18 @@
+#[derive(Debug, toasty::Model)]
+struct User {
+    #[key]
+    #[auto]
+    id: i64,
+    name: String,
+}
+
+fn main() {
+    let mut user = User {
+        id: 1,
+        name: "Alice".to_string(),
+    };
+
+    // `name` is a String field; the type error should point at `123`,
+    // even though the macro hoists the value out of the builder chain.
+    let _ = toasty::update!(user { name: 123 });
+}

--- a/tests/tests/ui/update_macro_value_type_mismatch.stderr
+++ b/tests/tests/ui/update_macro_value_type_mismatch.stderr
@@ -1,0 +1,27 @@
+error[E0277]: the trait bound `{integer}: Assign<std::string::String>` is not satisfied
+  --> tests/ui/update_macro_value_type_mismatch.rs:17:42
+   |
+17 |     let _ = toasty::update!(user { name: 123 });
+   |                                    ----  ^^^ the trait `Assign<std::string::String>` is not implemented for `{integer}`
+   |                                    |
+   |                                    required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `Assign<T>`:
+             `f32` implements `Assign<f32>`
+             `f64` implements `Assign<f64>`
+             `i16` implements `Assign<i16>`
+             `i32` implements `Assign<i32>`
+             `i64` implements `Assign<i64>`
+             `i8` implements `Assign<i8>`
+             `isize` implements `Assign<isize>`
+             `u16` implements `Assign<u16>`
+           and $N others
+note: required by a bound in `UserUpdate::<__toasty_T>::name`
+  --> tests/ui/update_macro_value_type_mismatch.rs:1:17
+   |
+ 1 | #[derive(Debug, toasty::Model)]
+   |                 ^^^^^^^^^^^^^ required by this bound in `UserUpdate::<__toasty_T>::name`
+...
+ 6 |     name: String,
+   |     ---- required by a bound in this associated function
+   = note: this error originates in the derive macro `toasty::Model` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
## Summary

`update!(todo { done: !todo.done })` failed with E0503: value expressions were evaluated inside the builder chain, after `.update()` took `&mut` on the target instance.

The macro now hoists every user-supplied value expression (plain values, method-shorthand args, embedded-patch values, list items, has-many create setters) out of the chain and evaluates them before the target is borrowed. Hoisted values are evaluated as a `match` scrutinee tuple rather than `let` bindings, so temporaries live for the whole builder chain — expressions that borrow from temporaries keep compiling as they did inline. Tuple evaluation preserves left-to-right field-order evaluation, and each hoisted expression keeps its original span so type errors point at user code.

Closes #1073

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

Regression tests in `crud_update_macro.rs` cover the issue scenario (`active: !user.active`) and the method-shorthand form (`name.set(user.name.to_uppercase())`). A new rustdoc example on `update!` documents the behavior and doubles as a compile test.

Three trybuild UI tests pin span propagation for the hoisted values: an unknown field name, a `field: value` type mismatch, and a method-shorthand argument type mismatch all point at the user's tokens inside the macro invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)