### PR TITLE
chore: release v0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,21 +72,21 @@ unsafe_code = "deny"
 
 [workspace.dependencies]
 # Toasty crates
-toasty = { version = "0.8.0", path = "crates/toasty" }
-toasty-cli = { version = "0.8.0", path = "crates/toasty-cli" }
-toasty-core = { version = "0.8.0", path = "crates/toasty-core" }
-toasty-macros = { version = "0.8.0", path = "crates/toasty-macros" }
-toasty-sql = { version = "0.8.0", path = "crates/toasty-sql" }
+toasty = { version = "0.9.0", path = "crates/toasty" }
+toasty-cli = { version = "0.9.0", path = "crates/toasty-cli" }
+toasty-core = { version = "0.9.0", path = "crates/toasty-core" }
+toasty-macros = { version = "0.9.0", path = "crates/toasty-macros" }
+toasty-sql = { version = "0.9.0", path = "crates/toasty-sql" }
 # Driver implementations
-toasty-driver-dynamodb = { version = "0.8.0", path = "crates/toasty-driver-dynamodb" }
-toasty-driver-mysql = { version = "0.8.0", path = "crates/toasty-driver-mysql" }
-toasty-driver-postgresql = { version = "0.8.0", path = "crates/toasty-driver-postgresql" }
-toasty-driver-sqlite = { version = "0.8.0", path = "crates/toasty-driver-sqlite" }
-toasty-driver-turso = { version = "0.8.0", path = "crates/toasty-driver-turso" }
+toasty-driver-dynamodb = { version = "0.9.0", path = "crates/toasty-driver-dynamodb" }
+toasty-driver-mysql = { version = "0.9.0", path = "crates/toasty-driver-mysql" }
+toasty-driver-postgresql = { version = "0.9.0", path = "crates/toasty-driver-postgresql" }
+toasty-driver-sqlite = { version = "0.9.0", path = "crates/toasty-driver-sqlite" }
+toasty-driver-turso = { version = "0.9.0", path = "crates/toasty-driver-turso" }
 
 # Driver integration test suite dependencies
-toasty-driver-integration-suite = { version = "0.8.0", path = "crates/toasty-driver-integration-suite" }
-toasty-driver-integration-suite-macros = { version = "0.8.0", path = "crates/toasty-driver-integration-suite-macros" }
+toasty-driver-integration-suite = { version = "0.9.0", path = "crates/toasty-driver-integration-suite" }
+toasty-driver-integration-suite-macros = { version = "0.9.0", path = "crates/toasty-driver-integration-suite-macros" }
 
 # Other crates
 assert-struct = "0.4.2"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <div align="center">
   <h3>The cozy, easy ORM for Rust</h3>
-  <a href="https://tokio-rs.github.io/toasty/0.8.0/guide/">Guide</a> •
+  <a href="https://tokio-rs.github.io/toasty/0.9.0/guide/">Guide</a> •
   <a href="https://docs.rs/toasty">API Docs</a> •
   <a href="https://crates.io/crates/toasty">Crates.io</a> •
   <a href="https://discord.gg/tokio">Discord</a>

--- a/crates/toasty-cli/CHANGELOG.md
+++ b/crates/toasty-cli/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-cli-v0.8.0...toasty-cli-v0.9.0) - 2026-07-23
+
+### Fixed
+
+- Serialize unconstrained numeric migration snapshots ([#1115])
+
+[#1115]: https://github.com/tokio-rs/toasty/pull/1115
+
 ## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-cli-v0.7.0...toasty-cli-v0.8.0) - 2026-07-06
 
 ### Added

--- a/crates/toasty-cli/Cargo.toml
+++ b/crates/toasty-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-cli"
-version = "0.8.0"
+version = "0.9.0"
 description = "Command-line interface for Toasty schema management"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-core/CHANGELOG.md
+++ b/crates/toasty-core/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-core-v0.8.0...toasty-core-v0.9.0) - 2026-07-23
+
+### Added
+
+- Native JSON and JSONB column storage ([#1114])
+- Filter associations when including related data ([#1089])
+- Inline SQL literals with LIMIT/OFFSET support ([#1001])
+- Integer storage for enum discriminants ([#1101])
+- Upsert support ([#1091])
+- Shared variant fields and enum-level #[index]/#[unique] attributes ([#1078])
+- Document storage for embedded types with nested-path filtering ([#1028])
+
+### Fixed
+
+- Serialization of unconstrained numeric migration snapshots ([#1115])
+- Support for any() on many-to-many relations ([#1097])
+- *(postgres)* Storage of Vec<native-enum> as native enum arrays ([#1092])
+
+[#1001]: https://github.com/tokio-rs/toasty/pull/1001
+[#1028]: https://github.com/tokio-rs/toasty/pull/1028
+[#1078]: https://github.com/tokio-rs/toasty/pull/1078
+[#1089]: https://github.com/tokio-rs/toasty/pull/1089
+[#1091]: https://github.com/tokio-rs/toasty/pull/1091
+[#1092]: https://github.com/tokio-rs/toasty/pull/1092
+[#1097]: https://github.com/tokio-rs/toasty/pull/1097
+[#1101]: https://github.com/tokio-rs/toasty/pull/1101
+[#1114]: https://github.com/tokio-rs/toasty/pull/1114
+[#1115]: https://github.com/tokio-rs/toasty/pull/1115
+
 ## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-core-v0.7.0...toasty-core-v0.8.0) - 2026-07-06
 
 ### Added

--- a/crates/toasty-core/Cargo.toml
+++ b/crates/toasty-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-core"
-version = "0.8.0"
+version = "0.9.0"
 description = "Core types, schema representations, and driver interface for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-dynamodb/CHANGELOG.md
+++ b/crates/toasty-driver-dynamodb/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-dynamodb-v0.8.0...toasty-driver-dynamodb-v0.9.0) - 2026-07-23
+
+### Added
+
+- Upsert support ([#1091])
+- #[document] storage for embedded types with nested-path filtering ([#1028])
+
+[#1028]: https://github.com/tokio-rs/toasty/pull/1028
+[#1091]: https://github.com/tokio-rs/toasty/pull/1091
+
 ## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-dynamodb-v0.7.0...toasty-driver-dynamodb-v0.8.0) - 2026-07-06
 
 ### Added

--- a/crates/toasty-driver-dynamodb/Cargo.toml
+++ b/crates/toasty-driver-dynamodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-dynamodb"
-version = "0.8.0"
+version = "0.9.0"
 description = "Amazon DynamoDB driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-integration-suite-macros/CHANGELOG.md
+++ b/crates/toasty-driver-integration-suite-macros/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-macros-v0.8.0...toasty-driver-integration-suite-macros-v0.9.0) - 2026-07-23
+
+- Internal improvements only.
+
 ## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-macros-v0.7.0...toasty-driver-integration-suite-macros-v0.8.0) - 2026-07-06
 
 ### Added

--- a/crates/toasty-driver-integration-suite-macros/Cargo.toml
+++ b/crates/toasty-driver-integration-suite-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-integration-suite-macros"
-version = "0.8.0"
+version = "0.9.0"
 description = "Proc macros for the Toasty driver integration test suite"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-integration-suite/CHANGELOG.md
+++ b/crates/toasty-driver-integration-suite/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-v0.8.0...toasty-driver-integration-suite-v0.9.0) - 2026-07-23
+
+### Added
+
+- support order_by in includes ([#1109](https://github.com/tokio-rs/toasty/pull/1109))
+- relation link/unlink return a builder instead of executing eagerly ([#1118](https://github.com/tokio-rs/toasty/pull/1118))
+- support serde_json::Value fields ([#1116](https://github.com/tokio-rs/toasty/pull/1116))
+- support native JSON and JSONB column storage ([#1114](https://github.com/tokio-rs/toasty/pull/1114))
+- [**breaking**] require explicit column types for JSON fields ([#1106](https://github.com/tokio-rs/toasty/pull/1106))
+- support temporal Vec fields ([#1105](https://github.com/tokio-rs/toasty/pull/1105))
+- filter associations in include ([#1089](https://github.com/tokio-rs/toasty/pull/1089))
+- introduce Expr::Static for inline SQL literals, hook up LIMIT/OFFSET ([#1001](https://github.com/tokio-rs/toasty/pull/1001))
+- support integer storage for enum discriminants ([#1101](https://github.com/tokio-rs/toasty/pull/1101))
+- add upsert support ([#1091](https://github.com/tokio-rs/toasty/pull/1091))
+- add #[shared] variant fields and enum-level #[index]/#[unique] ([#1078](https://github.com/tokio-rs/toasty/pull/1078))
+- *(macros)* add enum-level rename_all for embedded enum labels ([#1083](https://github.com/tokio-rs/toasty/pull/1083))
+- implement Scalar for unit enum embeds ([#1082](https://github.com/tokio-rs/toasty/pull/1082))
+- add #[document] storage for embedded types with nested-path filtering ([#1028](https://github.com/tokio-rs/toasty/pull/1028))
+
+### Fixed
+
+- *(ddb)* type indexed key discovery as primary keys ([#1113](https://github.com/tokio-rs/toasty/pull/1113))
+- *(postgresql)* decode NUMERIC array elements ([#1104](https://github.com/tokio-rs/toasty/pull/1104))
+- roll back transactions when finalization fails ([#1102](https://github.com/tokio-rs/toasty/pull/1102))
+- support any() on many-to-many relations ([#1097](https://github.com/tokio-rs/toasty/pull/1097))
+- *(postgres)* store Vec<native-enum> as a native enum array on Postgres ([#1092](https://github.com/tokio-rs/toasty/pull/1092))
+- *(engine)* compare composite-FK include filter against target fields ([#1086](https://github.com/tokio-rs/toasty/pull/1086))
+- *(engine)* return None for optional belongs_to with NULL foreign key ([#1090](https://github.com/tokio-rs/toasty/pull/1090))
+- *(engine)* lower IN-list over an embedded-field projection ([#1084](https://github.com/tokio-rs/toasty/pull/1084))
+- *(macros)* let update! value expressions read the target's fields ([#1074](https://github.com/tokio-rs/toasty/pull/1074))
 ## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-v0.7.0...toasty-driver-integration-suite-v0.8.0) - 2026-07-06
 
 ### Added

--- a/crates/toasty-driver-integration-suite/Cargo.toml
+++ b/crates/toasty-driver-integration-suite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-integration-suite"
-version = "0.8.0"
+version = "0.9.0"
 description = "Integration test suite for Toasty database drivers"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-mysql/CHANGELOG.md
+++ b/crates/toasty-driver-mysql/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-mysql-v0.8.0...toasty-driver-mysql-v0.9.0) - 2026-07-23
+
+### Added
+
+- Support native JSON and JSONB column storage ([#1114])
+- Support #[document] attribute on embedded types for nested-path filtering ([#1028])
+
+[#1028]: https://github.com/tokio-rs/toasty/pull/1028
+[#1114]: https://github.com/tokio-rs/toasty/pull/1114
+
 ## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-mysql-v0.7.0...toasty-driver-mysql-v0.8.0) - 2026-07-06
 
 ### Added

--- a/crates/toasty-driver-mysql/Cargo.toml
+++ b/crates/toasty-driver-mysql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-mysql"
-version = "0.8.0"
+version = "0.9.0"
 description = "MySQL driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-postgresql/CHANGELOG.md
+++ b/crates/toasty-driver-postgresql/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-postgresql-v0.8.0...toasty-driver-postgresql-v0.9.0) - 2026-07-23
+
+### Added
+
+- Native JSON and JSONB column storage ([#1114])
+- Temporal Vec fields ([#1105])
+- #[document] storage for embedded types with nested-path filtering ([#1028])
+
+### Fixed
+
+- *(postgresql)* NUMERIC array elements now decode correctly ([#1104])
+- *(postgres)* Vec<native-enum> fields stored as native enum arrays ([#1092])
+
+[#1028]: https://github.com/tokio-rs/toasty/pull/1028
+[#1092]: https://github.com/tokio-rs/toasty/pull/1092
+[#1104]: https://github.com/tokio-rs/toasty/pull/1104
+[#1105]: https://github.com/tokio-rs/toasty/pull/1105
+[#1114]: https://github.com/tokio-rs/toasty/pull/1114
+
 ## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-postgresql-v0.7.0...toasty-driver-postgresql-v0.8.0) - 2026-07-06
 
 ### Added

--- a/crates/toasty-driver-postgresql/Cargo.toml
+++ b/crates/toasty-driver-postgresql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-postgresql"
-version = "0.8.0"
+version = "0.9.0"
 description = "PostgreSQL driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-sqlite/CHANGELOG.md
+++ b/crates/toasty-driver-sqlite/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-sqlite-v0.8.0...toasty-driver-sqlite-v0.9.0) - 2026-07-23
+
+### Added
+
+- New #[document] attribute for storing embedded types with nested-path filtering ([#1028])
+
+[#1028]: https://github.com/tokio-rs/toasty/pull/1028
+
 ## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-sqlite-v0.7.0...toasty-driver-sqlite-v0.8.0) - 2026-07-06
 
 ### Added

--- a/crates/toasty-driver-sqlite/Cargo.toml
+++ b/crates/toasty-driver-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-sqlite"
-version = "0.8.0"
+version = "0.9.0"
 description = "SQLite driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-turso/CHANGELOG.md
+++ b/crates/toasty-driver-turso/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-turso-v0.8.0...toasty-driver-turso-v0.9.0) - 2026-07-23
+
+### Added
+
+- Support for Turso Sync ([#1072])
+- #[document] Storage for embedded types with nested-path filtering ([#1028])
+
+[#1028]: https://github.com/tokio-rs/toasty/pull/1028
+[#1072]: https://github.com/tokio-rs/toasty/pull/1072
+
 ## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-turso-v0.7.0...toasty-driver-turso-v0.8.0) - 2026-07-06
 
 ### Added

--- a/crates/toasty-driver-turso/Cargo.toml
+++ b/crates/toasty-driver-turso/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-turso"
-version = "0.8.0"
+version = "0.9.0"
 description = "Turso (SQLite-compatible) driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-macros/CHANGELOG.md
+++ b/crates/toasty-macros/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-macros-v0.8.0...toasty-macros-v0.9.0) - 2026-07-23
+
+### Added
+
+- Order-by support in includes ([#1109])
+- Relation link/unlink return a builder instead of executing eagerly ([#1118])
+- Support for serde_json::Value fields ([#1116])
+- Native JSON and JSONB column storage ([#1114])
+- [**breaking**] Explicit column types required for JSON fields ([#1106])
+- Filter associations in include ([#1089])
+- Integer storage for enum discriminants ([#1101])
+- Upsert support ([#1091])
+- Shared variant fields and enum-level index/unique attributes ([#1078])
+- Enum-level rename_all for embedded enum labels ([#1083])
+- Scalar implementation for unit enum embeds ([#1082])
+- Document storage for embedded types with nested-path filtering ([#1028])
+
+### Fixed
+
+- Support any() on many-to-many relations ([#1097])
+- Store Vec<native-enum> as native enum array on Postgres ([#1092])
+- Generate doc comments on model methods ([#1087])
+- Normalize raw identifiers in collision checks ([#1085])
+- Allow update! expressions to read target model fields ([#1074])
+
+[#1028]: https://github.com/tokio-rs/toasty/pull/1028
+[#1074]: https://github.com/tokio-rs/toasty/pull/1074
+[#1078]: https://github.com/tokio-rs/toasty/pull/1078
+[#1082]: https://github.com/tokio-rs/toasty/pull/1082
+[#1083]: https://github.com/tokio-rs/toasty/pull/1083
+[#1085]: https://github.com/tokio-rs/toasty/pull/1085
+[#1087]: https://github.com/tokio-rs/toasty/pull/1087
+[#1089]: https://github.com/tokio-rs/toasty/pull/1089
+[#1091]: https://github.com/tokio-rs/toasty/pull/1091
+[#1092]: https://github.com/tokio-rs/toasty/pull/1092
+[#1097]: https://github.com/tokio-rs/toasty/pull/1097
+[#1101]: https://github.com/tokio-rs/toasty/pull/1101
+[#1106]: https://github.com/tokio-rs/toasty/pull/1106
+[#1109]: https://github.com/tokio-rs/toasty/pull/1109
+[#1114]: https://github.com/tokio-rs/toasty/pull/1114
+[#1116]: https://github.com/tokio-rs/toasty/pull/1116
+[#1118]: https://github.com/tokio-rs/toasty/pull/1118
+
 ## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-macros-v0.7.0...toasty-macros-v0.8.0) - 2026-07-06
 
 ### Added

--- a/crates/toasty-macros/Cargo.toml
+++ b/crates/toasty-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-macros"
-version = "0.8.0"
+version = "0.9.0"
 description = "Derive macros for Toasty models and embeds"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-sql/CHANGELOG.md
+++ b/crates/toasty-sql/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-sql-v0.8.0...toasty-sql-v0.9.0) - 2026-07-23
+
+### Added
+
+- support native JSON and JSONB column storage ([#1114](https://github.com/tokio-rs/toasty/pull/1114))
+- introduce Expr::Static for inline SQL literals, hook up LIMIT/OFFSET ([#1001](https://github.com/tokio-rs/toasty/pull/1001))
+- add upsert support ([#1091](https://github.com/tokio-rs/toasty/pull/1091))
+- add #[document] storage for embedded types with nested-path filtering ([#1028](https://github.com/tokio-rs/toasty/pull/1028))
+
+### Fixed
+
+- *(sql)* target matched table when adding columns ([#1112](https://github.com/tokio-rs/toasty/pull/1112))
+- *(sql)* drop indexes before removing indexed columns ([#1111](https://github.com/tokio-rs/toasty/pull/1111))
+- *(postgres)* store Vec<native-enum> as a native enum array on Postgres ([#1092](https://github.com/tokio-rs/toasty/pull/1092))
 ## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-sql-v0.7.0...toasty-sql-v0.8.0) - 2026-07-06
 
 ### Added

--- a/crates/toasty-sql/Cargo.toml
+++ b/crates/toasty-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-sql"
-version = "0.8.0"
+version = "0.9.0"
 description = "SQL serialization layer for Toasty database drivers"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty/CHANGELOG.md
+++ b/crates/toasty/CHANGELOG.md
@@ -7,6 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-v0.8.0...toasty-v0.9.0) - 2026-07-23
+
+### Added
+
+- support order_by in includes ([#1109])
+- relation link/unlink return a builder instead of executing eagerly ([#1118])
+- support serde_json::Value fields ([#1116])
+- support native JSON and JSONB column storage ([#1114])
+- [**breaking**] require explicit column types for JSON fields ([#1106])
+- support temporal Vec fields ([#1105])
+- filter associations in include ([#1089])
+- introduce Expr::Static for inline SQL literals, hook up LIMIT/OFFSET ([#1001])
+- support integer storage for enum discriminants ([#1101])
+- add upsert support ([#1091])
+- add #[shared] variant fields and enum-level #[index]/#[unique] ([#1078])
+- implement Scalar for unit enum embeds ([#1082])
+- add #[document] storage for embedded types with nested-path filtering ([#1028])
+
+### Fixed
+
+- type indexed key discovery as primary keys on DynamoDB ([#1113])
+- serialize unconstrained numeric migration snapshots ([#1115])
+- roll back transactions when finalization fails ([#1102])
+- support any() on many-to-many relations ([#1097])
+- store Vec<native-enum> as a native enum array on Postgres ([#1092])
+- compare composite-FK include filter against target fields ([#1086])
+- return None for optional belongs_to with NULL foreign key ([#1090])
+- lower IN-list over an embedded-field projection ([#1084])
+
+[#1001]: https://github.com/tokio-rs/toasty/pull/1001
+[#1028]: https://github.com/tokio-rs/toasty/pull/1028
+[#1078]: https://github.com/tokio-rs/toasty/pull/1078
+[#1082]: https://github.com/tokio-rs/toasty/pull/1082
+[#1084]: https://github.com/tokio-rs/toasty/pull/1084
+[#1086]: https://github.com/tokio-rs/toasty/pull/1086
+[#1089]: https://github.com/tokio-rs/toasty/pull/1089
+[#1090]: https://github.com/tokio-rs/toasty/pull/1090
+[#1091]: https://github.com/tokio-rs/toasty/pull/1091
+[#1092]: https://github.com/tokio-rs/toasty/pull/1092
+[#1097]: https://github.com/tokio-rs/toasty/pull/1097
+[#1101]: https://github.com/tokio-rs/toasty/pull/1101
+[#1102]: https://github.com/tokio-rs/toasty/pull/1102
+[#1105]: https://github.com/tokio-rs/toasty/pull/1105
+[#1106]: https://github.com/tokio-rs/toasty/pull/1106
+[#1109]: https://github.com/tokio-rs/toasty/pull/1109
+[#1113]: https://github.com/tokio-rs/toasty/pull/1113
+[#1114]: https://github.com/tokio-rs/toasty/pull/1114
+[#1115]: https://github.com/tokio-rs/toasty/pull/1115
+[#1116]: https://github.com/tokio-rs/toasty/pull/1116
+[#1118]: https://github.com/tokio-rs/toasty/pull/1118
+
 ## [0.8.0](https://github.com/tokio-rs/toasty/compare/toasty-v0.7.0...toasty-v0.8.0) - 2026-07-06
 
 ### Added

--- a/crates/toasty/Cargo.toml
+++ b/crates/toasty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty"
-version = "0.8.0"
+version = "0.9.0"
 description = "An async ORM for Rust supporting SQL and NoSQL databases"
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `toasty-core`: 0.8.0 -> 0.9.0 (⚠ API breaking changes)
* `toasty-driver-dynamodb`: 0.8.0 -> 0.9.0 (✓ API compatible changes)
* `toasty-sql`: 0.8.0 -> 0.9.0 (⚠ API breaking changes)
* `toasty-driver-mysql`: 0.8.0 -> 0.9.0 (✓ API compatible changes)
* `toasty-driver-postgresql`: 0.8.0 -> 0.9.0 (✓ API compatible changes)
* `toasty-driver-sqlite`: 0.8.0 -> 0.9.0 (✓ API compatible changes)
* `toasty-driver-turso`: 0.8.0 -> 0.9.0 (⚠ API breaking changes)
* `toasty-macros`: 0.8.0 -> 0.9.0
* `toasty`: 0.8.0 -> 0.9.0 (⚠ API breaking changes)
* `toasty-cli`: 0.8.0 -> 0.9.0 (✓ API compatible changes)
* `toasty-driver-integration-suite-macros`: 0.8.0 -> 0.9.0
* `toasty-driver-integration-suite`: 0.8.0 -> 0.9.0 (⚠ API breaking changes)

### ⚠ `toasty-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Field.shared in /tmp/.tmplQeYqA/toasty/crates/toasty-core/src/schema/app/field.rs:66
  field Mapping.document_columns in /tmp/.tmplQeYqA/toasty/crates/toasty-core/src/schema/mapping.rs:67
  field Capability.driver_name in /tmp/.tmplQeYqA/toasty/crates/toasty-core/src/driver/capability.rs:27
  field Capability.upsert_primary_key in /tmp/.tmplQeYqA/toasty/crates/toasty-core/src/driver/capability.rs:62
  field Capability.upsert_unique in /tmp/.tmplQeYqA/toasty/crates/toasty-core/src/driver/capability.rs:68
  field Capability.upsert_branch_assignments in /tmp/.tmplQeYqA/toasty/crates/toasty-core/src/driver/capability.rs:77
  field Capability.upsert_targeted_ignore in /tmp/.tmplQeYqA/toasty/crates/toasty-core/src/driver/capability.rs:83
  field Capability.native_json in /tmp/.tmplQeYqA/toasty/crates/toasty-core/src/driver/capability.rs:121
  field Capability.native_jsonb in /tmp/.tmplQeYqA/toasty/crates/toasty-core/src/driver/capability.rs:124
  field Capability.document_collections in /tmp/.tmplQeYqA/toasty/crates/toasty-core/src/driver/capability.rs:314
  field Insert.upsert in /tmp/.tmplQeYqA/toasty/crates/toasty-core/src/stmt/insert.rs:36
  field Embedded.storage_ty in /tmp/.tmplQeYqA/toasty/crates/toasty-core/src/schema/app/embedded.rs:36
  field ExprCast.from in /tmp/.tmplQeYqA/toasty/crates/toasty-core/src/stmt/expr_cast.rs:26

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant ExprFunc:JsonExtract in /tmp/.tmplQeYqA/toasty/crates/toasty-core/src/stmt/expr_func.rs:28
  variant Operation:Upsert in /tmp/.tmplQeYqA/toasty/crates/toasty-core/src/driver/operation.rs:101
  variant Operation:Upsert in /tmp/.tmplQeYqA/toasty/crates/toasty-core/src/driver/operation.rs:101
  variant Expr:Incoming in /tmp/.tmplQeYqA/toasty/crates/toasty-core/src/stmt/expr.rs:92
  variant Expr:Static in /tmp/.tmplQeYqA/toasty/crates/toasty-core/src/stmt/expr.rs:161
  variant Type:Object in /tmp/.tmplQeYqA/toasty/crates/toasty-core/src/stmt/ty.rs:135
  variant Value:Object in /tmp/.tmplQeYqA/toasty/crates/toasty-core/src/stmt/value.rs:83
  variant Type:Document in /tmp/.tmplQeYqA/toasty/crates/toasty-core/src/schema/db/ty.rs:122
  variant Type:Json in /tmp/.tmplQeYqA/toasty/crates/toasty-core/src/schema/db/ty.rs:129
  variant Type:Jsonb in /tmp/.tmplQeYqA/toasty/crates/toasty-core/src/schema/db/ty.rs:132

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  Type::is_subtype_of, previously in file /tmp/.tmp3dFpdS/toasty-core/src/stmt/ty.rs:427

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  toasty_core::stmt::ValueStream::typed takes 1 parameters in /tmp/.tmp3dFpdS/toasty-core/src/stmt/value_stream.rs:239, but now takes 2 parameters in /tmp/.tmplQeYqA/toasty/crates/toasty-core/src/stmt/value_stream.rs:242
  toasty_core::stmt::Type::cast takes 1 parameters in /tmp/.tmp3dFpdS/toasty-core/src/stmt/ty.rs:325, but now takes 2 parameters in /tmp/.tmplQeYqA/toasty/crates/toasty-core/src/stmt/ty.rs:359
  toasty_core::stmt::Value::is_a takes 1 parameters in /tmp/.tmp3dFpdS/toasty-core/src/stmt/value.rs:297, but now takes 2 parameters in /tmp/.tmplQeYqA/toasty/crates/toasty-core/src/stmt/value.rs:308
```

### ⚠ `toasty-sql` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function toasty_sql::value_json::value_from_json, previously in file /tmp/.tmp3dFpdS/toasty-sql/src/value_json.rs:60
  function toasty_sql::value_json::value_list_from_json, previously in file /tmp/.tmp3dFpdS/toasty-sql/src/value_json.rs:121
  function toasty_sql::value_json::value_list_to_json, previously in file /tmp/.tmp3dFpdS/toasty-sql/src/value_json.rs:112
  function toasty_sql::value_json::value_to_json, previously in file /tmp/.tmp3dFpdS/toasty-sql/src/value_json.rs:21

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  toasty_sql::stmt::Statement::add_column takes 2 parameters in /tmp/.tmp3dFpdS/toasty-sql/src/stmt/add_column.rs:20, but now takes 3 parameters in /tmp/.tmplQeYqA/toasty/crates/toasty-sql/src/stmt/add_column.rs:20
  toasty_sql::Statement::add_column takes 2 parameters in /tmp/.tmp3dFpdS/toasty-sql/src/stmt/add_column.rs:20, but now takes 3 parameters in /tmp/.tmplQeYqA/toasty/crates/toasty-sql/src/stmt/add_column.rs:20

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/module_missing.ron

Failed in:
  mod toasty_sql::value_json, previously in file /tmp/.tmp3dFpdS/toasty-sql/src/value_json.rs:1
```

### ⚠ `toasty-driver-turso` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  Turso::experimental_encryption, previously in file /tmp/.tmp3dFpdS/toasty-driver-turso/src/lib.rs:262
  Turso::experimental_attach, previously in file /tmp/.tmp3dFpdS/toasty-driver-turso/src/lib.rs:269
  Turso::experimental_custom_types, previously in file /tmp/.tmp3dFpdS/toasty-driver-turso/src/lib.rs:276
  Turso::experimental_generated_columns, previously in file /tmp/.tmp3dFpdS/toasty-driver-turso/src/lib.rs:283
  Turso::experimental_materialized_views, previously in file /tmp/.tmp3dFpdS/toasty-driver-turso/src/lib.rs:297
  Turso::experimental_vacuum, previously in file /tmp/.tmp3dFpdS/toasty-driver-turso/src/lib.rs:304
  Turso::experimental_multiprocess_wal, previously in file /tmp/.tmp3dFpdS/toasty-driver-turso/src/lib.rs:311
  Turso::experimental_without_rowid, previously in file /tmp/.tmp3dFpdS/toasty-driver-turso/src/lib.rs:318
```

### ⚠ `toasty` breaking changes

```text
--- failure trait_newly_sealed: pub trait became sealed ---

Description:
A publicly-visible trait became sealed, so downstream crates are no longer able to implement it
        ref: https://rust-lang.github.io/api-guidelines/future-proofing.html#sealed-traits-protect-against-downstream-implementations-c-sealed
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_newly_sealed.ron

Failed in:
  trait toasty::schema::Scalar in file /tmp/.tmplQeYqA/toasty/crates/toasty/src/schema/field.rs:286
```

### ⚠ `toasty-driver-integration-suite` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant Fault::ConnectionLost 0 -> 1 in /tmp/.tmplQeYqA/toasty/crates/toasty-driver-integration-suite/src/instrumented_driver.rs:35

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant Fault:OperationFailed in /tmp/.tmplQeYqA/toasty/crates/toasty-driver-integration-suite/src/instrumented_driver.rs:28
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `toasty-core`

<blockquote>

## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-core-v0.8.0...toasty-core-v0.9.0) - 2026-07-23

### Added

- Native JSON and JSONB column storage ([#1114])
- Filter associations when including related data ([#1089])
- Inline SQL literals with LIMIT/OFFSET support ([#1001])
- Integer storage for enum discriminants ([#1101])
- Upsert support ([#1091])
- Shared variant fields and enum-level #[index]/#[unique] attributes ([#1078])
- Document storage for embedded types with nested-path filtering ([#1028])

### Fixed

- Serialization of unconstrained numeric migration snapshots ([#1115])
- Support for any() on many-to-many relations ([#1097])
- *(postgres)* Storage of Vec<native-enum> as native enum arrays ([#1092])

[#1001]: https://github.com/tokio-rs/toasty/pull/1001
[#1028]: https://github.com/tokio-rs/toasty/pull/1028
[#1078]: https://github.com/tokio-rs/toasty/pull/1078
[#1089]: https://github.com/tokio-rs/toasty/pull/1089
[#1091]: https://github.com/tokio-rs/toasty/pull/1091
[#1092]: https://github.com/tokio-rs/toasty/pull/1092
[#1097]: https://github.com/tokio-rs/toasty/pull/1097
[#1101]: https://github.com/tokio-rs/toasty/pull/1101
[#1114]: https://github.com/tokio-rs/toasty/pull/1114
[#1115]: https://github.com/tokio-rs/toasty/pull/1115
</blockquote>

## `toasty-driver-dynamodb`

<blockquote>

## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-dynamodb-v0.8.0...toasty-driver-dynamodb-v0.9.0) - 2026-07-23

### Added

- Upsert support ([#1091])
- #[document] storage for embedded types with nested-path filtering ([#1028])

[#1028]: https://github.com/tokio-rs/toasty/pull/1028
[#1091]: https://github.com/tokio-rs/toasty/pull/1091
</blockquote>

## `toasty-sql`

<blockquote>

## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-sql-v0.8.0...toasty-sql-v0.9.0) - 2026-07-23

### Added

- support native JSON and JSONB column storage ([#1114](https://github.com/tokio-rs/toasty/pull/1114))
- introduce Expr::Static for inline SQL literals, hook up LIMIT/OFFSET ([#1001](https://github.com/tokio-rs/toasty/pull/1001))
- add upsert support ([#1091](https://github.com/tokio-rs/toasty/pull/1091))
- add #[document] storage for embedded types with nested-path filtering ([#1028](https://github.com/tokio-rs/toasty/pull/1028))

### Fixed

- *(sql)* target matched table when adding columns ([#1112](https://github.com/tokio-rs/toasty/pull/1112))
- *(sql)* drop indexes before removing indexed columns ([#1111](https://github.com/tokio-rs/toasty/pull/1111))
- *(postgres)* store Vec<native-enum> as a native enum array on Postgres ([#1092](https://github.com/tokio-rs/toasty/pull/1092))
</blockquote>

## `toasty-driver-mysql`

<blockquote>

## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-mysql-v0.8.0...toasty-driver-mysql-v0.9.0) - 2026-07-23

### Added

- Support native JSON and JSONB column storage ([#1114])
- Support #[document] attribute on embedded types for nested-path filtering ([#1028])

[#1028]: https://github.com/tokio-rs/toasty/pull/1028
[#1114]: https://github.com/tokio-rs/toasty/pull/1114
</blockquote>

## `toasty-driver-postgresql`

<blockquote>

## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-postgresql-v0.8.0...toasty-driver-postgresql-v0.9.0) - 2026-07-23

### Added

- Native JSON and JSONB column storage ([#1114])
- Temporal Vec fields ([#1105])
- #[document] storage for embedded types with nested-path filtering ([#1028])

### Fixed

- *(postgresql)* NUMERIC array elements now decode correctly ([#1104])
- *(postgres)* Vec<native-enum> fields stored as native enum arrays ([#1092])

[#1028]: https://github.com/tokio-rs/toasty/pull/1028
[#1092]: https://github.com/tokio-rs/toasty/pull/1092
[#1104]: https://github.com/tokio-rs/toasty/pull/1104
[#1105]: https://github.com/tokio-rs/toasty/pull/1105
[#1114]: https://github.com/tokio-rs/toasty/pull/1114
</blockquote>

## `toasty-driver-sqlite`

<blockquote>

## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-sqlite-v0.8.0...toasty-driver-sqlite-v0.9.0) - 2026-07-23

### Added

- New #[document] attribute for storing embedded types with nested-path filtering ([#1028])

[#1028]: https://github.com/tokio-rs/toasty/pull/1028
</blockquote>

## `toasty-driver-turso`

<blockquote>

## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-turso-v0.8.0...toasty-driver-turso-v0.9.0) - 2026-07-23

### Added

- Support for Turso Sync ([#1072])
- #[document] Storage for embedded types with nested-path filtering ([#1028])

[#1028]: https://github.com/tokio-rs/toasty/pull/1028
[#1072]: https://github.com/tokio-rs/toasty/pull/1072
</blockquote>

## `toasty-macros`

<blockquote>

## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-macros-v0.8.0...toasty-macros-v0.9.0) - 2026-07-23

### Added

- Order-by support in includes ([#1109])
- Relation link/unlink return a builder instead of executing eagerly ([#1118])
- Support for serde_json::Value fields ([#1116])
- Native JSON and JSONB column storage ([#1114])
- [**breaking**] Explicit column types required for JSON fields ([#1106])
- Filter associations in include ([#1089])
- Integer storage for enum discriminants ([#1101])
- Upsert support ([#1091])
- Shared variant fields and enum-level index/unique attributes ([#1078])
- Enum-level rename_all for embedded enum labels ([#1083])
- Scalar implementation for unit enum embeds ([#1082])
- Document storage for embedded types with nested-path filtering ([#1028])

### Fixed

- Support any() on many-to-many relations ([#1097])
- Store Vec<native-enum> as native enum array on Postgres ([#1092])
- Generate doc comments on model methods ([#1087])
- Normalize raw identifiers in collision checks ([#1085])
- Allow update! expressions to read target model fields ([#1074])

[#1028]: https://github.com/tokio-rs/toasty/pull/1028
[#1074]: https://github.com/tokio-rs/toasty/pull/1074
[#1078]: https://github.com/tokio-rs/toasty/pull/1078
[#1082]: https://github.com/tokio-rs/toasty/pull/1082
[#1083]: https://github.com/tokio-rs/toasty/pull/1083
[#1085]: https://github.com/tokio-rs/toasty/pull/1085
[#1087]: https://github.com/tokio-rs/toasty/pull/1087
[#1089]: https://github.com/tokio-rs/toasty/pull/1089
[#1091]: https://github.com/tokio-rs/toasty/pull/1091
[#1092]: https://github.com/tokio-rs/toasty/pull/1092
[#1097]: https://github.com/tokio-rs/toasty/pull/1097
[#1101]: https://github.com/tokio-rs/toasty/pull/1101
[#1106]: https://github.com/tokio-rs/toasty/pull/1106
[#1109]: https://github.com/tokio-rs/toasty/pull/1109
[#1114]: https://github.com/tokio-rs/toasty/pull/1114
[#1116]: https://github.com/tokio-rs/toasty/pull/1116
[#1118]: https://github.com/tokio-rs/toasty/pull/1118
</blockquote>

## `toasty`

<blockquote>

## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-v0.8.0...toasty-v0.9.0) - 2026-07-23

### Added

- support order_by in includes ([#1109])
- relation link/unlink return a builder instead of executing eagerly ([#1118])
- support serde_json::Value fields ([#1116])
- support native JSON and JSONB column storage ([#1114])
- [**breaking**] require explicit column types for JSON fields ([#1106])
- support temporal Vec fields ([#1105])
- filter associations in include ([#1089])
- introduce Expr::Static for inline SQL literals, hook up LIMIT/OFFSET ([#1001])
- support integer storage for enum discriminants ([#1101])
- add upsert support ([#1091])
- add #[shared] variant fields and enum-level #[index]/#[unique] ([#1078])
- implement Scalar for unit enum embeds ([#1082])
- add #[document] storage for embedded types with nested-path filtering ([#1028])

### Fixed

- type indexed key discovery as primary keys on DynamoDB ([#1113])
- serialize unconstrained numeric migration snapshots ([#1115])
- roll back transactions when finalization fails ([#1102])
- support any() on many-to-many relations ([#1097])
- store Vec<native-enum> as a native enum array on Postgres ([#1092])
- compare composite-FK include filter against target fields ([#1086])
- return None for optional belongs_to with NULL foreign key ([#1090])
- lower IN-list over an embedded-field projection ([#1084])

[#1001]: https://github.com/tokio-rs/toasty/pull/1001
[#1028]: https://github.com/tokio-rs/toasty/pull/1028
[#1078]: https://github.com/tokio-rs/toasty/pull/1078
[#1082]: https://github.com/tokio-rs/toasty/pull/1082
[#1084]: https://github.com/tokio-rs/toasty/pull/1084
[#1086]: https://github.com/tokio-rs/toasty/pull/1086
[#1089]: https://github.com/tokio-rs/toasty/pull/1089
[#1090]: https://github.com/tokio-rs/toasty/pull/1090
[#1091]: https://github.com/tokio-rs/toasty/pull/1091
[#1092]: https://github.com/tokio-rs/toasty/pull/1092
[#1097]: https://github.com/tokio-rs/toasty/pull/1097
[#1101]: https://github.com/tokio-rs/toasty/pull/1101
[#1102]: https://github.com/tokio-rs/toasty/pull/1102
[#1105]: https://github.com/tokio-rs/toasty/pull/1105
[#1106]: https://github.com/tokio-rs/toasty/pull/1106
[#1109]: https://github.com/tokio-rs/toasty/pull/1109
[#1113]: https://github.com/tokio-rs/toasty/pull/1113
[#1114]: https://github.com/tokio-rs/toasty/pull/1114
[#1115]: https://github.com/tokio-rs/toasty/pull/1115
[#1116]: https://github.com/tokio-rs/toasty/pull/1116
[#1118]: https://github.com/tokio-rs/toasty/pull/1118
</blockquote>

## `toasty-cli`

<blockquote>

## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-cli-v0.8.0...toasty-cli-v0.9.0) - 2026-07-23

### Fixed

- Serialize unconstrained numeric migration snapshots ([#1115])

[#1115]: https://github.com/tokio-rs/toasty/pull/1115
</blockquote>

## `toasty-driver-integration-suite-macros`

<blockquote>

## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-macros-v0.8.0...toasty-driver-integration-suite-macros-v0.9.0) - 2026-07-23

- Internal improvements only.
</blockquote>

## `toasty-driver-integration-suite`

<blockquote>

## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-v0.8.0...toasty-driver-integration-suite-v0.9.0) - 2026-07-23

### Added

- support order_by in includes ([#1109](https://github.com/tokio-rs/toasty/pull/1109))
- relation link/unlink return a builder instead of executing eagerly ([#1118](https://github.com/tokio-rs/toasty/pull/1118))
- support serde_json::Value fields ([#1116](https://github.com/tokio-rs/toasty/pull/1116))
- support native JSON and JSONB column storage ([#1114](https://github.com/tokio-rs/toasty/pull/1114))
- [**breaking**] require explicit column types for JSON fields ([#1106](https://github.com/tokio-rs/toasty/pull/1106))
- support temporal Vec fields ([#1105](https://github.com/tokio-rs/toasty/pull/1105))
- filter associations in include ([#1089](https://github.com/tokio-rs/toasty/pull/1089))
- introduce Expr::Static for inline SQL literals, hook up LIMIT/OFFSET ([#1001](https://github.com/tokio-rs/toasty/pull/1001))
- support integer storage for enum discriminants ([#1101](https://github.com/tokio-rs/toasty/pull/1101))
- add upsert support ([#1091](https://github.com/tokio-rs/toasty/pull/1091))
- add #[shared] variant fields and enum-level #[index]/#[unique] ([#1078](https://github.com/tokio-rs/toasty/pull/1078))
- *(macros)* add enum-level rename_all for embedded enum labels ([#1083](https://github.com/tokio-rs/toasty/pull/1083))
- implement Scalar for unit enum embeds ([#1082](https://github.com/tokio-rs/toasty/pull/1082))
- add #[document] storage for embedded types with nested-path filtering ([#1028](https://github.com/tokio-rs/toasty/pull/1028))

### Fixed

- *(ddb)* type indexed key discovery as primary keys ([#1113](https://github.com/tokio-rs/toasty/pull/1113))
- *(postgresql)* decode NUMERIC array elements ([#1104](https://github.com/tokio-rs/toasty/pull/1104))
- roll back transactions when finalization fails ([#1102](https://github.com/tokio-rs/toasty/pull/1102))
- support any() on many-to-many relations ([#1097](https://github.com/tokio-rs/toasty/pull/1097))
- *(postgres)* store Vec<native-enum> as a native enum array on Postgres ([#1092](https://github.com/tokio-rs/toasty/pull/1092))
- *(engine)* compare composite-FK include filter against target fields ([#1086](https://github.com/tokio-rs/toasty/pull/1086))
- *(engine)* return None for optional belongs_to with NULL foreign key ([#1090](https://github.com/tokio-rs/toasty/pull/1090))
- *(engine)* lower IN-list over an embedded-field projection ([#1084](https://github.com/tokio-rs/toasty/pull/1084))
- *(macros)* let update! value expressions read the target's fields ([#1074](https://github.com/tokio-rs/toasty/pull/1074))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).