### PR TITLE
chore: fix guide docs

### DIFF
--- a/docs/guide/src/belongs-to.md
+++ b/docs/guide/src/belongs-to.md
@@ -341,7 +341,7 @@ For a `Post` model with `#[belongs_to] user: Deferred<User>`, Toasty generates:
 | Method | Returns | Description |
 |---|---|---|
 | `post.user()` | Relation accessor | Returns an accessor for the associated user |
-| `.get(&mut db)` | `Result<User>` | Loads the associated user from the database |
+| `.exec(&mut db)` | `Result<User>` | Loads the associated user from the database |
 | `toasty::create!(Post { user: &user })` | Create builder | Sets the foreign key from a parent reference |
 | `toasty::create!(Post { user_id: id })` | Create builder | Sets the foreign key directly |
 | `Post::fields().user()` | Field path | Used with `.include()` for preloading |

--- a/docs/guide/src/defining-models.md
+++ b/docs/guide/src/defining-models.md
@@ -251,8 +251,7 @@ user.delete();
   ```
 
 - The **query builder** returned by `User::all()` or `User::filter()` has
-  methods like `.exec()`, `.first()`, `.get()`, and `.collect::<Vec<_>>()` to
-  execute the query.
+  methods like `.exec()`, `.get()`, and `.first()` to execute the query.
 
 ### What types can you pass to setters?
 

--- a/docs/guide/src/has-one.md
+++ b/docs/guide/src/has-one.md
@@ -394,7 +394,7 @@ generates:
 | Method | Returns | Description |
 |---|---|---|
 | `user.profile()` | Relation accessor | Accessor for the associated profile |
-| `.get(&mut db)` | `Result<Option<Profile>>` | Load the associated profile |
+| `.exec(&mut db)` | `Result<Option<Profile>>` | Load the associated profile |
 | `.create()` | Create builder | Create a profile with the foreign key pre-filled |
 | `toasty::create!(User { profile: { ... } })` | Create builder | Associate a profile on creation |
 | `user.update().profile(...)` | Update builder | Replace or associate a profile |


### PR DESCRIPTION
## Summary
Fix some leftover references to the `collect` method and `get` in associations.

## Type of change

<!-- Check one. -->

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test
- [ ] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`):
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers
N/A
