### PR TITLE
feat: implement Scalar for unit enum embeds

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -25,6 +25,7 @@ pub mod crud_update_macro;
 pub mod deferred_embed;
 pub mod deferred_field;
 pub mod dynamodb_update_batch_filter;
+pub mod embed_enum_collection;
 pub mod embed_enum_data;
 pub mod embed_enum_filter;
 pub mod embed_enum_filter_comparison;

--- a/crates/toasty-driver-integration-suite/src/tests/embed_enum_collection.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embed_enum_collection.rs
@@ -1,0 +1,75 @@
+//! Tests for `Vec<enum>` where the element is a unit (data-less) enum. Such an
+//! enum is a scalar discriminant, so the collection is stored as a document
+//! array and offers the scalar-collection operators (`contains`, `len`, …).
+//! Gated on `document_collections`, like the struct-embed collections in
+//! `type_document`.
+
+use crate::prelude::*;
+
+#[derive(Clone, Copy, Debug, PartialEq, toasty::Embed)]
+enum Color {
+    #[column(variant = 1)]
+    Red,
+    #[column(variant = 2)]
+    Green,
+    #[column(variant = 3)]
+    Blue,
+}
+
+#[derive(Debug, toasty::Model)]
+struct Palette {
+    #[key]
+    #[auto]
+    id: uuid::Uuid,
+    colors: Vec<Color>,
+}
+
+/// A `Vec<unit-enum>` round-trips through INSERT and a fresh fetch: the
+/// discriminants are stored as a document array and reloaded back to variants.
+#[driver_test(requires(document_collections))]
+pub async fn vec_enum_create_get(t: &mut Test) -> Result<(), BoxError> {
+    let mut db = t.setup_db(models!(Palette)).await;
+
+    let colors = [Color::Red, Color::Blue];
+    let palette = toasty::create!(Palette { colors: &colors })
+        .exec(&mut db)
+        .await?;
+
+    let reloaded = Palette::get_by_id(&mut db, &palette.id).await?;
+    assert_eq!(reloaded.colors, colors);
+
+    Ok(())
+}
+
+/// The scalar-collection operators unlocked by the emitted `Scalar` impl:
+/// `contains(variant)` matches on discriminant membership and `len()` filters
+/// on cardinality.
+#[driver_test(requires(document_collections))]
+pub async fn vec_enum_contains_and_len(t: &mut Test) -> Result<(), BoxError> {
+    let mut db = t.setup_db(models!(Palette)).await;
+
+    toasty::create!(Palette::[
+        { colors: &[Color::Red, Color::Green] },
+        { colors: &[Color::Blue] },
+        { colors: &[Color::Red, Color::Green, Color::Blue] },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let reds = Palette::filter(Palette::fields().colors().contains(Color::Red))
+        .exec(&mut db)
+        .await?;
+    assert_eq!(reds.len(), 2);
+
+    let singletons = Palette::filter(Palette::fields().colors().len().eq(1))
+        .exec(&mut db)
+        .await?;
+    assert_eq!(singletons.len(), 1);
+
+    let triples = Palette::filter(Palette::fields().colors().len().eq(3))
+        .exec(&mut db)
+        .await?;
+    assert_eq!(triples.len(), 1);
+
+    Ok(())
+}

--- a/crates/toasty-driver-integration-suite/src/tests/embed_enum_collection.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embed_enum_collection.rs
@@ -31,9 +31,7 @@ pub async fn vec_enum_create_get(t: &mut Test) -> Result<(), BoxError> {
     let mut db = t.setup_db(models!(Palette)).await;
 
     let colors = [Color::Red, Color::Blue];
-    let palette = toasty::create!(Palette { colors })
-        .exec(&mut db)
-        .await?;
+    let palette = toasty::create!(Palette { colors }).exec(&mut db).await?;
 
     let reloaded = Palette::get_by_id(&mut db, &palette.id).await?;
     assert_eq!(reloaded.colors, colors);

--- a/crates/toasty-driver-integration-suite/src/tests/embed_enum_collection.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embed_enum_collection.rs
@@ -31,7 +31,7 @@ pub async fn vec_enum_create_get(t: &mut Test) -> Result<(), BoxError> {
     let mut db = t.setup_db(models!(Palette)).await;
 
     let colors = [Color::Red, Color::Blue];
-    let palette = toasty::create!(Palette { colors: &colors })
+    let palette = toasty::create!(Palette { colors })
         .exec(&mut db)
         .await?;
 
@@ -49,9 +49,9 @@ pub async fn vec_enum_contains_and_len(t: &mut Test) -> Result<(), BoxError> {
     let mut db = t.setup_db(models!(Palette)).await;
 
     toasty::create!(Palette::[
-        { colors: &[Color::Red, Color::Green] },
-        { colors: &[Color::Blue] },
-        { colors: &[Color::Red, Color::Green, Color::Blue] },
+        { colors: [Color::Red, Color::Green] },
+        { colors: [Color::Blue] },
+        { colors: [Color::Red, Color::Green, Color::Blue] },
     ])
     .exec(&mut db)
     .await?;

--- a/crates/toasty-macros/src/model/expand.rs
+++ b/crates/toasty-macros/src/model/expand.rs
@@ -247,11 +247,14 @@ pub(super) fn embedded_enum(model: &Model) -> TokenStream {
     let shared_column_checks = e.expand_shared_column_checks();
     let indexable_checks = e.expand_indexable_checks();
 
-    // A unit (data-less) enum maps to a single discriminant column, so it can
-    // serve as an index column. Data-carrying enums span multiple columns and
-    // therefore do not implement `IndexableField`.
-    let indexable_impl = if model.fields.is_empty() {
-        quote! { impl #toasty::index::IndexableField for #model_ident {} }
+    // A unit (data-less) enum is a single scalar discriminant: indexable, and a
+    // valid `Vec<Enum>` element (`Scalar` unlocks the container operators).
+    // Data-carrying enums span multiple columns and get neither.
+    let unit_enum_impls = if model.fields.is_empty() {
+        quote! {
+            impl #toasty::index::IndexableField for #model_ident {}
+            impl #toasty::Scalar for #model_ident {}
+        }
     } else {
         quote! {}
     };
@@ -263,7 +266,7 @@ pub(super) fn embedded_enum(model: &Model) -> TokenStream {
         #storage_compat_checks
         #shared_column_checks
         #indexable_checks
-        #indexable_impl
+        #unit_enum_impls
 
         impl #toasty::Embed for #model_ident {
             fn id() -> #toasty::core::schema::app::ModelId {

--- a/crates/toasty/src/codegen_support.rs
+++ b/crates/toasty/src/codegen_support.rs
@@ -17,8 +17,8 @@ pub use crate::{
     Db, Error, Executor, Result, Statement,
     schema::{
         Auto, Deferred, DiscoverItem, Document, Embed, Field, Load, Model, QueryMany, QueryOne,
-        QueryOptionOne, RelationManyField, RelationOneField, Scope, ViaMany, ViaManyField, ViaPath,
-        ViaTarget, generate_unique_id,
+        QueryOptionOne, RelationManyField, RelationOneField, Scalar, Scope, ViaMany, ViaManyField,
+        ViaPath, ViaTarget, generate_unique_id,
     },
     stmt::CreateMany,
     stmt::{self, Assign, IntoExpr, IntoInsert, IntoStatement, List, Path},


### PR DESCRIPTION
## Summary
With this pr it's now possible to store scalar/unit enums in a `Vec`.

<!-- What does this change and why? Link the issue it closes. -->

## Type of change

<!-- Check one. -->

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test
- [ ] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`):
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers
N/A
