### PR TITLE
feat(macros): add enum-level rename_all for embedded enum labels

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -32,6 +32,7 @@ pub mod embed_enum_filter_variant_field;
 pub mod embed_enum_index;
 pub mod embed_enum_native_ops;
 pub mod embed_enum_optional;
+pub mod embed_enum_rename_all;
 pub mod embed_enum_shared_column;
 pub mod embed_enum_shared_type;
 pub mod embed_enum_string_discriminant;

--- a/crates/toasty-driver-integration-suite/src/tests/embed_enum_rename_all.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embed_enum_rename_all.rs
@@ -1,0 +1,186 @@
+use crate::prelude::*;
+
+use toasty::Db;
+use toasty_core::schema::db;
+
+/// The (driver-independent) storage type of a database column.
+fn column_storage_ty(db: &Db, table: &str, column: &str) -> db::Type {
+    let schema = db.schema();
+    let table = schema
+        .db
+        .tables
+        .iter()
+        .find(|t| t.name == table || t.name.ends_with(table))
+        .unwrap_or_else(|| panic!("table '{table}' not in schema"));
+    table
+        .columns
+        .iter()
+        .find(|c| c.name == column)
+        .unwrap_or_else(|| panic!("column '{column}' not in table"))
+        .storage_ty
+        .clone()
+}
+
+/// The (type name, variant labels) of a native enum column, in declaration
+/// order. Panics if the column is not a native enum type.
+fn native_enum(db: &Db, table: &str, column: &str) -> (String, Vec<String>) {
+    match column_storage_ty(db, table, column) {
+        db::Type::Enum(e) => (
+            e.name.expect("a native enum type has a name"),
+            e.variants.into_iter().map(|v| v.name).collect(),
+        ),
+        other => panic!("expected a native enum column, got {other:?}"),
+    }
+}
+
+/// `#[column(rename_all = ...)]` derives each variant's default label; an
+/// explicit per-variant `#[column(variant = ...)]` still wins.
+#[driver_test]
+pub async fn rename_all_derives_labels(t: &mut Test) {
+    #[derive(Debug, toasty::Embed)]
+    #[column(rename_all = "PascalCase")]
+    enum Pascal {
+        Customer,
+        PreferredSupplier,
+    }
+
+    #[derive(Debug, toasty::Embed)]
+    #[column(rename_all = "SCREAMING_SNAKE_CASE")]
+    enum Screaming {
+        Customer,
+        PreferredSupplier,
+    }
+
+    #[derive(Debug, toasty::Embed)]
+    #[column(rename_all = "PascalCase")]
+    enum Overridden {
+        #[column(variant = "vip")]
+        PreferredSupplier,
+        Customer,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    #[allow(dead_code)]
+    struct Contact {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+        pascal: Pascal,
+        screaming: Screaming,
+        overridden: Overridden,
+    }
+
+    let db = t.setup_db(models!(Contact)).await;
+
+    assert_eq!(
+        native_enum(&db, "contacts", "pascal").1,
+        ["Customer", "PreferredSupplier"]
+    );
+    assert_eq!(
+        native_enum(&db, "contacts", "screaming").1,
+        ["CUSTOMER", "PREFERRED_SUPPLIER"]
+    );
+    assert_eq!(
+        native_enum(&db, "contacts", "overridden").1,
+        ["vip", "Customer"]
+    );
+}
+
+/// The renamed labels flow into every string storage mapping: native enum
+/// (default, explicit `type = enum`, and named `type = enum("...")`) and the
+/// plain `type = text` column. `rename_all` never affects the enum type name.
+#[driver_test]
+pub async fn rename_all_across_storage_mappings(t: &mut Test) {
+    #[derive(Debug, toasty::Embed)]
+    #[column(rename_all = "PascalCase")]
+    enum NativeDefault {
+        Customer,
+        Supplier,
+    }
+
+    #[derive(Debug, toasty::Embed)]
+    #[column(rename_all = "PascalCase", type = enum)]
+    enum NativeExplicit {
+        Customer,
+        Supplier,
+    }
+
+    #[derive(Debug, toasty::Embed)]
+    #[column(rename_all = "PascalCase", type = enum("party_kind"))]
+    enum NativeNamed {
+        Customer,
+        Supplier,
+    }
+
+    #[derive(Debug, toasty::Embed)]
+    #[column(rename_all = "PascalCase", type = text)]
+    enum TextMapped {
+        Customer,
+        Supplier,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    #[allow(dead_code)]
+    struct Contact {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+        native_default: NativeDefault,
+        native_explicit: NativeExplicit,
+        native_named: NativeNamed,
+        text_mapped: TextMapped,
+    }
+
+    let db = t.setup_db(models!(Contact)).await;
+    let renamed = ["Customer".to_string(), "Supplier".to_string()];
+
+    // Default native enum: type name derived from the ident in snake_case.
+    let (name, labels) = native_enum(&db, "contacts", "native_default");
+    assert!(name.ends_with("native_default"), "unexpected name: {name}");
+    assert_eq!(labels, renamed);
+
+    // Explicit `type = enum`: identical native representation.
+    assert_eq!(native_enum(&db, "contacts", "native_explicit").1, renamed);
+
+    // Named `type = enum("party_kind")`: custom type name, renamed labels.
+    let (name, labels) = native_enum(&db, "contacts", "native_named");
+    assert!(name.ends_with("party_kind"), "unexpected name: {name}");
+    assert_eq!(labels, renamed);
+
+    // Plain text mapping: a TEXT column, not a native enum type.
+    assert_eq!(
+        column_storage_ty(&db, "contacts", "text_mapped"),
+        db::Type::Text
+    );
+}
+
+/// End-to-end: a renamed enum round-trips through the database (create + read).
+#[driver_test]
+pub async fn rename_all_round_trip(t: &mut Test) -> Result<()> {
+    #[derive(Debug, PartialEq, toasty::Embed)]
+    #[column(rename_all = "PascalCase")]
+    enum PartyKind {
+        Customer,
+        Supplier,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Contact {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+        kind: PartyKind,
+    }
+
+    let mut db = t.setup_db(models!(Contact)).await;
+
+    let contact = toasty::create!(Contact {
+        kind: PartyKind::Supplier,
+    })
+    .exec(&mut db)
+    .await?;
+    let found = Contact::get_by_id(&mut db, &contact.id).await?;
+    assert_eq!(found.kind, PartyKind::Supplier);
+
+    Ok(())
+}

--- a/crates/toasty-macros/src/model/schema/column.rs
+++ b/crates/toasty-macros/src/model/schema/column.rs
@@ -31,6 +31,65 @@ pub(crate) struct Column {
     pub(crate) name: Option<syn::LitStr>,
     pub(crate) ty: Option<ColumnType>,
     pub(crate) variant: Option<VariantValue>,
+    pub(crate) rename_all: Option<RenameRule>,
+}
+
+/// A case-conversion rule applied to enum variant identifiers to derive their
+/// default string labels, spelled to match serde's `rename_all` vocabulary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RenameRule {
+    Lower,
+    Upper,
+    Pascal,
+    Camel,
+    Snake,
+    ScreamingSnake,
+    Kebab,
+    ScreamingKebab,
+}
+
+impl RenameRule {
+    fn from_lit(lit: &syn::LitStr) -> syn::Result<Self> {
+        Ok(match lit.value().as_str() {
+            "lowercase" => Self::Lower,
+            "UPPERCASE" => Self::Upper,
+            "PascalCase" => Self::Pascal,
+            "camelCase" => Self::Camel,
+            "snake_case" => Self::Snake,
+            "SCREAMING_SNAKE_CASE" => Self::ScreamingSnake,
+            "kebab-case" => Self::Kebab,
+            "SCREAMING-KEBAB-CASE" => Self::ScreamingKebab,
+            other => {
+                return Err(syn::Error::new_spanned(
+                    lit,
+                    format!(
+                        "unknown rename_all rule \"{other}\"; expected one of \
+                         \"lowercase\", \"UPPERCASE\", \"PascalCase\", \"camelCase\", \
+                         \"snake_case\", \"SCREAMING_SNAKE_CASE\", \"kebab-case\", \
+                         \"SCREAMING-KEBAB-CASE\""
+                    ),
+                ));
+            }
+        })
+    }
+
+    /// Applies the rule to a variant identifier, returning the derived label.
+    pub(crate) fn apply(self, ident: &str) -> String {
+        use heck::{
+            ToKebabCase, ToLowerCamelCase, ToShoutyKebabCase, ToShoutySnakeCase, ToSnakeCase,
+            ToUpperCamelCase,
+        };
+        match self {
+            Self::Lower => ident.to_lowercase(),
+            Self::Upper => ident.to_uppercase(),
+            Self::Pascal => ident.to_upper_camel_case(),
+            Self::Camel => ident.to_lower_camel_case(),
+            Self::Snake => ident.to_snake_case(),
+            Self::ScreamingSnake => ident.to_shouty_snake_case(),
+            Self::Kebab => ident.to_kebab_case(),
+            Self::ScreamingKebab => ident.to_shouty_kebab_case(),
+        }
+    }
 }
 
 impl Column {
@@ -45,6 +104,7 @@ impl syn::parse::Parse for Column {
             name: None,
             ty: None,
             variant: None,
+            rename_all: None,
         };
 
         // Loop through the list of comma separated arguments to fill in the result one by one.
@@ -55,6 +115,7 @@ impl syn::parse::Parse for Column {
         // #[column(type = <type>)]
         // #[column("name", type = <type>)]
         // #[column(type = <type>, "name")]
+        // #[column(rename_all = "<rule>")]
         loop {
             let lookahead = input.lookahead1();
 
@@ -63,6 +124,14 @@ impl syn::parse::Parse for Column {
                     return Err(syn::Error::new(input.span(), "duplicate column name"));
                 }
                 result.name = Some(input.parse()?);
+            } else if lookahead.peek(kw::rename_all) {
+                if result.rename_all.is_some() {
+                    return Err(syn::Error::new(input.span(), "duplicate rename_all"));
+                }
+                let _rename_all_token: kw::rename_all = input.parse()?;
+                let _eq_token: syn::Token![=] = input.parse()?;
+                let lit: syn::LitStr = input.parse()?;
+                result.rename_all = Some(RenameRule::from_lit(&lit)?);
             } else if lookahead.peek(kw::variant) {
                 if result.variant.is_some() {
                     return Err(syn::Error::new(
@@ -113,6 +182,7 @@ impl syn::parse::Parse for Column {
 
 mod kw {
     syn::custom_keyword!(variant);
+    syn::custom_keyword!(rename_all);
     syn::custom_keyword!(boolean);
 
     syn::custom_keyword!(int);

--- a/crates/toasty-macros/src/model/schema/model.rs
+++ b/crates/toasty-macros/src/model/schema/model.rs
@@ -375,8 +375,10 @@ impl Model {
             ));
         }
 
-        // Parse enum-level #[column(type = ...)] attribute to determine storage strategy.
+        // Parse enum-level #[column(type = ...)] attribute to determine storage
+        // strategy, and #[column(rename_all = ...)] to derive default labels.
         let mut enum_column_type: Option<ColumnType> = None;
+        let mut rename_all: Option<super::column::RenameRule> = None;
         for attr in &ast.attrs {
             if attr.path().is_ident("column") {
                 let col = Column::from_ast(attr)?;
@@ -388,6 +390,15 @@ impl Model {
                         ));
                     }
                     enum_column_type = Some(ty);
+                }
+                if let Some(rule) = col.rename_all {
+                    if rename_all.is_some() {
+                        return Err(syn::Error::new_spanned(
+                            attr,
+                            "duplicate #[column(rename_all = ...)] attribute on enum",
+                        ));
+                    }
+                    rename_all = Some(rule);
                 }
             }
         }
@@ -412,12 +423,21 @@ impl Model {
                 }
             };
 
-            // Resolve discriminant: explicit value or default to variant name in snake_case
+            // Resolve discriminant: explicit value, or default to the variant
+            // name converted by the enum-level rename_all rule (snake_case if
+            // no rule was given).
             let attr = match explicit_attr {
                 Some(a) => a,
-                None => VariantAttr {
-                    discriminant: VariantValue::String(variant.ident.to_string().to_snake_case()),
-                },
+                None => {
+                    let ident = variant.ident.to_string();
+                    let label = match rename_all {
+                        Some(rule) => rule.apply(&ident),
+                        None => ident.to_snake_case(),
+                    };
+                    VariantAttr {
+                        discriminant: VariantValue::String(label),
+                    }
+                }
             };
 
             let ast_fields = collect_ast_fields(&variant.fields)?;
@@ -519,6 +539,14 @@ impl Model {
                 return Err(syn::Error::new_spanned(
                     ast,
                     "#[column(type = ...)] is not supported for integer-discriminant enums",
+                ));
+            }
+            // `rename_all` derives string labels, so it is meaningless when the
+            // enum stores integer discriminants.
+            if rename_all.is_some() {
+                return Err(syn::Error::new_spanned(
+                    ast,
+                    "#[column(rename_all = ...)] is not supported for integer-discriminant enums",
                 ));
             }
             None

--- a/tests/tests/ui/rename_all_on_integer_enum.rs
+++ b/tests/tests/ui/rename_all_on_integer_enum.rs
@@ -1,0 +1,13 @@
+// `rename_all` derives string labels, so it is rejected on an enum that stores
+// integer discriminants.
+
+#[derive(toasty::Embed)]
+#[column(rename_all = "PascalCase")]
+enum Priority {
+    #[column(variant = 1)]
+    Low,
+    #[column(variant = 2)]
+    High,
+}
+
+fn main() {}

--- a/tests/tests/ui/rename_all_on_integer_enum.stderr
+++ b/tests/tests/ui/rename_all_on_integer_enum.stderr
@@ -1,0 +1,11 @@
+error: #[column(rename_all = ...)] is not supported for integer-discriminant enums
+  --> tests/ui/rename_all_on_integer_enum.rs:5:1
+   |
+ 5 | / #[column(rename_all = "PascalCase")]
+ 6 | | enum Priority {
+ 7 | |     #[column(variant = 1)]
+ 8 | |     Low,
+ 9 | |     #[column(variant = 2)]
+10 | |     High,
+11 | | }
+   | |_^


### PR DESCRIPTION
## Summary

This pr adds a new `#[column(rename_all = "...")]` attribute for renaming all enum labels.

## Type of change

<!-- Check one. -->

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test
- [ ] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`):
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers
N/A
