### PR TITLE
fix(macros): normalize raw identifiers in collision checks

### DIFF
--- a/crates/toasty-macros/src/model/expand/fields.rs
+++ b/crates/toasty-macros/src/model/expand/fields.rs
@@ -4,6 +4,11 @@ use crate::model::schema::ModelKind;
 use proc_macro2::TokenStream;
 use quote::{quote, quote_spanned};
 
+const FIELD_STRUCT_RESERVED_METHODS: &[&str] =
+    &["from_path", "path", "eq", "in_query", "into_root", "create"];
+
+const FIELD_LIST_STRUCT_RESERVED_METHODS: &[&str] = &["from_path", "path", "any", "all", "create"];
+
 impl Expand<'_> {
     pub(super) fn expand_field_struct(&self) -> TokenStream {
         let toasty = &self.toasty;
@@ -32,6 +37,9 @@ impl Expand<'_> {
             .fields
             .iter()
             .enumerate()
+            .filter(|(_, field)| {
+                !util::ident_is_reserved(&field.name.ident, FIELD_STRUCT_RESERVED_METHODS)
+            })
             .map(move |(offset, field)| {
                 let field_ident = &field.name.ident;
                 let field_offset = util::int(offset);
@@ -172,7 +180,13 @@ impl Expand<'_> {
             .fields
             .iter()
             .enumerate()
-            .filter(move |(_, field)| seen_names.insert(field.name.as_str().to_string()))
+            .filter(move |(_, field)| {
+                seen_names.insert(field.name.as_str().to_string())
+                    && !util::ident_is_reserved(
+                        &field.name.ident,
+                        FIELD_LIST_STRUCT_RESERVED_METHODS,
+                    )
+            })
             .map(move |(offset, field)| {
                 let field_ident = &field.name.ident;
                 let field_offset = util::int(offset);

--- a/crates/toasty-macros/src/model/expand/query.rs
+++ b/crates/toasty-macros/src/model/expand/query.rs
@@ -4,6 +4,28 @@ use crate::model::schema::{BelongsTo, Field, FieldTy, HasMany, HasOne};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
+const QUERY_LIST_RESERVED_METHODS: &[&str] = &[
+    "from_assoc_many",
+    "first",
+    "one",
+    "get",
+    "update",
+    "count",
+    "select",
+    "delete",
+    "paginate",
+    "filter",
+    "order_by",
+    "latest_by",
+    "limit",
+    "offset",
+    "insert",
+    "remove",
+    "include",
+    "exec",
+    "create",
+];
+
 impl Expand<'_> {
     pub(super) fn expand_query_struct(&self) -> TokenStream {
         let toasty = &self.toasty;
@@ -316,6 +338,9 @@ impl Expand<'_> {
         self.model
             .fields
             .iter()
+            .filter(|field| {
+                !util::ident_is_reserved(&field.name.ident, QUERY_LIST_RESERVED_METHODS)
+            })
             .filter_map(|field| match &field.ty {
                 FieldTy::BelongsTo(rel) => Some(self.expand_belongs_to_method(field, rel)),
                 FieldTy::HasMany(rel) if rel.via.is_some() => {

--- a/crates/toasty-macros/src/model/expand/relation.rs
+++ b/crates/toasty-macros/src/model/expand/relation.rs
@@ -1,4 +1,4 @@
-use super::Expand;
+use super::{Expand, util};
 use crate::model::schema::{BelongsTo, Field, FieldTy, HasMany, HasOne};
 
 use proc_macro2::TokenStream;
@@ -14,11 +14,22 @@ struct PairBelongsToCheck<'a> {
     label: &'static str,
 }
 
+const MODEL_RESERVED_METHODS: &[&str] = &[
+    "fields",
+    "create",
+    "create_many",
+    "update",
+    "all",
+    "filter",
+    "delete",
+];
+
 impl Expand<'_> {
     pub(super) fn expand_model_relation_methods(&self) -> TokenStream {
         self.model
             .fields
             .iter()
+            .filter(|field| !util::ident_is_reserved(&field.name.ident, MODEL_RESERVED_METHODS))
             .filter_map(|field| match &field.ty {
                 FieldTy::BelongsTo(rel) => {
                     Some(self.expand_model_relation_belongs_to_method(rel, field))

--- a/crates/toasty-macros/src/model/expand/util.rs
+++ b/crates/toasty-macros/src/model/expand/util.rs
@@ -34,3 +34,14 @@ pub(crate) fn respan(tokens: TokenStream, span: Span) -> TokenStream {
 pub(crate) fn ident(name: &str) -> syn::Ident {
     quote::format_ident!("__toasty_{name}")
 }
+
+/// Return the Rust method name an identifier occupies, without raw-ident syntax.
+pub(crate) fn bare_ident_name(ident: &syn::Ident) -> String {
+    let name = ident.to_string();
+    name.strip_prefix("r#").unwrap_or(&name).to_string()
+}
+
+pub(crate) fn ident_is_reserved(ident: &syn::Ident, reserved: &[&str]) -> bool {
+    let name = bare_ident_name(ident);
+    reserved.contains(&name.as_str())
+}

--- a/tests/tests/ui-pass/raw_identifier_reserved_methods.rs
+++ b/tests/tests/ui-pass/raw_identifier_reserved_methods.rs
@@ -1,0 +1,31 @@
+#![allow(dead_code)]
+
+#[derive(Debug, toasty::Model)]
+struct Item {
+    #[key]
+    id: i64,
+
+    r#count: i64,
+    r#all: i64,
+
+    #[has_many(pair = item)]
+    r#filter: toasty::Deferred<Vec<Comment>>,
+}
+
+#[derive(Debug, toasty::Model)]
+struct Comment {
+    #[key]
+    id: i64,
+
+    #[index]
+    item_id: i64,
+
+    #[belongs_to(key = item_id, references = id)]
+    item: toasty::Deferred<Item>,
+}
+
+fn main() {
+    let _ = Item::fields().r#count();
+    let _ = Item::fields().r#all();
+    let _ = Item::fields().r#filter();
+}

--- a/tests/tests/ui_pass.rs
+++ b/tests/tests/ui_pass.rs
@@ -1,0 +1,5 @@
+#[test]
+fn ui_pass() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/ui-pass/*.rs");
+}


### PR DESCRIPTION
## Summary

Closes #989.

Raw identifier fields like `r#count` stringify as `r#count`, but Rust treats the generated method name as `count`. This caused generated projection/relation shortcut collision checks to miss reserved method names and emit duplicate inherent methods.

This PR normalizes identifiers before reserved-method checks and skips colliding generated shortcuts on model, query, and field-path impls. It also adds a trybuild pass fixture for raw identifiers that normalize to reserved method names.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

Verified with:

- `cargo test -p tests ui_pass`
- `cargo test -p tests ui`
- `cargo test -p toasty-driver-integration-suite raw_identifier_fields --no-run`
- `cargo fmt`
