### PR TITLE
fix(engine): compare composite-FK include filter against target fields

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs
@@ -717,6 +717,42 @@ pub async fn composite_basic_has_many_and_belongs_to_preload(test: &mut Test) ->
     Ok(())
 }
 
+/// Preload a `belongs_to` whose foreign key spans two columns. Seeds two
+/// users so a filter that doesn't actually compare child FK columns against
+/// parent key columns (e.g. one comparing the child's own columns to
+/// themselves, which matches every user) is caught by the assertions.
+#[driver_test(scenario(crate::scenarios::composite_fk_has_many_belongs_to))]
+pub async fn composite_fk_belongs_to_preload(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let u1 = toasty::create!(User {
+        revision: 1,
+        name: "User 1"
+    })
+    .exec(&mut db)
+    .await?;
+    let u2 = toasty::create!(User {
+        revision: 1,
+        name: "User 2"
+    })
+    .exec(&mut db)
+    .await?;
+
+    for user in [&u1, &u2] {
+        let todo = toasty::create!(in user.todos() { title: "a todo" })
+            .exec(&mut db)
+            .await?;
+
+        let todo = Todo::filter_by_id(todo.id)
+            .include(Todo::fields().user())
+            .get(&mut db)
+            .await?;
+
+        assert_struct!(todo.user.get(), _ { id: == user.id, name: == user.name, .. });
+    }
+    Ok(())
+}
+
 #[driver_test(id(ID), scenario(crate::scenarios::composite_has_many_belongs_to))]
 pub async fn composite_preload_on_empty_query(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;

--- a/crates/toasty/src/engine/lower/include.rs
+++ b/crates/toasty/src/engine/lower/include.rs
@@ -356,7 +356,7 @@ impl LowerStatement<'_, '_> {
 
                     for fk_field in &rel.foreign_key.fields {
                         source_fk_fields.push(stmt::Expr::ref_parent_field(fk_field.source));
-                        target_pk_fields.push(stmt::Expr::ref_parent_field(fk_field.source));
+                        target_pk_fields.push(stmt::Expr::ref_self_field(fk_field.target));
                     }
 
                     source_fk = stmt::Expr::record_from_vec(source_fk_fields);


### PR DESCRIPTION
The multi-field `BelongsTo` arm of `build_relation_subquery` pushed the parent's FK source field into both sides of the equality, producing an always-true filter. An `.include()` over a composite foreign key then matched every target row, panicking in NestedMerge for single relations.

<!--
PR title uses Conventional Commits, e.g.
    feat: add upsert support
    fix: handle composite key in IN-list rewrite
See CONTRIBUTING.md for the full process.
-->

## Summary

<!-- What does this change and why? Link the issue it closes. -->

## Type of change

<!-- Check one. -->

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test
- [ ] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`):
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers
This was found and fixed by fable.
