### PR TITLE
fix(macros): emit doc comments on generated model methods

### DIFF
--- a/crates/toasty-macros/src/model/expand.rs
+++ b/crates/toasty-macros/src/model/expand.rs
@@ -1,4 +1,5 @@
 mod create;
+mod docs;
 mod embedded_enum;
 mod fields;
 mod filters;

--- a/crates/toasty-macros/src/model/expand/docs.rs
+++ b/crates/toasty-macros/src/model/expand/docs.rs
@@ -1,0 +1,136 @@
+//! Doc comments for the derive-generated public methods.
+//!
+//! Emitting real docs (rather than `#[allow(missing_docs)]`) keeps models
+//! usable from crates that `#![deny(missing_docs)]`. Plain code spans are used
+//! instead of intra-doc links so no `broken_intra_doc_links` warnings leak
+//! into the user's crate.
+
+use super::{Expand, Filter};
+
+impl Expand<'_> {
+    pub(super) fn doc_create(&self) -> String {
+        format!(
+            "Returns a builder that inserts a new `{}` record.\n\n\
+             Typically constructed through the `toasty::create!` macro.",
+            self.model.ident
+        )
+    }
+
+    pub(super) fn doc_create_many(&self) -> String {
+        format!(
+            "Returns a builder that inserts multiple `{}` records at once.",
+            self.model.ident
+        )
+    }
+
+    pub(super) fn doc_update(&self) -> String {
+        format!(
+            "Returns a builder that updates this `{}` record in place.",
+            self.model.ident
+        )
+    }
+
+    pub(super) fn doc_all(&self) -> String {
+        format!(
+            "Returns a query that selects every `{}` record.",
+            self.model.ident
+        )
+    }
+
+    pub(super) fn doc_filter(&self) -> String {
+        format!(
+            "Returns a query selecting the `{}` records matching `expr`.",
+            self.model.ident
+        )
+    }
+
+    pub(super) fn doc_delete(&self) -> String {
+        format!(
+            "Consumes this `{}` and returns a statement that deletes its record.",
+            self.model.ident
+        )
+    }
+
+    pub(super) fn doc_fields(&self) -> String {
+        format!(
+            "Returns a handle used to reference `{}`'s fields when building query expressions.",
+            self.model.ident
+        )
+    }
+
+    pub(super) fn doc_filter_get(&self, filter: &Filter) -> String {
+        format!(
+            "Fetches the single `{}` where {}, erroring if none exists.",
+            self.model.ident,
+            self.filter_fields_phrase(filter)
+        )
+    }
+
+    pub(super) fn doc_filter_update(&self, filter: &Filter) -> String {
+        format!(
+            "Returns a builder that updates the `{}` where {}.",
+            self.model.ident,
+            self.filter_fields_phrase(filter)
+        )
+    }
+
+    pub(super) fn doc_filter_delete(&self, filter: &Filter) -> String {
+        format!(
+            "Deletes the `{}` where {}.",
+            self.model.ident,
+            self.filter_fields_phrase(filter)
+        )
+    }
+
+    pub(super) fn doc_filter_query(&self, filter: &Filter) -> String {
+        format!(
+            "Returns a query selecting the `{}` records where {}.",
+            self.model.ident,
+            self.filter_fields_phrase(filter)
+        )
+    }
+
+    pub(super) fn doc_belongs_to(&self, field_ident: &syn::Ident) -> String {
+        format!(
+            "Returns a query for the `{field_ident}` record this `{}` belongs to.",
+            self.model.ident
+        )
+    }
+
+    pub(super) fn doc_has_many(&self, field_ident: &syn::Ident) -> String {
+        format!(
+            "Returns a query over the `{field_ident}` associated with this `{}`.",
+            self.model.ident
+        )
+    }
+
+    pub(super) fn doc_has_many_via(&self, field_ident: &syn::Ident) -> String {
+        format!(
+            "Returns a query over the `{field_ident}` reached from this `{}` through its relations.",
+            self.model.ident
+        )
+    }
+
+    pub(super) fn doc_has_one(&self, field_ident: &syn::Ident) -> String {
+        format!(
+            "Returns a query for the `{field_ident}` associated with this `{}`.",
+            self.model.ident
+        )
+    }
+
+    /// A human-readable phrase naming the fields a filter matches on — e.g.
+    /// `` `email` matches `` or `` `a` and `b` match ``.
+    fn filter_fields_phrase(&self, filter: &Filter) -> String {
+        let names: Vec<String> = filter
+            .fields
+            .iter()
+            .map(|index| format!("`{}`", self.model.fields[*index].name.as_str()))
+            .collect();
+
+        if names.len() == 1 {
+            format!("{} matches", names[0])
+        } else {
+            format!("{} match", names.join(" and "))
+        }
+    }
+}

--- a/crates/toasty-macros/src/model/expand/fields.rs
+++ b/crates/toasty-macros/src/model/expand/fields.rs
@@ -322,9 +322,12 @@ impl Expand<'_> {
         let model_ident = &self.model.ident;
         let schema_trait = self.schema_trait();
 
+        let doc_fields = self.doc_fields();
+
         // Generate fields() as a method instead of const to avoid const initialization issues
         // This will be placed inside the existing impl block for the model
         quote!(
+            #[doc = #doc_fields]
             #vis fn fields() -> #field_struct_ident<#model_ident> {
                 #field_struct_ident {
                     path: <#model_ident as #schema_trait>::path_root(),

--- a/crates/toasty-macros/src/model/expand/filters.rs
+++ b/crates/toasty-macros/src/model/expand/filters.rs
@@ -9,7 +9,7 @@ use quote::quote;
 #[derive(Debug)]
 pub(super) struct Filter {
     /// Fields to filter by
-    fields: Vec<usize>,
+    pub(super) fields: Vec<usize>,
 
     /// When true, only include the filter on relation structs
     only_relation: bool,
@@ -61,6 +61,10 @@ impl Expand<'_> {
         let arg_idents: Vec<_> = self.expand_filter_arg_idents(filter).collect();
         let update_query_struct_ident = &self.model.kind.as_root_unwrap().update_struct_ident;
 
+        let doc_get = self.doc_filter_get(filter);
+        let doc_update = self.doc_filter_update(filter);
+        let doc_delete = self.doc_filter_delete(filter);
+
         let self_arg;
         let base;
 
@@ -73,16 +77,19 @@ impl Expand<'_> {
         }
 
         quote! {
+            #[doc = #doc_get]
             #vis async fn #get_method_ident(#self_arg executor: &mut dyn #toasty::Executor, #( #args ),* ) -> #toasty::Result<#model_ident> {
                 #base #filter_method_ident( #( #arg_idents ),* )
                     .get(executor)
                     .await
             }
 
+            #[doc = #doc_update]
             #vis fn #update_method_ident(#self_arg #( #args ),* ) -> #update_query_struct_ident {
                 #base #filter_method_ident( #( #arg_idents ),* ).update()
             }
 
+            #[doc = #doc_delete]
             #vis async fn #delete_method_ident(#self_arg executor: &mut dyn #toasty::Executor, #( #args ),* ) -> #toasty::Result<()> {
                 #base #filter_method_ident( #( #arg_idents ),* )
                     .delete()
@@ -99,6 +106,9 @@ impl Expand<'_> {
         let filter_method_ident = &filter.filter_method_ident;
         let args = self.expand_filter_args(filter);
         let arg_idents = self.expand_filter_arg_idents(filter);
+
+        let doc_filter = self.doc_filter_query(filter);
+
         let self_arg;
         let body;
 
@@ -118,6 +128,7 @@ impl Expand<'_> {
         }
 
         quote! {
+            #[doc = #doc_filter]
             #vis fn #filter_method_ident( #self_arg #( #args ),* ) -> #query_struct_ident {
                 #body
             }

--- a/crates/toasty-macros/src/model/expand/model.rs
+++ b/crates/toasty-macros/src/model/expand/model.rs
@@ -46,6 +46,10 @@ impl Expand<'_> {
         let find_by_primary_key_body = self.expand_find_by_primary_key_body();
 
         quote! {
+            // Generated CRUD, filter, and relation methods carry no doc
+            // comments; suppress `missing_docs` so models in crates that
+            // `#![deny(missing_docs)]` still compile.
+            #[allow(missing_docs)]
             impl #model_ident {
                 #model_fields
                 #filter_methods
@@ -245,6 +249,7 @@ impl Expand<'_> {
         let model_fields = self.expand_model_field_struct_init();
 
         quote! {
+            #[allow(missing_docs)]
             impl #model_ident {
                 #model_fields
             }

--- a/crates/toasty-macros/src/model/expand/model.rs
+++ b/crates/toasty-macros/src/model/expand/model.rs
@@ -45,24 +45,30 @@ impl Expand<'_> {
         let primary_key_ty = self.expand_primary_key_ty();
         let find_by_primary_key_body = self.expand_find_by_primary_key_body();
 
+        let doc_create = self.doc_create();
+        let doc_create_many = self.doc_create_many();
+        let doc_update = self.doc_update();
+        let doc_all = self.doc_all();
+        let doc_filter = self.doc_filter();
+        let doc_delete = self.doc_delete();
+
         quote! {
-            // Generated CRUD, filter, and relation methods carry no doc
-            // comments; suppress `missing_docs` so models in crates that
-            // `#![deny(missing_docs)]` still compile.
-            #[allow(missing_docs)]
             impl #model_ident {
                 #model_fields
                 #filter_methods
                 #relation_methods
 
+                #[doc = #doc_create]
                 #vis fn create() -> #create_struct_ident {
                     #create_struct_ident::default()
                 }
 
+                #[doc = #doc_create_many]
                 #vis fn create_many() -> #toasty::stmt::CreateMany<#model_ident> {
                     #toasty::stmt::CreateMany::default()
                 }
 
+                #[doc = #doc_update]
                 #vis fn update(&mut self) -> #update_struct_ident<&mut Self> {
                     let mut s = #update_struct_ident {
                         assignments: #toasty::core::stmt::Assignments::default(),
@@ -74,14 +80,17 @@ impl Expand<'_> {
                     s
                 }
 
+                #[doc = #doc_all]
                 #vis fn all() -> #query_struct_ident {
                     #query_struct_ident::default()
                 }
 
+                #[doc = #doc_filter]
                 #vis fn filter(expr: #toasty::stmt::Expr<bool>) -> #query_struct_ident {
                     #query_struct_ident::from_stmt(#toasty::stmt::Query::all().filter(expr))
                 }
 
+                #[doc = #doc_delete]
                 #vis fn delete(self) -> #toasty::stmt::Delete<()> {
                     #into_delete_body
                 }
@@ -249,7 +258,6 @@ impl Expand<'_> {
         let model_fields = self.expand_model_field_struct_init();
 
         quote! {
-            #[allow(missing_docs)]
             impl #model_ident {
                 #model_fields
             }

--- a/crates/toasty-macros/src/model/expand/relation.rs
+++ b/crates/toasty-macros/src/model/expand/relation.rs
@@ -81,7 +81,10 @@ impl Expand<'_> {
             field_ident.span(),
         );
 
+        let doc = self.doc_belongs_to(field_ident);
+
         quote! {
+            #[doc = #doc]
             #vis fn #field_ident(&self) -> <#ty as #toasty::RelationOneField>::One {
                 // Suppress the unused field warning
                 if false {
@@ -113,12 +116,15 @@ impl Expand<'_> {
         // the rich `QueryMany<M>` builder — or a scalar field, where it yields
         // a plain `Query<List<scalar>>` projecting that field.
         if rel.via.is_some() {
+            let doc = self.doc_has_many_via(field_ident);
+
             // The association references the via field; its target and (for a
             // scalar terminal) terminal projection are resolved during lowering
             // from the schema, so nothing here needs the path's shape. The
             // declared element type is validated against the path by the typed
             // accessor and by the `schema()` expansion's terminal pin.
             return quote! {
+                #[doc = #doc]
                 #vis fn #field_ident(&self) -> #toasty::ViaMany<#ty> {
                     // Suppress the unused field warning
                     if false {
@@ -158,7 +164,10 @@ impl Expand<'_> {
             label: "Has many associations require the target to include a back-reference",
         });
 
+        let doc = self.doc_has_many(field_ident);
+
         quote! {
+            #[doc = #doc]
             #vis fn #field_ident(&self) -> #toasty::QueryMany<#target> {
                 // Suppress the unused field warning
                 if false {
@@ -208,7 +217,10 @@ impl Expand<'_> {
             })
         };
 
+        let doc = self.doc_has_one(field_ident);
+
         quote! {
+            #[doc = #doc]
             #vis fn #field_ident(&self) -> <#ty as #toasty::RelationOneField>::One {
                 // Suppress the unused field warning
                 if false {

--- a/tests/tests/deny_missing_docs.rs
+++ b/tests/tests/deny_missing_docs.rs
@@ -1,0 +1,54 @@
+//! Regression test for https://github.com/tokio-rs/toasty/issues/1046
+//!
+//! A crate that enforces `#![deny(missing_docs)]` must still be able to derive
+//! `toasty::Model`. The derive emits public inherent methods (`create`, `all`,
+//! `filter`, `fields`, `update`, `delete`, per-field filter methods, relation
+//! accessors, …) that carry no doc comments; they are marked
+//! `#[allow(missing_docs)]` so they do not trip the lint. If this file fails to
+//! compile, that suppression regressed.
+#![deny(missing_docs)]
+
+/// A user, exercising key, unique, indexed, and `has_many` fields so every
+/// generated inherent method kind is present on the model.
+#[derive(Debug, toasty::Model)]
+pub struct User {
+    /// Primary key.
+    #[key]
+    #[auto]
+    pub id: u64,
+
+    /// Unique email — generates `get_by_email` / `filter_by_email`.
+    #[unique]
+    pub email: String,
+
+    /// Indexed name — generates `filter_by_name`.
+    #[index]
+    pub name: String,
+
+    /// Posts authored by this user.
+    #[has_many]
+    pub posts: toasty::Deferred<Vec<Post>>,
+}
+
+/// A post that belongs to a user, exercising the `belongs_to` relation
+/// accessor codegen.
+#[derive(Debug, toasty::Model)]
+pub struct Post {
+    /// Primary key.
+    #[key]
+    #[auto]
+    pub id: u64,
+
+    /// Author id.
+    #[index]
+    pub user_id: u64,
+
+    /// Author.
+    #[belongs_to(key = user_id, references = id)]
+    pub user: toasty::Deferred<User>,
+}
+
+/// If this compiles, the derive-generated public methods do not trip
+/// `#![deny(missing_docs)]`.
+#[test]
+fn models_compile_under_deny_missing_docs() {}

--- a/tests/tests/deny_missing_docs.rs
+++ b/tests/tests/deny_missing_docs.rs
@@ -3,9 +3,8 @@
 //! A crate that enforces `#![deny(missing_docs)]` must still be able to derive
 //! `toasty::Model`. The derive emits public inherent methods (`create`, `all`,
 //! `filter`, `fields`, `update`, `delete`, per-field filter methods, relation
-//! accessors, …) that carry no doc comments; they are marked
-//! `#[allow(missing_docs)]` so they do not trip the lint. If this file fails to
-//! compile, that suppression regressed.
+//! accessors, …); each carries a generated doc comment so it does not trip the
+//! lint. If this file fails to compile, a generated method lost its docs.
 #![deny(missing_docs)]
 
 /// A user, exercising key, unique, indexed, and `has_many` fields so every


### PR DESCRIPTION
## Summary
With this pr the public generated methods by toasty now have doc comments.

## Type of change

<!-- Check one. -->

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test
- [ ] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`):
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers

Closes #1046
