### PR TITLE
docs: document embedded enum rename_all and string discriminants

### DIFF
--- a/crates/toasty-macros/src/lib.rs
+++ b/crates/toasty-macros/src/lib.rs
@@ -789,34 +789,31 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
 /// # Enums
 ///
 /// An embedded enum stores a discriminant value identifying the active
-/// variant. Each variant must have a `#[column(variant = N)]` attribute
-/// assigning a stable integer discriminant.
+/// variant. By default, Toasty derives a string label for each variant by
+/// converting its Rust name to `snake_case`. Use
+/// `#[column(rename_all = "...")]` on the enum to select another naming
+/// convention, or `#[column(variant = "...")]` on a variant to set one label.
 ///
 /// **Unit-only enum:**
 ///
 /// ```
 /// #[derive(toasty::Embed)]
 /// enum Status {
-///     #[column(variant = 1)]
 ///     Pending,
-///     #[column(variant = 2)]
-///     Active,
-///     #[column(variant = 3)]
+///     InProgress,
 ///     Archived,
 /// }
 /// ```
 ///
 /// A unit-only enum occupies a single column in the parent table. The
-/// column stores the discriminant as an integer.
+/// example stores the labels `pending`, `in_progress`, and `archived`.
 ///
 /// **Data-carrying enum:**
 ///
 /// ```
 /// #[derive(toasty::Embed)]
 /// enum ContactInfo {
-///     #[column(variant = 1)]
 ///     Email { address: String },
-///     #[column(variant = 2)]
 ///     Phone { number: String },
 /// }
 /// ```
@@ -832,11 +829,8 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
 /// ```
 /// #[derive(toasty::Embed)]
 /// enum Status {
-///     #[column(variant = 1)]
 ///     Pending,
-///     #[column(variant = 2)]
 ///     Failed { reason: String },
-///     #[column(variant = 3)]
 ///     Done,
 /// }
 /// ```
@@ -872,7 +866,7 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
 /// Newtypes wrapping non-`Auto` types stay non-`Auto`; nesting works
 /// transparently (`Outer(Inner(u64))` proxies through both layers).
 ///
-/// # Field-level attributes
+/// # Attributes
 ///
 /// ## `#[column(...)]` — customize the database column
 ///
@@ -892,19 +886,71 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
 /// See [`Model`][`derive@Model`] for the full list of supported column
 /// types.
 ///
-/// **On enum variants**, `#[column(variant = N)]` is **required** and
-/// assigns the integer discriminant stored in the database:
+/// **Changing stored enum discriminants.** On an enum,
+/// `#[column(rename_all = "...")]` changes how Toasty derives string labels
+/// for variants without an explicit label:
 ///
 /// ```
-/// # #[derive(toasty::Embed)]
-/// # enum Example {
-/// #[column(variant = 1)]
-/// Pending,
-/// # }
+/// #[derive(toasty::Embed)]
+/// #[column(rename_all = "SCREAMING_SNAKE_CASE")]
+/// enum PartyKind {
+///     Customer,
+///     PreferredSupplier,
+/// }
 /// ```
 ///
-/// Discriminant values must be unique across all variants of the enum.
-/// They are stored as `i64`.
+/// This example uses the labels `CUSTOMER` and `PREFERRED_SUPPLIER`. Without
+/// `rename_all`, Toasty uses `snake_case`.
+///
+/// The supported rules and their result for `PreferredSupplier` are:
+///
+/// | Rule | Label |
+/// | --- | --- |
+/// | `lowercase` | `preferredsupplier` |
+/// | `UPPERCASE` | `PREFERREDSUPPLIER` |
+/// | `PascalCase` | `PreferredSupplier` |
+/// | `camelCase` | `preferredSupplier` |
+/// | `snake_case` | `preferred_supplier` |
+/// | `SCREAMING_SNAKE_CASE` | `PREFERRED_SUPPLIER` |
+/// | `kebab-case` | `preferred-supplier` |
+/// | `SCREAMING-KEBAB-CASE` | `PREFERRED-SUPPLIER` |
+///
+/// Use `#[column(variant = "...")]` to set individual labels:
+///
+/// ```
+/// #[derive(toasty::Embed)]
+/// enum PartyKind {
+///     #[column(variant = "customer")]
+///     Customer,
+///     #[column(variant = "preferred-supplier")]
+///     PreferredSupplier,
+/// }
+/// ```
+///
+/// An explicit variant label takes precedence over `rename_all` when an enum
+/// uses both attributes.
+///
+/// String-label enums use Toasty's enum storage by default. Use
+/// `#[column(type = enum("type_name"))]` to set the database enum type name,
+/// or `#[column(type = text)]` or `#[column(type = varchar(N))]` to use a
+/// plain string column. `rename_all` changes variant labels only; it does not
+/// change the enum type name.
+///
+/// To store integers instead, assign an integer to every variant:
+///
+/// ```
+/// #[derive(toasty::Embed)]
+/// enum Priority {
+///     #[column(variant = 10)]
+///     Low,
+///     #[column(variant = 20)]
+///     High,
+/// }
+/// ```
+///
+/// An enum cannot mix string and integer discriminants. Integer discriminants
+/// are stored as `i64` and do not support `rename_all`. All discriminant values
+/// must be unique. String labels may contain at most 63 bytes.
 ///
 /// ## `#[index]` — add a database index
 ///
@@ -991,8 +1037,9 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
 /// - Embedded structs must have named fields (tuple structs are not
 ///   supported).
 /// - Generic parameters are not supported.
-/// - Every enum variant must have a `#[column(variant = N)]` attribute
-///   with a unique discriminant value.
+/// - Enum discriminants must all be strings or all be integers. Integer
+///   discriminants must be specified on every variant.
+/// - `#[column(rename_all = "...")]` applies only to string labels.
 /// - Enum variants may be unit variants or have named fields. Tuple
 ///   variants are not supported.
 /// - Embedded types cannot have primary keys, relations, `#[auto]`,
@@ -1003,12 +1050,10 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
 /// ```no_run
 /// # async fn example(mut db: toasty::Db) -> toasty::Result<()> {
 /// #[derive(Debug, PartialEq, toasty::Embed)]
+/// #[column(rename_all = "SCREAMING_SNAKE_CASE")]
 /// enum Priority {
-///     #[column(variant = 1)]
 ///     Low,
-///     #[column(variant = 2)]
 ///     Normal,
-///     #[column(variant = 3)]
 ///     High,
 /// }
 ///

--- a/docs/guide/src/embedded-types.md
+++ b/docs/guide/src/embedded-types.md
@@ -251,22 +251,19 @@ A `User` model with an `address: Address` field produces columns: `address_stree
 ## Embedded enums
 
 Enums annotated with `#[derive(toasty::Embed)]` store a variant discriminant in
-the database. Each variant must have an explicit `#[column(variant = N)]`
-attribute specifying its integer discriminant value.
+the database. By default, Toasty derives a string label for each variant by
+converting its Rust name to `snake_case`.
 
 ### Unit enums
 
-A unit enum (all variants have no fields) maps to a single integer column:
+A unit enum (all variants have no fields) maps to a single column:
 
 ```rust
 # use toasty::Model;
 #[derive(Debug, PartialEq, toasty::Embed)]
 enum Status {
-    #[column(variant = 1)]
     Pending,
-    #[column(variant = 2)]
-    Active,
-    #[column(variant = 3)]
+    InProgress,
     Done,
 }
 
@@ -281,15 +278,9 @@ struct Task {
 }
 ```
 
-The `status` column stores the discriminant as an integer:
-
-```sql
-CREATE TABLE tasks (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    title TEXT NOT NULL,
-    status INTEGER NOT NULL   -- 1 = Pending, 2 = Active, 3 = Done
-);
-```
+The `status` column stores `pending`, `in_progress`, or `done`. PostgreSQL uses
+a named enum type, MySQL uses `ENUM`, and SQLite uses `TEXT` with a check
+constraint. DynamoDB stores the label as a string attribute.
 
 Use it like any other field:
 
@@ -313,9 +304,7 @@ the parent table. Only the active variant's columns are non-null for a given row
 # use toasty::Model;
 #[derive(Debug, PartialEq, toasty::Embed)]
 enum ContactInfo {
-    #[column(variant = 1)]
     Email { address: String },
-    #[column(variant = 2)]
     Phone { number: String },
 }
 
@@ -330,18 +319,9 @@ struct User {
 }
 ```
 
-This produces three columns — one discriminant column plus one nullable column
-per variant field:
-
-```sql
-CREATE TABLE users (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    name TEXT NOT NULL,
-    contact INTEGER NOT NULL,         -- discriminant: 1 = Email, 2 = Phone
-    contact_address TEXT,             -- non-null when contact = 1
-    contact_number TEXT               -- non-null when contact = 2
-);
-```
+This produces three columns: one discriminant column containing `email` or
+`phone`, plus nullable `contact_address` and `contact_number` columns. Only the
+field for the active variant contains a value.
 
 Create records by passing enum values:
 
@@ -363,11 +343,8 @@ An enum can have both unit variants and data-carrying variants:
 ```rust,ignore
 #[derive(Debug, PartialEq, toasty::Embed)]
 enum Status {
-    #[column(variant = 1)]
     Pending,
-    #[column(variant = 2)]
     Failed { reason: String },
-    #[column(variant = 3)]
     Done,
 }
 ```
@@ -375,15 +352,60 @@ enum Status {
 Unit variants (`Pending`, `Done`) store only the discriminant. The `Failed`
 variant also stores its `reason` in a nullable column.
 
-### The `#[column(variant = N)]` attribute
+### Changing stored discriminants
 
-Every variant in an embedded enum must have `#[column(variant = N)]` where `N`
-is the integer stored in the database. This is required — Toasty does not
-auto-assign discriminant values.
+Without additional attributes, Toasty converts each variant name to
+`snake_case`. For example, `PreferredSupplier` uses the label
+`preferred_supplier`.
 
-The discriminant values do not need to be sequential. You can choose any `i64`
-values, which is useful when adding new variants to an existing schema without
-renumbering:
+Add `#[column(rename_all = "...")]` to the enum to select another naming rule:
+
+```rust
+#[derive(toasty::Embed)]
+#[column(rename_all = "SCREAMING_SNAKE_CASE")]
+enum PartyKind {
+    Customer,
+    PreferredSupplier,
+}
+```
+
+This enum uses `CUSTOMER` and `PREFERRED_SUPPLIER`. Toasty accepts the following
+rules:
+
+| Rule | `PreferredSupplier` label |
+| --- | --- |
+| `lowercase` | `preferredsupplier` |
+| `UPPERCASE` | `PREFERREDSUPPLIER` |
+| `PascalCase` | `PreferredSupplier` |
+| `camelCase` | `preferredSupplier` |
+| `snake_case` | `preferred_supplier` |
+| `SCREAMING_SNAKE_CASE` | `PREFERRED_SUPPLIER` |
+| `kebab-case` | `preferred-supplier` |
+| `SCREAMING-KEBAB-CASE` | `PREFERRED-SUPPLIER` |
+
+Set individual labels with `#[column(variant = "...")]`:
+
+```rust
+#[derive(toasty::Embed)]
+enum PartyKind {
+    #[column(variant = "customer")]
+    Customer,
+    #[column(variant = "preferred-supplier")]
+    PreferredSupplier,
+}
+```
+
+An explicit variant label takes precedence over `rename_all` when an enum uses
+both attributes. `rename_all` changes variant labels only; it does not change
+the database enum type name. It applies whether the labels use native enum
+storage or a plain `text` or `varchar` column.
+
+#### Integer discriminants
+
+To store integer discriminants, set `#[column(variant = N)]` on every variant.
+Toasty does not auto-assign integers. The values do not need to be sequential;
+you can choose any `i64` values. This lets you add variants to an existing
+schema without renumbering:
 
 ```rust,ignore
 #[derive(toasty::Embed)]
@@ -396,6 +418,9 @@ enum Priority {
     High,
 }
 ```
+
+An enum cannot mix string and integer discriminants. Integer-discriminant enums
+do not support `rename_all`.
 
 ## Filtering on embedded fields
 

--- a/docs/guide/src/embedded-types.md
+++ b/docs/guide/src/embedded-types.md
@@ -263,7 +263,7 @@ A unit enum (all variants have no fields) maps to a single column:
 #[derive(Debug, PartialEq, toasty::Embed)]
 enum Status {
     Pending,
-    InProgress,
+    Active,
     Done,
 }
 
@@ -278,8 +278,8 @@ struct Task {
 }
 ```
 
-The `status` column stores `pending`, `in_progress`, or `done`. PostgreSQL uses
-a named enum type, MySQL uses `ENUM`, and SQLite uses `TEXT` with a check
+The `status` column stores `pending`, `active`, or `done`. PostgreSQL uses a
+named enum type, MySQL uses `ENUM`, and SQLite uses `TEXT` with a check
 constraint. DynamoDB stores the label as a string attribute.
 
 Use it like any other field:
@@ -342,7 +342,7 @@ An enum can have both unit variants and data-carrying variants:
 
 ```rust,ignore
 #[derive(Debug, PartialEq, toasty::Embed)]
-enum Status {
+enum ImportStatus {
     Pending,
     Failed { reason: String },
     Done,
@@ -464,7 +464,7 @@ let tasks = Task::filter(Task::fields().status().is_active())
     .await?;
 ```
 
-This compiles to `WHERE status = 2`.
+This filters on the stored `active` label (`WHERE status = 'active'` in SQL).
 
 For unit enums, you can also use `.eq()` directly:
 


### PR DESCRIPTION
## Summary

The guide and the `Embed` rustdoc still described embedded enums as
requiring an integer `#[column(variant = N)]` on every variant. Since
#1082 and #1083, variants default to a `snake_case` string label,
`#[column(rename_all = "...")]` selects another naming rule, and
`#[column(variant = "...")]` overrides a single label. Integer
discriminants remain supported but are now the opt-in path.

Both documents now lead with string labels, list the eight supported
`rename_all` rules, and cover the constraints: string and integer
discriminants cannot be mixed, `rename_all` applies only to string
labels, and integer discriminants must be given on every variant.
The guide also drops the hand-written `CREATE TABLE` snippets, which
claimed an `INTEGER` discriminant column and no longer matched what
Toasty emits.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

Docs only — no code changes. Worth checking that the `rename_all` rule
table matches the conversions the macro actually performs.
