### PR TITLE
fix(engine): return None for optional belongs_to with NULL foreign key

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -67,6 +67,7 @@ pub mod record_not_found;
 pub mod relation_belongs_to_configured;
 pub mod relation_belongs_to_embed_key;
 pub mod relation_belongs_to_inferred;
+pub mod relation_belongs_to_null_fk;
 pub mod relation_belongs_to_one_way;
 pub mod relation_belongs_to_self_referential;
 pub mod relation_chain;

--- a/crates/toasty-driver-integration-suite/src/tests/relation_belongs_to_null_fk.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_belongs_to_null_fk.rs
@@ -1,0 +1,34 @@
+use crate::prelude::*;
+
+#[driver_test(id(ID))]
+pub async fn optional_belongs_to_null_fk(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Post {
+        #[key]
+        #[auto]
+        id: ID,
+
+        #[index]
+        user_id: Option<ID>,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: toasty::Deferred<Option<User>>,
+    }
+
+    let mut db = test.setup_db(models!(User, Post)).await;
+
+    let orphan = toasty::create!(Post {}).exec(&mut db).await?;
+    assert_eq!(orphan.user_id, None);
+
+    // Should return `None` rather than panic in the planner.
+    assert_none!(orphan.user().exec(&mut db).await?);
+
+    Ok(())
+}

--- a/crates/toasty/src/engine/plan/statement.rs
+++ b/crates/toasty/src/engine/plan/statement.rs
@@ -191,13 +191,18 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
 
         // For single VALUES queries (e.g., batch queries), the VALUES body is
         // the output expression. Extract it as a returning value so the planner
-        // can wire up sub-statement dependencies.
+        // can wire up sub-statement dependencies. An empty VALUES body (e.g. an
+        // optional `belongs_to` whose foreign key is NULL, so simplification
+        // proved the filter false) has no output expression; leave `returning`
+        // empty so the query plans as an empty constant and produces zero
+        // rows, the same shape as any other query that matches nothing.
         if returning.is_none()
             && let stmt::Statement::Query(query) = &mut stmt
             && let stmt::ExprSet::Values(values) = &mut query.body
+            && !values.rows.is_empty()
         {
             returning = Some(stmt::Returning::Expr(if query.single {
-                assert_eq!(1, values.rows.len());
+                assert_eq!(1, values.rows.len(), "single query has more than one row");
                 values.rows.drain(..).next().unwrap()
             } else {
                 stmt::Expr::list(std::mem::take(&mut values.rows))


### PR DESCRIPTION
## Summary
Loading an optional `belongs_to` whose foreign key column is `NULL` panicked in the
planner:

    assertion `left == right` failed: left: 1, right: 0
    crates/toasty/src/engine/plan/statement.rs

Simplification proves the relation filter false (`id == NULL`) and collapses the
query body to an empty `VALUES` set, but the planner's single-query extraction
asserted exactly one row. Skip the returning-extraction when the `VALUES` body is
empty so the query plans as an empty constant and produces zero rows — the same
shape as a dangling foreign key — which the existing single-row reduction maps to
`None`.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test
- [ ] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`):
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers
N/A

Closes #1066
