### PR TITLE
feat: support schema-less JSON payload storage

### DIFF
--- a/crates/toasty-core/src/schema/builder.rs
+++ b/crates/toasty-core/src/schema/builder.rs
@@ -291,13 +291,14 @@ impl BuildSchema<'_> {
                     })
                 };
 
-                let is_document = document_embed_id(&primitive.ty).is_some();
+                let is_document =
+                    document_embed_id(&primitive.ty).is_some() || primitive.ty.is_json();
 
                 if is_document {
                     if !self.db.document_collections {
                         return Err(crate::Error::unsupported_feature(format!(
-                            "model `{model_name}` field `{}` uses `#[document]` storage, \
-                             but this backend does not yet support `#[document]` fields.",
+                            "model `{model_name}` field `{}` uses document storage, \
+                             but this backend does not support document fields.",
                             field_name()
                         )));
                     }

--- a/crates/toasty-core/src/schema/db/ty.rs
+++ b/crates/toasty-core/src/schema/db/ty.rs
@@ -215,7 +215,7 @@ impl Type {
                 // `Type::list` collapses a list-of-documents back to one
                 // document, so a `#[document]` collection (`List(Model)`) lands
                 // here as a plain `Document`.
-                stmt::Type::Model(_) => Ok(Type::Document { binary: true }),
+                stmt::Type::Model(_) | stmt::Type::Json => Ok(Type::Document { binary: true }),
                 stmt::Type::List(elem) => Ok(Type::list(Self::from_app(elem, None, db)?)),
                 _ => Err(crate::Error::unsupported_feature(format!(
                     "type {:?} is not supported by this database",
@@ -267,6 +267,7 @@ impl Type {
             // document collection (`List(Model)`, whose storage collapses to
             // one document) keeps its list shape with `Object` elements.
             (Self::Document { .. }, stmt::Type::Model(_)) => stmt::Type::Object,
+            (Self::Document { .. }, stmt::Type::Json) => stmt::Type::Json,
             (Self::Document { .. }, stmt::Type::List(elem))
                 if matches!(**elem, stmt::Type::Model(_)) =>
             {

--- a/crates/toasty-core/src/stmt/sorted_index.rs
+++ b/crates/toasty-core/src/stmt/sorted_index.rs
@@ -187,6 +187,16 @@ fn value_total_cmp(a: &Value, b: &Value) -> Ordering {
             }
             a.len().cmp(&b.len())
         }
+        (Value::Object(a), Value::Object(b)) => {
+            for ((ak, av), (bk, bv)) in a.iter().zip(b.iter()) {
+                let ord = ak.cmp(bk).then_with(|| value_total_cmp(av, bv));
+                if ord != Ordering::Equal {
+                    return ord;
+                }
+            }
+            a.entries.len().cmp(&b.entries.len())
+        }
+        (Value::Json(a), Value::Json(b)) => value_total_cmp(a, b),
 
         // Feature-gated types.
         #[cfg(feature = "rust_decimal")]
@@ -237,6 +247,7 @@ fn variant_index(v: &Value) -> u8 {
         Value::List(_) => 16,
         Value::SparseRecord(_) => 17,
         Value::Object(_) => 25,
+        Value::Json(_) => 26,
         #[cfg(feature = "rust_decimal")]
         Value::Decimal(_) => 18,
         #[cfg(feature = "bigdecimal")]

--- a/crates/toasty-core/src/stmt/ty.rs
+++ b/crates/toasty-core/src/stmt/ty.rs
@@ -134,6 +134,9 @@ pub enum Type {
     /// document lowering and raising).
     Object,
 
+    /// A schema-less JSON value stored in a native document column.
+    Json,
+
     /// A byte array, more efficient than `List(U8)`.
     Bytes,
 
@@ -257,6 +260,11 @@ impl Type {
     /// Returns `true` if this is [`Type::Object`].
     pub fn is_object(&self) -> bool {
         matches!(self, Self::Object)
+    }
+
+    /// Returns `true` if this is [`Type::Json`].
+    pub fn is_json(&self) -> bool {
+        matches!(self, Self::Json)
     }
 
     /// Returns `true` if this is [`Type::Bytes`].
@@ -398,6 +406,18 @@ impl Type {
         Ok(match (value, self) {
             // Identity
             (value @ Value::String(_), Self::String) => value,
+            (value @ Value::Json(_), Self::Json) => value,
+            (
+                value @ (Value::Null
+                | Value::Bool(_)
+                | Value::I64(_)
+                | Value::U64(_)
+                | Value::F64(_)
+                | Value::String(_)
+                | Value::List(_)
+                | Value::Object(_)),
+                Self::Json,
+            ) => Value::Json(Box::new(value)),
             // String <-> Uuid
             (Value::Uuid(value), Self::String) => Value::String(value.to_string()),
             (Value::String(value), Self::Uuid) => {
@@ -545,6 +565,8 @@ impl Type {
     fn cast_document_leaf(&self, resolve: &impl Resolve, value: Value) -> Result<Value> {
         match (self, value) {
             (Self::Model(_), value @ Value::Object(_)) => self.raise_document(resolve, value),
+            (Self::Json, value @ Value::Json(_)) => Ok(value),
+            (Self::Json, value) => Ok(Value::Json(Box::new(value))),
             (Self::List(elem), Value::List(items)) => Ok(Value::List(
                 items
                     .into_iter()

--- a/crates/toasty-core/src/stmt/value.rs
+++ b/crates/toasty-core/src/stmt/value.rs
@@ -82,6 +82,10 @@ pub enum Value {
     /// document-stored fields, and consumed structurally by drivers.
     Object(ValueObject),
 
+    /// A schema-less JSON value. The wrapper distinguishes JSON null from
+    /// database null while the inner value preserves the JSON structure.
+    Json(Box<Value>),
+
     /// A list of values of the same type
     List(Vec<Value>),
 
@@ -322,6 +326,7 @@ impl Value {
             Self::U64(_) => ty.is_u64(),
             Self::F32(_) => ty.is_f32(),
             Self::F64(_) => ty.is_f64(),
+            Self::Json(_) => ty.is_json(),
             Self::List(value) => match ty {
                 Type::List(ty) => {
                     if value.is_empty() {
@@ -440,6 +445,7 @@ impl Value {
                     .map(|(_, value)| value.infer_ty())
                     .collect(),
             ),
+            Value::Json(_) => Type::Json,
             Value::String(_) => Type::String,
             Value::List(items) if items.is_empty() => Type::list(Type::Null),
             Value::List(items) => {
@@ -563,6 +569,7 @@ impl Value {
             // which have no element type.
             Value::List(_) => DbType::from_app(&self.infer_ty(), None, storage)
                 .map_err(|err| err.context(cannot_infer()))?,
+            Value::Json(_) => DbType::Document { binary: true },
             Value::Null | Value::Record(_) | Value::Object(_) | Value::SparseRecord(_) => {
                 return Err(cannot_infer());
             }

--- a/crates/toasty-core/src/stmt/value_set.rs
+++ b/crates/toasty-core/src/stmt/value_set.rs
@@ -125,10 +125,17 @@ pub(super) fn value_eq(a: &Value, b: &Value) -> bool {
         (F32(a), F32(b)) => a.to_bits() == b.to_bits(),
         (F64(a), F64(b)) => a.to_bits() == b.to_bits(),
         (String(a), String(b)) => a == b,
+        (Json(a), Json(b)) => value_eq(a, b),
         (Bytes(a), Bytes(b)) => a == b,
         (Uuid(a), Uuid(b)) => a == b,
         (List(a), List(b)) => a.len() == b.len() && a.iter().zip(b).all(|(x, y)| value_eq(x, y)),
         (Record(a), Record(b)) => record_eq(a, b),
+        (Object(a), Object(b)) => {
+            a.entries.len() == b.entries.len()
+                && a.iter()
+                    .zip(b.iter())
+                    .all(|((ak, av), (bk, bv))| ak == bk && value_eq(av, bv))
+        }
         (SparseRecord(a), SparseRecord(b)) => sparse_record_eq(a, b),
         #[cfg(feature = "rust_decimal")]
         (Decimal(a), Decimal(b)) => a == b,
@@ -176,6 +183,7 @@ pub(super) fn hash_value<H: Hasher>(v: &Value, state: &mut H) {
         Value::F32(x) => x.to_bits().hash(state),
         Value::F64(x) => x.to_bits().hash(state),
         Value::String(x) => x.hash(state),
+        Value::Json(x) => hash_value(x, state),
         Value::Bytes(x) => x.hash(state),
         Value::Uuid(x) => x.hash(state),
         Value::List(items) => {

--- a/crates/toasty-driver-dynamodb/src/value.rs
+++ b/crates/toasty-driver-dynamodb/src/value.rs
@@ -51,6 +51,7 @@ impl Value {
                     .collect();
                 stmt::Value::List(items)
             }
+            (Type::Json, val) => stmt::Value::Json(Box::new(Self::from_ddb_any(val))),
             // A `#[document]` column stored as a Map `M`: decode
             // shape-directed to the named wire object. The engine raises it
             // to the embed's positional record — the field layout is a
@@ -131,10 +132,33 @@ impl Value {
                 AV::M(map)
             }
             stmt::Value::List(items) => AV::L(items.iter().map(Self::to_ddb_document).collect()),
+            stmt::Value::Json(value) => Self::to_ddb_json(value),
             value => match value.document_storage_text() {
                 Some(text) => AV::S(text.to_string()),
                 None => Value(value.clone()).to_ddb(),
             },
+        }
+    }
+
+    fn to_ddb_json(value: &CoreValue) -> AttributeValue {
+        use AttributeValue as AV;
+
+        match value {
+            stmt::Value::Null => AV::Null(true),
+            stmt::Value::Bool(value) => AV::Bool(*value),
+            stmt::Value::I64(value) => AV::N(value.to_string()),
+            stmt::Value::U64(value) => AV::N(value.to_string()),
+            stmt::Value::F64(value) => AV::N(value.to_string()),
+            stmt::Value::String(value) => AV::S(value.clone()),
+            stmt::Value::List(values) => AV::L(values.iter().map(Self::to_ddb_json).collect()),
+            stmt::Value::Object(object) => AV::M(
+                object
+                    .iter()
+                    .map(|(key, value)| (key.clone(), Self::to_ddb_json(value)))
+                    .collect(),
+            ),
+            stmt::Value::Json(value) => Self::to_ddb_json(value),
+            value => panic!("invalid dynamic JSON value: {value:#?}"),
         }
     }
 
@@ -168,6 +192,7 @@ impl Value {
             // encode through the document leaf encoding
             // ([`to_ddb_document`](Self::to_ddb_document)).
             value @ stmt::Value::Object(_) => Self::to_ddb_document(value),
+            stmt::Value::Json(value) => Self::to_ddb_json(value),
             stmt::Value::Null => AV::Null(true),
             // Scalars whose DynamoDB representation is their string form
             // (temporals, decimals): the same `Type::cast` conversions the

--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -107,5 +107,6 @@ pub mod type_collection;
 pub mod type_decimal;
 pub mod type_document;
 pub mod type_jiff;
+pub mod type_json_value;
 pub mod type_primitives;
 pub mod type_serialize;

--- a/crates/toasty-driver-integration-suite/src/tests/type_json_value.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/type_json_value.rs
@@ -1,0 +1,136 @@
+use crate::prelude::*;
+
+#[driver_test(requires(document_collections))]
+pub async fn create_load_and_update(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Exchange {
+        #[key]
+        id: String,
+        request: toasty::JsonValue,
+        response: Option<toasty::JsonValue>,
+    }
+
+    let mut db = test.setup_db(models!(Exchange)).await;
+    assert_struct!(
+        column_storage_ty(&db, "exchanges", "request"),
+        toasty_core::schema::db::Type::Document { binary: true }
+    );
+    let request = serde_json::json!({
+        "action": "create",
+        "arguments": { "name": "Alice" },
+    });
+
+    let mut exchange = toasty::create!(Exchange {
+        id: "request-1",
+        request: request.clone(),
+    })
+    .exec(&mut db)
+    .await?;
+
+    assert_eq!(*exchange.request, request);
+    assert_none!(exchange.response);
+
+    let response = serde_json::json!([{"id": 1}, null, true]);
+    exchange
+        .update()
+        .response(toasty::JsonValue(response.clone()))
+        .exec(&mut db)
+        .await?;
+
+    let reloaded = Exchange::get_by_id(&mut db, "request-1").await?;
+    assert_eq!(*reloaded.request, request);
+    assert_eq!(*reloaded.response.unwrap(), response);
+
+    Ok(())
+}
+
+#[driver_test(requires(document_collections))]
+pub async fn nested_in_document(test: &mut Test) -> Result<()> {
+    #[derive(Debug, PartialEq, toasty::Embed)]
+    struct Profile {
+        name: String,
+        extra: toasty::JsonValue,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        id: String,
+        #[document]
+        profile: Profile,
+    }
+
+    let mut db = test.setup_db(models!(User)).await;
+    let extra = serde_json::json!({
+        "role": "admin",
+        "features": ["audit", "replay"],
+    });
+
+    toasty::create!(User {
+        id: "user-1",
+        profile: Profile {
+            name: "Alice".into(),
+            extra: extra.clone().into(),
+        },
+    })
+    .exec(&mut db)
+    .await?;
+
+    let user = User::get_by_id(&mut db, "user-1").await?;
+    assert_eq!(user.profile.name, "Alice");
+    assert_eq!(*user.profile.extra, extra);
+
+    Ok(())
+}
+
+#[driver_test(requires(document_collections))]
+pub async fn distinguishes_json_null_from_database_null(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct ValueHolder {
+        #[key]
+        id: String,
+        value: Option<toasty::JsonValue>,
+    }
+
+    let mut db = test.setup_db(models!(ValueHolder)).await;
+
+    toasty::create!(ValueHolder::[
+        { id: "database-null" },
+        { id: "json-null", value: toasty::JsonValue::null() },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let database_null = ValueHolder::get_by_id(&mut db, "database-null").await?;
+    assert_none!(database_null.value);
+
+    let json_null = ValueHolder::get_by_id(&mut db, "json-null").await?;
+    assert_eq!(*json_null.value.unwrap(), serde_json::Value::Null);
+
+    Ok(())
+}
+
+#[driver_test(requires(document_collections))]
+pub async fn updates_json_value_to_database_null(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct ValueHolder {
+        #[key]
+        id: String,
+        value: Option<toasty::JsonValue>,
+    }
+
+    let mut db = test.setup_db(models!(ValueHolder)).await;
+    let mut holder = toasty::create!(ValueHolder {
+        id: "json-null",
+        value: toasty::JsonValue::null(),
+    })
+    .exec(&mut db)
+    .await?;
+
+    holder.update().value(None).exec(&mut db).await?;
+
+    let reloaded = ValueHolder::get_by_id(&mut db, "json-null").await?;
+    assert_none!(reloaded.value);
+
+    Ok(())
+}

--- a/crates/toasty-driver-mysql/src/value.rs
+++ b/crates/toasty-driver-mysql/src/value.rs
@@ -235,7 +235,7 @@ fn typed_mysql_value_to_core(
             // A `#[document]` column (`Type::Object`): decode the JSON object
             // shape-directed to the named `Value::Object` wire form; the
             // engine raises it to the embed's positional record.
-            stmt::Type::Object => {
+            stmt::Type::Object | stmt::Type::Json => {
                 convert_or_null(value, |bytes: Vec<u8>| json_bytes_to_value(&bytes, ty))
             }
             _ => todo!("MySQL JSON column with stmt::Type {ty:#?}"),
@@ -451,7 +451,7 @@ impl ToValue for Value {
                     toasty_sql::json::to_vec(&self.0).expect("serialize JSON list column"),
                 )
             }
-            CoreValue::Object(_) => {
+            CoreValue::Object(_) | CoreValue::Json(_) => {
                 // Bound to a MySQL `JSON` column — a bare `#[document]` embed
                 // (`Value::Object`). Serialize the named object to JSON bytes,
                 // the same way the list arm handles a document collection.

--- a/crates/toasty-driver-sqlite/src/value.rs
+++ b/crates/toasty-driver-sqlite/src/value.rs
@@ -48,7 +48,7 @@ impl Value {
                 // A bare `#[document]` column (`Type::Object`) decodes
                 // shape-directed to the named `Value::Object` wire form; the
                 // engine raises it to the embed's positional record.
-                stmt::Type::Object => json_text_to_value(&value, ty),
+                stmt::Type::Object | stmt::Type::Json => json_text_to_value(&value, ty),
                 _ => stmt::Value::String(value),
             },
             Some(SqlValue::Blob(value)) => match ty {
@@ -98,9 +98,9 @@ impl ToSql for Value {
             Value::Null => Ok(ToSqlOutput::Owned(SqlValue::Null)),
             // A `Vec<scalar>` / document collection (`List`) or a bare
             // `#[document]` embed (`Object`) is stored as JSON text.
-            Value::List(_) | Value::Object(_) => Ok(ToSqlOutput::Owned(SqlValue::Text(
-                value_to_json_text(&self.0),
-            ))),
+            Value::List(_) | Value::Object(_) | Value::Json(_) => Ok(ToSqlOutput::Owned(
+                SqlValue::Text(value_to_json_text(&self.0)),
+            )),
             _ => todo!("value = {:#?}", self.0),
         }
     }

--- a/crates/toasty-driver-turso/src/value.rs
+++ b/crates/toasty-driver-turso/src/value.rs
@@ -32,7 +32,9 @@ pub(crate) fn to_turso(value: &CoreValue) -> TursoValue {
         CoreValue::Null => TursoValue::Null,
         // A `Vec<scalar>` / document collection (`List`) or a bare
         // `#[document]` embed (`Object`) is stored as JSON text.
-        CoreValue::List(_) | CoreValue::Object(_) => TursoValue::Text(value_to_json_text(value)),
+        CoreValue::List(_) | CoreValue::Object(_) | CoreValue::Json(_) => {
+            TursoValue::Text(value_to_json_text(value))
+        }
         _ => todo!("to_turso: value = {value:#?}"),
     }
 }
@@ -65,7 +67,7 @@ pub(crate) fn from_turso(value: TursoValue, ty: &stmt::Type) -> CoreValue {
             // A bare `#[document]` column (`Type::Object`) decodes
             // shape-directed to the named `Value::Object` wire form; the
             // engine raises it to the embed's positional record.
-            stmt::Type::Object => json_text_to_value(&v, ty),
+            stmt::Type::Object | stmt::Type::Json => json_text_to_value(&v, ty),
             _ => CoreValue::String(v),
         },
         TursoValue::Blob(v) => match ty {

--- a/crates/toasty-sql/src/json.rs
+++ b/crates/toasty-sql/src/json.rs
@@ -83,6 +83,7 @@ impl Serialize for Encode<'_> {
                 }
                 map.end()
             }
+            Value::Json(value) => EncodeJson(value).serialize(s),
             // Decimals and jiff temporal scalars store the shared document
             // text form ([`Value::document_storage_text`]): decimals as their
             // `Display` form, temporals as ISO 8601 / RFC 3339 text truncated
@@ -118,6 +119,42 @@ impl Serialize for Encode<'_> {
     }
 }
 
+/// JSON values preserve explicit null object members, unlike typed document
+/// objects where `Value::Null` represents an omitted `Option` field.
+struct EncodeJson<'a>(&'a Value);
+
+impl Serialize for EncodeJson<'_> {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        match self.0 {
+            Value::Null => s.serialize_unit(),
+            Value::Bool(v) => s.serialize_bool(*v),
+            Value::I64(v) => s.serialize_i64(*v),
+            Value::U64(v) => s.serialize_u64(*v),
+            Value::F64(v) if v.is_finite() => s.serialize_f64(*v),
+            Value::F64(_) => Err(S::Error::custom("non-finite JSON number")),
+            Value::String(v) => s.serialize_str(v),
+            Value::List(items) => {
+                let mut seq = s.serialize_seq(Some(items.len()))?;
+                for item in items {
+                    seq.serialize_element(&EncodeJson(item))?;
+                }
+                seq.end()
+            }
+            Value::Object(object) => {
+                let mut map = s.serialize_map(Some(object.entries.len()))?;
+                for (key, value) in object.iter() {
+                    map.serialize_entry(key, &EncodeJson(value))?;
+                }
+                map.end()
+            }
+            Value::Json(value) => EncodeJson(value).serialize(s),
+            other => Err(S::Error::custom(format!(
+                "cannot encode {other:?} as a dynamic JSON value"
+            ))),
+        }
+    }
+}
+
 /// Encode a `stmt::Value` as a JSON string.
 pub fn to_string(value: &Value) -> Result<String, serde_json::Error> {
     serde_json::to_string(&Encode(value))
@@ -147,6 +184,10 @@ impl<'de> DeserializeSeed<'de> for Seed<'_> {
     type Value = Value;
 
     fn deserialize<D: Deserializer<'de>>(self, de: D) -> Result<Value, D::Error> {
+        if matches!(self.ty, stmt::Type::Json) {
+            return de.deserialize_any(AnyVisitor { wrap_json: true });
+        }
+
         // JSON is self-describing, so `deserialize_any` lets the parser drive
         // the visit method by token; each method coerces using `self.ty`.
         de.deserialize_any(ValueVisitor { ty: self.ty })
@@ -169,11 +210,23 @@ impl<'de> DeserializeSeed<'de> for AnySeed {
     type Value = Value;
 
     fn deserialize<D: Deserializer<'de>>(self, de: D) -> Result<Value, D::Error> {
-        de.deserialize_any(AnyVisitor)
+        de.deserialize_any(AnyVisitor { wrap_json: false })
     }
 }
 
-struct AnyVisitor;
+struct AnyVisitor {
+    wrap_json: bool,
+}
+
+impl AnyVisitor {
+    fn wrap(&self, value: Value) -> Value {
+        if self.wrap_json {
+            Value::Json(Box::new(value))
+        } else {
+            value
+        }
+    }
+}
 
 impl<'de> Visitor<'de> for AnyVisitor {
     type Value = Value;
@@ -183,32 +236,32 @@ impl<'de> Visitor<'de> for AnyVisitor {
     }
 
     fn visit_unit<E: serde::de::Error>(self) -> Result<Value, E> {
-        Ok(Value::Null)
+        Ok(self.wrap(Value::Null))
     }
 
     fn visit_bool<E: serde::de::Error>(self, v: bool) -> Result<Value, E> {
-        Ok(Value::Bool(v))
+        Ok(self.wrap(Value::Bool(v)))
     }
 
     fn visit_i64<E: serde::de::Error>(self, v: i64) -> Result<Value, E> {
-        Ok(Value::I64(v))
+        Ok(self.wrap(Value::I64(v)))
     }
 
     fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Value, E> {
         // Integer fit: values representable as `i64` decode to `I64` so the
         // same stored number always has the same wire shape.
-        Ok(match i64::try_from(v) {
+        Ok(self.wrap(match i64::try_from(v) {
             Ok(v) => Value::I64(v),
             Err(_) => Value::U64(v),
-        })
+        }))
     }
 
     fn visit_f64<E: serde::de::Error>(self, v: f64) -> Result<Value, E> {
-        Ok(Value::F64(v))
+        Ok(self.wrap(Value::F64(v)))
     }
 
     fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Value, E> {
-        Ok(Value::String(v.to_owned()))
+        Ok(self.wrap(Value::String(v.to_owned())))
     }
 
     fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Value, A::Error> {
@@ -216,7 +269,7 @@ impl<'de> Visitor<'de> for AnyVisitor {
         while let Some(value) = seq.next_element_seed(AnySeed)? {
             items.push(value);
         }
-        Ok(Value::List(items))
+        Ok(self.wrap(Value::List(items)))
     }
 
     fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Value, A::Error> {
@@ -224,7 +277,7 @@ impl<'de> Visitor<'de> for AnyVisitor {
         while let Some(key) = map.next_key::<String>()? {
             entries.push((key, map.next_value_seed(AnySeed)?));
         }
-        Ok(Value::Object(stmt::ValueObject::from_vec(entries)))
+        Ok(self.wrap(Value::Object(stmt::ValueObject::from_vec(entries))))
     }
 }
 
@@ -307,7 +360,7 @@ impl<'de> Visitor<'de> for ValueVisitor<'_> {
         // raises the result to the embed's positional record — the field
         // layout is a model-level concept this codec does not know.
         match self.ty {
-            stmt::Type::Object => AnyVisitor.visit_map(map),
+            stmt::Type::Object => AnyVisitor { wrap_json: false }.visit_map(map),
             other => Err(A::Error::custom(format!(
                 "unexpected JSON object for type {other:?}"
             ))),

--- a/crates/toasty/src/lib.rs
+++ b/crates/toasty/src/lib.rs
@@ -138,9 +138,9 @@ pub use schema::Deferred;
 
 /// Typed statement, expression, and query builder types.
 pub mod stmt;
-#[cfg(feature = "serde")]
-pub use stmt::Json;
 pub use stmt::Statement;
+#[cfg(feature = "serde")]
+pub use stmt::{Json, JsonValue};
 
 /// Raw SQL execution helpers.
 pub mod sql;

--- a/crates/toasty/src/stmt.rs
+++ b/crates/toasty/src/stmt.rs
@@ -39,6 +39,11 @@ mod json;
 #[cfg(feature = "serde")]
 pub use json::Json;
 
+#[cfg(feature = "serde")]
+mod json_value;
+#[cfg(feature = "serde")]
+pub use json_value::JsonValue;
+
 mod list;
 pub use list::List;
 

--- a/crates/toasty/src/stmt/json_value.rs
+++ b/crates/toasty/src/stmt/json_value.rs
@@ -1,0 +1,219 @@
+use crate::schema::{Field, Load};
+use toasty_core::{schema::db, stmt};
+
+use super::{Expr, IntoExpr, List, Path};
+
+/// A schema-less JSON value stored in a database-native document column.
+///
+/// Unlike [`Json<T>`](super::Json), `JsonValue` is not encoded as an opaque
+/// string. PostgreSQL stores it as `jsonb`, MySQL as `JSON`, SQLite and Turso
+/// as JSON text, and DynamoDB as native document attributes.
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct JsonValue(pub serde_json::Value);
+
+impl JsonValue {
+    /// Returns a JSON null value.
+    pub const fn null() -> Self {
+        Self(serde_json::Value::Null)
+    }
+}
+
+impl From<serde_json::Value> for JsonValue {
+    fn from(value: serde_json::Value) -> Self {
+        Self(value)
+    }
+}
+
+impl From<JsonValue> for serde_json::Value {
+    fn from(value: JsonValue) -> Self {
+        value.0
+    }
+}
+
+impl std::ops::Deref for JsonValue {
+    type Target = serde_json::Value;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for JsonValue {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl AsRef<serde_json::Value> for JsonValue {
+    fn as_ref(&self) -> &serde_json::Value {
+        &self.0
+    }
+}
+
+impl AsMut<serde_json::Value> for JsonValue {
+    fn as_mut(&mut self) -> &mut serde_json::Value {
+        &mut self.0
+    }
+}
+
+impl serde_core::Serialize for JsonValue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde_core::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> serde_core::Deserialize<'de> for JsonValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde_core::Deserializer<'de>,
+    {
+        serde_json::Value::deserialize(deserializer).map(Self)
+    }
+}
+
+impl Load for JsonValue {
+    type Output = Self;
+
+    fn ty() -> stmt::Type {
+        stmt::Type::Json
+    }
+
+    fn load(value: stmt::Value) -> crate::Result<Self> {
+        let stmt::Value::Json(value) = value else {
+            return Err(toasty_core::Error::type_conversion(value, "JsonValue"));
+        };
+
+        Ok(Self(value_from_stmt(*value)?))
+    }
+
+    fn reload(target: &mut Self, value: stmt::Value) -> crate::Result<()> {
+        *target = Self::load(value)?;
+        Ok(())
+    }
+}
+
+impl Field for JsonValue {
+    type ExprTarget = Self;
+    type Path<Origin> = Path<Origin, Self>;
+    type ListPath<Origin> = Path<Origin, List<Self>>;
+    type Update<'a> = ();
+    type Inner = Self;
+
+    fn new_path<Origin>(path: Path<Origin, Self>) -> Self::Path<Origin> {
+        path
+    }
+
+    fn new_list_path<Origin>(path: Path<Origin, List<Self>>) -> Self::ListPath<Origin> {
+        path
+    }
+
+    fn new_update<'a>(
+        _assignments: &'a mut stmt::Assignments,
+        _projection: stmt::Projection,
+    ) -> Self::Update<'a> {
+    }
+
+    fn field_ty(storage_ty: Option<db::Type>) -> toasty_core::schema::app::FieldTy {
+        toasty_core::schema::app::FieldTy::Primitive(toasty_core::schema::app::FieldPrimitive {
+            ty: stmt::Type::Json,
+            storage_ty,
+            serialize: None,
+        })
+    }
+
+    fn key_constraint<Origin>(&self, _target: Path<Origin, Self>) -> Expr<bool> {
+        unreachable!("JsonValue fields cannot be used as foreign-key targets")
+    }
+}
+
+impl IntoExpr<JsonValue> for JsonValue {
+    fn into_expr(self) -> Expr<JsonValue> {
+        Expr::from_value(stmt::Value::Json(Box::new(value_into_stmt(self.0))))
+    }
+
+    fn by_ref(&self) -> Expr<JsonValue> {
+        Expr::from_value(stmt::Value::Json(Box::new(value_into_stmt(self.0.clone()))))
+    }
+}
+
+impl IntoExpr<JsonValue> for serde_json::Value {
+    fn into_expr(self) -> Expr<JsonValue> {
+        JsonValue(self).into_expr()
+    }
+
+    fn by_ref(&self) -> Expr<JsonValue> {
+        JsonValue(self.clone()).into_expr()
+    }
+}
+
+impl super::assignment::Assign<JsonValue> for JsonValue {
+    fn into_assignment(self) -> super::assignment::Assignment<JsonValue> {
+        super::set(self.into_expr())
+    }
+}
+
+impl super::assignment::Assign<JsonValue> for serde_json::Value {
+    fn into_assignment(self) -> super::assignment::Assignment<JsonValue> {
+        super::set(self.into_expr())
+    }
+}
+
+fn value_into_stmt(value: serde_json::Value) -> stmt::Value {
+    match value {
+        serde_json::Value::Null => stmt::Value::Null,
+        serde_json::Value::Bool(value) => stmt::Value::Bool(value),
+        serde_json::Value::Number(value) => {
+            if let Some(value) = value.as_i64() {
+                stmt::Value::I64(value)
+            } else if let Some(value) = value.as_u64() {
+                stmt::Value::U64(value)
+            } else {
+                stmt::Value::F64(value.as_f64().expect("JSON number is representable as f64"))
+            }
+        }
+        serde_json::Value::String(value) => stmt::Value::String(value),
+        serde_json::Value::Array(values) => {
+            stmt::Value::List(values.into_iter().map(value_into_stmt).collect())
+        }
+        serde_json::Value::Object(values) => stmt::Value::Object(stmt::ValueObject::from_vec(
+            values
+                .into_iter()
+                .map(|(key, value)| (key, value_into_stmt(value)))
+                .collect(),
+        )),
+    }
+}
+
+fn value_from_stmt(value: stmt::Value) -> crate::Result<serde_json::Value> {
+    Ok(match value {
+        stmt::Value::Null => serde_json::Value::Null,
+        stmt::Value::Bool(value) => serde_json::Value::Bool(value),
+        stmt::Value::I64(value) => serde_json::Value::Number(value.into()),
+        stmt::Value::U64(value) => serde_json::Value::Number(value.into()),
+        stmt::Value::F64(value) => serde_json::Number::from_f64(value)
+            .map(serde_json::Value::Number)
+            .ok_or_else(|| {
+                toasty_core::Error::from_args(format_args!(
+                    "cannot load non-finite number as JsonValue"
+                ))
+            })?,
+        stmt::Value::String(value) => serde_json::Value::String(value),
+        stmt::Value::List(values) => serde_json::Value::Array(
+            values
+                .into_iter()
+                .map(value_from_stmt)
+                .collect::<crate::Result<_>>()?,
+        ),
+        stmt::Value::Object(value) => serde_json::Value::Object(
+            value
+                .entries
+                .into_iter()
+                .map(|(key, value)| Ok((key, value_from_stmt(value)?)))
+                .collect::<crate::Result<_>>()?,
+        ),
+        value => return Err(toasty_core::Error::type_conversion(value, "JsonValue")),
+    })
+}

--- a/crates/toasty/tests/json_value.rs
+++ b/crates/toasty/tests/json_value.rs
@@ -1,0 +1,16 @@
+#![cfg(feature = "serde")]
+
+#[test]
+fn serde_round_trip() {
+    let value = toasty::JsonValue(serde_json::json!({
+        "request": {
+            "method": "POST",
+            "body": [1, null, true],
+        },
+    }));
+
+    let encoded = serde_json::to_string(&value).unwrap();
+    let decoded: toasty::JsonValue = serde_json::from_str(&encoded).unwrap();
+
+    assert_eq!(decoded, value);
+}

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -30,6 +30,7 @@ Guide-level design documents for specific features. Use
 - [DynamoDB Scan Support](./design/ddb-scan.md)
 - [Document and Collection Fields](./design/document-fields.md)
 - [Enums and Embedded Structs](./design/enums-and-embedded-structs.md)
+- [Native JSON Values](./design/native-json-values.md)
 - [Optimistic Concurrency with `#[version]`](./design/field-version.md)
 - [`query!` Macro](./design/query-macro.md)
 - [Static Assertions for `create!` Required Fields](./design/static-assertions-create-macro.md)

--- a/docs/dev/design/native-json-values.md
+++ b/docs/dev/design/native-json-values.md
@@ -54,6 +54,10 @@ let exchange = toasty::create!(Exchange {
 assert_eq!(exchange.request_body["action"], "create");
 ```
 
+`JsonValue` implements `serde::Serialize` and `serde::Deserialize`
+transparently. Serializing the wrapper produces the inner JSON value without
+an extra object or string layer.
+
 An embed can contain a dynamic JSON field. When the embed is column-expanded,
 the JSON field gets its own document column:
 

--- a/docs/dev/design/native-json-values.md
+++ b/docs/dev/design/native-json-values.md
@@ -1,0 +1,182 @@
+# Native JSON Values
+
+## Summary
+
+Toasty adds `JsonValue`, a field type for storing arbitrary
+`serde_json::Value` data in a database-native document column. Use it for
+values whose fields are not known when the model is defined, such as HTTP
+request and response bodies. `JsonValue` supports whole-value create, load,
+and update operations without adding dynamic path queries.
+
+## Motivation
+
+`Json<T>` stores a serde value through Toasty's string field type. This works
+for opaque application data, but it does not request a native document column
+from the driver. `#[document]` uses a native document column, but requires a
+`#[derive(Embed)]` struct whose fields are known at compile time.
+
+Applications that record third-party payloads often know neither the keys nor
+the nesting in advance. They need to preserve JSON objects, arrays, scalars,
+and null values without defining an embed type for each payload format.
+
+## User-facing API
+
+Enable Toasty's `serde` feature, then use `toasty::JsonValue` as a model or
+embedded-struct field:
+
+```rust
+#[derive(toasty::Model)]
+struct Exchange {
+    #[key]
+    #[auto]
+    id: uuid::Uuid,
+
+    request_body: toasty::JsonValue,
+    response_body: Option<toasty::JsonValue>,
+}
+```
+
+`JsonValue` wraps `serde_json::Value`. Constructors and setters accept either
+the wrapper or a bare `serde_json::Value`:
+
+```rust
+let request = serde_json::json!({
+    "action": "create",
+    "arguments": { "name": "Alice" }
+});
+
+let exchange = toasty::create!(Exchange {
+    request_body: request,
+})
+.exec(&mut db)
+.await?;
+
+assert_eq!(exchange.request_body["action"], "create");
+```
+
+An embed can contain a dynamic JSON field. When the embed is column-expanded,
+the JSON field gets its own document column:
+
+```rust
+#[derive(toasty::Embed)]
+struct Profile {
+    name: String,
+    extra: toasty::JsonValue,
+}
+```
+
+When the embed itself uses `#[document]`, the JSON value remains nested JSON
+instead of becoming an escaped JSON string:
+
+```rust
+#[derive(toasty::Model)]
+struct User {
+    #[key]
+    id: u64,
+
+    #[document]
+    profile: Profile,
+}
+```
+
+For the value `json!({"role": "admin"})`, the stored document contains:
+
+```json
+{
+  "name": "Alice",
+  "extra": { "role": "admin" }
+}
+```
+
+Use `Json<T>` when the database should treat a serde-encoded value as an
+opaque string. Use `JsonValue` when the database should store the value as a
+native JSON document.
+
+## Behavior
+
+`JsonValue` preserves the JSON data model: objects, arrays, strings, numbers,
+booleans, and JSON null round-trip through every supported driver. Create and
+update operations replace the complete JSON value. Loading returns the
+corresponding `serde_json::Value` through the wrapper.
+
+`JsonValue(serde_json::Value::Null)` stores JSON null. For an
+`Option<JsonValue>` field, `None` stores database null and `Some(JsonValue(
+serde_json::Value::Null))` stores JSON null. Drivers must preserve this
+distinction.
+
+Malformed JSON returned by a database produces a Toasty error. JSON numbers
+that cannot be represented by `serde_json::Number` also produce an error
+instead of truncating or wrapping.
+
+`JsonValue` supports whole-value equality only if Toasty later defines
+portable equality semantics. The initial API does not generate filter methods,
+foreign-key support, collection operators, or update helpers for JSON paths.
+
+## Edge cases
+
+JSON object key order is not part of the contract. PostgreSQL `jsonb` and
+DynamoDB maps may reorder keys. Applications that need byte-for-byte request
+replay must store the original body separately as `String` or `Vec<u8>`.
+
+`serde_json::Value` rejects non-finite floating-point values, so NaN and
+infinity cannot reach `JsonValue`. Large integer handling follows
+`serde_json::Number`.
+
+The empty object, empty array, and JSON null are values, not database null.
+`Option<JsonValue>` is the only nullable form.
+
+Schema migrations treat `JsonValue` as one document column. Changing keys or
+nested values does not produce a schema migration.
+
+## Driver integration
+
+Drivers store `JsonValue` in the same native document representation used for
+`#[document]` fields:
+
+| Driver | Storage |
+|---|---|
+| PostgreSQL | `jsonb` |
+| MySQL | `JSON` |
+| SQLite and Turso | JSON text |
+| DynamoDB | Native map, list, scalar, or null attribute |
+
+Drivers decode the complete value without consulting an application schema.
+SQL drivers receive a document-typed bind value. DynamoDB converts recursively
+between JSON values and `AttributeValue` variants.
+
+The existing document-storage capability gates `JsonValue`; no new operation
+variant is required. Out-of-tree drivers that already support document columns
+must accept dynamic JSON values. Drivers without document support reject the
+schema during database setup.
+
+## Alternatives considered
+
+Changing `Json<T>` to use native document storage would alter existing schemas
+and migrations. `Json<T>` remains an opaque serde-to-string wrapper.
+
+Implementing `Field` directly for `serde_json::Value` would make a third-party
+type part of Toasty's model API and leave no wrapper for future behavior or
+metadata. `JsonValue` makes the storage contract explicit and provides room
+for later path APIs.
+
+Using `#[document]` on `serde_json::Value` would conflate typed embeds with
+dynamic documents. `#[document]` continues to describe the storage of a known
+embed type.
+
+Storing request bodies only as `Vec<u8>` preserves exact bytes but prevents
+drivers from using native JSON validation and storage. Applications may keep
+both forms when they need structured storage and exact replay.
+
+## Open questions
+
+There are no blocking questions for whole-value storage. The syntax and
+semantics of dynamic JSON paths are deferred.
+
+## Out of scope
+
+- Dynamic path filters and projections require a separate typed conversion API.
+- Partial JSON updates require backend-specific path mutation support.
+- JSON indexes require explicit backend capabilities and index configuration.
+- Exact source-text preservation belongs to `String` or `Vec<u8>` fields.
+- Automatic migration from `Json<serde_json::Value>` to `JsonValue` is
+  database-specific.

--- a/docs/dev/roadmap.md
+++ b/docs/dev/roadmap.md
@@ -25,7 +25,7 @@ the entry lands here.
 - `BelongsTo` fields in embedded structs ([#670])
 - Native PostgreSQL enum types ([#641])
 - Migrations for enum representation changes ([#724])
-- Serde-serialized fields (JSON/JSONB for arbitrary Rust types) ([design](design/serialize-fields.md), [#672])
+- Native JSON values for schema-less payloads ([design](design/native-json-values.md), [#672])
 - Document and collection fields — `Vec`, `HashSet`, `HashMap`, with backend-chosen storage and a `#[document]` override ([design](design/document-fields.md))
 - Foreign key constraints ([#366])
 - Server-side check constraints ([#644])

--- a/docs/guide/src/field-options.md
+++ b/docs/guide/src/field-options.md
@@ -462,6 +462,67 @@ labels: toasty::Json<Option<Vec<String>>>,
 see a `NULL` for missing values. Use `Json<Option<T>>` when callers
 expect the column to always contain valid JSON.
 
+### Native dynamic JSON
+
+Use `toasty::JsonValue` for JSON whose fields are not known when the model is
+defined. Unlike `Json<T>`, `JsonValue` uses the database's native document
+storage: `jsonb` on PostgreSQL, `JSON` on MySQL, JSON text on SQLite and
+Turso, and native document attributes on DynamoDB.
+
+```rust
+# use toasty::Model;
+#[derive(Debug, toasty::Model)]
+struct Exchange {
+    #[key]
+    id: String,
+
+    request_body: toasty::JsonValue,
+    response_body: Option<toasty::JsonValue>,
+}
+```
+
+Set the field with either `JsonValue` or a bare `serde_json::Value`:
+
+```rust
+# use toasty::Model;
+# #[derive(Debug, toasty::Model)]
+# struct Exchange {
+#     #[key]
+#     id: String,
+#     request_body: toasty::JsonValue,
+#     response_body: Option<toasty::JsonValue>,
+# }
+# async fn __example(mut db: toasty::Db) -> toasty::Result<()> {
+let request = serde_json::json!({
+    "action": "create",
+    "arguments": { "name": "Alice" },
+});
+
+let exchange = toasty::create!(Exchange {
+    id: "request-1",
+    request_body: request,
+})
+.exec(&mut db)
+.await?;
+
+assert_eq!(exchange.request_body["action"], "create");
+# Ok(())
+# }
+```
+
+`JsonValue` implements `serde::Serialize` and `serde::Deserialize`
+transparently, so serializing a model field produces the inner JSON value
+without an extra wrapper or string layer.
+
+`JsonValue::null()` stores JSON null. `Option<JsonValue>::None` stores database
+null, so the two cases remain distinct. Updates replace the complete JSON
+value. Toasty does not currently expose filters or partial updates for paths
+inside `JsonValue`.
+
+An embedded struct can contain `JsonValue`. If the embed is itself stored with
+`#[document]`, the dynamic value remains nested JSON rather than an escaped
+JSON string.
+
 ## Scalar arrays
 
 A `Vec<T>` field where `T` is a scalar type stores a homogeneous,

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -26,6 +26,7 @@ rust_decimal.workspace = true
 bigdecimal.workspace = true
 hashbrown.workspace = true
 jiff.workspace = true
+serde_json.workspace = true
 toasty = { workspace = true, features = ["rust_decimal", "bigdecimal", "jiff"] }
 toasty-core.workspace = true
 toasty-macros.workspace = true

--- a/tests/tests/ui/relation_has_one_requires_attr.stderr
+++ b/tests/tests/ui/relation_has_one_requires_attr.stderr
@@ -15,11 +15,11 @@ help: the trait `toasty::schema::Field` is not implemented for `Profile`
              Arc<T>
              Box<T>
              Deferred<T>
+             JsonValue
              Option<T>
              Rc<T>
              Vec<T>
              Vec<bigdecimal::BigDecimal>
-             Vec<bool>
            and $N others
    = note: required for `Option<Profile>` to implement `toasty::schema::Field`
    = note: 1 redundant requirement hidden
@@ -42,11 +42,11 @@ help: the trait `toasty::schema::Field` is not implemented for `Profile`
              Arc<T>
              Box<T>
              Deferred<T>
+             JsonValue
              Option<T>
              Rc<T>
              Vec<T>
              Vec<bigdecimal::BigDecimal>
-             Vec<bool>
            and $N others
    = note: required for `Option<Profile>` to implement `toasty::schema::Field`
    = note: this error originates in the derive macro `toasty::Model` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -84,11 +84,11 @@ help: the trait `toasty::schema::Field` is not implemented for `Profile`
              Arc<T>
              Box<T>
              Deferred<T>
+             JsonValue
              Option<T>
              Rc<T>
              Vec<T>
              Vec<bigdecimal::BigDecimal>
-             Vec<bool>
            and $N others
    = note: required for `Option<Profile>` to implement `toasty::schema::Field`
    = note: 1 redundant requirement hidden
@@ -111,11 +111,11 @@ help: the trait `toasty::schema::Field` is not implemented for `Profile`
              Arc<T>
              Box<T>
              Deferred<T>
+             JsonValue
              Option<T>
              Rc<T>
              Vec<T>
              Vec<bigdecimal::BigDecimal>
-             Vec<bool>
            and $N others
    = note: required for `Option<Profile>` to implement `toasty::schema::Field`
 


### PR DESCRIPTION
## Summary

- Add `toasty::JsonValue` for schema-less JSON payloads stored in native document columns.
- Preserve objects, arrays, scalars, explicit JSON null, and transparent serde conversion.
- Keep the existing string-backed `Json<T>` behavior unchanged and defer JSON path operations.

Closes #672

## Type of change

- [x] Other: adds the roadmap entry, design document, implementation, and tests in one PR.

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API -> a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior -> the design doc covers it

## Notes for reviewers

Please focus on the `Value::Json` marker that distinguishes database NULL from JSON null and on the cross-driver document encoding. PostgreSQL `jsonb` and MySQL `JSON` behavior were verified against local database instances. SQLite and Turso runtime integration tests pass, as does the full workspace suite. DynamoDB compiles and passes Clippy but was not run against a live service.