### PR TITLE
fix: support any() on many-to-many relations

### DIFF
--- a/crates/toasty-core/src/schema/app/relation/via.rs
+++ b/crates/toasty-core/src/schema/app/relation/via.rs
@@ -22,6 +22,12 @@ use crate::{
 /// [`terminal`](Self::terminal) holds the terminal field's index on
 /// [`target`](Self::target) (the model the relation chain reaches), and
 /// [`path`](Self::path) still includes that terminal step as its last element.
+///
+/// A common model-terminal use is many-to-many traversal through a join model.
+/// If `User` has many `Membership` records and each membership belongs to a
+/// `Group`, `#[has_many(via = memberships.group)]` exposes the distinct groups
+/// reachable from a user. The join model owns the foreign keys and any fields
+/// that describe the connection.
 #[derive(Debug, Clone)]
 pub struct Via {
     /// The [`ModelId`] of the model the relation chain reaches. For a relation

--- a/crates/toasty-driver-integration-suite/src/scenarios.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios.rs
@@ -35,6 +35,7 @@ pub mod two_models_unique_title;
 pub mod user_account_subscription;
 pub mod user_comment_article;
 pub mod user_contact_info;
+pub mod user_group_membership;
 pub mod user_name_email;
 pub mod user_org_project_todo;
 pub mod user_post_comment;

--- a/crates/toasty-driver-integration-suite/src/scenarios/user_group_membership.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios/user_group_membership.rs
@@ -1,0 +1,110 @@
+use crate::prelude::*;
+
+scenario! {
+    //! A bidirectional many-to-many relation implemented with a join model.
+    //!
+    //! `User::groups` traverses `Membership::group`, while `Group::users`
+    //! traverses the same rows through `Membership::user`. The composite key
+    //! permits only one membership for each user-group pair. `role` represents
+    //! data stored on the relation itself.
+
+    #![id(ID)]
+
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+
+        name: String,
+
+        #[has_many]
+        memberships: toasty::Deferred<Vec<Membership>>,
+
+        #[has_many(via = memberships.group)]
+        groups: toasty::Deferred<Vec<Group>>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Group {
+        #[key]
+        #[auto]
+        id: ID,
+
+        name: String,
+
+        #[has_many]
+        memberships: toasty::Deferred<Vec<Membership>>,
+
+        #[has_many(via = memberships.user)]
+        users: toasty::Deferred<Vec<User>>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    #[key(user_id, group_id)]
+    struct Membership {
+        #[index]
+        user_id: ID,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: toasty::Deferred<User>,
+
+        #[index]
+        group_id: ID,
+
+        #[belongs_to(key = group_id, references = id)]
+        group: toasty::Deferred<Group>,
+
+        role: String,
+    }
+
+    struct Fixture {
+        alice: User,
+        carol: User,
+        rust: Group,
+        empty: Group,
+    }
+
+    async fn setup(test: &mut Test) -> toasty::Db {
+        test.setup_db(models!(User, Group, Membership)).await
+    }
+
+    async fn seed(db: &mut toasty::Db) -> Result<Fixture> {
+        let mut users = toasty::create!(User::[
+            { name: "Alice" },
+            { name: "Bob" },
+            { name: "Carol" },
+        ])
+        .exec(&mut *db)
+        .await?;
+        let alice = users.remove(0);
+        let bob = users.remove(0);
+        let carol = users.remove(0);
+
+        let mut groups = toasty::create!(Group::[
+            { name: "Rust" },
+            { name: "Databases" },
+            { name: "Empty" },
+        ])
+        .exec(&mut *db)
+        .await?;
+        let rust = groups.remove(0);
+        let databases = groups.remove(0);
+        let empty = groups.remove(0);
+
+        toasty::create!(Membership::[
+            { user: &alice, group: &rust,      role: "owner"  },
+            { user: &alice, group: &databases, role: "member" },
+            { user: &bob,   group: &rust,      role: "member" },
+        ])
+        .exec(&mut *db)
+        .await?;
+
+        Ok(Fixture {
+            alice,
+            carol,
+            rust,
+            empty,
+        })
+    }
+}

--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -90,6 +90,7 @@ pub mod relation_has_many_same_target;
 pub mod relation_has_many_scoped_query;
 pub mod relation_has_many_via;
 pub mod relation_has_one_crud;
+pub mod relation_many_to_many;
 pub mod relation_preload;
 pub mod relation_via_mutation_runtime_error;
 pub mod scan_no_index;

--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_via.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_via.rs
@@ -119,6 +119,75 @@ pub async fn via_relation_query_can_be_filtered(test: &mut Test) -> Result<()> {
     Ok(())
 }
 
+/// `.any()` on a `via` field filters parent records through the expanded
+/// relation path. The same predicate works when the path contains another
+/// `via` field.
+#[driver_test(
+    id(ID),
+    requires(sql),
+    scenario(crate::scenarios::user_org_project_todo)
+)]
+pub async fn filter_parent_by_via_any(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let users = toasty::create!(User::[{ name: "Alice" }, { name: "Bob" }])
+        .exec(&mut db)
+        .await?;
+    let alice_org = toasty::create!(Organization {
+        name: "Alice Org",
+        user: &users[0]
+    })
+    .exec(&mut db)
+    .await?;
+    let bob_org = toasty::create!(Organization {
+        name: "Bob Org",
+        user: &users[1]
+    })
+    .exec(&mut db)
+    .await?;
+    let alice_project = toasty::create!(Project {
+        name: "Alice Project",
+        organization: &alice_org
+    })
+    .exec(&mut db)
+    .await?;
+    let bob_project = toasty::create!(Project {
+        name: "Bob Project",
+        organization: &bob_org
+    })
+    .exec(&mut db)
+    .await?;
+
+    toasty::create!(Todo::[
+        { title: "match", project: &alice_project },
+        { title: "other", project: &bob_project },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let users: Vec<User> = User::filter(
+        User::fields()
+            .todos()
+            .any(Todo::fields().title().eq("match")),
+    )
+    .exec(&mut db)
+    .await?;
+    assert_eq!(users.len(), 1);
+    assert_eq!(users[0].name, "Alice");
+
+    let users: Vec<User> = User::filter(
+        User::fields()
+            .nested_todos()
+            .any(Todo::fields().title().eq("match")),
+    )
+    .exec(&mut db)
+    .await?;
+    assert_eq!(users.len(), 1);
+    assert_eq!(users[0].name, "Alice");
+
+    Ok(())
+}
+
 // ===== `.include()` / `.select()` of multi-step `via` relations =====
 //
 // The scenarios below cover via paths of different lengths and shapes:

--- a/crates/toasty-driver-integration-suite/src/tests/relation_many_to_many.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_many_to_many.rs
@@ -1,0 +1,312 @@
+//! Many-to-many relations use a join model with a `has_many` relation on each
+//! endpoint and a `has_many(via = ...)` relation for direct traversal.
+
+use crate::prelude::*;
+
+/// Both endpoints can traverse the same join rows. The derived query retains
+/// normal query operations such as ordering and returns an empty list when no
+/// join rows exist.
+#[driver_test(
+    id(ID),
+    requires(sql),
+    scenario(crate::scenarios::user_group_membership)
+)]
+pub async fn query_from_both_sides(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+    let fixture = seed(&mut db).await?;
+
+    let groups = fixture
+        .alice
+        .groups()
+        .order_by(Group::fields().name().asc())
+        .exec(&mut db)
+        .await?;
+    assert_eq!(
+        groups
+            .iter()
+            .map(|group| &group.name[..])
+            .collect::<Vec<_>>(),
+        ["Databases", "Rust"]
+    );
+
+    let users = fixture
+        .rust
+        .users()
+        .order_by(User::fields().name().asc())
+        .exec(&mut db)
+        .await?;
+    assert_eq!(
+        users.iter().map(|user| &user.name[..]).collect::<Vec<_>>(),
+        ["Alice", "Bob"]
+    );
+
+    assert!(fixture.carol.groups().exec(&mut db).await?.is_empty());
+    assert!(fixture.empty.users().exec(&mut db).await?.is_empty());
+
+    Ok(())
+}
+
+/// Parent queries can use `.any()` on the join relation. The predicate can
+/// traverse to the opposite endpoint and can also inspect fields stored on the
+/// join model.
+#[driver_test(
+    id(ID),
+    requires(sql),
+    scenario(crate::scenarios::user_group_membership)
+)]
+pub async fn filter_through_join_model(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+    seed(&mut db).await?;
+
+    let users: Vec<User> = User::filter(
+        User::fields()
+            .memberships()
+            .any(Membership::fields().group().name().eq("Rust")),
+    )
+    .exec(&mut db)
+    .await?;
+    assert_eq_unordered!(users.iter().map(|user| &user.name[..]), ["Alice", "Bob"]);
+
+    let groups: Vec<Group> = Group::filter(
+        Group::fields()
+            .memberships()
+            .any(Membership::fields().user().name().eq("Alice")),
+    )
+    .exec(&mut db)
+    .await?;
+    assert_eq_unordered!(
+        groups.iter().map(|group| &group.name[..]),
+        ["Rust", "Databases"]
+    );
+
+    let owners: Vec<User> = User::filter(
+        User::fields()
+            .memberships()
+            .any(Membership::fields().role().eq("owner")),
+    )
+    .exec(&mut db)
+    .await?;
+    assert_eq!(owners.len(), 1);
+    assert_eq!(owners[0].name, "Alice");
+
+    Ok(())
+}
+
+/// Preloading works in both directions and keeps results grouped under the
+/// correct endpoint, including endpoints with no join rows.
+#[driver_test(
+    id(ID),
+    requires(sql),
+    scenario(crate::scenarios::user_group_membership)
+)]
+pub async fn include_from_both_sides(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+    seed(&mut db).await?;
+
+    let users: Vec<User> = User::all()
+        .include(User::fields().groups())
+        .exec(&mut db)
+        .await?;
+    for user in &users {
+        let groups = user.groups.get().iter().map(|group| &group.name[..]);
+        match &user.name[..] {
+            "Alice" => {
+                assert_eq_unordered!(groups, ["Rust", "Databases"]);
+            }
+            "Bob" => {
+                assert_eq_unordered!(groups, ["Rust"]);
+            }
+            "Carol" => {
+                assert_eq!(groups.count(), 0);
+            }
+            name => panic!("unexpected user {name}"),
+        }
+    }
+
+    let groups: Vec<Group> = Group::all()
+        .include(Group::fields().users())
+        .exec(&mut db)
+        .await?;
+    for group in &groups {
+        let users = group.users.get().iter().map(|user| &user.name[..]);
+        match &group.name[..] {
+            "Rust" => {
+                assert_eq_unordered!(users, ["Alice", "Bob"]);
+            }
+            "Databases" => {
+                assert_eq_unordered!(users, ["Alice"]);
+            }
+            "Empty" => {
+                assert_eq!(users.count(), 0);
+            }
+            name => panic!("unexpected group {name}"),
+        }
+    }
+
+    Ok(())
+}
+
+/// Links are created, updated, and removed by mutating the join model. This
+/// preserves relation data such as `role` and leaves both endpoint records
+/// intact when the link is removed.
+#[driver_test(
+    id(ID),
+    requires(sql),
+    scenario(crate::scenarios::user_group_membership)
+)]
+pub async fn mutate_link_through_join_model(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user = toasty::create!(User { name: "Alice" })
+        .exec(&mut db)
+        .await?;
+    let group = toasty::create!(Group { name: "Rust" })
+        .exec(&mut db)
+        .await?;
+
+    let mut membership = toasty::create!(Membership {
+        user: &user,
+        group: &group,
+        role: "member"
+    })
+    .exec(&mut db)
+    .await?;
+
+    assert_eq!(user.groups().get(&mut db).await?.id, group.id);
+    assert_eq!(group.users().get(&mut db).await?.id, user.id);
+
+    membership.update().role("owner").exec(&mut db).await?;
+    assert_eq!(membership.role, "owner");
+
+    membership.delete().exec(&mut db).await?;
+    assert!(user.groups().exec(&mut db).await?.is_empty());
+    assert!(group.users().exec(&mut db).await?.is_empty());
+
+    assert_eq!(User::get_by_id(&mut db, user.id).await?.name, "Alice");
+    assert_eq!(Group::get_by_id(&mut db, group.id).await?.name, "Rust");
+
+    Ok(())
+}
+
+/// A composite primary key on the join model prevents duplicate links while
+/// allowing each endpoint to participate in other links.
+#[driver_test(
+    id(ID),
+    requires(sql),
+    scenario(crate::scenarios::user_group_membership)
+)]
+pub async fn composite_join_key_prevents_duplicate_links(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let users = toasty::create!(User::[{ name: "Alice" }, { name: "Bob" }])
+        .exec(&mut db)
+        .await?;
+    let groups = toasty::create!(Group::[{ name: "Rust" }, { name: "Databases" }])
+        .exec(&mut db)
+        .await?;
+
+    toasty::create!(Membership {
+        user: &users[0],
+        group: &groups[0],
+        role: "member"
+    })
+    .exec(&mut db)
+    .await?;
+
+    assert_err!(
+        toasty::create!(Membership {
+            user: &users[0],
+            group: &groups[0],
+            role: "owner"
+        })
+        .exec(&mut db)
+        .await
+    );
+
+    toasty::create!(Membership::[
+        { user: &users[0], group: &groups[1], role: "member" },
+        { user: &users[1], group: &groups[0], role: "member" },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    Ok(())
+}
+
+/// A self-referential many-to-many relation uses pair hints to distinguish
+/// the two foreign keys on the join model. Each direction then exposes its
+/// own `has_many(via = ...)` traversal.
+#[driver_test(id(ID), requires(sql))]
+pub async fn self_referential_followers_and_following(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: ID,
+
+        name: String,
+
+        #[has_many(pair = follower)]
+        outgoing_follows: toasty::Deferred<Vec<Follow>>,
+
+        #[has_many(pair = followed)]
+        incoming_follows: toasty::Deferred<Vec<Follow>>,
+
+        #[has_many(via = outgoing_follows.followed)]
+        following: toasty::Deferred<Vec<User>>,
+
+        #[has_many(via = incoming_follows.follower)]
+        followers: toasty::Deferred<Vec<User>>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    #[key(follower_id, followed_id)]
+    struct Follow {
+        #[index]
+        follower_id: ID,
+
+        #[belongs_to(key = follower_id, references = id)]
+        follower: toasty::Deferred<User>,
+
+        #[index]
+        followed_id: ID,
+
+        #[belongs_to(key = followed_id, references = id)]
+        followed: toasty::Deferred<User>,
+    }
+
+    let mut db = test.setup_db(models!(User, Follow)).await;
+
+    let users = toasty::create!(User::[
+        { name: "Alice" },
+        { name: "Bob" },
+        { name: "Carol" },
+    ])
+    .exec(&mut db)
+    .await?;
+    let (alice, bob, carol) = (&users[0], &users[1], &users[2]);
+
+    toasty::create!(Follow::[
+        { follower: alice, followed: bob   },
+        { follower: alice, followed: carol },
+        { follower: carol, followed: bob   },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let following = alice.following().exec(&mut db).await?;
+    assert_eq_unordered!(
+        following.iter().map(|user| &user.name[..]),
+        ["Bob", "Carol"]
+    );
+
+    let followers = bob.followers().exec(&mut db).await?;
+    assert_eq_unordered!(
+        followers.iter().map(|user| &user.name[..]),
+        ["Alice", "Carol"]
+    );
+
+    assert!(bob.following().exec(&mut db).await?.is_empty());
+
+    Ok(())
+}

--- a/crates/toasty-driver-integration-suite/src/tests/relation_many_to_many.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_many_to_many.rs
@@ -92,6 +92,41 @@ pub async fn filter_through_join_model(test: &mut Test) -> Result<()> {
     Ok(())
 }
 
+/// Parent queries can apply `.any()` directly to either derived relation,
+/// without spelling the join model in the predicate.
+#[driver_test(
+    id(ID),
+    requires(sql),
+    scenario(crate::scenarios::user_group_membership)
+)]
+pub async fn filter_through_via_from_both_sides(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+    seed(&mut db).await?;
+
+    let users: Vec<User> = User::filter(
+        User::fields()
+            .groups()
+            .any(Group::fields().name().eq("Rust")),
+    )
+    .exec(&mut db)
+    .await?;
+    assert_eq_unordered!(users.iter().map(|user| &user.name[..]), ["Alice", "Bob"]);
+
+    let groups: Vec<Group> = Group::filter(
+        Group::fields()
+            .users()
+            .any(User::fields().name().eq("Alice")),
+    )
+    .exec(&mut db)
+    .await?;
+    assert_eq_unordered!(
+        groups.iter().map(|group| &group.name[..]),
+        ["Rust", "Databases"]
+    );
+
+    Ok(())
+}
+
 /// Preloading works in both directions and keeps results grouped under the
 /// correct endpoint, including endpoints with no join rows.
 #[driver_test(

--- a/crates/toasty-macros/src/lib.rs
+++ b/crates/toasty-macros/src/lib.rs
@@ -547,6 +547,67 @@ use proc_macro::TokenStream;
 /// with `.select()` is supported on SQL backends; both are not yet available on
 /// DynamoDB.
 ///
+/// #### Many-to-many through a join model
+///
+/// Model a many-to-many relationship with a join model that belongs to both
+/// endpoints. Each endpoint has a direct `has_many` relation to the join model
+/// and a derived `has_many(via = ...)` relation to the opposite endpoint:
+///
+/// ```
+/// # use toasty::Model;
+/// #[derive(Debug, toasty::Model)]
+/// struct User {
+///     #[key]
+///     #[auto]
+///     id: i64,
+///
+///     #[has_many]
+///     memberships: toasty::Deferred<Vec<Membership>>,
+///
+///     #[has_many(via = memberships.group)]
+///     groups: toasty::Deferred<Vec<Group>>,
+/// }
+///
+/// #[derive(Debug, toasty::Model)]
+/// struct Group {
+///     #[key]
+///     #[auto]
+///     id: i64,
+///
+///     #[has_many]
+///     memberships: toasty::Deferred<Vec<Membership>>,
+///
+///     #[has_many(via = memberships.user)]
+///     users: toasty::Deferred<Vec<User>>,
+/// }
+///
+/// #[derive(Debug, toasty::Model)]
+/// #[key(user_id, group_id)]
+/// struct Membership {
+///     #[index]
+///     user_id: i64,
+///
+///     #[belongs_to(key = user_id, references = id)]
+///     user: toasty::Deferred<User>,
+///
+///     #[index]
+///     group_id: i64,
+///
+///     #[belongs_to(key = group_id, references = id)]
+///     group: toasty::Deferred<Group>,
+///
+///     role: String,
+/// }
+/// ```
+///
+/// The composite key prevents duplicate user-group links. Fields such as
+/// `role` belong on the join model because they describe one connection. The
+/// derived `groups` and `users` relations return distinct endpoints and are
+/// read-only; create, update, or delete `Membership` records to change links.
+/// Call `.any()` on a derived field to filter by the opposite endpoint, or on
+/// `memberships` to filter by join-model fields. Traversing, filtering,
+/// preloading, or projecting the derived `via` fields requires a SQL backend.
+///
 /// ## `#[has_one]` — one-to-one association
 ///
 /// Declares a single related model. The target model must have a

--- a/crates/toasty-macros/src/model/expand/docs.rs
+++ b/crates/toasty-macros/src/model/expand/docs.rs
@@ -106,7 +106,8 @@ impl Expand<'_> {
 
     pub(super) fn doc_has_many_via(&self, field_ident: &syn::Ident) -> String {
         format!(
-            "Returns a query over the `{field_ident}` reached from this `{}` through its relations.",
+            "Returns a read-only query over the `{field_ident}` reached from this `{}` through its relations.\n\n\
+             For a join-model many-to-many relation, create, update, or delete the join record to change the connection.",
             self.model.ident
         )
     }

--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -6,6 +6,7 @@ mod lift_in_subquery;
 mod lift_update_query;
 mod paginate;
 mod relation;
+mod relation_path;
 mod returning;
 mod via_join;
 

--- a/crates/toasty/src/engine/lower/association.rs
+++ b/crates/toasty/src/engine/lower/association.rs
@@ -146,82 +146,47 @@ impl<'a> RewriteVia<'a> {
         }
     }
 
-    /// Entry point for path unfolding. Pulls the seed `source_model_id` off
-    /// the association's source query and delegates to the recursive
-    /// [`unfold_steps`](Self::unfold_steps) helper. Returns an association
-    /// whose path is a single step that does **not** name a via relation.
+    /// Resolve the association path into direct relation fields, then wrap
+    /// each intermediate field in a nested `Source::Model { via }` query.
+    /// Returns an association whose path contains one direct relation step.
     fn unfold_path(&self, association: stmt::Association) -> stmt::Association {
         let stmt::Association { source, path } = association;
         let source_model_id = source.body.as_select_unwrap().source.model_id_unwrap();
-        self.unfold_steps(source, source_model_id, path.projection.as_slice())
+        let fields = super::relation_path::flatten_relation_path(
+            self.schema(),
+            source_model_id,
+            path.projection.as_slice(),
+        );
+
+        self.unfold_fields(source, &fields)
     }
 
-    /// Walk `steps`, splicing each via relation's resolved path inline and
-    /// wrapping every intermediate step in a nested `Source::Model { via }`.
-    /// Returns the outer single-step association the caller filters against.
-    ///
-    /// Via splicing allocates a `Vec<usize>` per via segment so the recursion
-    /// can borrow it as a slice. Paths are short (typically 1-3 steps) and
-    /// vias are rare, so this is cheap in practice.
-    fn unfold_steps(
+    fn unfold_fields(
         &self,
         source: Box<stmt::Query>,
-        source_model_id: app::ModelId,
-        steps: &[usize],
+        fields: &[app::FieldId],
     ) -> stmt::Association {
-        let [first, rest @ ..] = steps else {
-            unreachable!("unfold_steps called with empty steps")
+        let [field_id, rest @ ..] = fields else {
+            unreachable!("unfold_fields called with empty fields")
         };
-
-        let field = &self
-            .schema()
-            .app
-            .model(source_model_id)
-            .as_root_unwrap()
-            .fields[*first];
-
-        // If this step names a via relation, splice the via's resolved path
-        // in place of the via field and continue. Handles via-of-via
-        // naturally because the recursion re-examines the spliced steps. A
-        // scalar-terminal via contributes only its relation chain to the
-        // reachability filter — the terminal field is a projection, handled by
-        // the query's returning, not the filter.
-        let via_path = match &field.ty {
-            app::FieldTy::Via(via) => {
-                let projection = via.path.projection.as_slice();
-                Some(match via.terminal {
-                    Some(_) => &projection[..projection.len() - 1],
-                    None => projection,
-                })
-            }
-            _ => None,
-        };
-        if let Some(via_steps) = via_path {
-            let mut spliced = Vec::with_capacity(via_steps.len() + rest.len());
-            spliced.extend_from_slice(via_steps);
-            spliced.extend_from_slice(rest);
-            return self.unfold_steps(source, source_model_id, &spliced);
-        }
+        let field = self.schema().app.field(*field_id);
 
         // Base case: a single direct relation step stays on the outer
         // association.
         if rest.is_empty() {
             return stmt::Association {
                 source,
-                path: stmt::Path::from_index(source_model_id, *first),
+                path: stmt::Path::from_index(field_id.model, field_id.index),
             };
         }
 
-        let next_model_id = match &field.ty {
-            app::FieldTy::Has(rel) => rel.target,
-            app::FieldTy::Via(rel) => rel.target,
-            app::FieldTy::BelongsTo(rel) => rel.target,
-            other => todo!("non-relation field in via path: {other:#?}"),
-        };
+        let next_model_id = field
+            .relation_target_id()
+            .expect("unfolded association path field is not a relation");
 
         let inner = stmt::Association {
             source,
-            path: stmt::Path::from_index(source_model_id, *first),
+            path: stmt::Path::from_index(field_id.model, field_id.index),
         };
         let new_source = Box::new(stmt::Query::new_select(
             stmt::Source::Model(stmt::SourceModel {
@@ -231,7 +196,8 @@ impl<'a> RewriteVia<'a> {
             stmt::Expr::Value(stmt::Value::Bool(true)),
         ));
 
-        self.unfold_steps(new_source, next_model_id, rest)
+        debug_assert_eq!(rest[0].model, next_model_id);
+        self.unfold_fields(new_source, rest)
     }
 
     fn rewrite_association_belongs_to_as_filter(

--- a/crates/toasty/src/engine/lower/lift_in_subquery.rs
+++ b/crates/toasty/src/engine/lower/lift_in_subquery.rs
@@ -194,9 +194,9 @@ pub(super) fn lift_in_subquery(
         }
     };
 
-    // If the field is not a relation, abort. A direct relation lifts through
-    // its paired foreign key. A `via` has no single pair, so expand its path
-    // and lift each relation step from the target query back to the source.
+    // If the field is not a relation, abort. Direct relations lift through
+    // their paired foreign keys. A `via` has no single pair, so normalize its
+    // relation chain into a projected path and use the projection lift.
     match &field.ty {
         FieldTy::BelongsTo(belongs_to) => lift_belongs_to_in_subquery(cx, belongs_to, query),
         FieldTy::Has(has) => lift_has_n_in_subquery(has.target, has.pair(&cx.schema().app), query),
@@ -219,8 +219,9 @@ pub(super) fn lift_in_subquery(
 /// )
 /// ```
 ///
-/// The path is expanded first so nested vias use the same logic. Each direct
-/// relation is then lifted in reverse order, starting with the target query.
+/// The path is expanded into direct relation fields, converted to the same
+/// projected expression produced by an explicit relation chain, and then
+/// handled by the regular projection lift.
 fn lift_via_in_subquery(
     cx: &ExprContext,
     via: &app::Via,
@@ -230,9 +231,7 @@ fn lift_via_in_subquery(
         return None;
     }
 
-    let root = via.path.root.as_model()?;
-    let fields =
-        super::via_join::flatten_via_steps(cx.schema(), root, via.path.projection.as_slice());
+    let fields = super::relation_path::flatten_via_path(cx.schema(), via)?;
     let target = fields
         .last()
         .and_then(|field| cx.schema().app.field(*field).relation_target_id())?;
@@ -241,22 +240,19 @@ fn lift_via_in_subquery(
         return None;
     }
 
-    let mut fields = fields.into_iter().rev().peekable();
-    let mut query = query.clone();
+    let (base, projection) = fields.split_first()?;
+    let base = stmt::Expr::ref_self_field(*base);
+    let path = if projection.is_empty() {
+        base
+    } else {
+        let projection = projection
+            .iter()
+            .map(|field| field.index)
+            .collect::<Vec<_>>();
+        stmt::Expr::project(base, projection.as_slice())
+    };
 
-    while let Some(field_id) = fields.next() {
-        let source: stmt::Source = field_id.model.into();
-        let scoped_cx = cx.scope(&source);
-        let filter = lift_in_subquery(&scoped_cx, &stmt::Expr::ref_self_field(field_id), &query)?;
-
-        if fields.peek().is_none() {
-            return Some(filter);
-        }
-
-        query = stmt::Query::new_select(source, filter);
-    }
-
-    None
+    lift_in_subquery(cx, &path, query)
 }
 
 /// Lifts an `IN`-subquery whose left side is a path through a relation field.
@@ -310,12 +306,7 @@ fn lift_projection_in_subquery(
         return None;
     };
 
-    let target_model_id = match &field.ty {
-        FieldTy::Has(rel) => rel.target,
-        FieldTy::Via(rel) => rel.target,
-        FieldTy::BelongsTo(rel) => rel.target,
-        _ => return None,
-    };
+    let target_model_id = field.relation_target_id()?;
 
     let (head_idx, tail) = project_expr.projection.as_slice().split_first()?;
 
@@ -431,12 +422,8 @@ fn try_fuse_paired_relations(
         }
     }
 
-    let mut fused_subquery = query.clone();
-    fused_subquery.body.as_select_mut_unwrap().returning = stmt::Returning::Project(
-        super::key_field_refs(0, inner_pair.foreign_key.fields.iter().map(|fk| fk.source)),
-    );
-
-    Some(stmt::Expr::in_subquery(
+    lift_fk_in_subquery(
+        inner_has.target,
         super::key_field_refs(
             0,
             outer_belongs_to
@@ -445,8 +432,9 @@ fn try_fuse_paired_relations(
                 .iter()
                 .map(|fk| fk.source),
         ),
-        fused_subquery,
-    ))
+        super::key_field_refs(0, inner_pair.foreign_key.fields.iter().map(|fk| fk.source)),
+        query,
+    )
 }
 
 /// Rewrites a comparison that walks a relation field into a foreign-key
@@ -533,12 +521,7 @@ fn lift_relation_path_predicate(
         return None;
     };
 
-    let target_model_id = match &field.ty {
-        FieldTy::Has(rel) => rel.target,
-        FieldTy::Via(rel) => rel.target,
-        FieldTy::BelongsTo(rel) => rel.target,
-        _ => return None,
-    };
+    let target_model_id = field.relation_target_id()?;
 
     // The first step names the relation field on the source model; the
     // rest index into the target model. Drop the first step and re-root the
@@ -558,6 +541,26 @@ fn lift_relation_path_predicate(
         stmt::Query::new_select(stmt::Source::from(target_model_id), make_filter(target_lhs));
 
     lift_in_subquery(cx, &project_expr.base, &subquery)
+}
+
+/// Build a foreign-key `IN` subquery for one direct relation edge.
+///
+/// `lhs` references key fields on the current model. `returning` references
+/// the matching key fields on `target`, which is also the subquery source.
+fn lift_fk_in_subquery(
+    target: ModelId,
+    lhs: stmt::Expr,
+    returning: stmt::Expr,
+    query: &stmt::Query,
+) -> Option<stmt::Expr> {
+    if target != query.body.as_select_unwrap().source.model_id_unwrap() {
+        return None;
+    }
+
+    let mut subquery = query.clone();
+    subquery.body.as_select_mut_unwrap().returning = stmt::Returning::Project(returning);
+
+    Some(stmt::Expr::in_subquery(lhs, subquery))
 }
 
 /// BelongsTo branch: try to lift the subquery's filter into direct FK
@@ -597,16 +600,12 @@ fn lift_belongs_to_in_subquery(
     let all_fks_matched = lift.fk_field_matches.iter().all(|m| *m);
 
     if lift.fail || !all_fks_matched {
-        let mut subquery = query.clone();
-
-        subquery.body.as_select_mut_unwrap().returning = stmt::Returning::Project(
-            super::key_field_refs(0, belongs_to.foreign_key.fields.iter().map(|fk| fk.target)),
-        );
-
-        Some(stmt::Expr::in_subquery(
+        lift_fk_in_subquery(
+            belongs_to.target,
             super::key_field_refs(0, belongs_to.foreign_key.fields.iter().map(|fk| fk.source)),
-            subquery,
-        ))
+            super::key_field_refs(0, belongs_to.foreign_key.fields.iter().map(|fk| fk.target)),
+            query,
+        )
     } else {
         Some(if lift.operands.len() == 1 {
             lift.operands.into_iter().next().unwrap()
@@ -628,31 +627,11 @@ fn lift_has_n_in_subquery(
     pair: &BelongsTo,
     query: &stmt::Query,
 ) -> Option<stmt::Expr> {
-    if target != query.body.as_select_unwrap().source.model_id_unwrap() {
-        return None;
-    }
-
-    let mut subquery = query.clone();
-
-    match &mut subquery.body {
-        stmt::ExprSet::Select(select) => {
-            select.returning = stmt::Returning::Project(super::key_field_refs(
-                0,
-                pair.foreign_key.fields.iter().map(|fk| fk.source),
-            ));
-        }
-        _ => todo!(),
-    }
-
-    Some(
-        stmt::ExprInSubquery {
-            expr: Box::new(super::key_field_refs(
-                0,
-                pair.foreign_key.fields.iter().map(|fk| fk.target),
-            )),
-            query: Box::new(subquery),
-        }
-        .into(),
+    lift_fk_in_subquery(
+        target,
+        super::key_field_refs(0, pair.foreign_key.fields.iter().map(|fk| fk.target)),
+        super::key_field_refs(0, pair.foreign_key.fields.iter().map(|fk| fk.source)),
+        query,
     )
 }
 

--- a/crates/toasty/src/engine/lower/lift_in_subquery.rs
+++ b/crates/toasty/src/engine/lower/lift_in_subquery.rs
@@ -194,16 +194,69 @@ pub(super) fn lift_in_subquery(
         }
     };
 
-    // If the field is not a relation, abort. Multi-step (`via`) relations
-    // have no paired BelongsTo to lift through — they are already rewritten
-    // into nested IN subqueries by `RewriteVia` earlier in the lowering
-    // pipeline, so any reference reaching here that still names one is not
-    // something this pass can handle.
+    // If the field is not a relation, abort. A direct relation lifts through
+    // its paired foreign key. A `via` has no single pair, so expand its path
+    // and lift each relation step from the target query back to the source.
     match &field.ty {
         FieldTy::BelongsTo(belongs_to) => lift_belongs_to_in_subquery(cx, belongs_to, query),
         FieldTy::Has(has) => lift_has_n_in_subquery(has.target, has.pair(&cx.schema().app), query),
+        FieldTy::Via(via) => lift_via_in_subquery(cx, via, query),
         _ => None,
     }
+}
+
+/// Lift an `IN` subquery whose left side names a `via` relation.
+///
+/// For `User.groups.any(Group.name == "Rust")`, where `groups` follows
+/// `User.memberships.group`, this builds:
+///
+/// ```text
+/// User.id IN (
+///     SELECT Membership.user_id FROM Membership
+///     WHERE Membership.group_id IN (
+///         SELECT Group.id FROM Group WHERE Group.name == "Rust"
+///     )
+/// )
+/// ```
+///
+/// The path is expanded first so nested vias use the same logic. Each direct
+/// relation is then lifted in reverse order, starting with the target query.
+fn lift_via_in_subquery(
+    cx: &ExprContext,
+    via: &app::Via,
+    query: &stmt::Query,
+) -> Option<stmt::Expr> {
+    if via.is_scalar() {
+        return None;
+    }
+
+    let root = via.path.root.as_model()?;
+    let fields =
+        super::via_join::flatten_via_steps(cx.schema(), root, via.path.projection.as_slice());
+    let target = fields
+        .last()
+        .and_then(|field| cx.schema().app.field(*field).relation_target_id())?;
+
+    if target != via.target || target != query.body.as_select_unwrap().source.model_id_unwrap() {
+        return None;
+    }
+
+    let mut fields = fields.into_iter().rev().peekable();
+    let mut query = query.clone();
+
+    while let Some(field_id) = fields.next() {
+        let source: stmt::Source = field_id.model.into();
+        let scoped_cx = cx.scope(&source);
+        let filter = lift_in_subquery(&scoped_cx, &stmt::Expr::ref_self_field(field_id), &query)?;
+
+        if fields.peek().is_none() {
+            return Some(filter);
+        }
+
+        query = stmt::Query::new_select(source, filter);
+    }
+
+    None
 }
 
 /// Lifts an `IN`-subquery whose left side is a path through a relation field.

--- a/crates/toasty/src/engine/lower/relation_path.rs
+++ b/crates/toasty/src/engine/lower/relation_path.rs
@@ -1,0 +1,60 @@
+//! Helpers for resolving app-level relation paths.
+
+use toasty_core::schema::app;
+
+/// Walk a relation path, inlining each `via` field's resolved relation chain.
+///
+/// The result contains only direct relation fields. Scalar terminals are
+/// omitted because they project a value from the model reached by the
+/// relation chain; they do not add another relation step.
+pub(super) fn flatten_relation_path(
+    schema: &toasty_core::Schema,
+    source_model_id: app::ModelId,
+    initial_steps: &[usize],
+) -> Vec<app::FieldId> {
+    let mut result = Vec::with_capacity(initial_steps.len());
+    let mut current_model = source_model_id;
+    let mut queue: Vec<usize> = initial_steps.to_vec();
+    queue.reverse();
+
+    while let Some(index) = queue.pop() {
+        let field = &schema.app.model(current_model).as_root_unwrap().fields[index];
+        let field_id = app::FieldId {
+            model: current_model,
+            index,
+        };
+
+        if let app::FieldTy::Via(via) = &field.ty {
+            debug_assert_eq!(via.path.root.as_model(), Some(current_model));
+
+            for step in via_relation_steps(via).iter().rev() {
+                queue.push(*step);
+            }
+            continue;
+        }
+
+        current_model = field
+            .relation_target_id()
+            .expect("relation path step is not a relation");
+        result.push(field_id);
+    }
+
+    result
+}
+
+/// Return the direct relation fields that a `via` relation follows.
+pub(super) fn flatten_via_path(
+    schema: &toasty_core::Schema,
+    via: &app::Via,
+) -> Option<Vec<app::FieldId>> {
+    let root = via.path.root.as_model()?;
+    Some(flatten_relation_path(schema, root, via_relation_steps(via)))
+}
+
+fn via_relation_steps(via: &app::Via) -> &[usize] {
+    let projection = via.path.projection.as_slice();
+    match via.terminal {
+        Some(_) => &projection[..projection.len() - 1],
+        None => projection,
+    }
+}

--- a/crates/toasty/src/engine/lower/via_join.rs
+++ b/crates/toasty/src/engine/lower/via_join.rs
@@ -258,7 +258,7 @@ impl Edge {
 
 /// Walk a via path, inlining any `via` field's own resolved path so the
 /// result is a flat sequence of direct relation `FieldId`s.
-fn flatten_via_steps(
+pub(super) fn flatten_via_steps(
     schema: &toasty_core::Schema,
     source_model_id: app::ModelId,
     initial_steps: &[usize],

--- a/crates/toasty/src/engine/lower/via_join.rs
+++ b/crates/toasty/src/engine/lower/via_join.rs
@@ -135,12 +135,9 @@ impl ViaJoin {
         // For a scalar terminal the path's last step is the projected field,
         // not a relation; the relation chain (which the JOIN walks) is
         // everything before it.
-        let projection = via.path.projection.as_slice();
-        let relation_steps = match via.terminal {
-            Some(_) => &projection[..projection.len() - 1],
-            None => projection,
-        };
-        let steps = flatten_via_steps(schema, root, relation_steps);
+        let steps = super::relation_path::flatten_via_path(schema, via)
+            .expect("via relation path must start at a model");
+        debug_assert_eq!(steps.first().map(|field| field.model), Some(root));
         assert!(
             !steps.is_empty(),
             "via path must have at least one step (validated at schema build time)"
@@ -254,47 +251,6 @@ impl Edge {
             }
         }
     }
-}
-
-/// Walk a via path, inlining any `via` field's own resolved path so the
-/// result is a flat sequence of direct relation `FieldId`s.
-pub(super) fn flatten_via_steps(
-    schema: &toasty_core::Schema,
-    source_model_id: app::ModelId,
-    initial_steps: &[usize],
-) -> Vec<app::FieldId> {
-    let mut result = Vec::with_capacity(initial_steps.len());
-    let mut current_model = source_model_id;
-    let mut queue: Vec<usize> = initial_steps.to_vec();
-    queue.reverse(); // pop from the back
-
-    while let Some(idx) = queue.pop() {
-        let field = &schema.app.model(current_model).as_root_unwrap().fields[idx];
-        let field_id = app::FieldId {
-            model: current_model,
-            index: idx,
-        };
-
-        // If this step itself names a `via` relation, splice the nested
-        // path in place of it and continue (handles via-of-via naturally).
-        let nested_via = match &field.ty {
-            app::FieldTy::Via(via) => Some(via),
-            _ => None,
-        };
-        if let Some(via) = nested_via {
-            for step in via.path.projection.as_slice().iter().rev() {
-                queue.push(*step);
-            }
-            continue;
-        }
-
-        current_model = field
-            .relation_target_id()
-            .expect("via path step is a relation");
-        result.push(field_id);
-    }
-
-    result
 }
 
 /// The single-column mapping for a foreign-key field. Via include paths only

--- a/crates/toasty/src/lib.rs
+++ b/crates/toasty/src/lib.rs
@@ -30,6 +30,11 @@
 //! through `.include(...)` or generated relation accessors. Eager relations are
 //! loaded whenever the model is loaded.
 //!
+//! A many-to-many relationship uses a join model with one `BelongsTo` relation
+//! to each endpoint. Endpoint models can expose the opposite side with
+//! `#[has_many(via = memberships.group)]`; code mutates the join model and uses
+//! the derived `via` field for read-only traversal.
+//!
 //! The module also re-exports from `toasty-core` for inspecting the
 //! app-level and db-level schema representations at runtime.
 //!

--- a/crates/toasty/src/schema/relation.rs
+++ b/crates/toasty/src/schema/relation.rs
@@ -11,6 +11,11 @@ use toasty_core::stmt;
 /// impls is the source of truth for which Rust shapes are valid as a
 /// has-many field: anything outside those two combinations does not satisfy
 /// the trait.
+///
+/// A direct `#[has_many]` pairs with a `BelongsTo` on its target. A
+/// `#[has_many(via = ...)]` follows a relation path instead. Many-to-many
+/// models use a direct field for join-model records and a `via` field for the
+/// opposite endpoints.
 pub trait RelationManyField: Load<Output = Self> {
     /// The target model that this field references.
     type Target: Model;

--- a/crates/toasty/src/schema/via.rs
+++ b/crates/toasty/src/schema/via.rs
@@ -16,6 +16,11 @@ const UNRESOLVED_TARGET: ModelId = ModelId(usize::MAX);
 /// every `E`, so the derive can route a via field through [`ViaTarget`]
 /// without requiring `E: Model`. A single blanket impl per outer shape keeps
 /// it coherent with the per-target `ViaTarget` impls.
+///
+/// A join-model many-to-many field is a model-terminal via. For example,
+/// `#[has_many(via = memberships.group)] groups: Deferred<Vec<Group>>`
+/// follows the declaring model's `memberships` relation and then each
+/// membership's `group` relation.
 pub trait ViaManyField {
     /// The via's terminal type — the model or scalar the path projects.
     type Target: ViaTarget;

--- a/crates/toasty/src/stmt/path.rs
+++ b/crates/toasty/src/stmt/path.rs
@@ -396,6 +396,11 @@ impl<T, U> Path<T, List<U>> {
     /// parent model. The returned expression can be used as a filter on the
     /// parent query.
     ///
+    /// This also works on model-terminal `#[has_many(via = ...)]` fields. In a
+    /// join-model many-to-many relation, call `any` on the derived field to
+    /// filter by the opposite endpoint, or on the direct join-model field to
+    /// filter by data stored on the connection.
+    ///
     /// # Examples
     ///
     /// ```

--- a/docs/guide/src/SUMMARY.md
+++ b/docs/guide/src/SUMMARY.md
@@ -25,6 +25,7 @@
 - [Relationships](./relationships.md)
 - [BelongsTo](./belongs-to.md)
 - [HasMany](./has-many.md)
+- [Many-to-Many](./many-to-many.md)
 - [HasOne](./has-one.md)
 - [Preloading Associations](./preloading-associations.md)
 

--- a/docs/guide/src/belongs-to.md
+++ b/docs/guide/src/belongs-to.md
@@ -86,6 +86,11 @@ CREATE INDEX idx_posts_user_id ON posts (user_id);
 The parent model (`User`) typically declares a `#[has_many]` field pointing back
 at the child. See [HasMany](./has-many.md) for details.
 
+A [many-to-many relationship](./many-to-many.md) uses a join model with two
+`BelongsTo` fields, one for each endpoint. The endpoint models each declare a
+`HasMany` to the join model and can add a derived `has_many(via = ...)` field for
+direct traversal to the other endpoint.
+
 Use a plain relation field when every loaded child should also load its parent:
 
 ```rust,ignore

--- a/docs/guide/src/creating-records.md
+++ b/docs/guide/src/creating-records.md
@@ -216,6 +216,11 @@ let todo = user.todos().create()
 You don't need to set `user_id` — Toasty fills it in from the parent
 because the create builder is scoped to `user.todos()`.
 
+For a [many-to-many relationship](./many-to-many.md), create the join-model
+record instead of creating through the derived `has_many(via = ...)` accessor.
+The join record sets both endpoint relations and can store fields that describe
+the connection.
+
 ## Nested creation
 
 When models have relationships, you can create a parent and its children in a

--- a/docs/guide/src/filtering-with-expressions.md
+++ b/docs/guide/src/filtering-with-expressions.md
@@ -586,6 +586,11 @@ The path `User::fields().todos()` refers to the HasMany relation. Calling
 `.any()` on it takes a filter expression on the child model (`Todo`) and
 produces a filter expression on the parent (`User`).
 
+`.any()` also works on a model-terminal `has_many(via = ...)` path. For a
+[many-to-many relationship](./many-to-many.md), call `.any()` on the derived
+relation to filter by the opposite endpoint, or on the direct join-model
+relation to filter by fields stored on the connection.
+
 ### `all` — every related record matches
 
 `.all()` on a `HasMany` path is the universal counterpart to `.any()`:

--- a/docs/guide/src/has-many.md
+++ b/docs/guide/src/has-many.md
@@ -300,6 +300,11 @@ fields, read left to right from this model. This expresses a relationship that
 exists only *through* a third model — a user has many comments, each comment
 belongs to an article, so a user has many commented articles:
 
+A [many-to-many relationship](./many-to-many.md) uses this mechanism: each
+endpoint has a direct `HasMany` to a join model and a derived
+`has_many(via = ...)` to the opposite endpoint. The example below follows the
+same kind of path with `Comment` as the intermediate model.
+
 ```rust
 # use toasty::Model;
 #[derive(Debug, toasty::Model)]

--- a/docs/guide/src/introduction.md
+++ b/docs/guide/src/introduction.md
@@ -55,6 +55,7 @@ transactions.
 - **[Relationships](./relationships.md)** — overview of how models connect to each other
 - **[BelongsTo](./belongs-to.md)** — define and use many-to-one relationships
 - **[HasMany](./has-many.md)** — define and use one-to-many relationships
+- **[Many-to-Many](./many-to-many.md)** — connect two models through a join model
 - **[HasOne](./has-one.md)** — define and use one-to-one relationships
 - **[Preloading Associations](./preloading-associations.md)** — eager loading to avoid extra queries
 - **[Filtering with Expressions](./filtering-with-expressions.md)** — comparisons, AND/OR, and more

--- a/docs/guide/src/many-to-many.md
+++ b/docs/guide/src/many-to-many.md
@@ -1,0 +1,280 @@
+# Many-to-Many Relationships
+
+A many-to-many relationship connects multiple records on each side. A user can
+join multiple groups, and each group can contain multiple users. Relational
+databases store these connections in a join table with one foreign key for each
+endpoint.
+
+Toasty represents the join table as a model. Direct `HasMany` and `BelongsTo`
+relations connect each endpoint to that join model. A
+`#[has_many(via = ...)]` field provides direct, read-only traversal from one
+endpoint to the other.
+
+## Defining the join model
+
+The following schema connects `User` and `Group` through `Membership`:
+
+```rust
+# use toasty::Model;
+#[derive(Debug, toasty::Model)]
+struct User {
+    #[key]
+    #[auto]
+    id: u64,
+
+    name: String,
+
+    #[has_many]
+    memberships: toasty::Deferred<Vec<Membership>>,
+
+    #[has_many(via = memberships.group)]
+    groups: toasty::Deferred<Vec<Group>>,
+}
+
+#[derive(Debug, toasty::Model)]
+struct Group {
+    #[key]
+    #[auto]
+    id: u64,
+
+    name: String,
+
+    #[has_many]
+    memberships: toasty::Deferred<Vec<Membership>>,
+
+    #[has_many(via = memberships.user)]
+    users: toasty::Deferred<Vec<User>>,
+}
+
+#[derive(Debug, toasty::Model)]
+#[key(user_id, group_id)]
+struct Membership {
+    #[index]
+    user_id: u64,
+
+    #[belongs_to(key = user_id, references = id)]
+    user: toasty::Deferred<User>,
+
+    #[index]
+    group_id: u64,
+
+    #[belongs_to(key = group_id, references = id)]
+    group: toasty::Deferred<Group>,
+
+    role: String,
+}
+```
+
+Each relation has a separate job:
+
+- `User::memberships` and `Group::memberships` are direct, mutable relations to
+  the join model.
+- `Membership::user` and `Membership::group` own the two foreign keys.
+- `User::groups` follows `memberships.group` to reach groups without exposing
+  the join step to callers.
+- `Group::users` follows `memberships.user` in the opposite direction.
+
+The composite primary key on `(user_id, group_id)` permits one membership for
+each user-group pair. Use a separate generated primary key when duplicate join
+rows have distinct meanings. A `via` query still returns each target once; query
+the join model when each duplicate row must remain visible.
+
+The join model can store data about the connection. `Membership::role` belongs
+on `Membership` because it describes one user's role in one group, not the user
+or group independently.
+
+## Creating a link
+
+Create a join-model record to connect two existing endpoints:
+
+```rust,ignore
+let membership = toasty::create!(Membership {
+    user: &user,
+    group: &group,
+    role: "member",
+})
+.exec(&mut db)
+.await?;
+```
+
+The `user` and `group` setters fill `user_id` and `group_id`. Creating the
+membership does not update either endpoint row.
+
+The derived `user.groups()` relation is read-only. It does not generate
+`create`, `insert`, or `remove` operations because those operations would need
+to construct or identify a `Membership` row. Create and delete `Membership`
+records instead.
+
+## Querying both directions
+
+The derived relations return the opposite endpoints:
+
+```rust,ignore
+let groups: Vec<Group> = user.groups().exec(&mut db).await?;
+let users: Vec<User> = group.users().exec(&mut db).await?;
+```
+
+These accessors support the same query operations as other relation queries:
+
+```rust,ignore
+let rust_groups = user
+    .groups()
+    .filter(Group::fields().name().eq("Rust"))
+    .order_by(Group::fields().name().asc())
+    .exec(&mut db)
+    .await?;
+```
+
+A derived `via` relation returns distinct targets. If multiple join rows reach
+the same group, `user.groups()` returns that group once.
+
+## Filtering endpoints
+
+Use `.any()` on the derived relation when the condition only references the
+opposite endpoint:
+
+```rust,ignore
+let rust_users = User::filter(
+    User::fields()
+        .groups()
+        .any(Group::fields().name().eq("Rust")),
+)
+.exec(&mut db)
+.await?;
+```
+
+The expression reads as: select users for whom at least one related group is
+named `Rust`.
+
+Use `.any()` on the direct join-model relation when the condition needs fields
+from `Membership`:
+
+```rust,ignore
+let owners = User::filter(
+    User::fields()
+        .memberships()
+        .any(Membership::fields().role().eq("owner")),
+)
+.exec(&mut db)
+.await?;
+```
+
+The predicate can also traverse from the join model to the opposite endpoint:
+
+```rust,ignore
+let rust_users = User::filter(
+    User::fields()
+        .memberships()
+        .any(Membership::fields().group().name().eq("Rust")),
+)
+.exec(&mut db)
+.await?;
+```
+
+Choose the derived relation for endpoint fields and the direct join relation for
+join metadata.
+
+## Preloading endpoints
+
+Preload the derived relation when a query returns multiple endpoint records:
+
+```rust,ignore
+let users = User::all()
+    .include(User::fields().groups())
+    .exec(&mut db)
+    .await?;
+
+for user in &users {
+    let groups: &[Group] = user.groups.get();
+    println!("{} belongs to {} groups", user.name, groups.len());
+}
+```
+
+`.include()` loads and groups the distinct targets for every parent in the
+result. Accessing `user.groups.get()` reads the preloaded collection without
+issuing another query.
+
+## Updating and removing a link
+
+Update fields on the join model directly:
+
+```rust,ignore
+membership.update().role("owner").exec(&mut db).await?;
+```
+
+Delete the join-model record to remove the connection:
+
+```rust,ignore
+membership.delete().exec(&mut db).await?;
+```
+
+Deleting a membership leaves the `User` and `Group` records intact because the
+membership belongs to both endpoints; neither endpoint belongs to the
+membership.
+
+Deleting an endpoint removes its required membership rows but leaves records on
+the opposite endpoint intact. Deleting a user therefore removes that user's
+memberships without deleting any groups.
+
+## Self-referential many-to-many relationships
+
+A self-referential join model points both foreign keys at the same endpoint
+model. A follower graph uses one foreign key for the follower and one for the
+followed user:
+
+```rust
+# use toasty::Model;
+#[derive(Debug, toasty::Model)]
+struct User {
+    #[key]
+    #[auto]
+    id: u64,
+
+    name: String,
+
+    #[has_many(pair = follower)]
+    outgoing_follows: toasty::Deferred<Vec<Follow>>,
+
+    #[has_many(pair = followed)]
+    incoming_follows: toasty::Deferred<Vec<Follow>>,
+
+    #[has_many(via = outgoing_follows.followed)]
+    following: toasty::Deferred<Vec<User>>,
+
+    #[has_many(via = incoming_follows.follower)]
+    followers: toasty::Deferred<Vec<User>>,
+}
+
+#[derive(Debug, toasty::Model)]
+#[key(follower_id, followed_id)]
+struct Follow {
+    #[index]
+    follower_id: u64,
+
+    #[belongs_to(key = follower_id, references = id)]
+    follower: toasty::Deferred<User>,
+
+    #[index]
+    followed_id: u64,
+
+    #[belongs_to(key = followed_id, references = id)]
+    followed: toasty::Deferred<User>,
+}
+```
+
+`pair` tells Toasty which `Follow` relation matches each direct `HasMany`; model
+types alone cannot distinguish two `BelongsTo<User>` fields. The two `via` paths
+then name the direction explicitly: outgoing rows reach followed users, and
+incoming rows reach followers.
+
+## Backend support
+
+Queries that traverse `has_many(via = ...)`, including relation accessors,
+`.any()`, `.include()`, and `.select()`, require a SQL backend. They are supported
+on SQLite, PostgreSQL, and MySQL and are not available on DynamoDB. Creating,
+updating, querying, and deleting the join model use its ordinary model APIs.
+
+See [HasMany](./has-many.md#multi-step-relations-via) for the general `via`
+rules, [Filtering with Expressions](./filtering-with-expressions.md#filtering-on-associations)
+for association predicates, and [Preloading Associations](./preloading-associations.md)
+for loaded-state behavior.

--- a/docs/guide/src/preloading-associations.md
+++ b/docs/guide/src/preloading-associations.md
@@ -292,6 +292,9 @@ A [multi-step (`via`) relation](./has-many.md#multi-step-relations-via) reaches
 its target through a path of existing relations. Preload it with `.include()`
 the same way as a single-step relation:
 
+This includes [many-to-many relationships](./many-to-many.md), where the path
+crosses a join model to reach the opposite endpoint.
+
 ```rust,ignore
 let users = User::all()
     .include(User::fields().commented_articles())

--- a/docs/guide/src/querying-records.md
+++ b/docs/guide/src/querying-records.md
@@ -267,7 +267,8 @@ let name: Option<String> = User::filter_by_email("alice@example.com")
 `.select()` can also project a [multi-step (`via`)
 relation](./has-many.md#multi-step-relations-via), returning the related
 records per row — a `Vec<T>` for a `has_many` `via`, or a single optional
-record for a `has_one` `via`:
+record for a `has_one` `via`. A [many-to-many relation](./many-to-many.md) uses
+the same projection to return the opposite endpoints for each source record:
 
 ```rust,ignore
 // The distinct articles each user has commented on.

--- a/docs/guide/src/relationships.md
+++ b/docs/guide/src/relationships.md
@@ -29,13 +29,42 @@ users                    posts
 The `posts` table holds the foreign key (`user_id`). Each post points to exactly
 one user. A user can have many posts.
 
-This single pattern — a foreign key column in one table referencing the primary
-key of another — underlies all three relationship types in Toasty.
+This foreign-key pattern underlies each direct relationship type in Toasty. A
+many-to-many relationship uses two direct relationships joined through a third
+model.
+
+## Many-to-many uses a join model
+
+A many-to-many relationship lets each record on either side connect to multiple
+records on the other side. Users can join multiple groups, and groups can contain
+multiple users. A `memberships` table represents each user-group connection as a
+row with foreign keys to both endpoint tables:
+
+```text
+users              memberships                 groups
+┌────┬───────┐     ┌─────────┬──────────┐      ┌────┬───────────┐
+│ id │ name  │     │ user_id │ group_id │      │ id │ name      │
+├────┼───────┤     ├─────────┼──────────┤      ├────┼───────────┤
+│  1 │ Alice │◄────│       1 │       10 │─────►│ 10 │ Rust      │
+│  2 │ Bob   │◄────│       2 │       10 │─────►│ 20 │ Databases │
+└────┴───────┘     │       1 │       20 │─────►└────┴───────────┘
+                   └─────────┴──────────┘
+```
+
+In Toasty, the join table is a normal model such as `Membership`. Each endpoint
+has a direct `#[has_many]` relation to the join model and a derived
+`#[has_many(via = ...)]` relation to the opposite endpoint. Code creates,
+updates, and deletes join-model records to change the connections; the derived
+relation provides read-only traversal. The [Many-to-Many](./many-to-many.md)
+chapter shows the model definition, traversal, filtering, preloading, and link
+mutation.
 
 ## Relationship types
 
-Toasty supports three relationship types. They differ in how many records each
-side of the relationship holds, and which model contains the foreign key.
+Toasty supports three direct relationship types. They differ in how many records
+each side holds and which model contains the foreign key. Many-to-many is a
+modeling pattern composed from these types rather than a fourth relation
+attribute.
 
 | Type | Foreign key on | Parent has | Child has | Example |
 |---|---|---|---|---|
@@ -245,6 +274,7 @@ generates the appropriate cascade deletes or null-setting updates automatically.
 | A post has one author | `Post` → `Deferred<User>` or `User` + `User` → `Deferred<Vec<Post>>` or `Vec<Post>` | `posts.user_id` |
 | A user has one profile | `User` → `Deferred<Profile>` or `Profile` + `Profile` → `Deferred<User>` or `User` | `profiles.user_id` |
 | A comment belongs to a post | `Comment` → `Deferred<Post>` or `Post` + `Post` → `Deferred<Vec<Comment>>` or `Vec<Comment>` | `comments.post_id` |
+| Users join many groups and groups contain many users | Join model with two `BelongsTo` relations plus `has_many(via = ...)` on the endpoints | `memberships.user_id` and `memberships.group_id` |
 
 When deciding between `HasOne` and `HasMany`, ask: "Can the parent have more
 than one?" If yes, use `HasMany`. If exactly one (or zero), use `HasOne`. The
@@ -308,6 +338,8 @@ querying, creating, and updating:
   parent, setting the relation on create
 - [**HasMany**](./has-many.md) — querying children, creating through the
   relation, inserting and removing, scoped queries
+- [**Many-to-Many**](./many-to-many.md) — defining a join model, traversing in
+  both directions, filtering by endpoints or join metadata, and changing links
 - [**HasOne**](./has-one.md) — required vs optional, creating and updating the
   child, replace and unset behavior
 - [**Preloading Associations**](./preloading-associations.md) — avoiding extra


### PR DESCRIPTION
## Summary
- Add a shared `user_group_membership` scenario covering a bidirectional many-to-many relation through a join model
- Add integration tests for querying, filtering, preloading, mutating, and duplicate-link prevention across both directions
- Cover a self-referential many-to-many case with distinct join-key hints

## Testing
- Not run (not requested)