### PR TITLE
feat: add Markdown database driver and scan predicate support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ members = [
     # Driver implementations
     "crates/toasty-driver-dynamodb",
     "crates/toasty-driver-mysql",
+    "crates/toasty-driver-memory",
+    "crates/toasty-driver-markdown",
     "crates/toasty-driver-postgresql",
     "crates/toasty-driver-sqlite",
     "crates/toasty-driver-turso",
@@ -80,6 +82,8 @@ toasty-sql = { version = "0.8.0", path = "crates/toasty-sql" }
 # Driver implementations
 toasty-driver-dynamodb = { version = "0.8.0", path = "crates/toasty-driver-dynamodb" }
 toasty-driver-mysql = { version = "0.8.0", path = "crates/toasty-driver-mysql" }
+toasty-driver-memory = { version = "0.8.0", path = "crates/toasty-driver-memory" }
+toasty-driver-markdown = { version = "0.8.0", path = "crates/toasty-driver-markdown" }
 toasty-driver-postgresql = { version = "0.8.0", path = "crates/toasty-driver-postgresql" }
 toasty-driver-sqlite = { version = "0.8.0", path = "crates/toasty-driver-sqlite" }
 toasty-driver-turso = { version = "0.8.0", path = "crates/toasty-driver-turso" }
@@ -131,6 +135,7 @@ bigdecimal = "0.4.10"
 rusqlite = { version = "0.39", features = ["bundled"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
+serde_yaml = "0.9.34"
 syn = { version = "2.0.117", features = ["full", "extra-traits", "visit-mut"] }
 toml = "1.1.0"
 toml_edit = "0.25.8"
@@ -148,6 +153,7 @@ tracing = "0.1"
 turso = "0.6"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 trybuild = { version = "1.0.116", features = ["diff"] }
+unicode-casefold = "0.2.0"
 url = "2.5.8"
 uuid = { version = "1.23.0", features = ["v4", "v7", "fast-rng"] }
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@
 [discord-badge]: https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=flat-square
 [discord-url]: https://discord.gg/tokio
 
-Toasty supports SQL databases (SQLite/Turso, PostgreSQL, MySQL) and DynamoDB.
-It does not hide database capabilities — it exposes features based on the
-target database.
+Toasty supports SQL databases (SQLite/Turso, PostgreSQL, MySQL), DynamoDB, and
+read-only Markdown content. It does not hide backend capabilities — it exposes
+features based on the selected driver.
 
 ## Using Toasty
 
@@ -99,10 +99,10 @@ for todo in &todos {
 
 ## SQL and NoSQL
 
-Toasty supports both SQL and NoSQL databases. Current drivers are SQLite,
-Turso, PostgreSQL, MySQL, and DynamoDB. However, it does not aim to abstract
-the database. Instead, Toasty leans into the target database's capabilities
-and aims to help the user avoid issuing inefficient queries for that database.
+Toasty supports SQL and NoSQL databases as well as read-only content sources.
+Current drivers are SQLite, Turso, PostgreSQL, MySQL, DynamoDB, Markdown, and
+an immutable in-memory store. Toasty exposes each backend's capabilities rather
+than assigning one set of behavior to every driver.
 
 When targeting both SQL and NoSQL databases, Toasty generates query methods
 (e.g. `get_by_id` only for access patterns that are indexed). When targeting a

--- a/crates/toasty-core/Cargo.toml
+++ b/crates/toasty-core/Cargo.toml
@@ -26,6 +26,7 @@ serde = { workspace = true, optional = true }
 heck.workspace = true
 tokio-stream.workspace = true
 tracing.workspace = true
+unicode-casefold.workspace = true
 uuid.workspace = true
 
 [features]

--- a/crates/toasty-core/src/driver.rs
+++ b/crates/toasty-core/src/driver.rs
@@ -121,6 +121,16 @@ pub trait Driver: Debug + Send + Sync + 'static {
     /// Describes the driver's capability, which informs the query planner.
     fn capability(&self) -> &'static Capability;
 
+    /// Initializes schema-dependent driver state before the connection pool is
+    /// made available.
+    ///
+    /// Most drivers do not need this hook. File-backed and in-memory drivers
+    /// can use it to validate and load typed rows once the compiled schema is
+    /// available. The default is a no-op.
+    async fn initialize(&mut self, _schema: &Arc<Schema>) -> crate::Result<()> {
+        Ok(())
+    }
+
     /// Creates a new connection to the database.
     ///
     /// This method is called by the [`Pool`] whenever a [`Connection`] is requested while none is

--- a/crates/toasty-core/src/driver/capability.rs
+++ b/crates/toasty-core/src/driver/capability.rs
@@ -23,6 +23,13 @@ use crate::{schema::db, stmt};
 /// ```
 #[derive(Debug)]
 pub struct Capability {
+    /// Whether the driver supports inserting, updating, and deleting rows.
+    ///
+    /// When `false`, the query verifier rejects every mutation before lowering,
+    /// planning, connection acquisition, or execution. Drivers must still
+    /// reject mutation operations defensively when called directly.
+    pub data_mutations: bool,
+
     /// When `true`, the database uses a SQL-based query language and the
     /// planner will emit [`QuerySql`](super::operation::QuerySql) operations.
     pub sql: bool,
@@ -162,13 +169,13 @@ pub struct Capability {
     /// will not produce one.
     pub native_like: bool,
 
-    /// Whether the database has a native case-insensitive `LIKE` operator
-    /// (`ILIKE`). Only PostgreSQL has one.
+    /// Whether the backend implements case-insensitive `LIKE` semantics.
     ///
-    /// Toasty does not emulate `ILIKE` on backends that lack it: `.ilike()`
-    /// is a pass-through to the database's own operator. When `native_ilike`
-    /// is `false`, the query-verify pass rejects a case-insensitive
-    /// `Expr::Like` with an
+    /// SQL drivers use the database's own operator rather than emulating it;
+    /// PostgreSQL is the only SQL backend that provides `ILIKE`. Non-SQL
+    /// drivers may implement and document their own semantics. When
+    /// `native_ilike` is `false`, query verification rejects a
+    /// case-insensitive `Expr::Like` with an
     /// [`unsupported_feature`](crate::Error::unsupported_feature) error rather
     /// than silently degrading to plain `LIKE`, whose case behavior differs.
     ///
@@ -458,7 +465,7 @@ impl Capability {
         }
 
         // ILIKE is a case-insensitive LIKE; a backend cannot offer it without
-        // a native LIKE.
+        // LIKE support.
         if self.native_ilike && !self.native_like {
             return Err(crate::Error::invalid_driver_configuration(
                 "native_ilike is true but native_like is false",
@@ -536,6 +543,7 @@ impl Capability {
 
     /// SQLite capabilities.
     pub const SQLITE: Self = Self {
+        data_mutations: true,
         sql: true,
         sql_placeholder: Some(SqlPlaceholder::NumberedQuestionMark),
         storage_types: StorageTypes::SQLITE,
@@ -750,6 +758,7 @@ impl Capability {
 
     /// DynamoDB capabilities
     pub const DYNAMODB: Self = Self {
+        data_mutations: true,
         sql: false,
         sql_placeholder: None,
         storage_types: StorageTypes::DYNAMODB,

--- a/crates/toasty-core/src/driver/operation/scan.rs
+++ b/crates/toasty-core/src/driver/operation/scan.rs
@@ -3,9 +3,10 @@ use crate::{schema::db::TableId, stmt};
 
 /// A full-table scan operation.
 ///
-/// Sent to drivers that set [`Capability::scan`](crate::driver::Capability::scan) to `true`
-/// (currently only DynamoDB). The driver scans the entire table and applies
-/// `filter` to each row before returning results.
+/// Sent to non-SQL drivers that set
+/// [`Capability::scan`](crate::driver::Capability::scan) to `true`. The driver
+/// scans the table and applies the requested filter, ordering, pagination, and
+/// projection.
 #[derive(Debug, Clone)]
 pub struct Scan {
     /// Table to scan.
@@ -16,6 +17,12 @@ pub struct Scan {
 
     /// Optional filter expression applied to each row after scanning.
     pub filter: Option<stmt::Expr>,
+
+    /// Expressions used to order matching rows before pagination.
+    ///
+    /// This is only present for drivers with
+    /// [`Capability::scan_supports_sort`](crate::driver::Capability::scan_supports_sort).
+    pub order_by: Option<stmt::OrderBy>,
 
     /// Limit and pagination bounds. `None` means return all rows.
     ///

--- a/crates/toasty-core/src/stmt/eval.rs
+++ b/crates/toasty-core/src/stmt/eval.rs
@@ -24,6 +24,7 @@ use crate::{
     },
 };
 use std::cmp::Ordering;
+use unicode_casefold::UnicodeCaseFold;
 
 enum ScopeStack<'a> {
     Root,
@@ -198,10 +199,34 @@ impl Expr {
                 match expr_binary_op.op {
                     BinaryOp::Eq => Ok((lhs == rhs).into()),
                     BinaryOp::Ne => Ok((lhs != rhs).into()),
-                    BinaryOp::Ge => Ok((cmp_ordered(&lhs, &rhs)? != Ordering::Less).into()),
-                    BinaryOp::Gt => Ok((cmp_ordered(&lhs, &rhs)? == Ordering::Greater).into()),
-                    BinaryOp::Le => Ok((cmp_ordered(&lhs, &rhs)? != Ordering::Greater).into()),
-                    BinaryOp::Lt => Ok((cmp_ordered(&lhs, &rhs)? == Ordering::Less).into()),
+                    BinaryOp::Ge => Ok(ordered_predicate(
+                        &lhs,
+                        &rhs,
+                        input.ordered_nulls_are_false(),
+                        |order| order != Ordering::Less,
+                    )?
+                    .into()),
+                    BinaryOp::Gt => Ok(ordered_predicate(
+                        &lhs,
+                        &rhs,
+                        input.ordered_nulls_are_false(),
+                        |order| order == Ordering::Greater,
+                    )?
+                    .into()),
+                    BinaryOp::Le => Ok(ordered_predicate(
+                        &lhs,
+                        &rhs,
+                        input.ordered_nulls_are_false(),
+                        |order| order != Ordering::Greater,
+                    )?
+                    .into()),
+                    BinaryOp::Lt => Ok(ordered_predicate(
+                        &lhs,
+                        &rhs,
+                        input.ordered_nulls_are_false(),
+                        |order| order == Ordering::Less,
+                    )?
+                    .into()),
                     BinaryOp::Add => lhs.checked_add(&rhs).ok_or_else(|| {
                         crate::Error::expression_evaluation_failed(
                             "arithmetic overflow or type mismatch in `+`",
@@ -213,6 +238,17 @@ impl Expr {
                         )
                     }),
                 }
+            }
+            Expr::Between(expr_between) => {
+                let value = expr_between.expr.eval_ref(scope, input)?;
+                let low = expr_between.low.eval_ref(scope, input)?;
+                let high = expr_between.high.eval_ref(scope, input)?;
+                if value.is_null() || low.is_null() || high.is_null() {
+                    return Ok(false.into());
+                }
+                Ok((cmp_ordered(&value, &low)? != Ordering::Less
+                    && cmp_ordered(&value, &high)? != Ordering::Greater)
+                    .into())
             }
             Expr::Cast(expr_cast) => {
                 let value = expr_cast.expr.eval_ref(scope, input)?;
@@ -362,6 +398,52 @@ impl Expr {
 
                 Ok(items.iter().any(|item| item == &needle).into())
             }
+            Expr::Intersects(expr) => {
+                let lhs = expr.lhs.eval_ref(scope, input)?;
+                let rhs = expr.rhs.eval_ref(scope, input)?;
+                if lhs.is_null() || rhs.is_null() {
+                    return Ok(false.into());
+                }
+                let (Value::List(lhs), Value::List(rhs)) = (lhs, rhs) else {
+                    return Err(crate::Error::expression_evaluation_failed(
+                        "intersects operands must evaluate to lists",
+                    ));
+                };
+                Ok(lhs.iter().any(|value| rhs.contains(value)).into())
+            }
+            Expr::IsSuperset(expr) => {
+                let lhs = expr.lhs.eval_ref(scope, input)?;
+                let rhs = expr.rhs.eval_ref(scope, input)?;
+                if lhs.is_null() || rhs.is_null() {
+                    return Ok(false.into());
+                }
+                let (Value::List(lhs), Value::List(rhs)) = (lhs, rhs) else {
+                    return Err(crate::Error::expression_evaluation_failed(
+                        "is_superset operands must evaluate to lists",
+                    ));
+                };
+                Ok(rhs.iter().all(|value| lhs.contains(value)).into())
+            }
+            Expr::Length(expr) => match expr.expr.eval_ref(scope, input)? {
+                Value::List(items) => Ok(Value::I64(items.len() as i64)),
+                Value::Null => Ok(Value::Null),
+                _ => Err(crate::Error::expression_evaluation_failed(
+                    "length operand must evaluate to a list",
+                )),
+            },
+            Expr::Like(expr) => {
+                let value = expr.expr.eval_ref(scope, input)?;
+                let pattern = expr.pattern.eval_ref(scope, input)?;
+                if value.is_null() || pattern.is_null() {
+                    return Ok(false.into());
+                }
+                let (Value::String(value), Value::String(pattern)) = (value, pattern) else {
+                    return Err(crate::Error::expression_evaluation_failed(
+                        "LIKE operands must evaluate to strings",
+                    ));
+                };
+                Ok(like_matches(&value, &pattern, expr.escape, expr.case_insensitive)?.into())
+            }
             Expr::AnyOp(e) => {
                 let lhs = e.lhs.eval_ref(scope, input)?;
                 let rhs = e.rhs.eval_ref(scope, input)?;
@@ -370,7 +452,14 @@ impl Expr {
                         "ANY right-hand side must evaluate to a list",
                     ));
                 };
-                Ok(any_all_compare(&lhs, &items, e.op, /*all=*/ false)?.into())
+                Ok(any_all_compare(
+                    &lhs,
+                    &items,
+                    e.op,
+                    /*all=*/ false,
+                    input.ordered_nulls_are_false(),
+                )?
+                .into())
             }
             Expr::AllOp(e) => {
                 let lhs = e.lhs.eval_ref(scope, input)?;
@@ -380,7 +469,14 @@ impl Expr {
                         "ALL right-hand side must evaluate to a list",
                     ));
                 };
-                Ok(any_all_compare(&lhs, &items, e.op, /*all=*/ true)?.into())
+                Ok(any_all_compare(
+                    &lhs,
+                    &items,
+                    e.op,
+                    /*all=*/ true,
+                    input.ordered_nulls_are_false(),
+                )?
+                .into())
             }
             Expr::Match(expr_match) => {
                 let subject = expr_match.subject.eval_ref(scope, input)?;
@@ -410,10 +506,25 @@ impl Expr {
                         }
                         Ok(false.into())
                     }
-                    _ => todo!("ExprExists with non-Values body"),
+                    _ => Err(crate::Error::expression_evaluation_failed(
+                        "EXISTS can only evaluate VALUES subqueries client-side",
+                    )),
                 }
             }
             Expr::Value(value) => Ok(value.clone()),
+            Expr::StartsWith(expr) => {
+                let value = expr.expr.eval_ref(scope, input)?;
+                let prefix = expr.prefix.eval_ref(scope, input)?;
+                if value.is_null() || prefix.is_null() {
+                    return Ok(false.into());
+                }
+                let (Value::String(value), Value::String(prefix)) = (value, prefix) else {
+                    return Err(crate::Error::expression_evaluation_failed(
+                        "starts_with operands must evaluate to strings",
+                    ));
+                };
+                Ok(value.starts_with(&prefix).into())
+            }
             // A document path read: navigate the named wire form
             // (`Value::Object`) by key, then cast the leaf to the extraction's
             // declared type. This is how a driver-side in-memory check (e.g.
@@ -442,7 +553,9 @@ impl Expr {
             Expr::Func(_) => Err(crate::Error::expression_evaluation_failed(
                 "database functions cannot be evaluated client-side",
             )),
-            _ => todo!("expr={self:#?}"),
+            _ => Err(crate::Error::expression_evaluation_failed(format!(
+                "expression cannot be evaluated client-side: {self:#?}"
+            ))),
         }
     }
 
@@ -506,15 +619,41 @@ fn cmp_ordered(lhs: &Value, rhs: &Value) -> Result<Ordering> {
     })
 }
 
-fn any_all_compare(lhs: &Value, items: &[Value], op: BinaryOp, all: bool) -> Result<bool> {
+fn ordered_predicate(
+    lhs: &Value,
+    rhs: &Value,
+    nulls_are_false: bool,
+    predicate: impl FnOnce(Ordering) -> bool,
+) -> Result<bool> {
+    if nulls_are_false && (lhs.is_null() || rhs.is_null()) {
+        return Ok(false);
+    }
+    Ok(predicate(cmp_ordered(lhs, rhs)?))
+}
+
+fn any_all_compare(
+    lhs: &Value,
+    items: &[Value],
+    op: BinaryOp,
+    all: bool,
+    nulls_are_false: bool,
+) -> Result<bool> {
     for item in items {
         let matches = match op {
             BinaryOp::Eq => lhs == item,
             BinaryOp::Ne => lhs != item,
-            BinaryOp::Ge => cmp_ordered(lhs, item)? != Ordering::Less,
-            BinaryOp::Gt => cmp_ordered(lhs, item)? == Ordering::Greater,
-            BinaryOp::Le => cmp_ordered(lhs, item)? != Ordering::Greater,
-            BinaryOp::Lt => cmp_ordered(lhs, item)? == Ordering::Less,
+            BinaryOp::Ge => {
+                ordered_predicate(lhs, item, nulls_are_false, |order| order != Ordering::Less)?
+            }
+            BinaryOp::Gt => ordered_predicate(lhs, item, nulls_are_false, |order| {
+                order == Ordering::Greater
+            })?,
+            BinaryOp::Le => ordered_predicate(lhs, item, nulls_are_false, |order| {
+                order != Ordering::Greater
+            })?,
+            BinaryOp::Lt => {
+                ordered_predicate(lhs, item, nulls_are_false, |order| order == Ordering::Less)?
+            }
             BinaryOp::Add | BinaryOp::Sub => {
                 return Err(crate::Error::expression_evaluation_failed(
                     "ANY/ALL only supports comparison operators",
@@ -531,4 +670,77 @@ fn any_all_compare(lhs: &Value, items: &[Value], op: BinaryOp, all: bool) -> Res
     }
     // ANY over empty list → false; ALL over empty list → true.
     Ok(all)
+}
+
+#[derive(Clone, Copy)]
+enum LikeToken {
+    AnySequence,
+    AnyOne,
+    Literal(char),
+}
+
+fn like_matches(
+    value: &str,
+    pattern: &str,
+    escape: Option<char>,
+    case_insensitive: bool,
+) -> Result<bool> {
+    let mut tokens = Vec::new();
+    let mut chars = pattern.chars();
+    while let Some(ch) = chars.next() {
+        if Some(ch) == escape {
+            let Some(literal) = chars.next() else {
+                return Err(crate::Error::expression_evaluation_failed(
+                    "LIKE pattern ends with its escape character",
+                ));
+            };
+            push_like_literal(&mut tokens, literal, case_insensitive);
+        } else {
+            match ch {
+                '%' => tokens.push(LikeToken::AnySequence),
+                '_' => tokens.push(LikeToken::AnyOne),
+                literal => push_like_literal(&mut tokens, literal, case_insensitive),
+            }
+        }
+    }
+
+    let value: Vec<char> = if case_insensitive {
+        value.case_fold().collect()
+    } else {
+        value.chars().collect()
+    };
+    let mut reachable = vec![false; value.len() + 1];
+    reachable[0] = true;
+
+    for token in tokens {
+        let mut next = vec![false; value.len() + 1];
+        match token {
+            LikeToken::AnySequence => {
+                let mut seen = false;
+                for index in 0..=value.len() {
+                    seen |= reachable[index];
+                    next[index] = seen;
+                }
+            }
+            LikeToken::AnyOne => {
+                next[1..].copy_from_slice(&reachable[..value.len()]);
+            }
+            LikeToken::Literal(expected) => {
+                for index in 0..value.len() {
+                    next[index + 1] = reachable[index] && value[index] == expected;
+                }
+            }
+        }
+        reachable = next;
+    }
+
+    Ok(reachable[value.len()])
+}
+
+fn push_like_literal(tokens: &mut Vec<LikeToken>, literal: char, case_insensitive: bool) {
+    if case_insensitive {
+        tokens.extend(literal.case_fold().map(LikeToken::Literal));
+    } else {
+        tokens.push(LikeToken::Literal(literal));
+    }
 }

--- a/crates/toasty-core/src/stmt/input.rs
+++ b/crates/toasty-core/src/stmt/input.rs
@@ -54,6 +54,15 @@ pub trait Input {
         let _ = id;
         None
     }
+
+    /// Returns whether ordered comparisons involving null evaluate to false.
+    ///
+    /// The default evaluator contract reports these comparisons as undefined.
+    /// Backends with two-valued predicate semantics can override this method
+    /// so a null comparison excludes the row instead.
+    fn ordered_nulls_are_false(&self) -> bool {
+        false
+    }
 }
 
 /// Adapts an [`Input`]'s model resolution to the [`Resolve`] trait, so
@@ -137,6 +146,10 @@ impl<I: Input, T: Resolve> Input for TypedInput<'_, I, T> {
 
     fn resolve_model(&self, id: ModelId) -> Option<&Model> {
         self.cx.schema().model(id)
+    }
+
+    fn ordered_nulls_are_false(&self) -> bool {
+        self.input.ordered_nulls_are_false()
     }
 }
 

--- a/crates/toasty-core/tests/stmt_eval_predicates.rs
+++ b/crates/toasty-core/tests/stmt_eval_predicates.rs
@@ -1,0 +1,62 @@
+use toasty_core::stmt::{BinaryOp, Expr, Value};
+
+#[test]
+fn evaluates_read_driver_predicates() {
+    assert_eq!(
+        Expr::between(10_i64, 5_i64, 10_i64).eval_const().unwrap(),
+        Value::Bool(true)
+    );
+    assert_eq!(
+        Expr::starts_with("markdown", "mark").eval_const().unwrap(),
+        Value::Bool(true)
+    );
+    assert_eq!(
+        Expr::like("readme.md", "%.md").eval_const().unwrap(),
+        Value::Bool(true)
+    );
+    assert_eq!(
+        Expr::ilike("README.MD", "readme._d").eval_const().unwrap(),
+        Value::Bool(true)
+    );
+    assert_eq!(
+        Expr::ilike("Straße", "STRASSE").eval_const().unwrap(),
+        Value::Bool(true)
+    );
+    assert_eq!(
+        Expr::any_op(3_i64, BinaryOp::Gt, Expr::list([1_i64, 4_i64]),)
+            .eval_const()
+            .unwrap(),
+        Value::Bool(true)
+    );
+    assert_eq!(
+        Expr::all_op(3_i64, BinaryOp::Gt, Expr::list([1_i64, 2_i64]),)
+            .eval_const()
+            .unwrap(),
+        Value::Bool(true)
+    );
+}
+
+#[test]
+fn ordered_predicates_treat_null_as_not_matching() {
+    assert_eq!(
+        Expr::between(Value::Null, 1_i64, 2_i64)
+            .eval_const()
+            .unwrap(),
+        Value::Bool(false)
+    );
+}
+
+#[test]
+fn escaped_like_patterns_match_literals() {
+    assert_eq!(
+        Expr::like_with_escape("100%", "100\\%", '\\')
+            .eval_const()
+            .unwrap(),
+        Value::Bool(true)
+    );
+    assert!(
+        Expr::like_with_escape("value", "value\\", '\\')
+            .eval_const()
+            .is_err()
+    );
+}

--- a/crates/toasty-driver-dynamodb/src/op/scan.rs
+++ b/crates/toasty-driver-dynamodb/src/op/scan.rs
@@ -15,6 +15,7 @@ impl Connection {
         schema: &Arc<Schema>,
         op: operation::Scan,
     ) -> Result<ExecResponse> {
+        debug_assert!(op.order_by.is_none());
         let table = schema.db.table(op.table);
         let cx = ExprContext::new_with_target(&schema.db, table);
 

--- a/crates/toasty-driver-integration-suite/src/instrumented_driver.rs
+++ b/crates/toasty-driver-integration-suite/src/instrumented_driver.rs
@@ -138,6 +138,10 @@ impl Driver for InstrumentedDriver {
         self.inner.capability()
     }
 
+    async fn initialize(&mut self, schema: &Arc<Schema>) -> Result<()> {
+        self.inner.initialize(schema).await
+    }
+
     async fn connect(&self, cx: &ConnectContext) -> Result<Box<dyn Connection>> {
         Ok(Box::new(InstrumentedConnection {
             inner: self.inner.connect(cx).await?,

--- a/crates/toasty-driver-markdown/Cargo.toml
+++ b/crates/toasty-driver-markdown/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "toasty-driver-markdown"
+version = "0.8.0"
+description = "Read-only Markdown content driver for Toasty"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+categories.workspace = true
+readme.workspace = true
+documentation = "https://docs.rs/toasty-driver-markdown"
+
+[dependencies]
+async-trait.workspace = true
+serde_yaml.workspace = true
+toasty-core.workspace = true
+toasty-driver-memory.workspace = true
+
+[features]
+default = []
+rust_decimal = ["toasty-core/rust_decimal", "toasty-driver-memory/rust_decimal"]
+bigdecimal = ["toasty-core/bigdecimal", "toasty-driver-memory/bigdecimal"]
+jiff = ["toasty-core/jiff", "toasty-driver-memory/jiff"]
+
+[lints]
+workspace = true

--- a/crates/toasty-driver-markdown/src/lib.rs
+++ b/crates/toasty-driver-markdown/src/lib.rs
@@ -1,0 +1,818 @@
+//! Read-only Toasty driver for Markdown files with YAML front matter.
+
+use async_trait::async_trait;
+use serde_yaml::{Mapping, Value as Yaml};
+use std::{
+    borrow::Cow,
+    collections::{HashMap, HashSet},
+    ffi::OsStr,
+    fs,
+    path::{Component, Path, PathBuf},
+    sync::Arc,
+};
+use toasty_core::{
+    Error, Result, Schema,
+    driver::{Capability, ConnectContext, Driver},
+    schema::{db::Migration, diff},
+    stmt::{self, Value, ValueObject, ValueRecord},
+};
+use toasty_driver_memory::{Connection, Snapshot, SnapshotBuilder};
+
+/// Selects how a file path populates a string column.
+#[derive(Debug, Clone)]
+enum PathKey {
+    Stem(String),
+    RelativePath(String),
+}
+
+/// Per-table Markdown mapping configuration.
+#[derive(Debug, Clone)]
+pub struct Table {
+    directory: PathBuf,
+    columns: HashMap<String, String>,
+    body_column: BodyColumn,
+    path_key: Option<PathKey>,
+    recursive: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+enum BodyColumn {
+    #[default]
+    Conventional,
+    Named(String),
+    Disabled,
+}
+
+impl Table {
+    /// Creates a table mapping rooted at `directory`, relative to the content root.
+    pub fn new(directory: impl Into<PathBuf>) -> Self {
+        Self {
+            directory: directory.into(),
+            columns: HashMap::new(),
+            body_column: BodyColumn::Conventional,
+            path_key: None,
+            recursive: false,
+        }
+    }
+
+    /// Maps a YAML front-matter key to a database column name.
+    pub fn column(mut self, front_matter: impl Into<String>, column: impl Into<String>) -> Self {
+        self.columns.insert(front_matter.into(), column.into());
+        self
+    }
+
+    /// Maps the Markdown body to the named string column.
+    pub fn body_column(mut self, column: impl Into<String>) -> Self {
+        self.body_column = BodyColumn::Named(column.into());
+        self
+    }
+
+    /// Disables Markdown body mapping for this table.
+    pub fn disable_body(mut self) -> Self {
+        self.body_column = BodyColumn::Disabled;
+        self
+    }
+
+    /// Populates the named string column from each file stem.
+    pub fn key_from_stem(mut self, column: impl Into<String>) -> Self {
+        self.path_key = Some(PathKey::Stem(column.into()));
+        self
+    }
+
+    /// Populates the named string column from the relative path without `.md`.
+    pub fn key_from_relative_path(mut self, column: impl Into<String>) -> Self {
+        self.path_key = Some(PathKey::RelativePath(column.into()));
+        self
+    }
+
+    /// Enables or disables recursive `.md` discovery.
+    pub fn recursive(mut self, recursive: bool) -> Self {
+        self.recursive = recursive;
+        self
+    }
+}
+
+/// Builder for a [`Markdown`] driver.
+#[derive(Debug)]
+pub struct Builder {
+    root: PathBuf,
+    tables: HashMap<String, Table>,
+    strict: bool,
+}
+
+impl Builder {
+    /// Overrides conventions for one database table.
+    pub fn table(mut self, table: impl Into<String>, config: Table) -> Self {
+        self.tables.insert(table.into(), config);
+        self
+    }
+
+    /// Enables errors for unknown directories, metadata, and unmapped bodies.
+    pub fn strict(mut self, strict: bool) -> Self {
+        self.strict = strict;
+        self
+    }
+
+    /// Builds the driver. Files are loaded later during `Db::build()`.
+    pub fn build(self) -> Markdown {
+        Markdown {
+            root: self.root,
+            tables: self.tables,
+            strict: self.strict,
+            snapshot: None,
+        }
+    }
+}
+
+/// A read-only driver that presents Markdown files as Toasty rows.
+#[derive(Debug)]
+pub struct Markdown {
+    root: PathBuf,
+    tables: HashMap<String, Table>,
+    strict: bool,
+    snapshot: Option<Arc<Snapshot>>,
+}
+
+impl Markdown {
+    /// Creates a driver using the default directory and column conventions.
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self::builder(root).build()
+    }
+
+    /// Creates a configurable Markdown driver builder.
+    pub fn builder(root: impl Into<PathBuf>) -> Builder {
+        Builder {
+            root: root.into(),
+            tables: HashMap::new(),
+            strict: false,
+        }
+    }
+
+    fn load(&self, schema: &Arc<Schema>) -> Result<Snapshot> {
+        let root = self.root.canonicalize().map_err(|error| {
+            Error::from_args(format_args!(
+                "failed to open Markdown root `{}`: {error}",
+                self.root.display()
+            ))
+        })?;
+        if !root.is_dir() {
+            return Err(Error::invalid_driver_configuration(format!(
+                "Markdown root `{}` is not a directory",
+                root.display()
+            )));
+        }
+
+        for table_name in self.tables.keys() {
+            if !schema
+                .db
+                .tables
+                .iter()
+                .any(|table| &table.name == table_name)
+            {
+                return Err(Error::invalid_driver_configuration(format!(
+                    "Markdown configuration names unknown table `{table_name}`"
+                )));
+            }
+        }
+
+        if self.strict {
+            self.validate_root_directories(schema, &root)?;
+        }
+
+        let mut snapshot = SnapshotBuilder::new(schema.clone());
+        for table in &schema.db.tables {
+            let explicit = self.tables.get(&table.name);
+            let config = explicit
+                .cloned()
+                .unwrap_or_else(|| Table::new(table.name.clone()));
+            validate_table_config(table, &config)?;
+            validate_relative_directory(&config.directory)?;
+            let directory = root.join(&config.directory);
+
+            if !directory.exists() {
+                if explicit.is_some() {
+                    return Err(Error::invalid_driver_configuration(format!(
+                        "configured Markdown directory `{}` does not exist",
+                        directory.display()
+                    )));
+                }
+                continue;
+            }
+
+            let metadata = fs::symlink_metadata(&directory).map_err(file_error(&directory))?;
+            if metadata.file_type().is_symlink() || !metadata.is_dir() {
+                return Err(Error::invalid_driver_configuration(format!(
+                    "Markdown table path `{}` must be a real directory",
+                    directory.display()
+                )));
+            }
+
+            let canonical = directory.canonicalize().map_err(file_error(&directory))?;
+            if !canonical.starts_with(&root) {
+                return Err(Error::invalid_driver_configuration(format!(
+                    "Markdown table path `{}` escapes the content root",
+                    directory.display()
+                )));
+            }
+
+            let mut files = Vec::new();
+            discover_files(&directory, config.recursive, self.strict, &mut files)?;
+            files.sort();
+            for path in files {
+                let row = self.load_file(schema, table, &config, &directory, &path)?;
+                snapshot.insert(table.id, row)?;
+            }
+        }
+        snapshot.build()
+    }
+
+    fn validate_root_directories(&self, schema: &Schema, root: &Path) -> Result<()> {
+        let expected: HashSet<PathBuf> = schema
+            .db
+            .tables
+            .iter()
+            .map(|table| {
+                self.tables
+                    .get(&table.name)
+                    .map(|config| config.directory.clone())
+                    .unwrap_or_else(|| PathBuf::from(&table.name))
+            })
+            .filter_map(|path| {
+                path.components()
+                    .next()
+                    .map(|component| PathBuf::from(component.as_os_str()))
+            })
+            .collect();
+
+        for entry in fs::read_dir(root).map_err(file_error(root))? {
+            let entry = entry.map_err(file_error(root))?;
+            let metadata = fs::symlink_metadata(entry.path()).map_err(file_error(&entry.path()))?;
+            if metadata.is_dir() && !expected.contains(&PathBuf::from(entry.file_name())) {
+                return Err(Error::invalid_driver_configuration(format!(
+                    "unknown directory `{}` in strict Markdown root",
+                    entry.path().display()
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn load_file(
+        &self,
+        schema: &Schema,
+        table: &toasty_core::schema::db::Table,
+        config: &Table,
+        directory: &Path,
+        path: &Path,
+    ) -> Result<ValueRecord> {
+        let source = fs::read_to_string(path).map_err(file_error(path))?;
+        let (front_matter, body) = split_document(path, &source)?;
+        let mapping = parse_front_matter(path, front_matter)?;
+        let mut values = vec![Value::Null; table.columns.len()];
+        let mut populated = HashSet::new();
+
+        for (key, yaml) in mapping {
+            let Some(key) = key.as_str() else {
+                return Err(Error::invalid_driver_configuration(format!(
+                    "front matter in `{}` contains a non-string key",
+                    path.display()
+                )));
+            };
+            let column_name = config.columns.get(key).map(String::as_str).unwrap_or(key);
+            let Some(column) = table
+                .columns
+                .iter()
+                .find(|column| column.name == column_name)
+            else {
+                if self.strict {
+                    return Err(Error::invalid_driver_configuration(format!(
+                        "unknown front-matter key `{key}` in `{}`",
+                        path.display()
+                    )));
+                }
+                continue;
+            };
+            if !populated.insert(column.id.index) {
+                return Err(Error::invalid_driver_configuration(format!(
+                    "more than one source populates column `{}` in `{}`",
+                    column.name,
+                    path.display()
+                )));
+            }
+            values[column.id.index] = decode_yaml(schema, &column.ty, yaml).map_err(|error| {
+                error.context(Error::from_args(format_args!(
+                    "invalid front-matter key `{key}` in `{}`",
+                    path.display()
+                )))
+            })?;
+        }
+
+        let configured_path_key = config.path_key.is_some();
+        let path_key = config.path_key.clone().or_else(|| {
+            (table.primary_key.columns.len() == 1)
+                .then(|| table.primary_key_column(0))
+                .filter(|column| column.ty == stmt::Type::String)
+                .map(|column| PathKey::Stem(column.name.clone()))
+        });
+        if let Some(path_key) = path_key {
+            let (column_name, value) = match path_key {
+                PathKey::Stem(column) => (
+                    column,
+                    path.file_stem()
+                        .and_then(OsStr::to_str)
+                        .map(str::to_owned)
+                        .ok_or_else(|| invalid_utf8_path(path))?,
+                ),
+                PathKey::RelativePath(column) => {
+                    let relative = path.strip_prefix(directory).map_err(|_| {
+                        Error::invalid_driver_configuration("Markdown path escaped its table")
+                    })?;
+                    let mut relative = relative.to_path_buf();
+                    relative.set_extension("");
+                    let value = relative
+                        .components()
+                        .map(|component| component.as_os_str().to_str())
+                        .collect::<Option<Vec<_>>>()
+                        .ok_or_else(|| invalid_utf8_path(path))?
+                        .join("/");
+                    (column, value)
+                }
+            };
+            let column = table
+                .columns
+                .iter()
+                .find(|column| column.name == column_name)
+                .ok_or_else(|| {
+                    Error::invalid_driver_configuration(format!(
+                        "path key names unknown column `{column_name}` on table `{}`",
+                        table.name
+                    ))
+                })?;
+            if column.ty != stmt::Type::String {
+                return Err(Error::invalid_driver_configuration(format!(
+                    "path-derived column `{}` on table `{}` must be String",
+                    column.name, table.name
+                )));
+            }
+            if populated.contains(&column.id.index) {
+                if configured_path_key {
+                    return Err(Error::invalid_driver_configuration(format!(
+                        "front matter and the path both populate column `{}` in `{}`",
+                        column.name,
+                        path.display()
+                    )));
+                }
+            } else {
+                values[column.id.index] = Value::String(value);
+                populated.insert(column.id.index);
+            }
+        }
+
+        let body_column = match &config.body_column {
+            BodyColumn::Conventional => table
+                .columns
+                .iter()
+                .find(|column| column.name == "body")
+                .map(|column| column.name.as_str()),
+            BodyColumn::Named(column) => Some(column.as_str()),
+            BodyColumn::Disabled => None,
+        };
+        if let Some(body_column) = body_column {
+            let column = table
+                .columns
+                .iter()
+                .find(|column| column.name == body_column)
+                .ok_or_else(|| {
+                    Error::invalid_driver_configuration(format!(
+                        "body mapping names unknown column `{body_column}` on table `{}`",
+                        table.name
+                    ))
+                })?;
+            if column.ty != stmt::Type::String {
+                return Err(Error::invalid_driver_configuration(format!(
+                    "body column `{body_column}` on table `{}` must be String",
+                    table.name
+                )));
+            }
+            if populated.contains(&column.id.index) {
+                return Err(Error::invalid_driver_configuration(format!(
+                    "front matter and the Markdown body both populate column `{body_column}` in `{}`",
+                    path.display()
+                )));
+            }
+            values[column.id.index] = Value::String(body.to_owned());
+            populated.insert(column.id.index);
+        } else if self.strict && !body.is_empty() {
+            return Err(Error::invalid_driver_configuration(format!(
+                "non-empty Markdown body in `{}` has no body column",
+                path.display()
+            )));
+        }
+
+        for column in &table.columns {
+            if values[column.id.index].is_null() && !column.nullable {
+                return Err(Error::invalid_schema(format!(
+                    "missing required column `{}` in `{}`",
+                    column.name,
+                    path.display()
+                )));
+            }
+        }
+
+        Ok(ValueRecord::from_vec(values))
+    }
+}
+
+fn validate_table_config(table: &toasty_core::schema::db::Table, config: &Table) -> Result<()> {
+    let mut destinations = HashSet::new();
+    for (front_matter, column_name) in &config.columns {
+        if !destinations.insert(column_name) {
+            return Err(Error::invalid_driver_configuration(format!(
+                "front-matter keys map to column `{column_name}` more than once on table `{}`",
+                table.name
+            )));
+        }
+        if !table
+            .columns
+            .iter()
+            .any(|column| column.name == *column_name)
+        {
+            return Err(Error::invalid_driver_configuration(format!(
+                "front-matter key `{front_matter}` maps to unknown column `{column_name}` on table `{}`",
+                table.name
+            )));
+        }
+    }
+
+    let body_column = match &config.body_column {
+        BodyColumn::Conventional => table.columns.iter().find(|column| column.name == "body"),
+        BodyColumn::Named(column_name) => Some(
+            table
+                .columns
+                .iter()
+                .find(|column| column.name == *column_name)
+                .ok_or_else(|| {
+                    Error::invalid_driver_configuration(format!(
+                        "body mapping names unknown column `{column_name}` on table `{}`",
+                        table.name
+                    ))
+                })?,
+        ),
+        BodyColumn::Disabled => None,
+    };
+    if let Some(column) = body_column
+        && column.ty != stmt::Type::String
+    {
+        return Err(Error::invalid_driver_configuration(format!(
+            "body column `{}` on table `{}` must be String",
+            column.name, table.name
+        )));
+    }
+
+    if let Some(path_key) = &config.path_key {
+        let column_name = match path_key {
+            PathKey::Stem(column) | PathKey::RelativePath(column) => column,
+        };
+        let column = table
+            .columns
+            .iter()
+            .find(|column| column.name == *column_name)
+            .ok_or_else(|| {
+                Error::invalid_driver_configuration(format!(
+                    "path key names unknown column `{column_name}` on table `{}`",
+                    table.name
+                ))
+            })?;
+        if column.ty != stmt::Type::String {
+            return Err(Error::invalid_driver_configuration(format!(
+                "path-derived column `{}` on table `{}` must be String",
+                column.name, table.name
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_relative_directory(path: &Path) -> Result<()> {
+    if path.as_os_str().is_empty()
+        || path.is_absolute()
+        || path.components().any(|component| {
+            matches!(
+                component,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        })
+    {
+        return Err(Error::invalid_driver_configuration(format!(
+            "Markdown table directory `{}` must be a relative path inside the root",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn discover_files(
+    directory: &Path,
+    recursive: bool,
+    strict: bool,
+    files: &mut Vec<PathBuf>,
+) -> Result<()> {
+    for entry in fs::read_dir(directory).map_err(file_error(directory))? {
+        let entry = entry.map_err(file_error(directory))?;
+        let path = entry.path();
+        let metadata = fs::symlink_metadata(&path).map_err(file_error(&path))?;
+        if metadata.file_type().is_symlink() {
+            continue;
+        }
+        if metadata.is_dir() {
+            if recursive {
+                discover_files(&path, true, strict, files)?;
+            } else if strict {
+                return Err(Error::invalid_driver_configuration(format!(
+                    "nested directory `{}` requires recursive discovery",
+                    path.display()
+                )));
+            }
+        } else if metadata.is_file() && path.extension() == Some(OsStr::new("md")) {
+            files.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn split_document<'a>(path: &Path, source: &'a str) -> Result<(Option<&'a str>, &'a str)> {
+    let Some(first_end) = source.find('\n') else {
+        return if source.trim_end_matches('\r') == "---" {
+            Err(Error::invalid_driver_configuration(format!(
+                "front matter in `{}` has no closing delimiter",
+                path.display()
+            )))
+        } else {
+            Ok((None, source))
+        };
+    };
+    if source[..first_end].trim_end_matches('\r') != "---" {
+        return Ok((None, source));
+    }
+
+    let content_start = first_end + 1;
+    let mut offset = content_start;
+    for line in source[content_start..].split_inclusive('\n') {
+        let line_without_newline = line.trim_end_matches('\n').trim_end_matches('\r');
+        if line_without_newline == "---" {
+            let front_matter = &source[content_start..offset];
+            let body_start = offset + line.len();
+            return Ok((Some(front_matter), &source[body_start..]));
+        }
+        offset += line.len();
+    }
+    if offset < source.len() && source[offset..].trim_end_matches('\r') == "---" {
+        return Ok((Some(&source[content_start..offset]), ""));
+    }
+
+    Err(Error::invalid_driver_configuration(format!(
+        "front matter in `{}` has no closing delimiter",
+        path.display()
+    )))
+}
+
+fn parse_front_matter(path: &Path, source: Option<&str>) -> Result<Mapping> {
+    let Some(source) = source else {
+        return Ok(Mapping::new());
+    };
+    if source.trim().is_empty() {
+        return Ok(Mapping::new());
+    }
+    match serde_yaml::from_str(source).map_err(|error| {
+        Error::invalid_driver_configuration(format!(
+            "invalid YAML front matter in `{}`: {error}",
+            path.display()
+        ))
+    })? {
+        Yaml::Mapping(mapping) => Ok(mapping),
+        Yaml::Null => Ok(Mapping::new()),
+        _ => Err(Error::invalid_driver_configuration(format!(
+            "front matter in `{}` must be a YAML mapping",
+            path.display()
+        ))),
+    }
+}
+
+fn decode_yaml(schema: &Schema, ty: &stmt::Type, yaml: Yaml) -> Result<Value> {
+    if matches!(yaml, Yaml::Null) {
+        return Ok(Value::Null);
+    }
+
+    match ty {
+        stmt::Type::List(element) => {
+            let Yaml::Sequence(items) = yaml else {
+                return type_error(ty, yaml);
+            };
+            Ok(Value::List(
+                items
+                    .into_iter()
+                    .map(|item| decode_yaml(schema, element, item))
+                    .collect::<Result<_>>()?,
+            ))
+        }
+        stmt::Type::Record(fields) => {
+            let Yaml::Sequence(items) = yaml else {
+                return type_error(ty, yaml);
+            };
+            if items.len() != fields.len() {
+                return Err(Error::invalid_schema(format!(
+                    "expected {} record fields, got {}",
+                    fields.len(),
+                    items.len()
+                )));
+            }
+            Ok(Value::record_from_vec(
+                fields
+                    .iter()
+                    .zip(items)
+                    .map(|(field, item)| decode_yaml(schema, field, item))
+                    .collect::<Result<_>>()?,
+            ))
+        }
+        stmt::Type::Object => yaml_to_object(yaml),
+        stmt::Type::Bytes => match yaml {
+            Yaml::Sequence(items) => Ok(Value::Bytes(
+                items
+                    .into_iter()
+                    .map(|item| match decode_yaml(schema, &stmt::Type::U8, item)? {
+                        Value::U8(value) => Ok(value),
+                        _ => unreachable!(),
+                    })
+                    .collect::<Result<_>>()?,
+            )),
+            yaml => type_error(ty, yaml),
+        },
+        stmt::Type::Uuid => match yaml {
+            Yaml::String(value) => value
+                .parse()
+                .map(Value::Uuid)
+                .map_err(|_| Error::invalid_schema(format!("invalid UUID value `{value}`"))),
+            yaml => type_error(ty, yaml),
+        },
+        #[cfg(feature = "rust_decimal")]
+        stmt::Type::Decimal => match yaml {
+            Yaml::String(value) => value
+                .parse()
+                .map(Value::Decimal)
+                .map_err(|_| Error::invalid_schema(format!("invalid Decimal value `{value}`"))),
+            Yaml::Number(value) => value
+                .to_string()
+                .parse()
+                .map(Value::Decimal)
+                .map_err(|_| Error::invalid_schema(format!("invalid Decimal value `{value}`"))),
+            yaml => type_error(ty, yaml),
+        },
+        #[cfg(feature = "bigdecimal")]
+        stmt::Type::BigDecimal => match yaml {
+            Yaml::String(value) => value
+                .parse()
+                .map(Value::BigDecimal)
+                .map_err(|_| Error::invalid_schema(format!("invalid BigDecimal value `{value}`"))),
+            Yaml::Number(value) => value
+                .to_string()
+                .parse()
+                .map(Value::BigDecimal)
+                .map_err(|_| Error::invalid_schema(format!("invalid BigDecimal value `{value}`"))),
+            yaml => type_error(ty, yaml),
+        },
+        #[cfg(feature = "jiff")]
+        stmt::Type::Timestamp => parse_string_value(yaml, ty, Value::Timestamp),
+        #[cfg(feature = "jiff")]
+        stmt::Type::Zoned => parse_string_value(yaml, ty, Value::Zoned),
+        #[cfg(feature = "jiff")]
+        stmt::Type::Date => parse_string_value(yaml, ty, Value::Date),
+        #[cfg(feature = "jiff")]
+        stmt::Type::Time => parse_string_value(yaml, ty, Value::Time),
+        #[cfg(feature = "jiff")]
+        stmt::Type::DateTime => parse_string_value(yaml, ty, Value::DateTime),
+        _ => {
+            let value = yaml_to_value(yaml)?;
+            if value.is_a(schema, ty) {
+                Ok(value)
+            } else {
+                ty.cast(schema, value)
+            }
+        }
+    }
+}
+
+#[cfg(feature = "jiff")]
+fn parse_string_value<T>(
+    yaml: Yaml,
+    ty: &stmt::Type,
+    constructor: impl FnOnce(T) -> Value,
+) -> Result<Value>
+where
+    T: std::str::FromStr,
+{
+    let Yaml::String(value) = yaml else {
+        return type_error(ty, yaml);
+    };
+    value
+        .parse()
+        .map(constructor)
+        .map_err(|_| Error::invalid_schema(format!("invalid {ty:?} value `{value}`")))
+}
+
+fn yaml_to_value(yaml: Yaml) -> Result<Value> {
+    Ok(match yaml {
+        Yaml::Null => Value::Null,
+        Yaml::Bool(value) => Value::Bool(value),
+        Yaml::Number(value) => {
+            if let Some(value) = value.as_i64() {
+                Value::I64(value)
+            } else if let Some(value) = value.as_u64() {
+                Value::U64(value)
+            } else if let Some(value) = value.as_f64() {
+                Value::F64(value)
+            } else {
+                return Err(Error::invalid_schema(format!(
+                    "unsupported YAML number `{value}`"
+                )));
+            }
+        }
+        Yaml::String(value) => Value::String(value),
+        Yaml::Sequence(items) => Value::List(
+            items
+                .into_iter()
+                .map(yaml_to_value)
+                .collect::<Result<_>>()?,
+        ),
+        Yaml::Mapping(_) => return yaml_to_object(yaml),
+        Yaml::Tagged(tagged) => return yaml_to_value(tagged.value),
+    })
+}
+
+fn yaml_to_object(yaml: Yaml) -> Result<Value> {
+    let Yaml::Mapping(mapping) = yaml else {
+        return type_error(&stmt::Type::Object, yaml);
+    };
+    let mut entries = Vec::with_capacity(mapping.len());
+    for (key, value) in mapping {
+        let Yaml::String(key) = key else {
+            return Err(Error::invalid_schema(
+                "document mappings require string keys",
+            ));
+        };
+        entries.push((key, yaml_to_value(value)?));
+    }
+    Ok(Value::Object(ValueObject::from_vec(entries)))
+}
+
+fn type_error<T>(ty: &stmt::Type, yaml: Yaml) -> Result<T> {
+    Err(Error::invalid_schema(format!(
+        "expected {ty:?}, got YAML value {yaml:?}"
+    )))
+}
+
+fn file_error(path: &Path) -> impl FnOnce(std::io::Error) -> Error + '_ {
+    move |error| Error::from_args(format_args!("failed to read `{}`: {error}", path.display()))
+}
+
+fn invalid_utf8_path(path: &Path) -> Error {
+    Error::invalid_driver_configuration(format!(
+        "Markdown path `{}` is not valid UTF-8",
+        path.display()
+    ))
+}
+
+fn read_only_error() -> Error {
+    Error::unsupported_feature("the Markdown driver is read-only")
+}
+
+#[async_trait]
+impl Driver for Markdown {
+    fn url(&self) -> Cow<'_, str> {
+        Cow::Owned(format!("markdown:{}", self.root.display()))
+    }
+
+    fn capability(&self) -> &'static Capability {
+        &toasty_driver_memory::CAPABILITY
+    }
+
+    async fn initialize(&mut self, schema: &Arc<Schema>) -> Result<()> {
+        self.snapshot = Some(Arc::new(self.load(schema)?));
+        Ok(())
+    }
+
+    async fn connect(&self, _cx: &ConnectContext) -> Result<Box<dyn toasty_core::Connection>> {
+        let snapshot = self.snapshot.clone().ok_or_else(|| {
+            Error::invalid_driver_configuration("Markdown driver was not initialized")
+        })?;
+        Ok(Box::new(Connection::new(snapshot)))
+    }
+
+    fn generate_migration(&self, _schema_diff: &diff::Schema<'_>) -> Migration {
+        Migration::new_sql(String::new())
+    }
+
+    async fn reset_db(&self) -> Result<()> {
+        Err(read_only_error())
+    }
+}

--- a/crates/toasty-driver-memory/Cargo.toml
+++ b/crates/toasty-driver-memory/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "toasty-driver-memory"
+version = "0.8.0"
+description = "Reusable in-memory read executor for Toasty drivers"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+categories.workspace = true
+readme.workspace = true
+documentation = "https://docs.rs/toasty-driver-memory"
+
+[dependencies]
+async-trait.workspace = true
+toasty-core.workspace = true
+
+[features]
+default = []
+rust_decimal = ["toasty-core/rust_decimal"]
+bigdecimal = ["toasty-core/bigdecimal"]
+jiff = ["toasty-core/jiff"]
+
+[lints]
+workspace = true

--- a/crates/toasty-driver-memory/src/lib.rs
+++ b/crates/toasty-driver-memory/src/lib.rs
@@ -1,0 +1,690 @@
+//! Reusable in-memory storage and read execution for Toasty drivers.
+
+use async_trait::async_trait;
+use std::{borrow::Cow, cmp::Ordering, sync::Arc};
+use toasty_core::{
+    Error, Result, Schema,
+    driver::{
+        Capability, ConnectContext, Driver, ExecResponse, Operation, Rows, SchemaMutations,
+        StorageTypes, operation::Pagination,
+    },
+    schema::{
+        db::{self, AppliedMigration, IndexId, Migration, TableId},
+        diff,
+    },
+    stmt::{self, Input, Project, Projection, Value, ValueRecord},
+};
+
+/// Capabilities of the read-only in-memory executor.
+pub static CAPABILITY: Capability = Capability {
+    data_mutations: false,
+    sql: false,
+    sql_placeholder: None,
+    storage_types: StorageTypes {
+        default_string_type: db::Type::Text,
+        varchar: None,
+        default_uuid_type: db::Type::Uuid,
+        default_bytes_type: db::Type::Blob,
+        default_decimal_type: db::Type::Numeric(None),
+        default_bigdecimal_type: db::Type::Numeric(None),
+        default_timestamp_type: db::Type::Timestamp(9),
+        default_zoned_type: db::Type::Text,
+        default_date_type: db::Type::Date,
+        default_time_type: db::Type::Time(9),
+        default_datetime_type: db::Type::DateTime(9),
+        max_unsigned_integer: None,
+    },
+    schema_mutations: SchemaMutations {
+        alter_column_type: false,
+        alter_column_properties_atomic: false,
+    },
+    primary_key_ne_predicate: true,
+    bool_key_type: true,
+    native_timestamp: true,
+    native_date: true,
+    native_time: true,
+    native_datetime: true,
+    native_decimal: true,
+    decimal_arbitrary_precision: true,
+    bigdecimal_implemented: true,
+    index_or_predicate: true,
+    native_starts_with: true,
+    native_like: true,
+    native_ilike: true,
+    scan_supports_sort: true,
+    backward_pagination: true,
+    native_array: true,
+    bind_list_param: true,
+    predicate_match_any: true,
+    native_array_set_predicates: true,
+    ..Capability::DYNAMODB
+};
+
+/// Read access needed by [`Reader`].
+pub trait ReadStore: std::fmt::Debug + Send + Sync + 'static {
+    /// Returns every row in a table in storage order.
+    fn rows(&self, table: TableId) -> &[ValueRecord];
+
+    /// Returns row offsets in the natural order of an index.
+    fn index_rows(&self, table: TableId, index: IndexId) -> Option<Vec<usize>>;
+}
+
+#[derive(Debug)]
+struct IndexSnapshot {
+    rows: Vec<usize>,
+}
+
+#[derive(Debug)]
+struct TableSnapshot {
+    rows: Vec<ValueRecord>,
+    indices: Vec<IndexSnapshot>,
+}
+
+/// An immutable collection of typed database rows and index orderings.
+#[derive(Debug)]
+pub struct Snapshot {
+    tables: Vec<TableSnapshot>,
+}
+
+impl ReadStore for Snapshot {
+    fn rows(&self, table: TableId) -> &[ValueRecord] {
+        &self.tables[table.0].rows
+    }
+
+    fn index_rows(&self, table: TableId, index: IndexId) -> Option<Vec<usize>> {
+        self.tables
+            .get(table.0)?
+            .indices
+            .get(index.index)
+            .map(|index| index.rows.clone())
+    }
+}
+
+/// Builds and validates an immutable [`Snapshot`].
+#[derive(Debug)]
+pub struct SnapshotBuilder {
+    schema: Arc<Schema>,
+    tables: Vec<Vec<ValueRecord>>,
+}
+
+impl SnapshotBuilder {
+    /// Creates an empty builder for a compiled schema.
+    pub fn new(schema: Arc<Schema>) -> Self {
+        Self {
+            tables: vec![Vec::new(); schema.db.tables.len()],
+            schema,
+        }
+    }
+
+    /// Adds one row in database-column order.
+    pub fn insert(&mut self, table: TableId, row: ValueRecord) -> Result<()> {
+        let Some(rows) = self.tables.get_mut(table.0) else {
+            return Err(Error::invalid_schema(format!(
+                "invalid table ID {} while building memory snapshot",
+                table.0
+            )));
+        };
+        rows.push(row);
+        Ok(())
+    }
+
+    /// Adds rows to the table with the given database name.
+    pub fn insert_named(
+        &mut self,
+        table_name: &str,
+        rows: impl IntoIterator<Item = ValueRecord>,
+    ) -> Result<()> {
+        let table = self
+            .schema
+            .db
+            .tables
+            .iter()
+            .find(|table| table.name == table_name)
+            .ok_or_else(|| {
+                Error::invalid_schema(format!("unknown database table `{table_name}`"))
+            })?;
+        self.tables[table.id.0].extend(rows);
+        Ok(())
+    }
+
+    /// Validates all rows and builds declared index orderings.
+    pub fn build(self) -> Result<Snapshot> {
+        let mut tables = Vec::with_capacity(self.tables.len());
+
+        for (table_index, rows) in self.tables.into_iter().enumerate() {
+            let table = &self.schema.db.tables[table_index];
+            for (row_index, row) in rows.iter().enumerate() {
+                validate_row(&self.schema, table, row_index, row)?;
+            }
+
+            let mut indices = Vec::with_capacity(table.indices.len());
+            for index in &table.indices {
+                let mut entries: Vec<(Vec<Value>, usize)> = rows
+                    .iter()
+                    .enumerate()
+                    .map(|(row, value)| (index_key(value, index), row))
+                    .collect();
+
+                if index.unique || index.primary_key {
+                    for left in 0..entries.len() {
+                        if entries[left].0.iter().any(Value::is_null) {
+                            continue;
+                        }
+                        if entries[left + 1..]
+                            .iter()
+                            .any(|entry| entry.0 == entries[left].0)
+                        {
+                            return Err(Error::invalid_schema(format!(
+                                "duplicate value for index `{}` on table `{}`",
+                                index.name, table.name
+                            )));
+                        }
+                    }
+                }
+
+                entries.sort_by(|left, right| compare_keys(&left.0, &right.0));
+                indices.push(IndexSnapshot {
+                    rows: entries.into_iter().map(|entry| entry.1).collect(),
+                });
+            }
+
+            tables.push(TableSnapshot { rows, indices });
+        }
+
+        Ok(Snapshot { tables })
+    }
+}
+
+fn validate_row(
+    schema: &Schema,
+    table: &db::Table,
+    row_index: usize,
+    row: &ValueRecord,
+) -> Result<()> {
+    if row.len() != table.columns.len() {
+        return Err(Error::invalid_schema(format!(
+            "row {row_index} in table `{}` has {} values; expected {}",
+            table.name,
+            row.len(),
+            table.columns.len()
+        )));
+    }
+
+    for (column, value) in table.columns.iter().zip(row.iter()) {
+        if value.is_null() && (!column.nullable || column.primary_key) {
+            return Err(Error::invalid_schema(format!(
+                "row {row_index} in table `{}` has null for required column `{}`",
+                table.name, column.name
+            )));
+        }
+        if !value.is_a(schema, &column.ty) {
+            return Err(Error::invalid_schema(format!(
+                "row {row_index} in table `{}` has an invalid value for column `{}`; expected {:?}, got {:?}",
+                table.name, column.name, column.ty, value
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn index_key(row: &ValueRecord, index: &db::Index) -> Vec<Value> {
+    index
+        .columns
+        .iter()
+        .map(|column| row[column.column.index].clone())
+        .collect()
+}
+
+fn primary_key(row: &ValueRecord, table: &db::Table) -> Vec<Value> {
+    table
+        .primary_key
+        .columns
+        .iter()
+        .map(|column| row[column.index].clone())
+        .collect()
+}
+
+fn primary_key_value(row: &ValueRecord, table: &db::Table) -> Value {
+    Value::record_from_vec(primary_key(row, table))
+}
+
+fn key_matches(row: &ValueRecord, table: &db::Table, key: &Value) -> bool {
+    let actual = primary_key(row, table);
+    match key {
+        Value::Record(key) => actual.as_slice() == key.as_slice(),
+        key => actual.len() == 1 && actual[0] == *key,
+    }
+}
+
+fn compare_keys(left: &[Value], right: &[Value]) -> Ordering {
+    for (left, right) in left.iter().zip(right) {
+        let order = compare_values(left, right, stmt::Direction::Asc);
+        if order != Ordering::Equal {
+            return order;
+        }
+    }
+    left.len().cmp(&right.len())
+}
+
+fn compare_values(left: &Value, right: &Value, direction: stmt::Direction) -> Ordering {
+    let order = match (left, right) {
+        (Value::Null, Value::Null) => Ordering::Equal,
+        (Value::Null, _) => Ordering::Greater,
+        (_, Value::Null) => Ordering::Less,
+        _ => left.partial_cmp(right).unwrap_or(Ordering::Equal),
+    };
+    match direction {
+        stmt::Direction::Asc => order,
+        stmt::Direction::Desc => order.reverse(),
+    }
+}
+
+/// Executes Toasty read operations against a [`ReadStore`].
+#[derive(Debug, Clone)]
+pub struct Reader {
+    store: Arc<dyn ReadStore>,
+}
+
+impl Reader {
+    /// Creates a reader for a shared store.
+    pub fn new(store: Arc<dyn ReadStore>) -> Self {
+        Self { store }
+    }
+
+    /// Executes one read or transaction operation.
+    pub fn exec(&self, schema: &Arc<Schema>, operation: Operation) -> Result<ExecResponse> {
+        match operation {
+            Operation::GetByKey(operation) => self.get_by_key(schema, operation),
+            Operation::FindPkByIndex(operation) => self.find_pk_by_index(schema, operation),
+            Operation::QueryPk(operation) => self.query_pk(schema, operation),
+            Operation::Scan(operation) => self.scan(schema, operation),
+            Operation::Transaction(_) => Ok(ExecResponse::count(0)),
+            Operation::Insert(_) | Operation::DeleteByKey(_) | Operation::UpdateByKey(_) => {
+                Err(read_only_error())
+            }
+            Operation::QuerySql(_) | Operation::RawSql(_) => Err(Error::unsupported_feature(
+                "SQL operations are not supported by the in-memory reader",
+            )),
+        }
+    }
+
+    fn get_by_key(
+        &self,
+        schema: &Arc<Schema>,
+        operation: toasty_core::driver::operation::GetByKey,
+    ) -> Result<ExecResponse> {
+        let table = schema.db.table(operation.table);
+        let rows = self.store.rows(operation.table);
+        let mut result = Vec::new();
+        for key in &operation.keys {
+            if let Some(row) = rows.iter().find(|row| key_matches(row, table, key)) {
+                result.push(project(
+                    row,
+                    operation.select.iter().map(|column| column.index),
+                ));
+            }
+        }
+        Ok(response(result, None, None))
+    }
+
+    fn find_pk_by_index(
+        &self,
+        schema: &Arc<Schema>,
+        operation: toasty_core::driver::operation::FindPkByIndex,
+    ) -> Result<ExecResponse> {
+        let table = schema.db.table(operation.table);
+        let rows = self.store.rows(operation.table);
+        let candidates = self
+            .store
+            .index_rows(operation.table, operation.index)
+            .unwrap_or_else(|| (0..rows.len()).collect());
+        let mut result = Vec::new();
+        for row in candidates {
+            if eval_predicate(schema, &rows[row], &operation.filter)? {
+                result.push(Value::record_from_vec(primary_key(&rows[row], table)));
+            }
+        }
+        Ok(response(result, None, None))
+    }
+
+    fn query_pk(
+        &self,
+        schema: &Arc<Schema>,
+        operation: toasty_core::driver::operation::QueryPk,
+    ) -> Result<ExecResponse> {
+        let table = schema.db.table(operation.table);
+        let index = operation.index.unwrap_or(table.primary_key.index);
+        let rows = self.store.rows(operation.table);
+        let mut matches = self
+            .store
+            .index_rows(operation.table, index)
+            .unwrap_or_else(|| (0..rows.len()).collect());
+        if matches!(operation.order, Some(stmt::Direction::Desc)) {
+            matches.reverse();
+        }
+        let mut filtered = Vec::with_capacity(matches.len());
+        for row in matches {
+            if !eval_predicate(schema, &rows[row], &operation.pk_filter)? {
+                continue;
+            }
+            if let Some(filter) = &operation.filter
+                && !eval_predicate(schema, &rows[row], filter)?
+            {
+                continue;
+            }
+            filtered.push(row);
+        }
+        let matches = filtered;
+
+        let (matches, next_cursor, prev_cursor) = paginate(matches, operation.limit, rows, table)?;
+        let result = matches
+            .into_iter()
+            .map(|row| {
+                project(
+                    &rows[row],
+                    operation.select.iter().map(|column| column.index),
+                )
+            })
+            .collect();
+        Ok(response(result, next_cursor, prev_cursor))
+    }
+
+    fn scan(
+        &self,
+        schema: &Arc<Schema>,
+        operation: toasty_core::driver::operation::Scan,
+    ) -> Result<ExecResponse> {
+        let table = schema.db.table(operation.table);
+        let rows = self.store.rows(operation.table);
+        let mut matches: Vec<usize> = (0..rows.len()).collect();
+
+        if let Some(filter) = &operation.filter {
+            let mut filtered = Vec::with_capacity(matches.len());
+            for row in matches {
+                if eval_predicate(schema, &rows[row], filter)? {
+                    filtered.push(row);
+                }
+            }
+            matches = filtered;
+        }
+
+        if let Some(order_by) = &operation.order_by {
+            let mut keys = Vec::with_capacity(matches.len());
+            for row in matches {
+                let input = RowInput {
+                    schema,
+                    row: &rows[row],
+                };
+                let values = order_by
+                    .exprs
+                    .iter()
+                    .map(|order| order.expr.eval(input.clone()))
+                    .collect::<Result<Vec<_>>>()?;
+                keys.push((row, values));
+            }
+            keys.sort_by(|left, right| {
+                for (value_index, order) in order_by.exprs.iter().enumerate() {
+                    let direction = order.order.unwrap_or(stmt::Direction::Asc);
+                    let ordering =
+                        compare_values(&left.1[value_index], &right.1[value_index], direction);
+                    if ordering != Ordering::Equal {
+                        return ordering;
+                    }
+                }
+                compare_keys(
+                    &primary_key(&rows[left.0], table),
+                    &primary_key(&rows[right.0], table),
+                )
+            });
+            matches = keys.into_iter().map(|entry| entry.0).collect();
+        } else {
+            matches.sort_by(|left, right| {
+                compare_keys(
+                    &primary_key(&rows[*left], table),
+                    &primary_key(&rows[*right], table),
+                )
+            });
+        }
+
+        let (matches, next_cursor, prev_cursor) = paginate(matches, operation.limit, rows, table)?;
+        let result = matches
+            .into_iter()
+            .map(|row| project(&rows[row], operation.columns.iter().copied()))
+            .collect();
+        Ok(response(result, next_cursor, prev_cursor))
+    }
+}
+
+fn paginate(
+    rows: Vec<usize>,
+    pagination: Option<Pagination>,
+    values: &[ValueRecord],
+    table: &db::Table,
+) -> Result<(Vec<usize>, Option<Value>, Option<Value>)> {
+    let Some(pagination) = pagination else {
+        return Ok((rows, None, None));
+    };
+
+    match pagination {
+        Pagination::Offset { limit, offset } => {
+            let limit = usize::try_from(limit)
+                .map_err(|_| Error::invalid_statement("memory query limit must be non-negative"))?;
+            let offset = usize::try_from(offset.unwrap_or(0)).map_err(|_| {
+                Error::invalid_statement("memory query offset must be non-negative")
+            })?;
+            Ok((
+                rows.into_iter().skip(offset).take(limit).collect(),
+                None,
+                None,
+            ))
+        }
+        Pagination::Cursor { page_size, after } => {
+            let page_size = usize::try_from(page_size)
+                .map_err(|_| Error::invalid_statement("memory page size must be non-negative"))?;
+            let start = match after {
+                Some(after) => rows
+                    .iter()
+                    .position(|row| key_matches(&values[*row], table, &after))
+                    .map(|index| index + 1)
+                    .ok_or_else(|| {
+                        Error::invalid_statement("cursor does not belong to this query")
+                    })?,
+                None => 0,
+            };
+            let end = start.saturating_add(page_size).min(rows.len());
+            let page = rows[start..end].to_vec();
+            let next_cursor = if end < rows.len() {
+                page.last()
+                    .map(|row| primary_key_value(&values[*row], table))
+            } else {
+                None
+            };
+            let prev_cursor = if start > 0 {
+                page.first()
+                    .map(|row| primary_key_value(&values[*row], table))
+            } else {
+                None
+            };
+            Ok((page, next_cursor, prev_cursor))
+        }
+    }
+}
+
+fn project(row: &ValueRecord, columns: impl Iterator<Item = usize>) -> Value {
+    Value::record_from_vec(columns.map(|column| row[column].clone()).collect())
+}
+
+fn response(
+    rows: Vec<Value>,
+    next_cursor: Option<Value>,
+    prev_cursor: Option<Value>,
+) -> ExecResponse {
+    ExecResponse {
+        values: Rows::Stream(stmt::ValueStream::from_vec(rows)),
+        next_cursor,
+        prev_cursor,
+    }
+}
+
+#[derive(Clone)]
+struct RowInput<'a> {
+    schema: &'a Schema,
+    row: &'a ValueRecord,
+}
+
+impl Input for RowInput<'_> {
+    fn resolve_ref(
+        &mut self,
+        reference: &stmt::ExprReference,
+        projection: &Projection,
+    ) -> Option<stmt::Expr> {
+        let value = match reference {
+            stmt::ExprReference::Column(column) if column.nesting == 0 && column.table == 0 => {
+                self.row.get(column.column)?
+            }
+            stmt::ExprReference::Field { nesting: 0, index } => self.row.get(*index)?,
+            stmt::ExprReference::Model { nesting: 0 } => {
+                return Value::Record(self.row.clone()).project(projection);
+            }
+            _ => return None,
+        };
+        value.project(projection)
+    }
+
+    fn resolve_model(
+        &self,
+        id: toasty_core::schema::app::ModelId,
+    ) -> Option<&toasty_core::schema::app::Model> {
+        Some(self.schema.app.model(id))
+    }
+
+    fn ordered_nulls_are_false(&self) -> bool {
+        true
+    }
+}
+
+fn eval_predicate(schema: &Schema, row: &ValueRecord, expression: &stmt::Expr) -> Result<bool> {
+    expression.eval_bool(RowInput { schema, row })
+}
+
+fn read_only_error() -> Error {
+    Error::unsupported_feature("the in-memory store is read-only")
+}
+
+/// A schema-initialized connection backed by a [`ReadStore`].
+#[derive(Debug)]
+pub struct Connection {
+    reader: Reader,
+}
+
+impl Connection {
+    /// Creates a connection over a shared store.
+    pub fn new(store: Arc<dyn ReadStore>) -> Self {
+        Self {
+            reader: Reader::new(store),
+        }
+    }
+}
+
+#[async_trait]
+impl toasty_core::driver::Connection for Connection {
+    async fn exec(&mut self, schema: &Arc<Schema>, operation: Operation) -> Result<ExecResponse> {
+        self.reader.exec(schema, operation)
+    }
+
+    async fn push_schema(&mut self, _schema: &Schema) -> Result<()> {
+        Err(read_only_error())
+    }
+
+    async fn applied_migrations(&mut self) -> Result<Vec<AppliedMigration>> {
+        Err(read_only_error())
+    }
+
+    async fn apply_migration(
+        &mut self,
+        _id: u64,
+        _name: &str,
+        _migration: &Migration,
+    ) -> Result<()> {
+        Err(read_only_error())
+    }
+}
+
+/// Builder for a read-only in-memory [`Driver`].
+#[derive(Debug, Default)]
+pub struct MemoryBuilder {
+    tables: Vec<(String, Vec<ValueRecord>)>,
+}
+
+impl MemoryBuilder {
+    /// Supplies all rows for one database table.
+    pub fn table(
+        mut self,
+        name: impl Into<String>,
+        rows: impl IntoIterator<Item = ValueRecord>,
+    ) -> Self {
+        self.tables.push((name.into(), rows.into_iter().collect()));
+        self
+    }
+
+    /// Builds a driver whose rows are validated during `Db::build()`.
+    pub fn build(self) -> Memory {
+        Memory {
+            source: self.tables,
+            snapshot: None,
+        }
+    }
+}
+
+/// A read-only Toasty driver backed by rows supplied in memory.
+#[derive(Debug)]
+pub struct Memory {
+    source: Vec<(String, Vec<ValueRecord>)>,
+    snapshot: Option<Arc<Snapshot>>,
+}
+
+impl Memory {
+    /// Creates a builder for an in-memory driver.
+    pub fn builder() -> MemoryBuilder {
+        MemoryBuilder::default()
+    }
+}
+
+#[async_trait]
+impl Driver for Memory {
+    fn url(&self) -> Cow<'_, str> {
+        Cow::Borrowed("memory://")
+    }
+
+    fn capability(&self) -> &'static Capability {
+        &CAPABILITY
+    }
+
+    async fn initialize(&mut self, schema: &Arc<Schema>) -> Result<()> {
+        let mut builder = SnapshotBuilder::new(schema.clone());
+        for (name, rows) in std::mem::take(&mut self.source) {
+            builder.insert_named(&name, rows)?;
+        }
+        self.snapshot = Some(Arc::new(builder.build()?));
+        Ok(())
+    }
+
+    async fn connect(&self, _cx: &ConnectContext) -> Result<Box<dyn toasty_core::Connection>> {
+        let snapshot = self.snapshot.clone().ok_or_else(|| {
+            Error::invalid_driver_configuration("memory driver was not initialized")
+        })?;
+        Ok(Box::new(Connection::new(snapshot)))
+    }
+
+    fn max_connections(&self) -> Option<usize> {
+        None
+    }
+
+    fn generate_migration(&self, _schema_diff: &diff::Schema<'_>) -> Migration {
+        Migration::new_sql(String::new())
+    }
+
+    async fn reset_db(&self) -> Result<()> {
+        Err(read_only_error())
+    }
+}

--- a/crates/toasty/Cargo.toml
+++ b/crates/toasty/Cargo.toml
@@ -16,6 +16,7 @@ documentation = "https://docs.rs/toasty"
 [features]
 default = []
 dynamodb = ["dep:toasty-driver-dynamodb"]
+markdown = ["dep:toasty-driver-markdown"]
 migration = ["dep:serde", "dep:toml", "dep:toml_edit", "toasty-core/serde"]
 mysql = ["dep:toasty-driver-mysql"]
 postgresql = ["dep:toasty-driver-postgresql"]
@@ -26,6 +27,7 @@ rust_decimal = [
 	"toasty-core/rust_decimal",
 	"toasty-driver-postgresql?/rust_decimal",
 	"toasty-driver-mysql?/rust_decimal",
+	"toasty-driver-markdown?/rust_decimal",
 	"toasty-driver-sqlite?/rust_decimal",
 	"toasty-driver-turso?/rust_decimal",
 ]
@@ -34,6 +36,7 @@ bigdecimal = [
 	"toasty-core/bigdecimal",
 	"toasty-driver-postgresql?/bigdecimal",
 	"toasty-driver-mysql?/bigdecimal",
+	"toasty-driver-markdown?/bigdecimal",
 	"toasty-driver-sqlite?/bigdecimal",
 	"toasty-driver-turso?/bigdecimal",
 ]
@@ -42,6 +45,7 @@ jiff = [
 	"toasty-core/jiff",
 	"toasty-driver-postgresql?/jiff",
 	"toasty-driver-mysql?/jiff",
+	"toasty-driver-markdown?/jiff",
 	"toasty-driver-sqlite?/jiff",
 	"toasty-driver-turso?/jiff",
 ]
@@ -54,6 +58,7 @@ toasty-core.workspace = true
 
 # Built-in database drivers
 toasty-driver-dynamodb = { workspace = true, optional = true }
+toasty-driver-markdown = { workspace = true, optional = true }
 toasty-driver-mysql = { workspace = true, optional = true }
 toasty-driver-postgresql = { workspace = true, optional = true }
 toasty-driver-sqlite = { workspace = true, optional = true }
@@ -73,6 +78,7 @@ uuid.workspace = true
 indexmap.workspace = true
 index_vec.workspace = true
 inventory.workspace = true
+percent-encoding.workspace = true
 serde = { workspace = true, optional = true }
 tokio.workspace = true
 toml = { workspace = true, optional = true }

--- a/crates/toasty/src/db/builder.rs
+++ b/crates/toasty/src/db/builder.rs
@@ -287,7 +287,7 @@ impl Builder {
     ///     .unwrap();
     /// # });
     /// ```
-    pub async fn build(&mut self, driver: impl Driver) -> Result<Db> {
+    pub async fn build(&mut self, mut driver: impl Driver) -> Result<Db> {
         tracing::info!(models = self.models.len(), "building database schema");
         let capability = driver.capability();
         capability.validate()?;
@@ -295,7 +295,10 @@ impl Builder {
 
         tracing::info!(tables = schema.db.tables.len(), "schema built successfully");
 
-        let engine = Engine::new(Arc::new(schema), capability);
+        let schema = Arc::new(schema);
+        driver.initialize(&schema).await?;
+
+        let engine = Engine::new(schema, capability);
         let pool = Pool::new(driver, engine.clone(), self.pool.clone())?;
 
         let shared = Arc::new(Shared { engine, pool });

--- a/crates/toasty/src/db/connect.rs
+++ b/crates/toasty/src/db/connect.rs
@@ -35,6 +35,7 @@ impl Connect {
     /// | `postgresql` / `postgres` | PostgreSQL | `postgresql` |
     /// | `mysql` | MySQL | `mysql` |
     /// | `dynamodb` | DynamoDB | `dynamodb` |
+    /// | `markdown` | Markdown | `markdown` |
     /// | `turso` | Turso | `turso` |
     ///
     /// # Errors
@@ -45,6 +46,7 @@ impl Connect {
         #![cfg_attr(
             not(any(
                 feature = "dynamodb",
+                feature = "markdown",
                 feature = "mysql",
                 feature = "postgresql",
                 feature = "sqlite",
@@ -68,6 +70,19 @@ impl Connect {
             "dynamodb" => {
                 return Err(toasty_core::Error::unsupported_feature(
                     "`dynamodb` feature not enabled",
+                ));
+            }
+
+            #[cfg(feature = "markdown")]
+            "markdown" => Box::new(toasty_driver_markdown::Markdown::new(
+                percent_encoding::percent_decode(url.path().as_bytes())
+                    .decode_utf8_lossy()
+                    .to_string(),
+            )),
+            #[cfg(not(feature = "markdown"))]
+            "markdown" => {
+                return Err(toasty_core::Error::unsupported_feature(
+                    "`markdown` feature not enabled",
                 ));
             }
 
@@ -126,6 +141,10 @@ impl Driver for Connect {
 
     fn capability(&self) -> &'static Capability {
         self.driver.capability()
+    }
+
+    async fn initialize(&mut self, schema: &std::sync::Arc<toasty_core::Schema>) -> Result<()> {
+        self.driver.initialize(schema).await
     }
 
     async fn connect(&self, cx: &ConnectContext) -> Result<Box<dyn Connection>> {

--- a/crates/toasty/src/engine/eval.rs
+++ b/crates/toasty/src/engine/eval.rs
@@ -82,11 +82,22 @@ fn verify_expr(expr: &stmt::Expr) -> bool {
     match expr {
         Arg(_) => true,
         And(expr_and) => expr_and.operands.iter().all(verify_expr),
+        AllOp(expr) => verify_expr(&expr.lhs) && verify_expr(&expr.rhs),
+        AnyOp(expr) => verify_expr(&expr.lhs) && verify_expr(&expr.rhs),
+        Any(expr) => verify_expr(&expr.expr),
+        Between(expr) => {
+            verify_expr(&expr.expr) && verify_expr(&expr.low) && verify_expr(&expr.high)
+        }
         Or(expr_or) => expr_or.operands.iter().all(verify_expr),
         BinaryOp(expr) => verify_expr(&expr.lhs) && verify_expr(&expr.rhs),
         Cast(expr) => verify_expr(&expr.expr),
+        InList(expr) => verify_expr(&expr.expr) && verify_expr(&expr.list),
+        Intersects(expr) => verify_expr(&expr.lhs) && verify_expr(&expr.rhs),
         IsNull(expr) => verify_expr(&expr.expr),
+        IsSuperset(expr) => verify_expr(&expr.lhs) && verify_expr(&expr.rhs),
+        Length(expr) => verify_expr(&expr.expr),
         Let(expr) => expr.bindings.iter().all(verify_expr) && verify_expr(&expr.body),
+        Like(expr) => verify_expr(&expr.expr) && verify_expr(&expr.pattern),
         List(expr) => expr.items.iter().all(verify_expr),
         Map(expr) => verify_expr(&expr.base) && verify_expr(&expr.map),
         Match(expr_match) => {
@@ -95,13 +106,16 @@ fn verify_expr(expr: &stmt::Expr) -> bool {
         }
         Project(expr) => verify_expr(&expr.base),
         Record(expr) => expr.fields.iter().all(verify_expr),
+        StartsWith(expr) => verify_expr(&expr.expr) && verify_expr(&expr.prefix),
+        Not(expr) => verify_expr(&expr.expr),
         Exists(expr_exists) => match &expr_exists.subquery.body {
             stmt::ExprSet::Values(values) => values.rows.iter().all(verify_expr),
             _ => false,
         },
         Reference(_) => false,
+        Func(stmt::ExprFunc::JsonExtract(expr)) => verify_expr(&expr.base),
         Func(_) => false,
         Value(_) => true,
-        _ => todo!("expr={expr:#?}"),
+        _ => false,
     }
 }

--- a/crates/toasty/src/engine/exec/query_pk.rs
+++ b/crates/toasty/src/engine/exec/query_pk.rs
@@ -51,6 +51,7 @@ impl Exec<'_> {
         let filters = self.split_filter(pk_filter, action.table);
         let mut all_rows = Vec::new();
         let mut response_cursor = None;
+        let mut response_prev_cursor = None;
 
         // A limit or pagination clause is only meaningful against a single
         // partition key query. With multiple filters, each partition call
@@ -86,8 +87,9 @@ impl Exec<'_> {
                 .await?;
 
             // Only capture cursor when paginating a single filter
-            if paginated && res.next_cursor.is_some() {
+            if paginated {
                 response_cursor = res.next_cursor;
+                response_prev_cursor = res.prev_cursor;
             }
 
             all_rows.extend(res.values.into_value_stream().collect().await?);
@@ -99,7 +101,7 @@ impl Exec<'_> {
             ExecResponse {
                 values: Rows::Stream(stmt::ValueStream::from_vec(all_rows)),
                 next_cursor: response_cursor,
-                prev_cursor: None,
+                prev_cursor: response_prev_cursor,
             },
         );
 

--- a/crates/toasty/src/engine/exec/scan.rs
+++ b/crates/toasty/src/engine/exec/scan.rs
@@ -26,6 +26,9 @@ pub(crate) struct Scan {
     /// Filter to apply to each scanned row.
     pub row_filter: Option<stmt::Expr>,
 
+    /// Expressions used to order matching rows before pagination.
+    pub order_by: Option<stmt::OrderBy>,
+
     /// Limit and pagination bounds. `None` means return all rows.
     pub limit: Option<Pagination>,
 }
@@ -33,11 +36,17 @@ pub(crate) struct Scan {
 impl Exec<'_> {
     pub(super) async fn action_scan(&mut self, action: &Scan) -> Result<()> {
         let mut row_filter = action.row_filter.clone();
+        let mut order_by = action.order_by.clone();
 
         if let Some(input) = &action.input {
             let input = self.collect_input(&[*input]).await?;
             if let Some(ref mut f) = row_filter {
                 f.substitute(&input);
+            }
+            if let Some(ref mut order_by) = order_by {
+                for order in &mut order_by.exprs {
+                    order.expr.substitute(&input);
+                }
             }
         }
 
@@ -49,12 +58,15 @@ impl Exec<'_> {
                     table: action.table,
                     columns: action.columns.iter().map(|col_id| col_id.index).collect(),
                     filter: row_filter,
+                    order_by,
                     limit: action.limit.clone(),
                 }
                 .into(),
             )
             .await?;
 
+        let next_cursor = res.next_cursor;
+        let prev_cursor = res.prev_cursor;
         let rows: Vec<stmt::Value> = res.values.into_value_stream().collect().await?;
 
         self.vars.store(
@@ -62,8 +74,8 @@ impl Exec<'_> {
             action.output.num_uses,
             ExecResponse {
                 values: Rows::Stream(stmt::ValueStream::from_vec(rows)),
-                next_cursor: res.next_cursor,
-                prev_cursor: None,
+                next_cursor,
+                prev_cursor,
             },
         );
 

--- a/crates/toasty/src/engine/mir/scan.rs
+++ b/crates/toasty/src/engine/mir/scan.rs
@@ -26,6 +26,9 @@ pub(crate) struct Scan {
     /// Filter expression applied to each scanned row.
     pub(crate) row_filter: Option<stmt::Expr>,
 
+    /// Expressions used to order matching rows before pagination.
+    pub(crate) order_by: Option<stmt::OrderBy>,
+
     /// Limit and pagination bounds. `None` means return all rows.
     pub(crate) limit: Option<Pagination>,
 
@@ -72,6 +75,7 @@ impl Scan {
             table: self.table,
             columns,
             row_filter: self.row_filter.clone(),
+            order_by: self.order_by.clone(),
             limit: self.limit.clone(),
         }
     }

--- a/crates/toasty/src/engine/plan/statement.rs
+++ b/crates/toasty/src/engine/plan/statement.rs
@@ -1266,6 +1266,19 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
             debug_assert!(self.load_data.select_items.is_empty());
         }
 
+        // A sortable scan can honor arbitrary ordering expressions. QueryPk
+        // only carries the direction of an index sort key, so selecting it for
+        // another ORDER BY expression would return rows in the wrong order.
+        if stmt
+            .as_query()
+            .and_then(|query| query.order_by.as_ref())
+            .is_some()
+            && self.planner.engine.capability().scan_supports_sort
+        {
+            let ty = self.infer_nosql_record_ty(&stmt);
+            return self.plan_scan_execution(stmt, ty);
+        }
+
         // Without SQL capability, we have to plan the execution of the
         // statement based on available indices.
         let index_plan_opt = self.planner.engine.plan_index_path(&stmt)?;
@@ -1348,6 +1361,13 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
         };
         self.legalize_kv_expr(&mut row_filter);
 
+        let mut order_by = stmt.as_query().and_then(|query| query.order_by.clone());
+        if let Some(order_by) = &mut order_by {
+            for order in &mut order_by.exprs {
+                self.planner.engine.legalize_table_expr(&mut order.expr);
+            }
+        }
+
         let limit = extract_pagination(&stmt);
 
         Ok(self.insert_mir_with_deps(mir::Scan {
@@ -1355,6 +1375,7 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
             table: table_id,
             columns: self.load_data.select_items.extract_expr_references(),
             row_filter,
+            order_by,
             limit,
             ty,
         }))

--- a/crates/toasty/src/engine/verify.rs
+++ b/crates/toasty/src/engine/verify.rs
@@ -40,7 +40,13 @@ impl Engine {
 }
 
 impl stmt::Visit for Verify<'_, '_> {
+    fn visit_stmt_insert(&mut self, i: &stmt::Insert) {
+        self.verify_data_mutation();
+        stmt::visit::visit_stmt_insert(self, i);
+    }
+
     fn visit_stmt_delete(&mut self, i: &stmt::Delete) {
+        self.verify_data_mutation();
         stmt::visit::visit_stmt_delete(self, i);
 
         VerifyExpr {
@@ -88,6 +94,7 @@ impl stmt::Visit for Verify<'_, '_> {
     }
 
     fn visit_stmt_update(&mut self, i: &stmt::Update) {
+        self.verify_data_mutation();
         stmt::visit::visit_stmt_update(self, i);
 
         // Is not an empty update
@@ -105,6 +112,14 @@ impl stmt::Visit for Verify<'_, '_> {
 }
 
 impl Verify<'_, '_> {
+    fn verify_data_mutation(&mut self) {
+        if !self.capability.data_mutations && self.error.is_none() {
+            *self.error = Some(Error::unsupported_feature(
+                "this database is read-only and does not support data mutations",
+            ));
+        }
+    }
+
     fn verify_offset_key_matches_order_by(&self, i: &stmt::Query) {
         let Some(stmt::Limit::Cursor(cursor)) = i.limit.as_ref() else {
             return;
@@ -342,14 +357,11 @@ impl stmt::Visit for VerifyExpr<'_, '_> {
     }
 
     fn visit_expr_like(&mut self, i: &stmt::ExprLike) {
-        // `.ilike()` is a pass-through to the database's own case-insensitive
-        // LIKE operator. Only PostgreSQL has one (`ILIKE`), so reject a
-        // case-insensitive match on any other backend rather than silently
-        // emitting plain `LIKE`, whose case behavior differs across engines.
+        // SQL drivers pass `.ilike()` through to the database's operator;
+        // non-SQL drivers may provide their own documented implementation.
         if i.case_insensitive && !self.capability.native_ilike {
             self.record(Error::unsupported_feature(
-                "ilike requires a native ILIKE operator, which only PostgreSQL provides; \
-                 use like instead",
+                "ilike is not supported by this database; use like instead",
             ));
         }
         stmt::visit::visit_expr_like(self, i);

--- a/crates/toasty/src/lib.rs
+++ b/crates/toasty/src/lib.rs
@@ -1,6 +1,6 @@
 #![warn(missing_docs)]
-//! Toasty is an async ORM for Rust supporting both SQL (SQLite, PostgreSQL,
-//! MySQL) and NoSQL (DynamoDB) databases.
+//! Toasty is an async ORM for Rust supporting SQL (SQLite, PostgreSQL, MySQL),
+//! NoSQL (DynamoDB), and read-only Markdown content.
 //!
 //! This crate is the user-facing API. It contains the database handle,
 //! query execution traits, and the types that generated code builds on. For

--- a/docs/dev/design/markdown-driver.md
+++ b/docs/dev/design/markdown-driver.md
@@ -1,0 +1,514 @@
+# Read-only Markdown driver
+
+## Summary
+
+Toasty gains a read-only Markdown driver that presents a directory of Markdown
+files as typed models. The driver loads the complete directory into an immutable
+in-memory snapshot when `Db` is built, then executes Toasty's normal reads,
+filters, relations, ordering, and pagination against that snapshot. The
+filesystem mapping stays in `toasty-driver-markdown`; row storage and read-query
+execution live in a reusable `toasty-driver-memory` crate so another file-backed
+driver, and an eventual mutable in-memory driver, can use the same evaluator.
+A new `Capability::data_mutations` flag lets the engine reject creates, updates,
+and deletes before it lowers or dispatches them.
+
+## Motivation
+
+Documentation sites, blogs, and small content repositories commonly keep data
+as Markdown with YAML front matter. The files are easy to review and edit, but
+applications still need typed access, filtering, relations, and pagination.
+Loading the same content into a separate database adds a synchronization step
+and makes the database, rather than the repository, the source of truth.
+
+The data set is already finite and local. Loading it once makes useful queries
+possible without introducing a SQL runtime or translating Toasty's statement
+tree to another query language. It also gives every query in one `Db` instance
+a stable view of the content.
+
+This work exposes a second need. Toasty's expression evaluator can already
+evaluate many scalar expressions, and the non-SQL planner already produces
+primary-key lookups, index queries, and scans. The missing piece is a reusable
+row store and executor around those facilities. Keeping that piece independent
+of Markdown avoids building a one-off query engine and provides the read half
+of a future in-memory Toasty driver.
+
+Finally, read-only behavior must be an engine contract. Rejecting writes only
+when they reach a driver is too late for batches, nested statements, and plans
+that perform reads before writes. The engine needs to know that the entire data
+source is immutable before it starts planning or executing a statement.
+
+## User-facing API
+
+### Opening a Markdown directory
+
+Create a `Markdown` driver with the content root and pass it to `Db::builder()`:
+
+```rust
+use toasty::Db;
+use toasty_driver_markdown::Markdown;
+
+let driver = Markdown::new("content");
+let mut db = Db::builder()
+    .models(toasty::models!(Post, Author))
+    .build(driver)
+    .await?;
+```
+
+`build()` reads and validates the content before it returns. A successful build
+means subsequent reads do not touch the filesystem.
+
+### Directory and file conventions
+
+By default, each immediate child directory of the root represents a database
+table, and each `.md` file directly inside that directory represents one row:
+
+```text
+content/
+  posts/
+    hello-world.md
+    release-notes.md
+  authors/
+    carl.md
+```
+
+Directory names match Toasty's database table names. YAML front-matter keys
+match database column names. The Markdown following the front matter maps to a
+string column named `body` when that column exists.
+
+For example, `content/posts/hello-world.md` can back this model:
+
+```rust
+#[derive(Debug, toasty::Model)]
+struct Post {
+    #[key]
+    slug: String,
+    title: String,
+    published: bool,
+    tags: Vec<String>,
+    body: String,
+}
+```
+
+with this file:
+
+```markdown
+---
+title: Hello, world
+published: true
+tags:
+  - introduction
+  - rust
+---
+# Hello, world
+
+This is the first post.
+```
+
+The `slug` is absent from the front matter, so the default single-string-key
+convention derives it from the file stem: `hello-world`. If a table does not
+have exactly one string primary-key column, every key column must appear in the
+front matter or have an explicit configured source.
+
+The driver treats front matter as data and the body as an uninterpreted UTF-8
+string. It does not render Markdown or extract headings and links.
+
+### Overriding the conventions
+
+Use `Markdown::builder()` when the repository's layout or vocabulary does not
+match the defaults. Configuration is per database table and uses database
+names, because mapping files to columns is a driver responsibility:
+
+```rust
+use toasty_driver_markdown::{Markdown, Table};
+
+let driver = Markdown::builder("content")
+    .table(
+        "posts",
+        Table::new("articles")
+            .column("date", "published_at")
+            .body_column("markdown")
+            .key_from_stem("slug"),
+    )
+    .strict(true)
+    .build();
+```
+
+This maps the `posts` table to `content/articles`, maps the `date` front-matter
+key to the `published_at` column, maps the Markdown body to `markdown`, and uses
+the file stem for `slug`.
+
+The table configuration supports these overrides in the first release:
+
+- directory name;
+- front-matter key to column renames;
+- the body column, including disabling body mapping;
+- a file-stem or relative-path source for one string column; and
+- recursive discovery, disabled by default.
+
+With recursive discovery enabled, files below the configured directory are
+included. A table must use front-matter keys or a relative-path key source when
+two files can have the same stem. Relative paths use `/` separators on every
+platform and omit the `.md` suffix.
+
+Unknown directories and unknown front-matter keys are ignored by default so an
+existing content repository can carry metadata unrelated to Toasty. Strict mode
+turns both into build errors and also rejects a non-empty body with no body
+column. An explicitly configured directory that does not exist is always an
+error. An unconfigured table with no matching directory is an empty table.
+
+### Querying content
+
+Markdown models use the same read API as other Toasty models:
+
+```rust
+let posts = Post::filter(
+    Post::fields()
+        .published()
+        .eq(true)
+        .and(Post::fields().title().ilike("%rust%")),
+)
+.order_by(Post::fields().title().asc())
+.limit(20)
+.exec(&mut db)
+.await?;
+```
+
+Primary-key lookups, equality and ordered comparisons, `IN`, `BETWEEN`, null
+checks, boolean composition, `starts_with`, `like`, `ilike`, collection
+predicates, document-path predicates, ordering, limits, offsets, and cursor
+pagination are supported. Relation filters and `include` work when the files
+contain the foreign-key columns described by the models; Toasty's engine keeps
+responsibility for decomposing and merging those reads.
+
+The Markdown backend defines its own string-matching behavior. `starts_with`
+and `like` are case-sensitive. In `like` and `ilike`, `%` matches zero or more
+Unicode scalar values, `_` matches one, and the optional escape character has
+the same meaning as Toasty's existing escaped LIKE API. `ilike` compares
+literals using locale-independent Unicode case folding. It does not apply
+Unicode normalization or a language-specific collation.
+
+### Read-only errors
+
+Generated mutation methods remain available because models are independent of
+the driver selected at runtime. Executing one against Markdown returns
+`Error::unsupported_feature`:
+
+```rust
+let error = Post::create()
+    .slug("new-post")
+    .title("New post")
+    .published(false)
+    .tags(Vec::new())
+    .body("Draft")
+    .exec(&mut db)
+    .await
+    .unwrap_err();
+
+assert!(error.is_unsupported_feature());
+```
+
+`db.capability().data_mutations` lets infrastructure inspect the same contract
+before offering an editing workflow. It is informational for application code;
+the engine check remains authoritative.
+
+## Behavior
+
+### Building the snapshot
+
+`Db::builder().build(driver)` first compiles the Toasty schema, then gives that
+schema to the driver for initialization. The Markdown driver walks the root in
+sorted path order, reads every selected file, decodes its front matter and
+body, and converts each field to the database column type. It then builds one
+immutable in-memory snapshot containing all rows and declared indices. The
+snapshot is shared by every pooled connection through `Arc`; reads need no
+locks.
+
+The body is loaded along with the front matter. Eagerly loading only metadata
+would let a later body read observe a different filesystem version and would
+make a query's result depend on when a field was projected. The snapshot uses
+memory proportional to decoded rows, bodies, and indices.
+
+Filesystem changes are not visible after `build()` returns. There is no watcher
+or automatic reload. Drop the `Db` and build another one to observe a new
+version. A cursor belongs to the snapshot and query shape that produced it; a
+cursor with the wrong table or ordering shape returns an invalid-cursor error.
+
+### Decoding rows
+
+A file may start with YAML front matter delimited by `---` lines. Without a
+front-matter block, its attribute map is empty and the entire file is the body.
+The delimiters and their structural newline are not included in `body`; all
+remaining UTF-8 text is preserved. An opening delimiter without a closing
+delimiter is a build error rather than body text.
+
+YAML values are converted according to the compiled database schema. Booleans,
+integers, strings, sequences, mappings, UUIDs, decimals, and temporal values
+must have a representation accepted by the target column type. The driver does
+not stringify incompatible YAML values. A missing optional column becomes
+`Value::Null`. A missing required column is a build error unless its value comes
+from the file path. `#[auto]` does not generate values in a read-only source.
+
+If the configured body column is present in front matter as well as in the
+file body, initialization reports an ambiguous-column error. An empty body is
+still a present empty string. Every decoded row is validated for width and
+type, and duplicate primary or unique keys fail the build. Errors identify the
+file, front-matter key or body mapping, expected Toasty type, and offending
+value without printing unrelated file contents.
+
+A unique-key value containing null is not entered in the uniqueness map, so
+multiple rows may omit the same optional unique field. Primary-key columns
+cannot be null.
+
+The loader does not follow symbolic links. This avoids cycles and prevents a
+content root from implicitly reading files outside itself. Only lowercase
+`.md` files match the default convention.
+
+### Executing reads
+
+The engine continues to simplify, lower, and plan statements. It emits the
+same non-SQL operations used by other key-value drivers:
+
+- `GetByKey` for exact primary-key reads;
+- `QueryPk` and `FindPkByIndex` when a declared index satisfies the query; and
+- `Scan` as the fallback for all other reads.
+
+The reusable in-memory executor applies a read in this semantic order: choose
+candidate rows, evaluate the remaining predicate, order the matches, apply a
+cursor or offset and limit, then project the requested columns. Index selection
+is an optimization and cannot change the result.
+
+Declared primary and secondary indices are built eagerly. A query without a
+usable index scans the in-memory table. The first release does not add a query
+optimizer or collect cardinality statistics; the existing Toasty planner
+chooses the access operation.
+
+Queries without `order_by` retain Toasty's unspecified-order contract. The
+implementation iterates the primary-key index for repeatability, but users must
+not rely on that order. Explicit ordering is stable. The executor appends the
+primary key as an internal tie-breaker, places null before non-null when sorting
+descending and after non-null when sorting ascending, and compares other values
+according to their Toasty type. Cursor values contain the explicit ordering
+values and primary key, which prevents duplicates or omissions while traversing
+the immutable snapshot.
+
+Cursor pagination without an explicit ordering uses primary-key order as its
+backend cursor order. Forward and backward pagination are both supported.
+
+Predicate evaluation is two-valued. Missing optional fields are null;
+`is_none()` and `is_some()` test them directly. Equality uses Toasty value
+equality, so null equals null and differs from a non-null value. Ordered,
+string, and collection predicates involving null do not match. `AND`, `OR`,
+and `NOT` then operate on the resulting booleans. These are the native semantics
+of the in-memory backend, not SQL three-valued logic.
+
+### Relations, batching, and transactions
+
+Relations are not materialized inside Markdown rows. Front matter stores the
+same foreign-key values another driver would store in columns. The Toasty
+engine performs relation filters, batched association loads, and nested merges
+using ordinary reads from the snapshot.
+
+All connections share the same immutable snapshot, so a multi-read plan is
+consistent without locking. Transaction lifecycle operations succeed as
+no-ops. This lets existing read-only batches and relation-loading plans use the
+normal execution path. It does not make mutation statements acceptable.
+
+### Rejecting mutations
+
+When `Capability::data_mutations` is false, statement verification rejects
+every `Insert`, `Update`, and `Delete`. The visitor checks nested statements,
+CTEs, and batches as well as the top-level statement. Verification runs before
+lowering, planning, connection acquisition, or execution, so a mixed read/write
+batch performs no reads before it fails.
+
+The in-memory executor also rejects mutation `Operation` variants. That is a
+defensive check for callers that invoke `Connection::exec` directly; normal
+Toasty queries fail at the earlier engine boundary.
+
+Raw SQL is unsupported because the Markdown driver reports `sql: false`.
+`push_schema`, migrations, and `reset_db` return unsupported-feature errors;
+`data_mutations` describes row mutations and does not claim that a driver can
+rewrite its external schema or source files.
+
+## Edge cases
+
+- An empty root, a missing unconfigured table directory, or a table directory
+  with no `.md` files produces an empty table.
+- A configured directory must remain inside the content root after path
+  normalization. Absolute paths and `..` escapes are rejected.
+- File stems and relative-path keys must be valid UTF-8. Two paths that decode
+  to the same typed key are duplicates even if their spellings differ.
+- Front-matter key renames must be one-to-one. Two keys cannot populate one
+  column, and one key cannot populate two columns.
+- Composite keys are supported when every component is supplied explicitly.
+  File-stem derivation applies to at most one string column.
+- Optional front matter may use explicit YAML `null`; required columns reject
+  it. An absent optional body column and a present empty body remain distinct
+  only when the model type can represent absence.
+- LIKE matching operates on Unicode scalar values rather than bytes or user-
+  perceived grapheme clusters. Canonically equivalent but differently encoded
+  strings compare as different strings.
+- Offset and cursor bounds are applied after filtering and ordering. A page is
+  therefore filled up to its requested size when enough matching rows remain.
+- Concurrent queries can run on separate connections without coordination.
+  Snapshot construction finishes before any connection becomes available.
+- A malformed file fails the whole build. The driver never publishes a
+  partially loaded snapshot.
+
+## Driver integration
+
+### Data-mutation capability
+
+`Capability` gains one field:
+
+```rust
+pub struct Capability {
+    pub data_mutations: bool,
+    // existing fields
+}
+```
+
+All existing in-tree drivers set it to `true`. The Markdown driver and the
+initial read-only memory driver set it to `false`. The query verifier uses the
+flag as described above. This capability is independent of `SchemaMutations`,
+which describes how a backend changes column definitions, and independent of a
+server-side read-only transaction error.
+
+Out-of-tree drivers must add the field to their capability constant. A driver
+that already supports Toasty's insert, update, and delete operations should set
+it to `true`; a driver that cannot persist any of them should set it to `false`.
+
+### Schema-aware driver initialization
+
+Drivers currently receive the compiled schema only after a connection is asked
+to execute an operation. Eager, typed loading needs it before the pool accepts
+queries. `Driver` therefore gains an asynchronous hook with a no-op default:
+
+```rust
+async fn initialize(&mut self, schema: &Arc<Schema>) -> Result<()> {
+    Ok(())
+}
+```
+
+`Db::builder().build()` calls `initialize` after capability validation and
+schema construction, but before constructing the pool. `Connect` delegates the
+hook to its selected driver. Existing drivers and out-of-tree drivers require
+no implementation change. The Markdown implementation parses files and builds
+its shared snapshot here, so filesystem and decoding errors surface from
+`build()`.
+
+### Reusable in-memory crate
+
+The reusable crate is `toasty-driver-memory`. It has no Markdown or filesystem
+dependencies. It owns:
+
+- database rows in database-column order using Toasty's existing `Value` and
+  `ValueRecord` types;
+- immutable snapshot construction and schema validation;
+- primary, unique, and secondary index construction;
+- execution of `GetByKey`, `QueryPk`, `FindPkByIndex`, and `Scan`;
+- row projection, filtering, ordering, limit/offset handling, and cursor
+  encoding; and
+- a read-only `Driver` wrapper for callers that want to supply rows directly.
+
+Its central reusable boundary is a read executor over a store interface. The
+crate ships an immutable `Snapshot` implementation, while the executor depends
+only on access to table rows and declared indices. A future mutable memory store
+can implement the same read interface and reuse the entire query path while
+adding insert, update, delete, index maintenance, and transaction behavior.
+Mutation support does not belong in the initial interface merely to anticipate
+that future work.
+
+`toasty-driver-markdown` owns only source-specific behavior:
+
+- path discovery and containment checks;
+- YAML front-matter and UTF-8 body parsing;
+- convention and configuration resolution;
+- conversion from source values into typed database rows; and
+- file-oriented diagnostics.
+
+After initialization, the Markdown connection delegates every supported read
+operation to the memory executor. Similar drivers for JSON, static assets, or
+configuration repositories can build the same snapshot without copying query
+execution code.
+
+Expression evaluation remains in `toasty-core::stmt`, because the Toasty engine
+already uses it for client-side filters, guards, and nested merges. The work
+completes its predicate coverage for the expressions advertised by the memory
+backend: `BETWEEN`, `starts_with`, `LIKE` and `ILIKE` with escapes, length,
+collection membership and set predicates, and lowered document extraction.
+The memory crate supplies a typed row as evaluator input; it does not implement
+a second statement AST or planner. Unsupported expression shapes return
+`Error::unsupported_feature` during verification rather than reaching a
+`todo!` or panic in evaluation.
+
+The memory crate has its own operation-level conformance suite. The Markdown
+driver runs the read-only portion of Toasty's driver integration suite plus
+loader tests for conventions, overrides, type errors, duplicate keys, snapshot
+isolation, and path handling. A future mutable memory driver adds the mutation
+portion without duplicating read tests.
+
+### Scan ordering contract
+
+The existing `scan_supports_sort` capability says a driver can order a scan,
+but `Operation::Scan` does not carry the ordering expressions. The operation
+gains an optional field:
+
+```rust
+pub struct Scan {
+    pub table: TableId,
+    pub columns: Vec<usize>,
+    pub filter: Option<stmt::Expr>,
+    pub order_by: Option<stmt::OrderBy>,
+    pub limit: Option<Pagination>,
+}
+```
+
+The planner preserves the lowered `order_by` when it chooses a scan. A driver
+with `scan_supports_sort: true` must apply filtering, ordering, and pagination
+in that order. A driver with the flag set to `false` continues to receive an
+early unsupported-feature error for an ordered scan and never receives a scan
+with `order_by: Some(_)`. DynamoDB remains in that group. SQL drivers do not
+receive `Operation::Scan`. When an index can satisfy a filter but not an
+arbitrary requested order, the planner may choose the sortable scan instead;
+it must not choose an index access path that changes or rejects an otherwise
+supported ordering.
+
+The Markdown and read-only memory capabilities report `sql: false`,
+`data_mutations: false`, `scan: true`, and `scan_supports_sort: true`. They also
+advertise native support for the scalar, string, document, and collection
+predicates implemented by the shared evaluator. Here, “native” means the
+backend implements the operator with its documented semantics; it does not
+mean the operator must come from an external database process. The
+`native_ilike` documentation and verifier error are generalized accordingly;
+PostgreSQL remains the only SQL backend with native `ILIKE`, while the memory
+backend supplies its own documented case-insensitive matcher.
+
+## Open questions
+
+There are no blocking open questions. Exact Rust type names may be adjusted
+during implementation, but the mapping defaults, snapshot lifecycle,
+read-only contract, query semantics, and crate boundary are part of this
+design.
+
+## Out of scope
+
+- **Writing Markdown files.** There is no create, update, delete, rename, or
+  formatting-preservation behavior until a concrete mutation use case exists.
+- **A mutable in-memory driver.** The shared crate is structured to support it,
+  but mutation semantics, index maintenance, and transactions need their own
+  design.
+- **File watching and reload.** A `Db` is one immutable snapshot; rebuilding it
+  is the only refresh mechanism.
+- **Aggregates and grouping.** `count()`, `GROUP BY`, and other aggregates keep
+  their current non-SQL unsupported-feature errors in the first release.
+- **Raw SQL.** The driver evaluates Toasty operations, not a SQL language.
+- **Markdown interpretation.** Rendering, full-text search, headings, links,
+  and syntax extensions are application concerns.
+- **Other metadata formats and extensions.** The first release accepts YAML
+  front matter in lowercase `.md` files. TOML, JSON, and `.markdown` discovery
+  can be added without changing the snapshot or evaluator contracts.
+- **Out-of-core execution.** The design targets content sets that fit in
+  memory. Streaming and spill-to-disk execution require a different lifecycle.
+- **Schema management.** Toasty validates models against files but does not
+  create directories, rewrite front matter, or apply migrations to content.

--- a/docs/guide/src/SUMMARY.md
+++ b/docs/guide/src/SUMMARY.md
@@ -53,3 +53,4 @@
 - [SQLite](./sqlite.md)
 - [Turso](./turso.md)
 - [DynamoDB](./dynamodb.md)
+- [Markdown](./markdown.md)

--- a/docs/guide/src/database-setup.md
+++ b/docs/guide/src/database-setup.md
@@ -51,6 +51,7 @@ requires its corresponding feature flag in `Cargo.toml`.
 | `postgresql` or `postgres` | PostgreSQL | `postgresql` |
 | `mysql` | MySQL | `mysql` |
 | `dynamodb` | DynamoDB | `dynamodb` |
+| `markdown` | Markdown directory (read-only) | `markdown` |
 
 Examples:
 
@@ -69,11 +70,15 @@ Examples:
 
 // DynamoDB (uses AWS config from environment)
 .connect("dynamodb://us-east-1")
+
+// Markdown content directory
+.connect("markdown:./content")
 ```
 
 For per-backend details — URL query parameters, TLS, type mapping,
 and per-driver behavior — see the
-[Database Backends](./postgresql.md) chapters.
+[Database Backends](./postgresql.md) chapters. The read-only Markdown source is
+documented in [Markdown](./markdown.md).
 
 ## Using a driver directly
 

--- a/docs/guide/src/markdown.md
+++ b/docs/guide/src/markdown.md
@@ -1,0 +1,108 @@
+# Markdown
+
+The Markdown driver presents a directory of `.md` files as typed, read-only
+Toasty models. It loads and validates the selected files when `Db` is built,
+then answers queries from one immutable in-memory snapshot.
+
+## Enabling the driver
+
+Enable the `markdown` feature to connect with a URL:
+
+```toml
+[dependencies]
+toasty = { version = "{{toasty_version}}", features = ["markdown"] }
+```
+
+```rust,ignore
+let mut db = toasty::Db::builder()
+    .models(toasty::models!(Post))
+    .connect("markdown:./content")
+    .await?;
+```
+
+Add `toasty-driver-markdown` as a dependency and construct `Markdown` directly
+when the content mapping needs configuration.
+
+## Default mapping
+
+Each immediate child directory matches a database table name. Each lowercase
+`.md` file directly in that directory is one row. YAML front-matter keys match
+database columns, the remaining text maps to a string column named `body`, and
+a missing single-string primary key comes from the filename without `.md`.
+
+```text
+content/
+  posts/
+    hello-world.md
+```
+
+```rust,ignore
+#[derive(Debug, toasty::Model)]
+struct Post {
+    #[key]
+    slug: String,
+    title: String,
+    published: bool,
+    body: String,
+}
+```
+
+```markdown
+---
+title: Hello, world
+published: true
+---
+# Hello, world
+```
+
+This file has the key `hello-world`. Front matter can supply the key explicitly
+instead. Missing optional fields become `None`; missing required fields and
+values that do not match the compiled column type make `Db::build` fail.
+
+## Configuring a table
+
+`Markdown::builder` can change a table directory, rename front-matter keys,
+select or disable the body column, derive one string column from the file stem
+or relative path, and enable recursive file discovery:
+
+```rust,ignore
+use toasty_driver_markdown::{Markdown, Table};
+
+let driver = Markdown::builder("content")
+    .table(
+        "posts",
+        Table::new("articles")
+            .column("date", "published_at")
+            .body_column("markdown")
+            .key_from_relative_path("slug")
+            .recursive(true),
+    )
+    .strict(true)
+    .build();
+
+let mut db = toasty::Db::builder()
+    .models(toasty::models!(Post))
+    .build(driver)
+    .await?;
+```
+
+Relative-path keys omit `.md` and always use `/` separators. Strict mode
+rejects unknown root directories, unknown front-matter keys, nested directories
+without recursive discovery, and non-empty bodies without a body mapping.
+The loader skips symbolic links and rejects configured paths that escape the
+content root.
+
+## Queries and snapshots
+
+Primary-key reads, filters, relations, ordering, limits, offsets, and cursor
+pagination use Toasty's normal model API. The in-memory backend implements
+`between`, `starts_with`, `like`, `ilike`, collection predicates, and document
+path predicates. `ilike` uses locale-independent Unicode case folding.
+
+The snapshot includes front matter and bodies. Filesystem changes are not
+visible after `Db::build` returns; build another `Db` to load them.
+
+The driver reports `db.capability().data_mutations == false`. Create, update,
+and delete statements return `Error::unsupported_feature` before the engine
+plans or executes them. Schema changes, migrations, reset, and raw SQL are also
+unsupported.

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -26,7 +26,7 @@ rust_decimal.workspace = true
 bigdecimal.workspace = true
 hashbrown.workspace = true
 jiff.workspace = true
-toasty = { workspace = true, features = ["rust_decimal", "bigdecimal", "jiff"] }
+toasty = { workspace = true, features = ["rust_decimal", "bigdecimal", "jiff", "markdown"] }
 toasty-core.workspace = true
 toasty-macros.workspace = true
 tokio.workspace = true
@@ -40,6 +40,8 @@ toasty-driver-turso = { workspace = true, optional = true }
 toasty-driver-mysql = { workspace = true, optional = true }
 toasty-driver-postgresql = { workspace = true, optional = true }
 toasty-driver-dynamodb = { workspace = true, optional = true }
+toasty-driver-markdown.workspace = true
+toasty-driver-memory.workspace = true
 
 # Database clients used directly by per-driver integration test binaries
 tokio-postgres = { workspace = true, optional = true }
@@ -52,6 +54,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 trybuild.workspace = true
 url.workspace = true
+tempfile.workspace = true
 
 # Fixtures
 tests-fixture-post = { path = "tests/fixtures/post" }

--- a/tests/tests/markdown.rs
+++ b/tests/tests/markdown.rs
@@ -1,0 +1,294 @@
+use std::{fs, path::Path};
+
+use toasty::stmt::Page as ResultPage;
+use toasty_driver_markdown::{Markdown, Table};
+
+#[derive(Debug, toasty::Model)]
+#[table = "posts"]
+struct Post {
+    #[key]
+    slug: String,
+    title: String,
+    published: bool,
+    score: i64,
+    tags: Vec<String>,
+    body: String,
+}
+
+#[derive(Debug, toasty::Model)]
+#[table = "pages"]
+struct Page {
+    #[key]
+    slug: String,
+    heading: String,
+    markdown: String,
+}
+
+#[derive(Debug, toasty::Model)]
+#[table = "notes"]
+struct Note {
+    #[key]
+    id: String,
+    text: String,
+}
+
+fn write(path: impl AsRef<Path>, contents: &str) {
+    let path = path.as_ref();
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, contents).unwrap();
+}
+
+fn post(title: &str, published: bool, score: i64, tags: &[&str], body: &str) -> String {
+    let tags = tags
+        .iter()
+        .map(|tag| format!("  - {tag}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "---\ntitle: {title}\npublished: {published}\nscore: {score}\ntags:\n{tags}\n---\n{body}"
+    )
+}
+
+#[tokio::test]
+async fn loads_conventions_and_executes_memory_queries() {
+    let content = tempfile::tempdir().unwrap();
+    write(
+        content.path().join("posts/rust-guide.md"),
+        &post("Rust Guide", true, 10, &["rust", "guide"], "# Rust Guide\n"),
+    );
+    write(
+        content.path().join("posts/rust-news.md"),
+        &post("RUST News", true, 30, &["rust", "news"], "# News\n"),
+    );
+    write(
+        content.path().join("posts/draft.md"),
+        &post("Rust Draft", false, 50, &["draft"], "# Draft\n"),
+    );
+
+    let url = format!("markdown:{}", content.path().display());
+    let mut db = toasty::Db::builder()
+        .models(toasty::models!(Post))
+        .connect(&url)
+        .await
+        .unwrap();
+
+    assert!(!db.capability().data_mutations);
+
+    let guide = Post::get_by_slug(&mut db, "rust-guide").await.unwrap();
+    assert_eq!(guide.title, "Rust Guide");
+    assert_eq!(guide.tags, ["rust", "guide"]);
+    assert_eq!(guide.body, "# Rust Guide\n");
+
+    let selected: Vec<Post> = Post::filter(
+        Post::fields()
+            .published()
+            .eq(true)
+            .and(Post::fields().title().ilike("%rust%".to_string()))
+            .and(Post::fields().score().between(10_i64, 40_i64))
+            .and(Post::fields().tags().intersects(vec!["rust".to_string()])),
+    )
+    .order_by(Post::fields().score().desc())
+    .limit(1)
+    .exec(&mut db)
+    .await
+    .unwrap();
+
+    assert_eq!(selected.len(), 1);
+    assert_eq!(selected[0].slug, "rust-news");
+
+    let first: ResultPage<Post> = Post::all()
+        .order_by(Post::fields().score().asc())
+        .paginate(2)
+        .exec(&mut db)
+        .await
+        .unwrap();
+    assert_eq!(
+        first
+            .iter()
+            .map(|post| post.slug.as_str())
+            .collect::<Vec<_>>(),
+        ["rust-guide", "rust-news"]
+    );
+    let second = first.next(&mut db).await.unwrap().unwrap();
+    assert_eq!(second[0].slug, "draft");
+    assert!(second.has_prev());
+    let previous = second.prev(&mut db).await.unwrap().unwrap();
+    assert_eq!(
+        previous
+            .iter()
+            .map(|post| post.slug.as_str())
+            .collect::<Vec<_>>(),
+        ["rust-guide", "rust-news"]
+    );
+}
+
+#[tokio::test]
+async fn keeps_an_explicit_front_matter_key() {
+    let content = tempfile::tempdir().unwrap();
+    write(
+        content.path().join("posts/filename.md"),
+        "---\nslug: canonical\ntitle: Canonical\npublished: true\nscore: 1\ntags: []\n---\nbody",
+    );
+
+    let mut db = toasty::Db::builder()
+        .models(toasty::models!(Post))
+        .build(Markdown::new(content.path()))
+        .await
+        .unwrap();
+
+    let loaded = Post::get_by_slug(&mut db, "canonical").await.unwrap();
+    assert_eq!(loaded.body, "body");
+    assert!(Post::get_by_slug(&mut db, "filename").await.is_err());
+}
+
+#[tokio::test]
+async fn supports_configured_recursive_mappings() {
+    let content = tempfile::tempdir().unwrap();
+    write(
+        content.path().join("articles/guide/intro.md"),
+        "---\ntitle: Introduction\n---\nWelcome.\n",
+    );
+
+    let driver = Markdown::builder(content.path())
+        .table(
+            "pages",
+            Table::new("articles")
+                .column("title", "heading")
+                .body_column("markdown")
+                .key_from_relative_path("slug")
+                .recursive(true),
+        )
+        .strict(true)
+        .build();
+    let mut db = toasty::Db::builder()
+        .models(toasty::models!(Page))
+        .build(driver)
+        .await
+        .unwrap();
+
+    let page = Page::get_by_slug(&mut db, "guide/intro").await.unwrap();
+    assert_eq!(page.heading, "Introduction");
+    assert_eq!(page.markdown, "Welcome.\n");
+}
+
+#[tokio::test]
+async fn snapshot_is_stable_and_mutations_are_rejected() {
+    let content = tempfile::tempdir().unwrap();
+    let path = content.path().join("posts/stable.md");
+    let original = post("Original", true, 1, &["stable"], "Original body\n");
+    write(&path, &original);
+
+    let mut db = toasty::Db::builder()
+        .models(toasty::models!(Post))
+        .build(Markdown::new(content.path()))
+        .await
+        .unwrap();
+
+    let changed = post("Changed", false, 2, &["changed"], "Changed body\n");
+    write(&path, &changed);
+    let loaded = Post::get_by_slug(&mut db, "stable").await.unwrap();
+    assert_eq!(loaded.title, "Original");
+
+    let create_error = Post::create()
+        .slug("new")
+        .title("New")
+        .published(false)
+        .score(0)
+        .tags(Vec::<String>::new())
+        .body("Draft")
+        .exec(&mut db)
+        .await
+        .unwrap_err();
+    assert!(create_error.is_unsupported_feature());
+
+    let mut loaded = loaded;
+    let update_error = loaded
+        .update()
+        .title("Updated")
+        .exec(&mut db)
+        .await
+        .unwrap_err();
+    assert!(update_error.is_unsupported_feature());
+
+    let loaded = Post::get_by_slug(&mut db, "stable").await.unwrap();
+    let delete_error = loaded.delete().exec(&mut db).await.unwrap_err();
+    assert!(delete_error.is_unsupported_feature());
+    assert_eq!(fs::read_to_string(path).unwrap(), changed);
+}
+
+#[tokio::test]
+async fn rejects_invalid_content_and_configuration_during_build() {
+    let duplicate = tempfile::tempdir().unwrap();
+    for name in ["one", "two"] {
+        write(
+            duplicate.path().join(format!("posts/{name}.md")),
+            "---\nslug: duplicate\ntitle: Duplicate\npublished: true\nscore: 1\ntags: []\n---\n",
+        );
+    }
+    let error = toasty::Db::builder()
+        .models(toasty::models!(Post))
+        .build(Markdown::new(duplicate.path()))
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("duplicate value"));
+
+    let invalid_type = tempfile::tempdir().unwrap();
+    write(
+        invalid_type.path().join("posts/wrong.md"),
+        "---\ntitle: Wrong\npublished: true\nscore: not-a-number\ntags: []\n---\n",
+    );
+    let error = toasty::Db::builder()
+        .models(toasty::models!(Post))
+        .build(Markdown::new(invalid_type.path()))
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("score"));
+
+    let invalid_mapping = tempfile::tempdir().unwrap();
+    fs::create_dir(invalid_mapping.path().join("posts")).unwrap();
+    let driver = Markdown::builder(invalid_mapping.path())
+        .table(
+            "posts",
+            Table::new("posts")
+                .column("one", "title")
+                .column("two", "title"),
+        )
+        .build();
+    let error = toasty::Db::builder()
+        .models(toasty::models!(Post))
+        .build(driver)
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("more than once"));
+
+    let escaping = Markdown::builder(invalid_mapping.path())
+        .table("posts", Table::new("../posts"))
+        .build();
+    let error = toasty::Db::builder()
+        .models(toasty::models!(Post))
+        .build(escaping)
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("relative path"));
+}
+
+#[tokio::test]
+async fn reusable_memory_driver_reads_typed_rows() {
+    let driver = toasty_driver_memory::Memory::builder()
+        .table(
+            "notes",
+            [toasty_core::stmt::ValueRecord::from_vec(vec![
+                "one".into(),
+                "hello".into(),
+            ])],
+        )
+        .build();
+    let mut db = toasty::Db::builder()
+        .models(toasty::models!(Note))
+        .build(driver)
+        .await
+        .unwrap();
+
+    let note = Note::get_by_id(&mut db, "one").await.unwrap();
+    assert_eq!(note.text, "hello");
+}


### PR DESCRIPTION
## Summary

- Add a Markdown-backed driver with setup and integration-test support.
- Extend scan operations and predicate evaluation across the query engine and drivers.
- Document Markdown database configuration and usage.
- Add supporting in-memory driver and capability updates.

## Testing

Not run (not requested).