### PR TITLE
fix: roll back transactions when finalization fails

### DIFF
--- a/crates/toasty-driver-integration-suite/src/instrumented_driver.rs
+++ b/crates/toasty-driver-integration-suite/src/instrumented_driver.rs
@@ -23,6 +23,10 @@ use toasty_core::{
 /// past) the underlying driver.
 #[derive(Debug, Clone)]
 pub enum Fault {
+    /// Causes the next `exec` to return `Error::driver_operation_failed`
+    /// without touching the underlying connection or marking it invalid.
+    OperationFailed,
+
     /// Causes the next `exec` to return `Error::connection_lost` without
     /// touching the underlying connection. The wrapping
     /// `InstrumentedConnection`'s `is_valid` flips to `false`, mirroring
@@ -186,6 +190,11 @@ impl Connection for InstrumentedConnection {
             .pop_front();
         if let Some(fault) = fault {
             match fault {
+                Fault::OperationFailed => {
+                    return Err(toasty_core::Error::driver_operation_failed(
+                        std::io::Error::other("injected operation failure"),
+                    ));
+                }
                 Fault::ConnectionLost => {
                     self.valid.store(false, Ordering::Release);
                     return Err(toasty_core::Error::connection_lost(std::io::Error::other(
@@ -249,6 +258,11 @@ impl Connection for InstrumentedConnection {
             .pop_front();
         if let Some(fault) = fault {
             match fault {
+                Fault::OperationFailed => {
+                    return Err(toasty_core::Error::driver_operation_failed(
+                        std::io::Error::other("injected operation failure"),
+                    ));
+                }
                 Fault::ConnectionLost => {
                     self.valid.store(false, Ordering::Release);
                     return Err(toasty_core::Error::connection_lost(std::io::Error::other(

--- a/crates/toasty-driver-integration-suite/src/tests/tx_interactive.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/tx_interactive.rs
@@ -1,3 +1,4 @@
+use crate::Fault;
 use crate::prelude::*;
 
 use toasty_core::driver::{Operation, operation::IsolationLevel, operation::Transaction};
@@ -48,6 +49,111 @@ pub async fn drop_without_finalize_rolls_back(t: &mut Test) -> Result<()> {
 
     let users = User::all().exec(&mut db).await?;
     assert!(users.is_empty());
+
+    Ok(())
+}
+
+/// A failed commit rolls back before the connection returns to the pool.
+#[driver_test(requires(sql))]
+pub async fn commit_failure_rolls_back_before_connection_reuse(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        id: i64,
+    }
+
+    let mut db = t.setup_db(models!(Item)).await;
+
+    t.log().clear();
+
+    let tx = db.transaction().await?;
+    t.inject_fault(Fault::OperationFailed);
+    let err = tx.commit().await.unwrap_err();
+    assert!(err.is_driver_operation_failed());
+
+    let tx = db.transaction().await?;
+    tx.rollback().await?;
+
+    assert_struct!(
+        t.log().pop_op(),
+        Operation::Transaction(Transaction::Start {
+            isolation: None,
+            read_only: false,
+            ..
+        })
+    );
+    assert_struct!(
+        t.log().pop_op(),
+        Operation::Transaction(Transaction::Rollback)
+    );
+    assert_struct!(
+        t.log().pop_op(),
+        Operation::Transaction(Transaction::Start {
+            isolation: None,
+            read_only: false,
+            ..
+        })
+    );
+    assert_struct!(
+        t.log().pop_op(),
+        Operation::Transaction(Transaction::Rollback)
+    );
+    assert!(t.log().is_empty());
+
+    Ok(())
+}
+
+/// A failed rollback is retried before the connection returns to the pool.
+#[driver_test(requires(sql))]
+pub async fn rollback_failure_retries_before_connection_reuse(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        id: i64,
+    }
+
+    let mut db = t.setup_db(models!(Item)).await;
+
+    let tx = db.transaction().await?;
+    t.inject_fault(Fault::OperationFailed);
+    let err = tx.rollback().await.unwrap_err();
+    assert!(err.is_driver_operation_failed());
+
+    let tx = db.transaction().await?;
+    tx.rollback().await?;
+
+    Ok(())
+}
+
+/// Cancelling a queued commit keeps the connection reusable.
+#[driver_test(requires(sql))]
+pub async fn cancel_queued_commit_keeps_connection_reusable(t: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        id: i64,
+    }
+
+    let mut db = t.setup_db(models!(Item)).await;
+
+    t.log().clear();
+
+    let tx = db.transaction().await?;
+    let mut commit = Box::pin(tx.commit());
+
+    tokio::select! {
+        biased;
+        _ = async {
+            while t.log().len() < 2 {
+                tokio::task::yield_now().await;
+            }
+        } => {}
+        result = &mut commit => panic!("commit completed before cancellation: {result:?}"),
+    }
+    drop(commit);
+
+    let tx = db.transaction().await?;
+    tx.rollback().await?;
 
     Ok(())
 }

--- a/crates/toasty/src/db/tx.rs
+++ b/crates/toasty/src/db/tx.rs
@@ -182,11 +182,6 @@ impl<'a> Transaction<'a> {
     /// Commit the transaction.
     pub async fn commit(mut self) -> Result<()> {
         tracing::debug!("committing transaction");
-        // Because driver operations are done in a background task, all the operations aren't
-        // cancelled and will continue even if this future is dropped. Setting the finalized flag
-        // to true early here makes sure that if the future is dropped we don't queue a rollback
-        // command.
-        self.finalized = true;
         match self.savepoint {
             Some(_) => self
                 .conn
@@ -196,14 +191,13 @@ impl<'a> Transaction<'a> {
                 .exec_operation(operation::Transaction::Commit.into()),
         }
         .await?;
+        self.finalized = true;
         Ok(())
     }
 
     /// Roll back the transaction.
     pub async fn rollback(mut self) -> Result<()> {
         tracing::debug!("rolling back transaction");
-        // See `commit` why we're setting the finalized flag to true early.
-        self.finalized = true;
         match self.savepoint {
             Some(_) => self.conn.exec_operation(
                 operation::Transaction::RollbackToSavepoint(self.savepoint()).into(),
@@ -213,6 +207,7 @@ impl<'a> Transaction<'a> {
                 .exec_operation(operation::Transaction::Rollback.into()),
         }
         .await?;
+        self.finalized = true;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- Mark interactive transactions finalized only after commit or rollback succeeds, so failed finalization schedules cleanup before the connection returns to the pool.
- Add integration coverage for failed commits, failed rollbacks, and cancelled commit futures.

Closes #1098

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

The regression tests inject a non-fatal driver operation failure and verify that the same pooled connection can begin another transaction.