### PR TITLE
fix(postgresql): decode NUMERIC array elements

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/type_decimal.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/type_decimal.rs
@@ -36,6 +36,34 @@ pub async fn ty_decimal(test: &mut Test) -> Result<(), BoxError> {
     Ok(())
 }
 
+#[driver_test(requires(and(native_array, native_decimal)))]
+pub async fn ty_decimal_vec(test: &mut Test) -> Result<(), BoxError> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: u64,
+        values: Vec<Decimal>,
+    }
+
+    let mut db = test.setup_db(models!(Item)).await;
+    let values = vec![
+        Decimal::from_str("123.456")?,
+        Decimal::from_str("-0.0000000001")?,
+    ];
+
+    let item = toasty::create!(Item {
+        values: values.clone(),
+    })
+    .exec(&mut db)
+    .await?;
+
+    let reloaded = Item::get_by_id(&mut db, &item.id).await?;
+    assert_eq!(reloaded.values, values);
+
+    Ok(())
+}
+
 #[driver_test(id(ID))]
 pub async fn ty_decimal_as_text(test: &mut Test) -> Result<(), BoxError> {
     use rust_decimal::Decimal;

--- a/crates/toasty-driver-postgresql/src/value.rs
+++ b/crates/toasty-driver-postgresql/src/value.rs
@@ -459,6 +459,18 @@ fn decode_array_element(elem_pg_ty: &Type, bytes: &[u8], elem_ty: &stmt::Type) -
             f64::from_sql(elem_pg_ty, bytes).expect("decode FLOAT8 array element"),
             elem_ty,
         )
+    } else if elem_pg_ty == &Type::NUMERIC {
+        #[cfg(feature = "rust_decimal")]
+        {
+            stmt::Value::Decimal(
+                rust_decimal::Decimal::from_sql(elem_pg_ty, bytes)
+                    .expect("decode NUMERIC array element"),
+            )
+        }
+        #[cfg(not(feature = "rust_decimal"))]
+        {
+            panic!("NUMERIC array elements require rust_decimal feature to be enabled")
+        }
     } else if elem_pg_ty == &Type::UUID {
         stmt::Value::Uuid(
             uuid::Uuid::from_sql(elem_pg_ty, bytes).expect("decode UUID array element"),


### PR DESCRIPTION
## Summary
Add support for decoding NUMERIC arrays.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test
- [ ] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`):
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers
N/A
