### PR TITLE
feat: support temporal Vec fields

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/type_collection.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/type_collection.rs
@@ -41,7 +41,7 @@ pub async fn vec_zoned_create_get(t: &mut Test) -> Result<(), BoxError> {
     struct Item {
         #[key]
         #[auto]
-        id: u64,
+        id: uuid::Uuid,
         values: Vec<jiff::Zoned>,
     }
 

--- a/crates/toasty-driver-integration-suite/src/tests/type_collection.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/type_collection.rs
@@ -7,6 +7,146 @@
 
 use crate::prelude::*;
 
+#[driver_test(requires(and(native_array, native_timestamp)))]
+pub async fn vec_timestamp_create_get(t: &mut Test) -> Result<(), BoxError> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: u64,
+        values: Vec<jiff::Timestamp>,
+    }
+
+    let mut db = t.setup_db(models!(Item)).await;
+    let values = vec![
+        "2023-11-14T22:13:20.123456Z".parse()?,
+        "2020-01-02T03:04:05.654321Z".parse()?,
+    ];
+
+    let item = toasty::create!(Item {
+        values: values.clone(),
+    })
+    .exec(&mut db)
+    .await?;
+
+    let reloaded = Item::get_by_id(&mut db, &item.id).await?;
+    assert_eq!(reloaded.values, values);
+
+    Ok(())
+}
+
+#[driver_test(requires(vec_scalar))]
+pub async fn vec_zoned_create_get(t: &mut Test) -> Result<(), BoxError> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: u64,
+        values: Vec<jiff::Zoned>,
+    }
+
+    let mut db = t.setup_db(models!(Item)).await;
+    let values = vec![
+        "2021-06-15T14:30:00-04:00[America/New_York]".parse()?,
+        "2025-12-31T23:59:59+09:00[Asia/Tokyo]".parse()?,
+    ];
+
+    let item = toasty::create!(Item {
+        values: values.clone(),
+    })
+    .exec(&mut db)
+    .await?;
+
+    let reloaded = Item::get_by_id(&mut db, &item.id).await?;
+    assert_eq!(reloaded.values, values);
+
+    Ok(())
+}
+
+#[driver_test(requires(and(native_array, native_date)))]
+pub async fn vec_date_create_get(t: &mut Test) -> Result<(), BoxError> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: u64,
+        values: Vec<jiff::civil::Date>,
+    }
+
+    let mut db = t.setup_db(models!(Item)).await;
+    let values = vec![
+        jiff::civil::date(2025, 6, 15),
+        jiff::civil::date(2020, 1, 2),
+    ];
+
+    let item = toasty::create!(Item {
+        values: values.clone(),
+    })
+    .exec(&mut db)
+    .await?;
+
+    let reloaded = Item::get_by_id(&mut db, &item.id).await?;
+    assert_eq!(reloaded.values, values);
+
+    Ok(())
+}
+
+#[driver_test(requires(and(native_array, native_time)))]
+pub async fn vec_time_create_get(t: &mut Test) -> Result<(), BoxError> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: u64,
+        values: Vec<jiff::civil::Time>,
+    }
+
+    let mut db = t.setup_db(models!(Item)).await;
+    let values = vec![
+        jiff::civil::time(9, 30, 45, 123_456_000),
+        jiff::civil::time(3, 4, 5, 654_321_000),
+    ];
+
+    let item = toasty::create!(Item {
+        values: values.clone(),
+    })
+    .exec(&mut db)
+    .await?;
+
+    let reloaded = Item::get_by_id(&mut db, &item.id).await?;
+    assert_eq!(reloaded.values, values);
+
+    Ok(())
+}
+
+#[driver_test(requires(and(native_array, native_datetime)))]
+pub async fn vec_datetime_create_get(t: &mut Test) -> Result<(), BoxError> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: u64,
+        values: Vec<jiff::civil::DateTime>,
+    }
+
+    let mut db = t.setup_db(models!(Item)).await;
+    let values = vec![
+        jiff::civil::datetime(2025, 6, 15, 9, 30, 45, 123_456_000),
+        jiff::civil::datetime(2020, 1, 2, 3, 4, 5, 654_321_000),
+    ];
+
+    let item = toasty::create!(Item {
+        values: values.clone(),
+    })
+    .exec(&mut db)
+    .await?;
+
+    let reloaded = Item::get_by_id(&mut db, &item.id).await?;
+    assert_eq!(reloaded.values, values);
+
+    Ok(())
+}
+
 /// `Vec<String>` round-trips through INSERT, RETURNING, and a fresh fetch
 /// — covers both the PG bind path (driver receives `Value::List` as one
 /// `text[]` parameter) and the read path (`text[]` decoded back to

--- a/crates/toasty-driver-postgresql/src/value.rs
+++ b/crates/toasty-driver-postgresql/src/value.rs
@@ -463,6 +463,52 @@ fn decode_array_element(elem_pg_ty: &Type, bytes: &[u8], elem_ty: &stmt::Type) -
         stmt::Value::Uuid(
             uuid::Uuid::from_sql(elem_pg_ty, bytes).expect("decode UUID array element"),
         )
+    } else if elem_pg_ty == &Type::TIMESTAMPTZ {
+        #[cfg(feature = "jiff")]
+        {
+            stmt::Value::Timestamp(
+                jiff::Timestamp::from_sql(elem_pg_ty, bytes)
+                    .expect("decode TIMESTAMPTZ array element"),
+            )
+        }
+        #[cfg(not(feature = "jiff"))]
+        {
+            panic!("TIMESTAMPTZ requires jiff feature to be enabled")
+        }
+    } else if elem_pg_ty == &Type::TIMESTAMP {
+        #[cfg(feature = "jiff")]
+        {
+            stmt::Value::DateTime(
+                jiff::civil::DateTime::from_sql(elem_pg_ty, bytes)
+                    .expect("decode TIMESTAMP array element"),
+            )
+        }
+        #[cfg(not(feature = "jiff"))]
+        {
+            panic!("TIMESTAMP requires jiff feature to be enabled")
+        }
+    } else if elem_pg_ty == &Type::DATE {
+        #[cfg(feature = "jiff")]
+        {
+            stmt::Value::Date(
+                jiff::civil::Date::from_sql(elem_pg_ty, bytes).expect("decode DATE array element"),
+            )
+        }
+        #[cfg(not(feature = "jiff"))]
+        {
+            panic!("DATE requires jiff feature to be enabled")
+        }
+    } else if elem_pg_ty == &Type::TIME {
+        #[cfg(feature = "jiff")]
+        {
+            stmt::Value::Time(
+                jiff::civil::Time::from_sql(elem_pg_ty, bytes).expect("decode TIME array element"),
+            )
+        }
+        #[cfg(not(feature = "jiff"))]
+        {
+            panic!("TIME requires jiff feature to be enabled")
+        }
     } else if matches!(elem_pg_ty.kind(), Kind::Enum(_)) {
         // Enum labels are plain UTF-8; `EnumString` accepts `Kind::Enum` where
         // `String` won't.

--- a/crates/toasty/src/schema/field.rs
+++ b/crates/toasty/src/schema/field.rs
@@ -379,6 +379,15 @@ impl_scalar!(rust_decimal::Decimal);
 #[cfg(feature = "bigdecimal")]
 impl_scalar!(bigdecimal::BigDecimal);
 
+#[cfg(feature = "jiff")]
+impl_scalar!(
+    jiff::Timestamp,
+    jiff::Zoned,
+    jiff::civil::Date,
+    jiff::civil::Time,
+    jiff::civil::DateTime
+);
+
 impl<T: Field> Field for Option<T> {
     type ExprTarget = Self;
     type Path<Origin> = stmt::Path<Origin, Self>;


### PR DESCRIPTION
## Summary
Adds support for temporal fields in arrays.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test
- [ ] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`):
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers
N/A
