### PR TITLE
feat!: require explicit column types for JSON fields

### DIFF
--- a/crates/toasty-driver-integration-suite/src/scenarios/deferred_json_document.rs
+++ b/crates/toasty-driver-integration-suite/src/scenarios/deferred_json_document.rs
@@ -17,6 +17,7 @@ scenario! {
         id: ID,
 
         name: String,
+        #[column(type = text)]
         payload: toasty::Deferred<toasty::Json<Payload>>,
     }
 

--- a/crates/toasty-driver-integration-suite/src/tests/type_serialize.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/type_serialize.rs
@@ -224,3 +224,41 @@ pub async fn json_custom_struct(t: &mut Test) -> Result<(), BoxError> {
 
     Ok(())
 }
+
+#[driver_test(id(ID))]
+pub async fn json_data_enum_field(t: &mut Test) -> Result<(), BoxError> {
+    #[derive(Debug, PartialEq, toasty::Embed)]
+    enum Payload {
+        Data {
+            #[column(type = text)]
+            tags: Json<Vec<String>>,
+        },
+        Empty,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: ID,
+        payload: Payload,
+    }
+
+    let mut db = t.setup_db(models!(Item)).await;
+    let tags = vec!["rust".to_string(), "toasty".to_string()];
+
+    let item = toasty::create!(Item {
+        payload: Payload::Data {
+            tags: Json(tags.clone()),
+        },
+    })
+    .exec(&mut db)
+    .await?;
+
+    assert_eq!(
+        Item::get_by_id(&mut db, &item.id).await?.payload,
+        Payload::Data { tags: Json(tags) }
+    );
+
+    Ok(())
+}

--- a/crates/toasty-driver-integration-suite/src/tests/type_serialize.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/type_serialize.rs
@@ -39,6 +39,7 @@ pub async fn json_vec_string(t: &mut Test) -> Result<(), BoxError> {
         #[key]
         #[auto]
         id: ID,
+        #[column(type = text)]
         tags: Json<Vec<String>>,
     }
 
@@ -98,6 +99,7 @@ pub async fn json_option_outside_sql_null(t: &mut Test) -> Result<(), BoxError> 
         #[key]
         #[auto]
         id: ID,
+        #[column(type = text)]
         data: Option<Json<HashMap<String, String>>>,
     }
 
@@ -146,6 +148,7 @@ pub async fn json_option_inside_json_null(t: &mut Test) -> Result<(), BoxError> 
         #[key]
         #[auto]
         id: ID,
+        #[column(type = text)]
         extra: Json<Option<String>>,
     }
 
@@ -199,6 +202,7 @@ pub async fn json_custom_struct(t: &mut Test) -> Result<(), BoxError> {
         #[key]
         #[auto]
         id: ID,
+        #[column(type = text)]
         meta: Json<Metadata>,
     }
 

--- a/crates/toasty-macros/src/lib.rs
+++ b/crates/toasty-macros/src/lib.rs
@@ -310,8 +310,11 @@ use proc_macro::TokenStream;
 /// ## JSON-encoded fields via [`Json<T>`](toasty::stmt::Json)
 ///
 /// Wrap a serde-typed value in [`toasty::Json<T>`](toasty::stmt::Json) to
-/// store it as a JSON string in the database. Requires the `serde` feature
-/// and that `T` implements `serde::Serialize` and `serde::Deserialize`.
+/// serialize it as JSON in the database. Every JSON field must select its
+/// database column type with `#[column(type = ...)]`. Use `text` for
+/// text-backed JSON, or a custom type such as `"jsonb"` when the target driver
+/// supports native JSON storage. JSON fields require the `serde` feature and
+/// `T: serde::Serialize + serde::Deserialize`.
 ///
 /// ```
 /// # use toasty::Model;
@@ -320,6 +323,7 @@ use proc_macro::TokenStream;
 /// #     #[key]
 /// #     #[auto]
 /// #     id: i64,
+/// #[column(type = text)]
 /// tags: toasty::Json<Vec<String>>,
 /// # }
 /// ```
@@ -335,6 +339,7 @@ use proc_macro::TokenStream;
 /// #     #[key]
 /// #     #[auto]
 /// #     id: i64,
+/// #[column(type = text)]
 /// metadata: Option<toasty::Json<HashMap<String, String>>>,
 /// # }
 /// ```
@@ -769,6 +774,7 @@ use proc_macro::TokenStream;
 ///
 ///     title: String,
 ///
+///     #[column(type = text)]
 ///     tags: toasty::Json<Vec<String>>,
 ///
 ///     #[index]

--- a/crates/toasty-macros/src/lib.rs
+++ b/crates/toasty-macros/src/lib.rs
@@ -312,8 +312,7 @@ use proc_macro::TokenStream;
 /// Wrap a serde-typed value in [`toasty::Json<T>`](toasty::stmt::Json) to
 /// serialize it as JSON in the database. Every JSON field must select its
 /// database column type with `#[column(type = ...)]`. Use `text` for
-/// text-backed JSON, or a custom type such as `"jsonb"` when the target driver
-/// supports native JSON storage. JSON fields require the `serde` feature and
+/// text-backed JSON. JSON fields require the `serde` feature and
 /// `T: serde::Serialize + serde::Deserialize`.
 ///
 /// ```

--- a/crates/toasty-macros/src/model/expand.rs
+++ b/crates/toasty-macros/src/model/expand.rs
@@ -43,6 +43,7 @@ impl Expand<'_> {
         let update_builder = self.expand_update_builder();
         let upsert_builders = self.expand_upsert_builders();
         let storage_compat_checks = self.expand_storage_compat_checks();
+        let column_type_requirement_checks = self.expand_column_type_requirement_checks();
         let auto_compat_checks = self.expand_auto_compat_checks();
         let version_compat_checks = self.expand_version_compat_checks();
         let indexable_checks = self.expand_indexable_checks();
@@ -56,6 +57,7 @@ impl Expand<'_> {
             #update_builder
             #upsert_builders
             #storage_compat_checks
+            #column_type_requirement_checks
             #auto_compat_checks
             #version_compat_checks
             #indexable_checks
@@ -101,6 +103,7 @@ pub(super) fn embedded_model(model: &Model) -> TokenStream {
     let embedded_model_impls = expand.expand_embedded_model_impls();
     let embedded_update_builder = expand.expand_embedded_update_builder();
     let storage_compat_checks = expand.expand_storage_compat_checks();
+    let column_type_requirement_checks = expand.expand_column_type_requirement_checks();
     let indexable_checks = expand.expand_indexable_checks();
     let newtype_marker = expand.expand_embedded_newtype_marker();
     let newtype_indexable_impl = expand.expand_embedded_indexable_impl();
@@ -118,6 +121,7 @@ pub(super) fn embedded_model(model: &Model) -> TokenStream {
         #embedded_model_impls
 
         #storage_compat_checks
+        #column_type_requirement_checks
         #indexable_checks
 
         impl #toasty::Embed for #model_ident {
@@ -256,6 +260,7 @@ pub(super) fn embedded_enum(model: &Model) -> TokenStream {
     let enum_field_list_struct = e.expand_field_list_struct();
     let field_register_calls = e.expand_field_register_calls();
     let storage_compat_checks = e.expand_storage_compat_checks();
+    let column_type_requirement_checks = e.expand_column_type_requirement_checks();
     let discriminant_storage_compat_impls = e.expand_enum_discriminant_compat_impls();
     let shared_column_checks = e.expand_shared_column_checks();
     let indexable_checks = e.expand_indexable_checks();
@@ -277,6 +282,7 @@ pub(super) fn embedded_enum(model: &Model) -> TokenStream {
         #enum_field_list_struct
 
         #storage_compat_checks
+        #column_type_requirement_checks
         #discriminant_storage_compat_impls
         #shared_column_checks
         #indexable_checks

--- a/crates/toasty-macros/src/model/expand/embedded_enum.rs
+++ b/crates/toasty-macros/src/model/expand/embedded_enum.rs
@@ -411,6 +411,18 @@ impl Expand<'_> {
                     None => quote! { None },
                 };
                 let ty = primitive_ty_unwrap(field);
+                let storage_ty = match field
+                    .attrs
+                    .column
+                    .as_ref()
+                    .and_then(|column| column.ty.as_ref())
+                {
+                    Some(column_ty) => {
+                        let expanded = column_ty.expand_with(toasty);
+                        quote! { Some(#expanded) }
+                    }
+                    None => quote! { None },
+                };
                 let variant_index = field.variant.expect("enum field must have variant");
                 let variant_idx = util::int(variant_index);
                 quote! {
@@ -423,7 +435,7 @@ impl Expand<'_> {
                             app: Some(#app_name.to_string()),
                             storage: #storage_name,
                         },
-                        ty: <#ty as #toasty::Field>::field_ty(None),
+                        ty: <#ty as #toasty::Field>::field_ty(#storage_ty),
                         nullable: <#ty as #toasty::Field>::NULLABLE,
                         primary_key: false,
                         auto: None,

--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -419,6 +419,46 @@ impl Expand<'_> {
         quote! { #( #checks )* }
     }
 
+    /// Reject field types that require an explicit `#[column(type = ...)]`
+    /// when the attribute is absent.
+    ///
+    /// The field type communicates the requirement through `Field` trait
+    /// dispatch. The macro only checks whether the attribute supplied a type;
+    /// it never inspects the Rust type syntax. This also makes aliases and
+    /// transparent wrappers behave the same as the underlying field type.
+    pub(super) fn expand_column_type_requirement_checks(&self) -> TokenStream {
+        let toasty = &self.toasty;
+
+        let checks = self.model.fields.iter().filter_map(|field| {
+            let FieldTy::Primitive(ty) = &field.ty else {
+                return None;
+            };
+
+            if field
+                .attrs
+                .column
+                .as_ref()
+                .and_then(|column| column.ty.as_ref())
+                .is_some()
+            {
+                return None;
+            }
+
+            Some(quote_spanned! { ty.span()=>
+                const _: () = {
+                    if <#ty as #toasty::Field>::REQUIRES_EXPLICIT_COLUMN_TYPE {
+                        panic!(
+                            "`toasty::Json<T>` fields require `#[column(type = ...)]`; use \
+                             `#[column(type = text)]` for text-backed JSON storage"
+                        );
+                    }
+                };
+            })
+        });
+
+        quote! { #( #checks )* }
+    }
+
     /// Emit one obligation per field with an explicit `#[auto(...)]` strategy
     /// that the field's Rust type implements
     /// `codegen_support::auto::AutoCompatible<Tag>` for the matching tag.

--- a/crates/toasty-macros/src/model/schema/column.rs
+++ b/crates/toasty-macros/src/model/schema/column.rs
@@ -429,7 +429,9 @@ impl ColumnType {
                     "ColumnType::Enum should be expanded via expand_enum_storage_ty, not expand_with"
                 )
             }
-            Self::Custom(custom) => quote! { #toasty::core::schema::db::Type::Custom(#custom) },
+            Self::Custom(custom) => {
+                quote! { #toasty::core::schema::db::Type::Custom(#custom.to_string()) }
+            }
         }
     }
 }

--- a/crates/toasty/src/codegen_support/storage.rs
+++ b/crates/toasty/src/codegen_support/storage.rs
@@ -158,6 +158,15 @@ impl CompatibleWith<tag::F64> for f32 {}
 impl CompatibleWith<tag::Text> for String {}
 impl CompatibleWith<tag::VarChar> for String {}
 
+// `Json<T>` serializes through Toasty's string expression type, so users may
+// explicitly select either standard string storage type. Driver-native JSON
+// types use the custom string form of `#[column(type = ...)]`, which does not
+// have a portable compatibility marker.
+#[cfg(feature = "serde")]
+impl<T> CompatibleWith<tag::Text> for crate::Json<T> {}
+#[cfg(feature = "serde")]
+impl<T> CompatibleWith<tag::VarChar> for crate::Json<T> {}
+
 impl CompatibleWith<tag::Binary> for Vec<u8> {}
 impl CompatibleWith<tag::Blob> for Vec<u8> {}
 

--- a/crates/toasty/src/schema/deferred.rs
+++ b/crates/toasty/src/schema/deferred.rs
@@ -145,6 +145,8 @@ impl<T: Load<Output = T>> Load for Deferred<T> {
 }
 
 impl<T: Field> Field for Deferred<T> {
+    const REQUIRES_EXPLICIT_COLUMN_TYPE: bool = T::REQUIRES_EXPLICIT_COLUMN_TYPE;
+
     type ExprTarget = T::ExprTarget;
     type Path<Origin> = T::Path<Origin>;
     type ListPath<Origin> = T::ListPath<Origin>;

--- a/crates/toasty/src/schema/field.rs
+++ b/crates/toasty/src/schema/field.rs
@@ -21,6 +21,15 @@ use toasty_core::schema::{
             …) or a wrapper around one (`Option<_>`, `Vec<_>`, `Box<_>`, `Arc<_>`, `Rc<_>`)."
 )]
 pub trait Field: Load<Output = Self> {
+    /// Whether this field type requires `#[column(type = ...)]`.
+    ///
+    /// Generated model code evaluates this constant when a field omits an
+    /// explicit column type. Wrapper implementations propagate the value from
+    /// their inner field type, which lets the Rust type checker resolve aliases
+    /// and nested wrappers without the derive macro inspecting type syntax.
+    #[doc(hidden)]
+    const REQUIRES_EXPLICIT_COLUMN_TYPE: bool = false;
+
     /// The expression-level type of this field.
     ///
     /// This drives both the field's path target (the second parameter of
@@ -380,6 +389,8 @@ impl_scalar!(rust_decimal::Decimal);
 impl_scalar!(bigdecimal::BigDecimal);
 
 impl<T: Field> Field for Option<T> {
+    const REQUIRES_EXPLICIT_COLUMN_TYPE: bool = T::REQUIRES_EXPLICIT_COLUMN_TYPE;
+
     type ExprTarget = Self;
     type Path<Origin> = stmt::Path<Origin, Self>;
     type ListPath<Origin> = stmt::Path<Origin, List<Self::ExprTarget>>;
@@ -426,6 +437,8 @@ impl<T: Field> Field for Option<T> {
 }
 
 impl<T: Field> Field for std::sync::Arc<T> {
+    const REQUIRES_EXPLICIT_COLUMN_TYPE: bool = T::REQUIRES_EXPLICIT_COLUMN_TYPE;
+
     type ExprTarget = Self;
     type Path<Origin> = stmt::Path<Origin, Self>;
     type ListPath<Origin> = stmt::Path<Origin, List<Self::ExprTarget>>;
@@ -464,6 +477,8 @@ impl<T: Field> Field for std::sync::Arc<T> {
 }
 
 impl<T: Field> Field for std::rc::Rc<T> {
+    const REQUIRES_EXPLICIT_COLUMN_TYPE: bool = T::REQUIRES_EXPLICIT_COLUMN_TYPE;
+
     type ExprTarget = Self;
     type Path<Origin> = stmt::Path<Origin, Self>;
     type ListPath<Origin> = stmt::Path<Origin, List<Self::ExprTarget>>;
@@ -502,6 +517,8 @@ impl<T: Field> Field for std::rc::Rc<T> {
 }
 
 impl<T: Field> Field for Box<T> {
+    const REQUIRES_EXPLICIT_COLUMN_TYPE: bool = T::REQUIRES_EXPLICIT_COLUMN_TYPE;
+
     type ExprTarget = Self;
     type Path<Origin> = stmt::Path<Origin, Self>;
     type ListPath<Origin> = stmt::Path<Origin, List<Self::ExprTarget>>;

--- a/crates/toasty/src/stmt/json.rs
+++ b/crates/toasty/src/stmt/json.rs
@@ -5,7 +5,7 @@ use toasty_core::{schema::db, stmt};
 
 use std::fmt;
 
-/// A field wrapper that stores `T` as a JSON-encoded string in the database.
+/// A field wrapper that serializes `T` as JSON in a database column.
 ///
 /// Use `Json<T>` as a model field type when the column has no native database
 /// representation for `T` — for example, a serde-derived struct, a `HashMap`,
@@ -14,9 +14,10 @@ use std::fmt;
 /// [`serde::Deserialize`](serde::Deserialize). The value is JSON-encoded on
 /// insert and update, and decoded on read.
 ///
-/// The column is stored as `TEXT` (or the backend equivalent). Use a
-/// `#[column(type = "jsonb")]` annotation (or similar) on the field if a
-/// driver-native JSON column type is preferred.
+/// Every `Json<T>` field must select its database column type with
+/// `#[column(type = ...)]`. Use `#[column(type = text)]` for text-backed JSON,
+/// or a custom type such as `#[column(type = "jsonb")]` when the target driver
+/// supports native JSON storage.
 ///
 /// # Two nullable variants
 ///
@@ -54,6 +55,7 @@ use std::fmt;
 /// struct Repository {
 ///     #[key] #[auto]
 ///     id: uuid::Uuid,
+///     #[column(type = text)]
 ///     schema: toasty::Deferred<toasty::Json<MySchema>>,
 /// }
 /// ```
@@ -70,6 +72,7 @@ use std::fmt;
 /// struct Item {
 ///     #[key] #[auto]
 ///     id: i64,
+///     #[column(type = text)]
 ///     tags: toasty::Json<Tags>,
 /// }
 /// ```
@@ -141,6 +144,8 @@ impl<T> Field for Json<T>
 where
     T: serde_core::Serialize + for<'de> serde_core::Deserialize<'de>,
 {
+    const REQUIRES_EXPLICIT_COLUMN_TYPE: bool = true;
+
     type ExprTarget = Self;
     type Path<Origin> = Path<Origin, Self>;
     type ListPath<Origin> = Path<Origin, List<Self::ExprTarget>>;
@@ -161,7 +166,7 @@ where
     ) -> Self::Update<'a> {
     }
 
-    /// Tag the schema entry as a JSON-serialized String column.
+    /// Tag the schema entry as JSON-serialized with explicit storage.
     ///
     /// The macro never inspects the wrapper at the AST level; the
     /// `serialize: Some(Json)` metadata flows through trait dispatch
@@ -169,9 +174,14 @@ where
     /// see that the column is JSON-typed even though the encoding itself is
     /// invisible to the macro.
     fn field_ty(storage_ty: Option<db::Type>) -> FieldTy {
+        let storage_ty = storage_ty.expect(
+            "`toasty::Json<T>` fields require `#[column(type = ...)]`; use \
+             `#[column(type = text)]` for text-backed JSON storage",
+        );
+
         FieldTy::Primitive(FieldPrimitive {
             ty: stmt::Type::String,
-            storage_ty,
+            storage_ty: Some(storage_ty),
             serialize: Some(SerializeFormat::Json),
         })
     }

--- a/crates/toasty/src/stmt/json.rs
+++ b/crates/toasty/src/stmt/json.rs
@@ -15,9 +15,7 @@ use std::fmt;
 /// insert and update, and decoded on read.
 ///
 /// Every `Json<T>` field must select its database column type with
-/// `#[column(type = ...)]`. Use `#[column(type = text)]` for text-backed JSON,
-/// or a custom type such as `#[column(type = "jsonb")]` when the target driver
-/// supports native JSON storage.
+/// `#[column(type = ...)]`. Use `#[column(type = text)]` for text-backed JSON.
 ///
 /// # Two nullable variants
 ///

--- a/docs/guide/src/field-options.md
+++ b/docs/guide/src/field-options.md
@@ -409,8 +409,7 @@ struct Post {
 Toasty serializes the value to a JSON string on insert and update, and
 deserializes it back when reading. Use `#[column(type = text)]` for text-backed
 JSON, `#[column(type = varchar(1000))]` for bounded text on databases that
-support `varchar`, or a custom type such as `#[column(type = "jsonb")]` when
-the target driver supports native JSON storage.
+support `varchar`.
 
 ```rust,ignore
 # use toasty::Model;

--- a/docs/guide/src/field-options.md
+++ b/docs/guide/src/field-options.md
@@ -356,9 +356,10 @@ struct Event {
 
 ## JSON serialization
 
-Wrap a field type in [`toasty::Json<T>`][json-doc] to store it as a JSON
-string in the database. The inner `T` must implement `serde::Serialize`
-and `serde::Deserialize`.
+Wrap a field type in [`toasty::Json<T>`][json-doc] to serialize it as JSON
+in the database. The inner `T` must implement `serde::Serialize` and
+`serde::Deserialize`. Each `Json<T>` field must select its database column
+type with `#[column(type = ...)]`.
 
 [json-doc]: https://docs.rs/toasty/latest/toasty/stmt/struct.Json.html
 
@@ -394,15 +395,16 @@ struct Post {
 
     // Arbitrary serde type — `Json<T>` stores it as one opaque JSON
     // column. Toasty cannot query into it.
+    #[column(type = text)]
     meta: toasty::Json<Metadata>,
 }
 ```
 
 Toasty serializes the value to a JSON string on insert and update, and
-deserializes it back when reading. The default database column type is `TEXT`.
-You can override this with `#[column(type = ...)]` if needed — for example,
-`#[column(type = varchar(1000))]` to limit the stored JSON size on databases
-that support `varchar`.
+deserializes it back when reading. Use `#[column(type = text)]` for text-backed
+JSON, `#[column(type = varchar(1000))]` for bounded text on databases that
+support `varchar`, or a custom type such as `#[column(type = "jsonb")]` when
+the target driver supports native JSON storage.
 
 ```rust,ignore
 # use toasty::Model;
@@ -419,6 +421,7 @@ that support `varchar`.
 #     id: u64,
 #     title: String,
 #     tags: Vec<String>,
+#     #[column(type = text)]
 #     meta: toasty::Json<Metadata>,
 # }
 # async fn __example(mut db: toasty::Db) -> toasty::Result<()> {
@@ -456,11 +459,13 @@ encoded inside the JSON itself:
 #     #[auto]
 #     id: u64,
 #     title: String,
-// `None` maps to SQL `NULL`; `Some(v)` to a JSON string.
+// `None` maps to SQL `NULL`; `Some(v)` to encoded JSON.
+#[column(type = text)]
 metadata: Option<toasty::Json<HashMap<String, String>>>,
 
-// `None` maps to the JSON literal `"null"` (still a non-null string);
-// `Some(v)` to a JSON string.
+// `None` maps to the JSON literal `"null"` (still a non-null column value);
+// `Some(v)` to encoded JSON.
+#[column(type = text)]
 labels: toasty::Json<Option<Vec<String>>>,
 # }
 ```

--- a/docs/guide/src/field-options.md
+++ b/docs/guide/src/field-options.md
@@ -361,6 +361,12 @@ in the database. The inner `T` must implement `serde::Serialize` and
 `serde::Deserialize`. Each `Json<T>` field must select its database column
 type with `#[column(type = ...)]`.
 
+> [!IMPORTANT]
+> The requirement to write `#[column(type = ...)]` is temporary. A future
+> Toasty release will select each database's native JSON column type by
+> default. Explicit overrides will remain available for models that need a
+> different representation.
+
 [json-doc]: https://docs.rs/toasty/latest/toasty/stmt/struct.Json.html
 
 Reach for `Json<T>` when the field is a serde-typed value that Toasty

--- a/examples/cms-article-fields/src/main.rs
+++ b/examples/cms-article-fields/src/main.rs
@@ -67,6 +67,7 @@ struct Article {
     // A large column omitted from the default SELECT; load it on demand with `.include()`.
     body: toasty::Deferred<String>,
 
+    #[column(type = text)]
     seo: toasty::Json<SeoMeta>,
 }
 

--- a/tests/tests/ui-pass/json_explicit_column_types.rs
+++ b/tests/tests/ui-pass/json_explicit_column_types.rs
@@ -1,0 +1,19 @@
+type Payload = toasty::Json<Vec<String>>;
+
+#[derive(Debug, toasty::Model)]
+struct Item {
+    #[key]
+    #[auto]
+    id: i64,
+
+    #[column(type = text)]
+    payload: Payload,
+
+    #[column("optional_payload", type = text)]
+    optional: Option<Payload>,
+
+    #[column(type = "jsonb")]
+    deferred: toasty::Deferred<Payload>,
+}
+
+fn main() {}

--- a/tests/tests/ui/json_requires_column_type.rs
+++ b/tests/tests/ui/json_requires_column_type.rs
@@ -1,0 +1,15 @@
+// The derive must resolve aliases and transparent field wrappers through the
+// `Field` trait instead of inspecting the field's type syntax.
+
+type Payload = toasty::Json<Vec<String>>;
+
+#[derive(Debug, toasty::Model)]
+struct Item {
+    #[key]
+    #[auto]
+    id: i64,
+
+    payload: Option<Payload>,
+}
+
+fn main() {}

--- a/tests/tests/ui/json_requires_column_type.stderr
+++ b/tests/tests/ui/json_requires_column_type.stderr
@@ -1,0 +1,5 @@
+error[E0080]: evaluation panicked: `toasty::Json<T>` fields require `#[column(type = ...)]`; use `#[column(type = text)]` for text-backed JSON storage
+  --> tests/ui/json_requires_column_type.rs:12:14
+   |
+12 |     payload: Option<Payload>,
+   |              ^^^^^^ evaluation of `_::_` failed here


### PR DESCRIPTION
## Summary

- Require every `Json<T>` field to declare `#[column(type = ...)]`.
- Propagate the requirement through field wrappers and support text-backed JSON compatibility.
- Update documentation, examples, integration coverage, and UI tests.

## Testing

- Not run (not requested)