### PR TITLE
fix: serialize unconstrained numeric types in snapshots

### DIFF
--- a/crates/toasty-core/src/schema/db/ty.rs
+++ b/crates/toasty-core/src/schema/db/ty.rs
@@ -86,7 +86,7 @@ pub enum Type {
     /// Decimal number with optional precision and scale.
     /// - `None`: Arbitrary-precision decimal
     /// - `Some((precision, scale))`: Fixed precision and scale
-    Numeric(Option<(u32, u32)>),
+    Numeric(#[cfg_attr(feature = "serde", serde(with = "numeric_serde"))] Option<(u32, u32)>),
 
     /// Unconstrained binary type
     Blob,
@@ -127,6 +127,37 @@ pub enum Type {
 
     /// User-specified unrecognized type
     Custom(String),
+}
+
+#[cfg(feature = "serde")]
+mod numeric_serde {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+
+    pub(super) fn serialize<S>(value: &Option<(u32, u32)>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some((precision, scale)) => [*precision, *scale].serialize(serializer),
+            None => <[u32; 0]>::default().serialize(serializer),
+        }
+    }
+
+    pub(super) fn deserialize<'de, D>(deserializer: D) -> Result<Option<(u32, u32)>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let values = Vec::<u32>::deserialize(deserializer)?;
+
+        match values.as_slice() {
+            [] => Ok(None),
+            &[precision, scale] => Ok(Some((precision, scale))),
+            _ => Err(de::Error::invalid_length(
+                values.len(),
+                &"zero or two numeric type parameters",
+            )),
+        }
+    }
 }
 
 impl Type {

--- a/crates/toasty/src/migration/snapshot.rs
+++ b/crates/toasty/src/migration/snapshot.rs
@@ -36,7 +36,8 @@ impl Snapshot {
 
     /// Save the snapshot to a TOML file.
     pub fn save(&self, path: impl AsRef<Path>) -> Result<()> {
-        std::fs::write(path.as_ref(), self.to_string())?;
+        let doc = self.to_toml_document()?;
+        std::fs::write(path.as_ref(), doc.to_string())?;
         Ok(())
     }
 
@@ -61,8 +62,10 @@ impl Snapshot {
                                 if item.is_array() {
                                     let mut placeholder = Item::None;
                                     std::mem::swap(item, &mut placeholder);
-                                    let array = placeholder.into_array_of_tables().unwrap();
-                                    *item = array.into();
+                                    *item = match placeholder.into_array_of_tables() {
+                                        Ok(array) => array.into(),
+                                        Err(item) => item,
+                                    };
                                 }
                             }
                         }

--- a/crates/toasty/tests/migration_generate.rs
+++ b/crates/toasty/tests/migration_generate.rs
@@ -63,3 +63,35 @@ fn generate_returns_migration_and_next_snapshot() {
     assert!(sql.contains("CREATE TABLE"));
     assert!(sql.contains("users"));
 }
+
+#[cfg(feature = "rust_decimal")]
+#[test]
+fn snapshot_round_trips_decimal_column() {
+    let mut schema = users_schema();
+    schema.tables[0].columns.push(db::Column {
+        id: db::ColumnId {
+            table: db::TableId(0),
+            index: 1,
+        },
+        name: "weight".to_string(),
+        ty: stmt::Type::Decimal,
+        storage_ty: db::Type::Numeric(None),
+        nullable: false,
+        primary_key: false,
+        auto_increment: false,
+        versionable: false,
+    });
+
+    let snapshot = migration::Snapshot::new(schema);
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snapshot.toml");
+
+    snapshot.save(&path).unwrap();
+    let loaded = migration::Snapshot::load(path).unwrap();
+
+    assert_eq!(loaded.schema.tables[0].columns[1].ty, stmt::Type::Decimal);
+    assert_eq!(
+        loaded.schema.tables[0].columns[1].storage_ty,
+        db::Type::Numeric(None)
+    );
+}


### PR DESCRIPTION
## Summary
The column type repr of numeric (`Numeric(Option<(i32, i32)>)`) panics when trying to serialize `Numeric(None)` to toml. Toml can't represent this. Now we encode this as an array of either length 0 representing `Numeric(None)` or length 2 representing `Numeric(Some(..., ...))`.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test
- [ ] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`):
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers
N/A

Closes #1107