### PR TITLE
fix(sql): drop indexes before removing indexed columns

### DIFF
--- a/crates/toasty-sql/src/migration.rs
+++ b/crates/toasty-sql/src/migration.rs
@@ -144,6 +144,26 @@ impl<'a> MigrationStatement<'a> {
                             )
                         });
 
+                    // Drop existing indices before changing columns because they may
+                    // reference a column that is being removed or altered.
+                    for item in indices.iter() {
+                        match item {
+                            diff::Index::Drop(index) => {
+                                result.push(Self::new(
+                                    Statement::drop_index(index),
+                                    Cow::Borrowed(schema_diff.previous()),
+                                ));
+                            }
+                            diff::Index::Alter { previous, .. } => {
+                                result.push(Self::new(
+                                    Statement::drop_index(previous),
+                                    Cow::Borrowed(schema_diff.previous()),
+                                ));
+                            }
+                            diff::Index::Create(_) => {}
+                        }
+                    }
+
                     if needs_recreation {
                         Self::emit_table_recreation(
                             &mut result,
@@ -157,7 +177,8 @@ impl<'a> MigrationStatement<'a> {
                         Self::emit_column_changes(&mut result, schema, columns, capability);
                     }
 
-                    // Indices diff
+                    // Create new indices after the column changes so they reference
+                    // the next schema's column definitions.
                     for item in indices.iter() {
                         match item {
                             diff::Index::Create(index) => {
@@ -166,22 +187,13 @@ impl<'a> MigrationStatement<'a> {
                                     Cow::Borrowed(schema_diff.next()),
                                 ));
                             }
-                            diff::Index::Drop(index) => {
-                                result.push(Self::new(
-                                    Statement::drop_index(index),
-                                    Cow::Borrowed(schema_diff.previous()),
-                                ));
-                            }
-                            diff::Index::Alter { previous, next } => {
-                                result.push(Self::new(
-                                    Statement::drop_index(previous),
-                                    Cow::Borrowed(schema_diff.previous()),
-                                ));
+                            diff::Index::Alter { next, .. } => {
                                 result.push(Self::new(
                                     Statement::create_index(next),
                                     Cow::Borrowed(schema_diff.next()),
                                 ));
                             }
+                            diff::Index::Drop(_) => {}
                         }
                     }
                 }

--- a/crates/toasty-sql/tests/migration_drop_column.rs
+++ b/crates/toasty-sql/tests/migration_drop_column.rs
@@ -1,7 +1,10 @@
 use toasty_core::{
     driver::Capability,
     schema::{
-        db::{Column, ColumnId, IndexId, PrimaryKey, Schema, Table, TableId, Type},
+        db::{
+            Column, ColumnId, Index, IndexColumn, IndexId, IndexOp, IndexScope, PrimaryKey, Schema,
+            Table, TableId, Type,
+        },
         diff,
     },
     stmt as core_stmt,
@@ -88,6 +91,60 @@ fn drop_column_sqlite() {
 
     assert_eq!(sql.len(), 1);
     assert_eq!(sql[0], "ALTER TABLE \"users\" DROP COLUMN \"name\";");
+}
+
+#[test]
+fn drop_index_before_indexed_column() {
+    let mut from_table = make_table(
+        0,
+        "users",
+        vec![
+            make_column(0, 0, "id", Type::Integer(8)),
+            make_column(0, 1, "email", Type::Text),
+        ],
+    );
+    from_table.indices.push(Index {
+        id: IndexId {
+            table: TableId(0),
+            index: 0,
+        },
+        name: "idx_users_email".to_string(),
+        on: TableId(0),
+        columns: vec![IndexColumn {
+            column: ColumnId {
+                table: TableId(0),
+                index: 1,
+            },
+            op: IndexOp::Eq,
+            scope: IndexScope::Local,
+        }],
+        unique: false,
+        primary_key: false,
+    });
+
+    let from = Schema {
+        tables: vec![from_table],
+    };
+    let to = Schema {
+        tables: vec![make_table(
+            0,
+            "users",
+            vec![make_column(0, 0, "id", Type::Integer(8))],
+        )],
+    };
+
+    let hints = diff::RenameHints::new();
+    let diff = diff::Schema::from(&from, &to, &hints);
+    let stmts = MigrationStatement::from_diff(&diff, &Capability::SQLITE);
+    let sql = serialize_migration(&stmts, "sqlite");
+
+    assert_eq!(
+        sql,
+        [
+            "DROP INDEX \"idx_users_email\";",
+            "ALTER TABLE \"users\" DROP COLUMN \"email\";",
+        ]
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
When dropping an indexed field, make sure to drop the index before the field.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test
- [ ] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`):
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers
Closes #935
