### PR TITLE
fix(sql): target matched table when adding columns

### DIFF
--- a/crates/toasty-sql/src/migration.rs
+++ b/crates/toasty-sql/src/migration.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use toasty_core::{
     driver::Capability,
     schema::{
-        db::{Column, Schema, Table, Type, TypeEnum},
+        db::{Column, Schema, Table, TableId, Type, TypeEnum},
         diff,
     },
 };
@@ -154,7 +154,13 @@ impl<'a> MigrationStatement<'a> {
                             capability,
                         );
                     } else {
-                        Self::emit_column_changes(&mut result, schema, columns, capability);
+                        Self::emit_column_changes(
+                            &mut result,
+                            schema,
+                            previous.id,
+                            columns,
+                            capability,
+                        );
                     }
 
                     // Indices diff
@@ -289,6 +295,7 @@ impl<'a> MigrationStatement<'a> {
     fn emit_column_changes(
         result: &mut Vec<Self>,
         schema: Cow<'a, Schema>,
+        table: TableId,
         columns: &[diff::Column<'_>],
         capability: &Capability,
     ) {
@@ -296,7 +303,7 @@ impl<'a> MigrationStatement<'a> {
             match item {
                 diff::Column::Add(column) => {
                     result.push(Self::new(
-                        Statement::add_column(column, capability),
+                        Statement::add_column(table, column, capability),
                         schema.clone(),
                     ));
                 }

--- a/crates/toasty-sql/src/stmt/add_column.rs
+++ b/crates/toasty-sql/src/stmt/add_column.rs
@@ -17,9 +17,9 @@ pub struct AddColumn {
 
 impl Statement {
     /// Adds a column to a table.
-    pub fn add_column(column: &Column, capability: &Capability) -> Self {
+    pub fn add_column(table: TableId, column: &Column, capability: &Capability) -> Self {
         AddColumn {
-            table: column.id.table,
+            table,
             column: ColumnDef::from_schema(column, &capability.storage_types, capability),
         }
         .into()

--- a/crates/toasty-sql/tests/migration_add_column.rs
+++ b/crates/toasty-sql/tests/migration_add_column.rs
@@ -191,3 +191,36 @@ fn add_multiple_columns() {
     assert!(sql.iter().any(|s| s.contains("\"email\"")));
     assert!(sql.iter().all(|s| s.contains("ADD COLUMN")));
 }
+
+#[test]
+fn add_column_after_reordering_tables() {
+    let from = Schema {
+        tables: vec![
+            make_table(0, "users", vec![make_column(0, 0, "id", Type::Integer(8))]),
+            make_table(1, "posts", vec![make_column(1, 0, "id", Type::Integer(8))]),
+        ],
+    };
+    let to = Schema {
+        tables: vec![
+            make_table(0, "posts", vec![make_column(0, 0, "id", Type::Integer(8))]),
+            make_table(
+                1,
+                "users",
+                vec![
+                    make_column(1, 0, "id", Type::Integer(8)),
+                    make_column(1, 1, "name", Type::Text),
+                ],
+            ),
+        ],
+    };
+
+    let hints = diff::RenameHints::new();
+    let diff = diff::Schema::from(&from, &to, &hints);
+    let stmts = MigrationStatement::from_diff(&diff, &Capability::SQLITE);
+    let sql = serialize_migration(&stmts, "sqlite");
+
+    assert_eq!(
+        sql,
+        ["ALTER TABLE \"users\" ADD COLUMN \"name\" TEXT NOT NULL;"]
+    );
+}


### PR DESCRIPTION
## Summary
`ADD COLUMN` was using the table ID from the new schema while serializing against the previous schema. If models were reordered, this could add the column to the wrong table.



## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test
- [ ] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`):
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers
Closes #955
