### PR TITLE
fix(ddb): type indexed key discovery as primary keys

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/dynamodb_update_batch_filter.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/dynamodb_update_batch_filter.rs
@@ -14,6 +14,29 @@
 
 use crate::prelude::*;
 
+#[driver_test(id(ID), requires(not(sql)), scenario(crate::scenarios::user_with_age))]
+pub async fn update_via_secondary_index_uses_primary_key_type(t: &mut Test) -> Result<()> {
+    let mut db = setup(t).await;
+
+    toasty::create!(User {
+        name: "Alice",
+        age: 7,
+    })
+    .exec(&mut db)
+    .await?;
+
+    User::filter_by_age(7)
+        .update()
+        .name("updated")
+        .exec(&mut db)
+        .await?;
+
+    let users = User::filter_by_age(7).exec(&mut db).await?;
+    assert_struct!(users, [{ name: "updated", age: 7 }]);
+
+    Ok(())
+}
+
 /// All items match the filter — every key is updated.
 #[driver_test(requires(not(sql)), scenario(crate::scenarios::tagged_item))]
 pub async fn batch_update_filter_all_match(t: &mut Test) -> Result<()> {

--- a/crates/toasty/src/engine/plan/statement.rs
+++ b/crates/toasty/src/engine/plan/statement.rs
@@ -90,6 +90,7 @@
 use std::mem;
 
 use indexmap::{IndexMap, IndexSet};
+use toasty_core::schema::db;
 use toasty_core::stmt::{self, visit_mut};
 
 use toasty_core::driver::operation::Pagination;
@@ -1590,14 +1591,14 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
         // For mutations, unique indexes, or other cases, use FindPkByIndex + GetByKey
         // - Mutations only need primary keys, not full records
         // - Unique indexes don't have full column projections in DynamoDB
-        let index_key_ty = self.index_key_ty(index_plan);
+        let primary_key_ty = self.table_primary_key_ty(index_plan.index.on);
 
         let get_by_key_input = self.insert_mir_with_deps(mir::FindPkByIndex {
             inputs,
             table: index_plan.index.on,
             index: index_plan.index.id,
             filter: index_plan.index_filter.take(),
-            ty: index_key_ty,
+            ty: primary_key_ty,
         });
 
         self.build_key_operation(&stmt, index_plan, get_by_key_input, ty)
@@ -2008,6 +2009,13 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
         // Type of the index key. Value for single index keys, record for
         // composite.
         stmt::Type::list(self.planner.engine.index_key_record_ty(index_plan.index))
+    }
+
+    fn table_primary_key_ty(&self, table: db::TableId) -> stmt::Type {
+        let table = self.planner.engine.schema.db.table(table);
+        let primary_key = self.planner.engine.schema.db.index(table.primary_key.index);
+
+        stmt::Type::list(self.planner.engine.index_key_record_ty(primary_key))
     }
 
     fn stmt(&self) -> &stmt::Statement {


### PR DESCRIPTION
## Summary
When doing something like  `User::update_by_age(...).name(...).exec(...)` in dynamodb, it first fetches the primary keys matching the filter and then updates all records with those primary keys.

However before the engine inferred the return type of the first query to be the type of the secondary index used in the filter. With this pr it's now the type of the primary key since the query return a list of primary keys.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test
- [ ] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`):
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers
N/A
