### PR TITLE
fix: serialize unconstrained numeric migration snapshots

### DIFF
--- a/crates/toasty-cli/src/migration/generate.rs
+++ b/crates/toasty-cli/src/migration/generate.rs
@@ -295,6 +295,7 @@ impl GenerateCommand {
             checksum: None,
         });
 
+        let snapshot = generated.snapshot.to_toml_string()?;
         let migration = generated.migration;
         let Migration::Sql(sql) = migration;
         std::fs::write(&migration_path, format!("{sql}\n"))?;
@@ -304,7 +305,7 @@ impl GenerateCommand {
             style(format!("Created migration file: {}", migration_name)).dim()
         );
 
-        generated.snapshot.save(&snapshot_path)?;
+        std::fs::write(&snapshot_path, snapshot)?;
         println!(
             "  {} {}",
             style("✓").green().bold(),

--- a/crates/toasty-cli/src/migration/snapshot.rs
+++ b/crates/toasty-cli/src/migration/snapshot.rs
@@ -27,7 +27,7 @@ impl SnapshotCommand {
         let snapshot = Snapshot::new(toasty::schema::db::Schema::clone(&db.schema().db));
 
         // Print the snapshot with nice formatting
-        let snapshot_str = snapshot.to_string();
+        let snapshot_str = snapshot.to_toml_string()?;
         for line in snapshot_str.lines() {
             if line.starts_with('[') {
                 println!("  {}", style(line).yellow().bold());

--- a/crates/toasty-core/src/schema/db/ty.rs
+++ b/crates/toasty-core/src/schema/db/ty.rs
@@ -86,7 +86,7 @@ pub enum Type {
     /// Decimal number with optional precision and scale.
     /// - `None`: Arbitrary-precision decimal
     /// - `Some((precision, scale))`: Fixed precision and scale
-    Numeric(Option<(u32, u32)>),
+    Numeric(#[cfg_attr(feature = "serde", serde(with = "numeric_serde"))] Option<(u32, u32)>),
 
     /// Unconstrained binary type
     Blob,
@@ -127,6 +127,44 @@ pub enum Type {
 
     /// User-specified unrecognized type
     Custom(String),
+}
+
+#[cfg(feature = "serde")]
+mod numeric_serde {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as _};
+
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Repr {
+        Values(Vec<u32>),
+        Legacy(Option<(u32, u32)>),
+    }
+
+    pub fn serialize<S>(value: &Option<(u32, u32)>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some((precision, scale)) => [*precision, *scale].serialize(serializer),
+            None => <[u32; 0]>::default().serialize(serializer),
+        }
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<(u32, u32)>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        match Repr::deserialize(deserializer)? {
+            Repr::Values(values) => match values.as_slice() {
+                [] => Ok(None),
+                [precision, scale] => Ok(Some((*precision, *scale))),
+                _ => Err(D::Error::custom(
+                    "numeric storage type requires zero or two parameters",
+                )),
+            },
+            Repr::Legacy(value) => Ok(value),
+        }
+    }
 }
 
 impl Type {

--- a/crates/toasty/src/migration/snapshot.rs
+++ b/crates/toasty/src/migration/snapshot.rs
@@ -34,9 +34,14 @@ impl Snapshot {
         contents.parse()
     }
 
+    /// Serialize the snapshot as TOML.
+    pub fn to_toml_string(&self) -> Result<String> {
+        Ok(self.to_toml_document()?.to_string())
+    }
+
     /// Save the snapshot to a TOML file.
     pub fn save(&self, path: impl AsRef<Path>) -> Result<()> {
-        std::fs::write(path.as_ref(), self.to_string())?;
+        std::fs::write(path.as_ref(), self.to_toml_string()?)?;
         Ok(())
     }
 
@@ -48,21 +53,35 @@ impl Snapshot {
             if item.is_inline_table() {
                 let mut placeholder = Item::None;
                 std::mem::swap(item, &mut placeholder);
-                let mut table = placeholder.into_table().unwrap();
+                let mut table = match placeholder.into_table() {
+                    Ok(table) => table,
+                    Err(original) => {
+                        *item = original;
+                        continue;
+                    }
+                };
 
                 for (_key, item) in table.iter_mut() {
                     if item.is_array() {
                         let mut placeholder = Item::None;
                         std::mem::swap(item, &mut placeholder);
-                        let mut array = placeholder.into_array_of_tables().unwrap();
+                        let mut array = match placeholder.into_array_of_tables() {
+                            Ok(array) => array,
+                            Err(original) => {
+                                *item = original;
+                                continue;
+                            }
+                        };
 
                         for table in array.iter_mut() {
                             for (_key, item) in table.iter_mut() {
                                 if item.is_array() {
                                     let mut placeholder = Item::None;
                                     std::mem::swap(item, &mut placeholder);
-                                    let array = placeholder.into_array_of_tables().unwrap();
-                                    *item = array.into();
+                                    match placeholder.into_array_of_tables() {
+                                        Ok(array) => *item = array.into(),
+                                        Err(original) => *item = original,
+                                    }
                                 }
                             }
                         }

--- a/crates/toasty/tests/migration_generate.rs
+++ b/crates/toasty/tests/migration_generate.rs
@@ -5,6 +5,17 @@ use toasty::schema::{db, diff};
 use toasty_core::stmt;
 use toasty_driver_sqlite::Sqlite;
 
+fn round_trip_snapshot(schema: db::Schema) -> (String, migration::Snapshot) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snapshot.toml");
+
+    migration::Snapshot::new(schema).save(&path).unwrap();
+
+    let contents = std::fs::read_to_string(&path).unwrap();
+    let snapshot = migration::Snapshot::load(path).unwrap();
+    (contents, snapshot)
+}
+
 fn users_schema() -> db::Schema {
     let table_id = db::TableId(0);
     let id = db::ColumnId {
@@ -62,4 +73,53 @@ fn generate_returns_migration_and_next_snapshot() {
     let db::Migration::Sql(sql) = generated.migration;
     assert!(sql.contains("CREATE TABLE"));
     assert!(sql.contains("users"));
+}
+
+#[test]
+fn snapshot_round_trips_empty_indices() {
+    let (_, snapshot) = round_trip_snapshot(users_schema());
+
+    assert!(snapshot.schema.tables[0].indices.is_empty());
+}
+
+#[test]
+fn snapshot_round_trips_unconstrained_numeric() {
+    let mut schema = users_schema();
+    schema.tables[0].columns[0].storage_ty = db::Type::Numeric(None);
+
+    let (contents, snapshot) = round_trip_snapshot(schema);
+
+    assert!(contents.contains("storage_ty = { Numeric = [] }"));
+    assert_eq!(
+        snapshot.schema.tables[0].columns[0].storage_ty,
+        db::Type::Numeric(None)
+    );
+}
+
+#[test]
+fn snapshot_round_trips_bounded_numeric() {
+    let mut schema = users_schema();
+    schema.tables[0].columns[0].storage_ty = db::Type::Numeric(Some((28, 10)));
+
+    let (contents, snapshot) = round_trip_snapshot(schema);
+
+    assert!(contents.contains("storage_ty = { Numeric = [28, 10] }"));
+    assert_eq!(
+        snapshot.schema.tables[0].columns[0].storage_ty,
+        db::Type::Numeric(Some((28, 10)))
+    );
+}
+
+#[test]
+fn snapshot_round_trips_list_of_unconstrained_numeric() {
+    let mut schema = users_schema();
+    schema.tables[0].columns[0].storage_ty = db::Type::List(Box::new(db::Type::Numeric(None)));
+
+    let (contents, snapshot) = round_trip_snapshot(schema);
+
+    assert!(contents.contains("storage_ty = { List = { Numeric = [] } }"));
+    assert_eq!(
+        snapshot.schema.tables[0].columns[0].storage_ty,
+        db::Type::List(Box::new(db::Type::Numeric(None)))
+    );
 }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -26,7 +26,8 @@ rust_decimal.workspace = true
 bigdecimal.workspace = true
 hashbrown.workspace = true
 jiff.workspace = true
-toasty = { workspace = true, features = ["rust_decimal", "bigdecimal", "jiff"] }
+toasty = { workspace = true, features = ["rust_decimal", "bigdecimal", "jiff", "migration"] }
+toasty-cli.workspace = true
 toasty-core.workspace = true
 toasty-macros.workspace = true
 tokio.workspace = true
@@ -51,6 +52,7 @@ aws-sdk-dynamodb = { workspace = true, optional = true }
 tracing.workspace = true
 tracing-subscriber.workspace = true
 trybuild.workspace = true
+tempfile.workspace = true
 url.workspace = true
 
 # Fixtures

--- a/tests/tests/migration_generate.rs
+++ b/tests/tests/migration_generate.rs
@@ -1,0 +1,108 @@
+use async_trait::async_trait;
+use std::{borrow::Cow, sync::Arc};
+use toasty::db::{Capability, ConnectContext, Driver, ExecResponse};
+use toasty_core::{
+    Schema,
+    driver::{Connection, Operation},
+    schema::{
+        db::{AppliedMigration, Migration, Type},
+        diff,
+    },
+    stmt,
+};
+
+#[derive(Debug)]
+struct PostgresSchemaDriver;
+
+#[async_trait]
+impl Driver for PostgresSchemaDriver {
+    fn url(&self) -> Cow<'_, str> {
+        "postgresql://test".into()
+    }
+
+    fn capability(&self) -> &'static Capability {
+        &Capability::POSTGRESQL
+    }
+
+    async fn connect(&self, _cx: &ConnectContext) -> toasty::Result<Box<dyn Connection>> {
+        Ok(Box::new(SchemaConnection))
+    }
+
+    fn generate_migration(&self, _schema_diff: &diff::Schema<'_>) -> Migration {
+        Migration::Sql("-- generated migration".to_string())
+    }
+
+    async fn reset_db(&self) -> toasty::Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct SchemaConnection;
+
+#[async_trait]
+impl Connection for SchemaConnection {
+    async fn exec(
+        &mut self,
+        _schema: &Arc<Schema>,
+        _plan: Operation,
+    ) -> toasty::Result<ExecResponse> {
+        unreachable!()
+    }
+
+    async fn push_schema(&mut self, _schema: &Schema) -> toasty::Result<()> {
+        unreachable!()
+    }
+
+    async fn applied_migrations(&mut self) -> toasty::Result<Vec<AppliedMigration>> {
+        unreachable!()
+    }
+
+    async fn apply_migration(
+        &mut self,
+        _id: u64,
+        _name: &str,
+        _migration: &Migration,
+    ) -> toasty::Result<()> {
+        unreachable!()
+    }
+}
+
+#[tokio::test]
+async fn migration_generate_with_decimal_model_writes_snapshot() {
+    #[derive(Debug, toasty::Model)]
+    struct SomeModel {
+        #[key]
+        #[auto]
+        id: u64,
+
+        weight: rust_decimal::Decimal,
+    }
+
+    let db = toasty::Db::builder()
+        .models(toasty::models!(SomeModel))
+        .table_name_prefix("svc_")
+        .build(PostgresSchemaDriver)
+        .await
+        .unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let config =
+        toasty_cli::Config::new().migration(toasty_cli::MigrationConfig::new().path(dir.path()));
+
+    toasty_cli::ToastyCli::with_config(db, config)
+        .parse_from(["toasty", "migration", "generate"])
+        .await
+        .unwrap();
+
+    assert!(dir.path().join("migrations/0000_migration.sql").is_file());
+
+    let snapshot =
+        toasty::migration::Snapshot::load(dir.path().join("snapshots/0000_snapshot.toml")).unwrap();
+    let weight = snapshot.schema.tables[0]
+        .columns
+        .iter()
+        .find(|column| column.name == "weight")
+        .unwrap();
+    assert_eq!(weight.ty, stmt::Type::Decimal);
+    assert_eq!(weight.storage_ty, Type::Numeric(None));
+}


### PR DESCRIPTION
## Summary

Closes #1107.

- encode unconstrained numeric storage types as `Numeric = []` in TOML snapshots while preserving `Numeric = [precision, scale]` for bounded numerics
- propagate snapshot serialization errors and render snapshots before writing migration SQL
- preserve empty nested arrays during snapshot formatting and add round-trip coverage for scalar and list numeric types

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [ ] Touches a public API → no design doc; this adds a fallible snapshot serialization helper

## Notes for reviewers

The decoder accepts the previous nullable Serde representation. Existing bounded numeric snapshots keep the same `Numeric = [precision, scale]` format.

`Snapshot::to_toml_string` is a small additive API used by `toasty-cli`; no design document is included.