### PR TITLE
feat: support serde_json::Value fields

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/type_serialize.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/type_serialize.rs
@@ -348,6 +348,61 @@ pub async fn json_native_round_trip(t: &mut Test) -> Result<(), BoxError> {
 }
 
 #[driver_test(requires(native_json))]
+pub async fn json_value_native_round_trip(t: &mut Test) -> Result<(), BoxError> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: u64,
+        #[column(type = json)]
+        payload: serde_json::Value,
+    }
+
+    let mut db = t.setup_db(models!(Item)).await;
+    assert_eq!(column_storage_ty(&db, "items", "payload"), db::Type::Json);
+    let item_table = table_id(&db, "items");
+
+    let payload = serde_json::json!({
+        "array": [1, true, null, "quoted \"text\""],
+        "nested": {"language": "日本語"},
+    });
+    let expected_json = serde_json::to_string(&payload).unwrap();
+    t.log().clear();
+    let mut item = toasty::create!(Item {
+        payload: payload.clone(),
+    })
+    .exec(&mut db)
+    .await?;
+
+    let (op, _) = t.log().pop();
+    assert_native_json_insert(&op, item_table, db::Type::Json, &expected_json);
+    assert!(t.log().is_empty());
+
+    let read = Item::get_by_id(&mut db, &item.id).await?;
+    assert_eq!(read.payload, payload);
+    let (op, _) = t.log().pop();
+    assert_native_json_query(&op, item_table);
+    assert!(t.log().is_empty());
+
+    let updated = serde_json::json!([{"version": 2}, "updated", false]);
+    let expected_json = serde_json::to_string(&updated).unwrap();
+    item.update().payload(updated.clone()).exec(&mut db).await?;
+
+    let (op, resp) = t.log().pop();
+    assert_native_json_update(&op, item_table, db::Type::Json, &expected_json);
+    assert_struct!(resp, { values: Rows::Count(1) });
+    assert!(t.log().is_empty());
+
+    let read = Item::get_by_id(&mut db, &item.id).await?;
+    assert_eq!(read.payload, updated);
+    let (op, _) = t.log().pop();
+    assert_native_json_query(&op, item_table);
+    assert!(t.log().is_empty());
+
+    Ok(())
+}
+
+#[driver_test(requires(native_json))]
 pub async fn json_native_nulls(t: &mut Test) -> Result<(), BoxError> {
     #[derive(Debug, toasty::Model)]
     struct Item {
@@ -371,6 +426,34 @@ pub async fn json_native_nulls(t: &mut Test) -> Result<(), BoxError> {
 
     assert_eq!(item.sql_null, None);
     assert_eq!(item.json_null, Json(None));
+
+    Ok(())
+}
+
+#[driver_test(requires(native_json))]
+pub async fn json_value_native_nulls(t: &mut Test) -> Result<(), BoxError> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: u64,
+        #[column(type = json)]
+        sql_null: Option<serde_json::Value>,
+        #[column(type = json)]
+        json_null: serde_json::Value,
+    }
+
+    let mut db = t.setup_db(models!(Item)).await;
+    let item = toasty::create!(Item {
+        sql_null: None,
+        json_null: serde_json::Value::Null,
+    })
+    .exec(&mut db)
+    .await?;
+    let item = Item::get_by_id(&mut db, &item.id).await?;
+
+    assert_eq!(item.sql_null, None);
+    assert_eq!(item.json_null, serde_json::Value::Null);
 
     Ok(())
 }
@@ -405,6 +488,62 @@ pub async fn jsonb_native_round_trip(t: &mut Test) -> Result<(), BoxError> {
 
     let read = Item::get_by_id(&mut db, &item.id).await?;
     assert_eq!(read.payload, Json(payload));
+    let (op, _) = t.log().pop();
+    assert_native_json_query(&op, item_table);
+    assert!(t.log().is_empty());
+
+    Ok(())
+}
+
+#[driver_test(requires(native_jsonb))]
+pub async fn json_value_jsonb_native_round_trip(t: &mut Test) -> Result<(), BoxError> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        #[auto]
+        id: u64,
+        #[column(type = jsonb)]
+        payload: serde_json::Value,
+    }
+
+    let mut db = t.setup_db(models!(Item)).await;
+    assert_eq!(column_storage_ty(&db, "items", "payload"), db::Type::Jsonb);
+    let item_table = table_id(&db, "items");
+
+    let payload = serde_json::json!({
+        "array": [{"name": "one"}, {"name": "two"}],
+        "enabled": true,
+        "nullable": null,
+    });
+    let expected_json = serde_json::to_string(&payload).unwrap();
+    t.log().clear();
+    let mut item = toasty::create!(Item {
+        payload: payload.clone(),
+    })
+    .exec(&mut db)
+    .await?;
+
+    let (op, _) = t.log().pop();
+    assert_native_json_insert(&op, item_table, db::Type::Jsonb, &expected_json);
+    assert!(t.log().is_empty());
+
+    let read = Item::get_by_id(&mut db, &item.id).await?;
+    assert_eq!(read.payload, payload);
+    let (op, _) = t.log().pop();
+    assert_native_json_query(&op, item_table);
+    assert!(t.log().is_empty());
+
+    let updated = serde_json::json!({"version": 2, "items": []});
+    let expected_json = serde_json::to_string(&updated).unwrap();
+    item.update().payload(updated.clone()).exec(&mut db).await?;
+
+    let (op, resp) = t.log().pop();
+    assert_native_json_update(&op, item_table, db::Type::Jsonb, &expected_json);
+    assert_struct!(resp, { values: Rows::Count(1) });
+    assert!(t.log().is_empty());
+
+    let read = Item::get_by_id(&mut db, &item.id).await?;
+    assert_eq!(read.payload, updated);
     let (op, _) = t.log().pop();
     assert_native_json_query(&op, item_table);
     assert!(t.log().is_empty());

--- a/crates/toasty-macros/src/lib.rs
+++ b/crates/toasty-macros/src/lib.rs
@@ -312,7 +312,8 @@ use proc_macro::TokenStream;
 /// Wrap a serde-typed value in [`toasty::Json<T>`](toasty::stmt::Json) to
 /// serialize it as JSON in the database. Every JSON field must select its
 /// database column type with `#[column(type = ...)]`. Use `text` for
-/// text-backed JSON. JSON fields require the `serde` feature and
+/// text-backed JSON, `json` for PostgreSQL or MySQL native JSON, and `jsonb`
+/// for PostgreSQL JSONB. JSON fields require the `serde` feature and
 /// `T: serde::Serialize + serde::Deserialize`.
 ///
 /// ```
@@ -324,6 +325,22 @@ use proc_macro::TokenStream;
 /// #     id: i64,
 /// #[column(type = text)]
 /// tags: toasty::Json<Vec<String>>,
+/// # }
+/// ```
+///
+/// Use `serde_json::Value` directly when the field already contains a
+/// dynamic JSON value:
+///
+/// ```
+/// # use toasty::Model;
+/// # use toasty::codegen_support::serde_json;
+/// # #[derive(Model)]
+/// # struct Example {
+/// #     #[key]
+/// #     #[auto]
+/// #     id: i64,
+/// #[column(type = json)]
+/// payload: serde_json::Value,
 /// # }
 /// ```
 ///

--- a/crates/toasty/src/codegen_support/storage.rs
+++ b/crates/toasty/src/codegen_support/storage.rs
@@ -160,7 +160,7 @@ impl CompatibleWith<tag::F64> for f32 {}
 impl CompatibleWith<tag::Text> for String {}
 impl CompatibleWith<tag::VarChar> for String {}
 
-// `Json<T>` serializes through Toasty's string expression type. It supports
+// JSON fields serialize through Toasty's string expression type. They support
 // text storage and the native JSON types recognized by the SQL drivers.
 #[cfg(feature = "serde")]
 impl<T> CompatibleWith<tag::Text> for crate::Json<T> {}
@@ -170,6 +170,14 @@ impl<T> CompatibleWith<tag::VarChar> for crate::Json<T> {}
 impl<T> CompatibleWith<tag::Json> for crate::Json<T> {}
 #[cfg(feature = "serde")]
 impl<T> CompatibleWith<tag::Jsonb> for crate::Json<T> {}
+#[cfg(feature = "serde")]
+impl CompatibleWith<tag::Text> for serde_json::Value {}
+#[cfg(feature = "serde")]
+impl CompatibleWith<tag::VarChar> for serde_json::Value {}
+#[cfg(feature = "serde")]
+impl CompatibleWith<tag::Json> for serde_json::Value {}
+#[cfg(feature = "serde")]
+impl CompatibleWith<tag::Jsonb> for serde_json::Value {}
 
 impl CompatibleWith<tag::Binary> for Vec<u8> {}
 impl CompatibleWith<tag::Blob> for Vec<u8> {}

--- a/crates/toasty/src/stmt/json.rs
+++ b/crates/toasty/src/stmt/json.rs
@@ -1,9 +1,33 @@
-use super::{Expr, IntoExpr, List, Path, Value};
+use super::{Expr, IntoExpr, List, Path, Value as StmtValue};
 use crate::schema::{Field, Load};
+use serde_json::Value as JsonValue;
 use toasty_core::schema::app::{FieldPrimitive, FieldTy, SerializeFormat};
 use toasty_core::{schema::db, stmt};
 
 use std::fmt;
+
+fn load_json<T>(value: stmt::Value) -> crate::Result<T>
+where
+    T: for<'de> serde_core::Deserialize<'de>,
+{
+    let json = <String as Load>::load(value)?;
+    serde_json::from_str(&json).map_err(|e| {
+        toasty_core::Error::from_args(format_args!("failed to deserialize JSON field: {e}"))
+    })
+}
+
+fn json_field_ty(storage_ty: Option<db::Type>, missing_type_message: &'static str) -> FieldTy {
+    FieldTy::Primitive(FieldPrimitive {
+        ty: stmt::Type::String,
+        storage_ty: Some(storage_ty.expect(missing_type_message)),
+        serialize: Some(SerializeFormat::Json),
+    })
+}
+
+fn json_expr<T>(value: &(impl serde_core::Serialize + ?Sized)) -> Expr<T> {
+    let json = serde_json::to_string(value).expect("failed to serialize JSON field");
+    Expr::<String>::from_value(StmtValue::from(json)).cast()
+}
 
 /// A field wrapper that serializes `T` as JSON in a database column.
 ///
@@ -17,6 +41,8 @@ use std::fmt;
 /// Every `Json<T>` field must select its database column type with
 /// `#[column(type = ...)]`. Use `text` or `varchar(...)` for text-backed JSON,
 /// `json` for PostgreSQL or MySQL native JSON, and `jsonb` for PostgreSQL JSONB.
+/// A field whose Rust type is already [`serde_json::Value`] does not need the
+/// `Json<T>` wrapper and supports the same column types.
 ///
 /// # Two nullable variants
 ///
@@ -127,10 +153,7 @@ where
         // JSON literal `"null"` as a non-null string, so its `None` case
         // comes through as `Value::String("null")` and `serde_json` decodes
         // it. A bare `Value::Null` at this point is a driver bug.
-        let json = <String as Load>::load(value)?;
-        serde_json::from_str(&json).map(Json).map_err(|e| {
-            toasty_core::Error::from_args(format_args!("failed to deserialize JSON field: {e}"))
-        })
+        load_json(value).map(Json)
     }
 
     fn reload(target: &mut Self, value: stmt::Value) -> crate::Result<()> {
@@ -173,16 +196,11 @@ where
     /// see that the column is JSON-typed even though the encoding itself is
     /// invisible to the macro.
     fn field_ty(storage_ty: Option<db::Type>) -> FieldTy {
-        let storage_ty = storage_ty.expect(
+        json_field_ty(
+            storage_ty,
             "`toasty::Json<T>` fields require `#[column(type = ...)]`; use \
              `#[column(type = text)]` for text-backed JSON storage",
-        );
-
-        FieldTy::Primitive(FieldPrimitive {
-            ty: stmt::Type::String,
-            storage_ty: Some(storage_ty),
-            serialize: Some(SerializeFormat::Json),
-        })
+        )
     }
 
     fn key_constraint<Origin>(&self, _target: Path<Origin, Self::Inner>) -> Expr<bool> {
@@ -199,13 +217,11 @@ where
     T: serde_core::Serialize,
 {
     fn into_expr(self) -> Expr<Json<T>> {
-        let json = serde_json::to_string(&self.0).expect("failed to serialize");
-        Expr::<String>::from_value(Value::from(json)).cast()
+        json_expr(&self.0)
     }
 
     fn by_ref(&self) -> Expr<Json<T>> {
-        let json = serde_json::to_string(&self.0).expect("failed to serialize");
-        Expr::<String>::from_value(Value::from(json)).cast()
+        json_expr(&self.0)
     }
 }
 
@@ -229,13 +245,11 @@ where
     T: serde_core::Serialize,
 {
     fn into_expr(self) -> Expr<Json<T>> {
-        let json = serde_json::to_string(&self).expect("failed to serialize");
-        Expr::<String>::from_value(Value::from(json)).cast()
+        json_expr(&self)
     }
 
     fn by_ref(&self) -> Expr<Json<T>> {
-        let json = serde_json::to_string(self).expect("failed to serialize");
-        Expr::<String>::from_value(Value::from(json)).cast()
+        json_expr(self)
     }
 }
 
@@ -260,6 +274,75 @@ where
 {
     fn into_assignment(self) -> super::assignment::Assignment<Json<T>> {
         super::set(<Self as IntoExpr<Json<T>>>::into_expr(self))
+    }
+}
+
+impl Load for JsonValue {
+    type Output = Self;
+
+    fn ty() -> stmt::Type {
+        stmt::Type::String
+    }
+
+    fn load(value: stmt::Value) -> crate::Result<Self> {
+        load_json(value)
+    }
+
+    fn reload(target: &mut Self, value: stmt::Value) -> crate::Result<()> {
+        *target = Self::load(value)?;
+        Ok(())
+    }
+}
+
+impl Field for JsonValue {
+    const REQUIRES_EXPLICIT_COLUMN_TYPE: bool = true;
+
+    type ExprTarget = Self;
+    type Path<Origin> = Path<Origin, Self>;
+    type ListPath<Origin> = Path<Origin, List<Self::ExprTarget>>;
+    type Update<'a> = ();
+    type Inner = Self;
+
+    fn new_path<Origin>(path: Path<Origin, Self>) -> Self::Path<Origin> {
+        path
+    }
+
+    fn new_list_path<Origin>(path: Path<Origin, List<Self::ExprTarget>>) -> Self::ListPath<Origin> {
+        path
+    }
+
+    fn new_update<'a>(
+        _assignments: &'a mut toasty_core::stmt::Assignments,
+        _projection: toasty_core::stmt::Projection,
+    ) -> Self::Update<'a> {
+    }
+
+    fn field_ty(storage_ty: Option<db::Type>) -> FieldTy {
+        json_field_ty(
+            storage_ty,
+            "`serde_json::Value` fields require `#[column(type = ...)]`; use \
+             `#[column(type = text)]` for text-backed JSON storage",
+        )
+    }
+
+    fn key_constraint<Origin>(&self, _target: Path<Origin, Self::Inner>) -> Expr<bool> {
+        unreachable!("serde_json::Value fields cannot be used as foreign-key targets")
+    }
+}
+
+impl IntoExpr<JsonValue> for JsonValue {
+    fn into_expr(self) -> Expr<JsonValue> {
+        json_expr(&self)
+    }
+
+    fn by_ref(&self) -> Expr<JsonValue> {
+        json_expr(self)
+    }
+}
+
+impl super::assignment::Assign<JsonValue> for JsonValue {
+    fn into_assignment(self) -> super::assignment::Assignment<JsonValue> {
+        super::set(<Self as IntoExpr<JsonValue>>::into_expr(self))
     }
 }
 

--- a/docs/guide/src/SUMMARY.md
+++ b/docs/guide/src/SUMMARY.md
@@ -19,6 +19,9 @@
 
 - [Indexes and Unique Constraints](./indexes-and-unique-constraints.md)
 - [Field Options](./field-options.md)
+- [Embedded Types](./embedded-types.md)
+- [`#[document]` Fields](./document-fields.md)
+- [JSON Encoding](./json-encoding.md)
 - [`Vec<scalar>` Fields](./vec-scalar-fields.md)
 
 # Relationships
@@ -37,7 +40,6 @@
 
 # Advanced Features
 
-- [Embedded Types](./embedded-types.md)
 - [Deferred Fields](./deferred-fields.md)
 - [Batch Operations](./batch-operations.md)
 - [Transactions](./transactions.md)

--- a/docs/guide/src/defining-models.md
+++ b/docs/guide/src/defining-models.md
@@ -43,9 +43,10 @@ Toasty supports these Rust types as model fields:
 | `f32`, `f64` | Floating point |
 | `uuid::Uuid` | UUID |
 | `Vec<u8>` | Binary / Blob |
-| `Vec<T>` (T scalar, not `u8`) | Native array column on PostgreSQL (`text[]`, `int8[]`, …); JSON on MySQL / SQLite; List `L` on DynamoDB. See [field-options.md](./field-options.md#scalar-arrays). |
+| `Vec<T>` (T scalar, not `u8`) | Native array column on PostgreSQL (`text[]`, `int8[]`, …); JSON on MySQL / SQLite; List `L` on DynamoDB. See [`Vec<scalar>` Fields](./vec-scalar-fields.md). |
 | `Option<T>` | Nullable version of `T` |
 | Embedded types (`#[derive(toasty::Embed)]`) | Flattened into parent table columns (see [Embedded Types](./embedded-types.md)) |
+| Document fields (`#[document]`) | One structured column whose scalar leaves remain queryable (see [`#[document]` Fields](./document-fields.md)) |
 
 With optional feature flags:
 
@@ -57,6 +58,7 @@ With optional feature flags:
 | `jiff` | `jiff::civil::Date` | Date |
 | `jiff` | `jiff::civil::Time` | Time |
 | `jiff` | `jiff::civil::DateTime` | DateTime |
+| `serde` | `toasty::Json<T>`, `serde_json::Value` | Explicit text, `json`, or `jsonb` column (see [JSON Encoding](./json-encoding.md)) |
 
 Enable feature flags in your `Cargo.toml`:
 

--- a/docs/guide/src/document-fields.md
+++ b/docs/guide/src/document-fields.md
@@ -174,7 +174,7 @@ types, and supported `jiff` temporal types can appear inside a document.
 Toasty uses canonical text encodings for temporal and decimal leaves so
 filters compare the same values that reads reconstruct.
 
-Current restrictions are explicit:
+Current restrictions:
 
 - Embedded enums cannot be encoded inside a document.
 - Tuple structs are rejected because their fields have no names for

--- a/docs/guide/src/document-fields.md
+++ b/docs/guide/src/document-fields.md
@@ -1,0 +1,209 @@
+# `#[document]` Fields
+
+`#[document]` stores a `#[derive(toasty::Embed)]` struct in one
+structured column instead of expanding its fields into separate
+columns. Toasty retains the embedded schema, so queries can address
+scalar fields inside the stored object.
+
+Use document storage when a value belongs to its parent row but its
+fields still participate in filters. Use [JSON Encoding](./json-encoding.md)
+for an opaque serde payload whose fields do not need generated query
+paths.
+
+## Column expansion and document storage
+
+An embedded struct expands into one column per leaf field by default:
+
+```rust
+# use toasty::Model;
+#[derive(Debug, toasty::Embed)]
+struct Address {
+    city: String,
+    postal_code: String,
+}
+
+#[derive(Debug, toasty::Model)]
+struct User {
+    #[key]
+    #[auto]
+    id: u64,
+
+    address: Address,
+}
+```
+
+This form creates columns such as `address_city` and
+`address_postal_code`. Adding `#[document]` stores the same `Address`
+value in one column:
+
+```rust
+# use toasty::Model;
+# #[derive(Debug, toasty::Embed)]
+# struct Address {
+#     city: String,
+#     postal_code: String,
+# }
+#[derive(Debug, toasty::Model)]
+struct User {
+    #[key]
+    #[auto]
+    id: u64,
+
+    #[document]
+    address: Address,
+}
+```
+
+The Rust field type and create API are unchanged. The attribute changes
+the database mapping and the way field paths lower into backend
+queries.
+
+## Storage by backend
+
+Each built-in driver chooses a document representation:
+
+| Driver | Stored representation |
+|---|---|
+| PostgreSQL | `jsonb` |
+| MySQL | `JSON` |
+| SQLite and Turso | JSON text |
+| DynamoDB | Map (`M`) |
+
+Applications do not add `#[column(type = ...)]` to a document field.
+The driver capability selects the representation, and Toasty rejects a
+driver that cannot store document fields.
+
+## Creating and reading documents
+
+Create a record by passing the embedded value:
+
+```rust,ignore
+let user = toasty::create!(User {
+    address: Address {
+        city: "Seattle".to_string(),
+        postal_code: "98101".to_string(),
+    },
+})
+.exec(&mut db)
+.await?;
+
+assert_eq!(user.address.city, "Seattle");
+```
+
+The driver encodes the object using the embed's named fields. Nested
+embedded structs become nested document objects rather than additional
+database columns.
+
+## Filtering document fields
+
+Generated field accessors keep the embedded structure:
+
+```rust,ignore
+let users = User::filter(
+    User::fields().address().city().eq("Seattle"),
+)
+.exec(&mut db)
+.await?;
+```
+
+The query engine lowers `address().city()` to the backend's document
+path operation. PostgreSQL extracts a JSONB path, MySQL uses its JSON
+functions, SQLite and Turso use JSON1, and DynamoDB uses a document path
+expression.
+
+Equality, ordering, and optional-field checks work on supported scalar
+leaves. Comparing the entire document to an `Address` value is not yet
+supported.
+
+## Updating documents
+
+Assigning a new embedded value replaces the complete document:
+
+```rust,ignore
+user.update()
+    .address(Address {
+        city: "Portland".to_string(),
+        postal_code: "97205".to_string(),
+    })
+    .exec(&mut db)
+    .await?;
+```
+
+`stmt::patch` updates individual fields of a column-expanded embed, but
+it does not yet produce an in-place mutation for a `#[document]`
+column. Replace the document when one of its fields changes.
+
+## Collections of documents
+
+A `Vec<T>` where `T` is an embedded struct stores a document array. No
+attribute is required:
+
+```rust
+# use toasty::Model;
+#[derive(Debug, toasty::Embed)]
+struct LineItem {
+    sku: String,
+    quantity: i64,
+}
+
+#[derive(Debug, toasty::Model)]
+struct Order {
+    #[key]
+    #[auto]
+    id: u64,
+
+    items: Vec<LineItem>,
+}
+```
+
+PostgreSQL, MySQL, SQLite, and Turso encode the field as an array of JSON
+objects. DynamoDB stores it as a List (`L`) of Map (`M`) values.
+
+Whole-value create, read, and replacement work for document
+collections. `stmt::push` appends one embedded value. Element predicates
+and the removal operations are not yet supported for document
+collections.
+
+## Supported document fields
+
+The document root must be a named embedded struct or a collection of
+named embedded structs. Document keys come from Rust field names.
+
+Nested embedded structs, scalar lists, optional scalar fields, decimal
+types, and supported `jiff` temporal types can appear inside a document.
+Toasty uses canonical text encodings for temporal and decimal leaves so
+filters compare the same values that reads reconstruct.
+
+Current restrictions are explicit:
+
+- Embedded enums cannot be encoded inside a document.
+- Tuple structs are rejected because their fields have no names for
+  document keys.
+- Relations cannot appear inside a document.
+- `jiff::Zoned` is rejected because its IANA time-zone annotation does
+  not have a supported document representation.
+- `Vec<u8>` is rejected because JSON has no binary scalar type.
+- `#[column]` renames inside an embedded document are rejected because
+  document keys use Rust field names.
+- `#[index]`, `#[unique]`, and `#[column]` cannot be placed on the
+  `#[document]` field.
+- An optional document root is not yet supported; optional fields inside
+  the document are supported.
+
+Toasty validates these rules while building the schema, before the
+driver creates a table.
+
+## Document values at the driver boundary
+
+The query engine represents a document as a named object whose shape
+comes from the application schema. Before calling a driver, Toasty
+converts the embedded record into that object representation.
+
+Drivers encode and decode named objects without consulting the
+application schema. The schema-aware conversion remains in the engine,
+while the driver handles only the backend's JSON, map, or list format.
+
+This differs from [`Json<T>`](./json-encoding.md), which crosses the
+engine and driver boundary as an already serialized string. The
+document representation preserves typed field paths; JSON encoding
+accepts arbitrary serde types.

--- a/docs/guide/src/dynamodb.md
+++ b/docs/guide/src/dynamodb.md
@@ -8,7 +8,7 @@ model code still works — [`create!`](./creating-records.md),
 [`filter_by_<indexed>`](./querying-records.md#filtering-by-indexed-fields),
 [`#[unique]`](./indexes-and-unique-constraints.md#unique-fields),
 [`#[version]`](./concurrency-control.md),
-[`Vec<scalar>` fields](./field-options.md#scalar-arrays) — but the set
+[`Vec<scalar>` fields](./vec-scalar-fields.md) — but the set
 of queries you can write is narrower, and the chapter below catalogues
 the gaps so you can avoid building a model that the driver cannot
 serve.
@@ -262,7 +262,7 @@ The query builder methods that translate cleanly to DynamoDB:
   underlying operation.
 - [`.starts_with("prefix")`](./filtering-with-expressions.md#starts_with)
   on a string column — native `begins_with()`.
-- [`Vec<scalar>` predicates](./field-options.md#scalar-arrays):
+- [`Vec<scalar>` predicates](./vec-scalar-fields.md):
   `.contains(v)`, `.len()`, `.is_empty()` lower to DynamoDB's
   `contains()` and `size()` functions.
 
@@ -304,7 +304,7 @@ error at planning time. Order is only available on a `Query`, which
 means the partition key must be pinned.
 
 **`is_superset` / `intersects` with a non-literal right-hand side.**
-For [`Vec<scalar>` fields](./field-options.md#scalar-arrays) these
+For [`Vec<scalar>` fields](./vec-scalar-fields.md) these
 predicates expand to one `contains()` clause per element on the
 right-hand side, so the right-hand side has to be a concrete `Vec<T>`
 known at query-construction time. A column

--- a/docs/guide/src/embedded-types.md
+++ b/docs/guide/src/embedded-types.md
@@ -459,9 +459,8 @@ struct Task {
 ```
 
 Every discriminant must fit both the enum-level type and any narrower
-field-level override. `#[document]` is outside these rules: Toasty currently
-rejects enum embeds inside document-stored structs because enum document
-encoding is not supported.
+field-level override. [`#[document]` storage](./document-fields.md) currently
+rejects enum embeds because enum document encoding is not supported.
 
 An enum cannot mix string and integer discriminants. Integer-discriminant enums
 do not support `rename_all`.

--- a/docs/guide/src/field-options.md
+++ b/docs/guide/src/field-options.md
@@ -416,6 +416,17 @@ database stores that JSON:
 | `json` | PostgreSQL and MySQL native JSON |
 | `jsonb` | PostgreSQL JSONB |
 
+When the Rust field type is already `serde_json::Value`, use it directly
+without the `Json<T>` wrapper:
+
+```rust,ignore
+#[column(type = json)]
+payload: serde_json::Value,
+```
+
+`serde_json::Value::Null` stores the JSON literal `null`. Use
+`Option<serde_json::Value>` when `None` should store SQL `NULL`.
+
 For example, this field uses PostgreSQL or MySQL native JSON storage:
 
 ```rust,ignore

--- a/docs/guide/src/field-options.md
+++ b/docs/guide/src/field-options.md
@@ -1,8 +1,7 @@
 # Field Options
 
-Toasty provides several field-level attributes to control how fields map to
-database columns: custom column names, explicit types, default values, update
-expressions, and JSON serialization.
+Field-level attributes control column names, explicit types, default values,
+and update expressions.
 
 ## Custom column names
 
@@ -77,6 +76,8 @@ Supported type values:
 | `uint`, `u8`, `u16`, `u32`, `u64` | Unsigned integer |
 | `text` | Text |
 | `varchar(N)` | Variable-length string with max length |
+| `json` | Native JSON on PostgreSQL and MySQL |
+| `jsonb` | Native binary JSON on PostgreSQL |
 | `numeric`, `numeric(P, S)` | Decimal with optional precision and scale |
 | `binary(N)`, `blob` | Binary data |
 | `timestamp(P)` | Timestamp with precision |
@@ -354,163 +355,12 @@ struct Event {
 }
 ```
 
-## JSON serialization
+## JSON-encoded fields
 
-Wrap a field type in [`toasty::Json<T>`][json-doc] to serialize it as JSON
-in the database. The inner `T` must implement `serde::Serialize` and
-`serde::Deserialize`. Each `Json<T>` field must select its database column
-type with `#[column(type = ...)]`.
-
-> [!IMPORTANT]
-> The requirement to write `#[column(type = ...)]` is temporary. A future
-> Toasty release will select each database's native JSON column type by
-> default. Explicit overrides will remain available for models that need a
-> different representation.
-
-[json-doc]: https://docs.rs/toasty/latest/toasty/stmt/struct.Json.html
-
-Reach for `Json<T>` when the field is a serde-typed value that Toasty
-doesn't natively support — for example, a third-party type or a struct
-you don't want to declare as `#[derive(toasty::Embed)]`. For
-`Vec<scalar>` fields, prefer the native form (`tags: Vec<String>`,
-documented in [Defining Models](./defining-models.md)) which is
-queryable and supports collection mutations via `stmt::push`,
-`stmt::extend`, `stmt::pop`, `stmt::remove`, `stmt::remove_at`, and
-`stmt::clear`.
-
-```rust,ignore
-# use toasty::Model;
-use serde::{Serialize, Deserialize};
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct Metadata {
-    version: u32,
-    labels: Vec<String>,
-}
-
-#[derive(Debug, toasty::Model)]
-struct Post {
-    #[key]
-    #[auto]
-    id: u64,
-
-    title: String,
-
-    // Native `Vec<scalar>` storage — no wrapper needed.
-    tags: Vec<String>,
-
-    // Arbitrary serde type — `Json<T>` stores it as one opaque JSON
-    // column. Toasty cannot query into it.
-    #[column(type = text)]
-    meta: toasty::Json<Metadata>,
-}
-```
-
-Toasty serializes the value to a JSON string on insert and update, and
-deserializes it back when reading. The selected column type determines how the
-database stores that JSON:
-
-| Column type | Support |
-|---|---|
-| `text` or `varchar(...)` | SQL databases with the selected text type |
-| `json` | PostgreSQL and MySQL native JSON |
-| `jsonb` | PostgreSQL JSONB |
-
-When the Rust field type is already `serde_json::Value`, use it directly
-without the `Json<T>` wrapper:
-
-```rust,ignore
-#[column(type = json)]
-payload: serde_json::Value,
-```
-
-`serde_json::Value::Null` stores the JSON literal `null`. Use
-`Option<serde_json::Value>` when `None` should store SQL `NULL`.
-
-For example, this field uses PostgreSQL or MySQL native JSON storage:
-
-```rust,ignore
-#[column(type = json)]
-meta: toasty::Json<Metadata>,
-```
-
-Toasty rejects `json` or `jsonb` during schema construction when the selected
-database does not support that column type.
-
-```rust,ignore
-# use toasty::Model;
-# use serde::{Serialize, Deserialize};
-# #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-# struct Metadata {
-#     version: u32,
-#     labels: Vec<String>,
-# }
-# #[derive(Debug, toasty::Model)]
-# struct Post {
-#     #[key]
-#     #[auto]
-#     id: u64,
-#     title: String,
-#     tags: Vec<String>,
-#     #[column(type = text)]
-#     meta: toasty::Json<Metadata>,
-# }
-# async fn __example(mut db: toasty::Db) -> toasty::Result<()> {
-let post = toasty::create!(Post {
-    title: "Hello",
-    tags: vec!["rust".to_string(), "toasty".to_string()],
-    // The bare value is accepted via the `IntoExpr<Json<T>> for T`
-    // blanket — wrapping with `toasty::Json(...)` is optional.
-    meta: Metadata {
-        version: 1,
-        labels: vec!["alpha".to_string()],
-    },
-})
-.exec(&mut db)
-.await?;
-
-assert_eq!(post.tags, vec!["rust", "toasty"]);
-assert_eq!(post.meta.version, 1);
-# Ok(())
-# }
-```
-
-### Nullable JSON fields
-
-`Json<T>` composes with `Option` in two distinct, both-useful ways
-depending on whether `None` should land in a SQL `NULL` cell or be
-encoded inside the JSON itself:
-
-```rust,ignore
-# use toasty::Model;
-# use std::collections::HashMap;
-# #[derive(Debug, toasty::Model)]
-# struct Post {
-#     #[key]
-#     #[auto]
-#     id: u64,
-#     title: String,
-// `None` maps to SQL `NULL`; `Some(v)` to encoded JSON.
-#[column(type = text)]
-metadata: Option<toasty::Json<HashMap<String, String>>>,
-
-// `None` maps to the JSON literal `"null"` (still a non-null column value);
-// `Some(v)` to encoded JSON.
-#[column(type = text)]
-labels: toasty::Json<Option<Vec<String>>>,
-# }
-```
-
-`Option<Json<T>>` is the common case — pick it when the database should
-see a `NULL` for missing values. Use `Json<Option<T>>` when callers
-expect the column to always contain valid JSON.
-
-## Scalar arrays
-
-A `Vec<T>` field where `T` is a scalar type stores a homogeneous,
-ordered collection in a single column. These fields have their own
-guide page covering the element types, storage per driver, creation,
-querying, and updates — see [`Vec<scalar>` Fields](./vec-scalar-fields.md).
+`toasty::Json<T>` and `serde_json::Value` fields require
+`#[column(type = text)]`, `varchar(...)`, `json`, or `jsonb`. See [JSON
+Encoding](./json-encoding.md) for feature setup, storage support, null
+representations, setters, deferred loading, and query limitations.
 
 ## Attribute summary
 
@@ -522,11 +372,6 @@ querying, and updates — see [`Vec<scalar>` Fields](./vec-scalar-fields.md).
 | `#[update(expr)]` | Automatic value | Create, update, and both upsert branches |
 | `#[auto]` on `created_at` | Shorthand for `#[default(jiff::Timestamp::now())]` | Create and the create branch of upsert |
 | `#[auto]` on `updated_at` | Shorthand for `#[update(jiff::Timestamp::now())]` | Create, update, and both upsert branches |
-
-JSON storage is handled by the [`toasty::Json<T>`][json-doc] field
-wrapper — see [JSON serialization](#json-serialization) above. Use
-`Option<Json<T>>` to allow SQL `NULL`, or `Json<Option<T>>` to embed
-the JSON literal `"null"` instead.
 
 See [Concurrency Control](./concurrency-control.md) for the `#[version]`
 attribute.

--- a/docs/guide/src/introduction.md
+++ b/docs/guide/src/introduction.md
@@ -52,7 +52,7 @@ transactions.
 - **[Upserting Records](./upserting-records.md)** — create or update atomically by a key or unique constraint
 - **[Deleting Records](./deleting-records.md)** — remove records
 - **[Indexes and Unique Constraints](./indexes-and-unique-constraints.md)** — add indexes and unique constraints
-- **[Field Options](./field-options.md)** — column names, types, defaults, and JSON serialization
+- **[Field Options](./field-options.md)** — column names, types, defaults, and update expressions
 - **[Relationships](./relationships.md)** — overview of how models connect to each other
 - **[BelongsTo](./belongs-to.md)** — define and use many-to-one relationships
 - **[HasMany](./has-many.md)** — define and use one-to-many relationships
@@ -62,6 +62,9 @@ transactions.
 - **[Filtering with Expressions](./filtering-with-expressions.md)** — comparisons, AND/OR, and more
 - **[Sorting, Limits, and Pagination](./sorting-limits-and-pagination.md)** — order results and paginate
 - **[Embedded Types](./embedded-types.md)** — store structs and enums inline
+- **[`#[document]` Fields](./document-fields.md)** — store an embedded struct in one document with queryable scalar leaves
+- **[JSON Encoding](./json-encoding.md)** — store a serde type or `serde_json::Value` in one opaque column
+- **[`Vec<scalar>` Fields](./vec-scalar-fields.md)** — store and query a scalar collection in one field
 - **[Batch Operations](./batch-operations.md)** — multiple queries in one round-trip
 - **[Transactions](./transactions.md)** — atomic operations
 - **[Database Setup](./database-setup.md)** — connection URLs, table creation, and supported databases

--- a/docs/guide/src/json-encoding.md
+++ b/docs/guide/src/json-encoding.md
@@ -1,0 +1,248 @@
+# JSON Encoding
+
+`toasty::Json<T>` stores a serde-compatible Rust value in one database
+column. Toasty serializes `T` before the query engine processes the value
+and deserializes it after the driver reads the column.
+
+Use JSON encoding for data that the application reads and writes as a
+whole. Toasty does not expose typed paths into a `Json<T>` field because
+the query engine sees the encoded value as a string rather than as the
+fields of `T`.
+
+## Choosing a field representation
+
+Toasty has three ways to store structured or collection data in one
+field:
+
+| Rust field | Use it for | Query support |
+|---|---|---|
+| `toasty::Json<T>` | Any `T` with serde serialization | No typed paths into `T` |
+| `#[document]` on an embedded struct | A fixed object whose fields Toasty knows | Filters on scalar fields inside the object |
+| `Vec<T>` where `T` is a scalar | A homogeneous list | Collection predicates and incremental mutations |
+
+[`#[document]` Fields](./document-fields.md) explains schema-aware
+document storage. [`Vec<scalar>` Fields](./vec-scalar-fields.md) covers
+typed lists. Use `Json<T>` when generated paths and collection operators
+are not required or when `T` cannot derive `toasty::Embed`.
+
+## Enabling JSON encoding
+
+Enable Toasty's `serde` feature together with the selected database
+driver. The application also needs `serde` for typed payloads and
+`serde_json` when it constructs dynamic JSON values:
+
+```toml
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+toasty = { version = "{{toasty_version}}", features = ["postgresql", "serde"] }
+```
+
+The inner `T` in `Json<T>` must implement `serde::Serialize` and
+`serde::Deserialize`.
+
+## Encoding a typed payload
+
+Wrap the model field in `toasty::Json<T>` and select a column type with
+`#[column(type = ...)]`:
+
+```rust,ignore
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct Metadata {
+    version: u32,
+    labels: Vec<String>,
+}
+
+#[derive(Debug, toasty::Model)]
+struct Post {
+    #[key]
+    #[auto]
+    id: u64,
+
+    title: String,
+
+    #[column(type = json)]
+    metadata: toasty::Json<Metadata>,
+}
+```
+
+Every `Json<T>` field requires an explicit column type. The Rust type
+determines how Toasty encodes and decodes the value; the column
+attribute determines how the database stores the encoded JSON.
+
+## Column types
+
+JSON fields accept these column types:
+
+| Column type | Database representation |
+|---|---|
+| `text` | JSON text in the backend's string type |
+| `varchar(N)` | Length-limited JSON text on backends with native `VARCHAR` |
+| `json` | Native JSON on PostgreSQL and MySQL |
+| `jsonb` | Native binary JSON on PostgreSQL |
+
+Use `text` on SQLite, Turso, DynamoDB, or any backend where the database
+does not provide a native JSON column. Toasty's serializer still emits
+valid JSON, but a text column does not ask the database to validate
+external writes.
+
+Use `json` when PostgreSQL or MySQL should validate the stored value as
+JSON. Use `jsonb` on PostgreSQL when its binary representation and JSONB
+operators are required outside Toasty's typed query API.
+
+Toasty checks `json` and `jsonb` against the selected driver's
+capabilities during schema construction. A model that requests `jsonb`
+on MySQL or SQLite fails before Toasty sends unsupported DDL.
+
+## Creating and updating values
+
+Create and update setters accept the inner `T`, so callers do not need
+to construct `Json(T)`:
+
+```rust,ignore
+let mut post = toasty::create!(Post {
+    title: "Encoding data",
+    metadata: Metadata {
+        version: 1,
+        labels: vec!["rust".to_string()],
+    },
+})
+.exec(&mut db)
+.await?;
+
+post.update()
+    .metadata(Metadata {
+        version: 2,
+        labels: vec!["rust".to_string(), "orm".to_string()],
+    })
+    .exec(&mut db)
+    .await?;
+```
+
+The loaded model retains the wrapper. `Json<T>` implements `Deref` and
+`AsRef`, so code can read the inner value without moving it:
+
+```rust,ignore
+assert_eq!(post.metadata.version, 2);
+let metadata: &Metadata = post.metadata.as_ref();
+```
+
+An update replaces the entire encoded value. Toasty does not generate
+an assignment for one field inside `T` because `T` has no field paths in
+the statement schema.
+
+## Dynamic JSON values
+
+Use `serde_json::Value` directly when the application needs a dynamic
+JSON object or array:
+
+```rust,ignore
+#[derive(Debug, toasty::Model)]
+struct Event {
+    #[key]
+    #[auto]
+    id: u64,
+
+    #[column(type = jsonb)]
+    payload: serde_json::Value,
+}
+```
+
+`serde_json::Value` uses the same encoding, storage types, and
+whole-value update behavior as `Json<T>`. The wrapper would add no type
+information because `serde_json::Value` already represents arbitrary
+JSON.
+
+```rust,ignore
+let event = toasty::create!(Event {
+    payload: serde_json::json!({
+        "kind": "published",
+        "article_id": 42,
+        "tags": ["rust", "orm"],
+    }),
+})
+.exec(&mut db)
+.await?;
+```
+
+## SQL `NULL` and JSON `null`
+
+The position of `Option` determines whether absence belongs to the
+database column or to the JSON value:
+
+| Field type | Rust value | Stored value |
+|---|---|---|
+| `Option<Json<T>>` | `None` | SQL `NULL` |
+| `Json<Option<T>>` | `Json(None)` | JSON `null` in a non-null column |
+| `Option<serde_json::Value>` | `None` | SQL `NULL` |
+| `serde_json::Value` | `Value::Null` | JSON `null` in a non-null column |
+
+Use `Option<Json<T>>` when the row may have no payload. Use
+`Json<Option<T>>` when every row must contain JSON and `null` is part of
+the payload's data model.
+
+```rust,ignore
+#[derive(Debug, toasty::Model)]
+struct Import {
+    #[key]
+    #[auto]
+    id: u64,
+
+    #[column(type = json)]
+    result: Option<toasty::Json<ImportResult>>,
+
+    #[column(type = json)]
+    external_value: serde_json::Value,
+}
+```
+
+## Deferring a JSON field
+
+Wrap the JSON field in `toasty::Deferred` when ordinary queries should
+omit a large payload:
+
+```rust,ignore
+#[column(type = jsonb)]
+payload: toasty::Deferred<toasty::Json<Payload>>,
+```
+
+The field follows the normal deferred loading rules. A regular query
+leaves it unloaded, `.include(Model::fields().payload())` adds the
+column to that query, and assigning a new payload leaves the in-memory
+field loaded with the assigned value. See [Deferred
+Fields](./deferred-fields.md) for the loading API.
+
+`toasty::Deferred<serde_json::Value>` is also supported and uses the
+same explicit column types.
+
+## Query architecture
+
+A `Json<T>` field registers an application-level string type plus JSON
+serialization metadata and the selected database storage type. Its
+`IntoExpr` implementation serializes `T` into one string expression
+before planning.
+
+SQL drivers bind that string directly to `text`, `json`, or `jsonb`.
+When a driver reads a native JSON column for a `Json<T>` or
+`serde_json::Value` field, it returns the JSON text rather than a
+structural Toasty value. DynamoDB stores text-backed JSON in an `S`
+attribute. The field's `Load` implementation invokes `serde_json` to
+reconstruct the Rust value.
+
+This boundary makes arbitrary serde types possible without registering
+their fields in Toasty's schema. It also explains why a path such as
+`Post::fields().metadata().version()` does not exist: the query engine
+knows the column and its storage type, but it does not know the shape of
+`Metadata`.
+
+Use [`#[document]`](./document-fields.md) when Toasty must retain the
+object's field structure for filters. Use a relation when the nested
+data needs independent keys, indexes, or lifecycle.
+
+> **Runnable example:** [`cms-article-fields`] stores an SEO payload in
+> `Json<T>` alongside a queryable `Vec<scalar>` and a deferred text
+> column.
+
+[`cms-article-fields`]: https://github.com/tokio-rs/toasty/tree/main/examples/cms-article-fields

--- a/docs/guide/src/mysql.md
+++ b/docs/guide/src/mysql.md
@@ -128,7 +128,7 @@ s)` for `bigdecimal::BigDecimal` here. PostgreSQL falls back to text
 for `BigDecimal`; MySQL is currently the only backend that exchanges
 it as a native decimal value over the wire.
 
-**[`Vec<scalar>`](./field-options.md#scalar-arrays) goes in a `JSON`
+**[`Vec<scalar>`](./vec-scalar-fields.md) goes in a `JSON`
 column.** Toasty serializes the list to a JSON array at bind time and
 parses it back on read. Array predicates (`contains`, `is_superset`,
 `intersects`, `len`, `is_empty`) lower to MySQL's `JSON_CONTAINS`,

--- a/docs/guide/src/postgresql.md
+++ b/docs/guide/src/postgresql.md
@@ -121,7 +121,7 @@ PostgreSQL. No configuration is required.
 Primary keys and unique constraints can be conflict targets, and
 `on_create`, `on_update`, and `or_ignore` are supported.
 
-**Native arrays for [`Vec<scalar>` fields](./field-options.md#scalar-arrays).**
+**Native arrays for [`Vec<scalar>` fields](./vec-scalar-fields.md).**
 A `tags: Vec<String>` field is a `text[]` column. The array predicates
 (`contains`, `is_superset`, `intersects`, `len`, `is_empty`) lower to
 PostgreSQL's native operators (`= ANY(col)`, `@>`, `&&`,

--- a/docs/guide/src/sqlite.md
+++ b/docs/guide/src/sqlite.md
@@ -167,7 +167,7 @@ lowers to `col GLOB 'abc*'`, a case-sensitive prefix match. The optimizer can
 use a regular index for the common-prefix lookup.
 
 **Scalar arrays use JSON1.** A
-[`Vec<T>` field](./field-options.md#scalar-arrays) lives in a `TEXT`
+[`Vec<T>` field](./vec-scalar-fields.md) lives in a `TEXT`
 column holding a JSON array. The array predicates lower to JSON1
 expressions:
 
@@ -180,7 +180,7 @@ expressions:
 
 These subqueries scan the JSON document, so array predicates against
 a large table do not use an index. See
-[Field Options](./field-options.md#scalar-arrays) for the model-level
+[`Vec<scalar>` Fields](./vec-scalar-fields.md) for the model-level
 view.
 
 **No row-level locking.** SQLite has no `SELECT ... FOR UPDATE`.


### PR DESCRIPTION
## Summary

Allow `serde_json::Value` to be used directly as a model field with an explicit `text`, `varchar`, `json`, or `jsonb` column type. The field reuses the existing `Json<T>` serialization path, so native JSON drivers continue to receive one serialized JSON value.

Add shared driver coverage for create, read, update, nested values, JSON null versus SQL `NULL`, PostgreSQL `json` and `jsonb`, and MySQL `json`. Document the direct field form in the derive documentation and user guide.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [ ] Touches a public API → a design doc under `docs/dev/design/` describes the behavior

## Notes for reviewers

No design doc is included because this maps `serde_json::Value` onto the existing `Json<T>` field behavior without adding a statement type or driver operation.

Validation includes the serde-enabled Toasty suite, macro doctests, shared-suite Clippy, PostgreSQL execution of the `json`, `jsonb`, and null cases, and MySQL execution of the `json` and null cases.