### PR TITLE
feat: relation link/unlink return a builder instead of executing eagerly

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs
@@ -576,7 +576,7 @@ pub async fn composite_remove_add_single_relation_option_belongs_to(test: &mut T
     let todos: Vec<_> = user.todos().exec(&mut db).await?;
     assert_eq!(2, todos.len());
 
-    user.todos().remove(&mut db, &todos[0]).await?;
+    user.todos().remove(&todos[0]).exec(&mut db).await?;
 
     let todos_reloaded: Vec<_> = user.todos().exec(&mut db).await?;
     assert_eq!(1, todos_reloaded.len());
@@ -587,7 +587,7 @@ pub async fn composite_remove_add_single_relation_option_belongs_to(test: &mut T
     let todo = Todo::get_by_id(&mut db, todos[0].id).await?;
     assert_none!(todo.user_id);
 
-    user.todos().insert(&mut db, &todos[0]).await?;
+    user.todos().insert(&todos[0]).exec(&mut db).await?;
 
     let todos_reloaded: Vec<_> = user.todos().exec(&mut db).await?;
     assert!(todos_reloaded.iter().any(|t| t.id == todos[0].id));
@@ -617,7 +617,10 @@ pub async fn composite_add_remove_single_relation_required_belongs_to(
     }
 
     // Unlinking a required belongs_to is a delete
-    user.todos().remove(&mut db, &todos_reloaded[0]).await?;
+    user.todos()
+        .remove(&todos_reloaded[0])
+        .exec(&mut db)
+        .await?;
 
     assert_err!(Todo::get_by_user_id_and_id(&mut db, &user.id, &todos_reloaded[0].id).await);
 
@@ -643,7 +646,7 @@ pub async fn composite_reassign_relation_required_belongs_to(test: &mut Test) ->
 
     let t1 = u1.todos().create().title("a todo").exec(&mut db).await?;
 
-    u2.todos().insert(&mut db, &t1).await?;
+    u2.todos().insert(&t1).exec(&mut db).await?;
 
     assert!(u1.todos().exec(&mut db).await?.is_empty());
 
@@ -667,9 +670,9 @@ pub async fn composite_add_remove_multiple_relation_option_belongs_to(
 
     let ids = vec![t1.id, t2.id, t3.id];
 
-    user.todos().insert(&mut db, &t1).await?;
-    user.todos().insert(&mut db, &t2).await?;
-    user.todos().insert(&mut db, &t3).await?;
+    user.todos().insert(&t1).exec(&mut db).await?;
+    user.todos().insert(&t2).exec(&mut db).await?;
+    user.todos().insert(&t3).exec(&mut db).await?;
 
     let todos_reloaded: Vec<_> = user.todos().exec(&mut db).await?;
     assert_eq!(todos_reloaded.len(), 3);

--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_link_unlink.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_link_unlink.rs
@@ -17,7 +17,7 @@ pub async fn remove_add_single_relation_option_belongs_to(test: &mut Test) -> Re
     assert_eq!(2, todos.len());
 
     // Remove a todo from the list.
-    user.todos().remove(&mut db, &todos[0]).await?;
+    user.todos().remove(&todos[0]).exec(&mut db).await?;
 
     let todos_reloaded: Vec<_> = user.todos().exec(&mut db).await?;
     assert_eq!(1, todos_reloaded.len());
@@ -39,14 +39,14 @@ pub async fn remove_add_single_relation_option_belongs_to(test: &mut Test) -> Re
     let u2_todos = u2.todos().exec(&mut db).await?;
 
     // Try unlinking u2's todo via user. This should fail
-    assert_err!(user.todos().remove(&mut db, &u2_todos[0]).await);
+    assert_err!(user.todos().remove(&u2_todos[0]).exec(&mut db).await);
 
     // Reload u2's todo
     let u2_todo = Todo::get_by_id(&mut db, u2_todos[0].id).await?;
     assert_eq!(*u2_todo.user_id.as_ref().unwrap(), u2.id);
 
     // Link the TODO back up
-    user.todos().insert(&mut db, &todos[0]).await?;
+    user.todos().insert(&todos[0]).exec(&mut db).await?;
 
     // The TODO is in the association again
     let todos_reloaded: Vec<_> = user.todos().exec(&mut db).await?;
@@ -77,7 +77,10 @@ pub async fn add_remove_single_relation_required_belongs_to(test: &mut Test) -> 
     }
 
     // Unlinking a todo deletes it
-    user.todos().remove(&mut db, &todos_reloaded[0]).await?;
+    user.todos()
+        .remove(&todos_reloaded[0])
+        .exec(&mut db)
+        .await?;
 
     // The TODO no longer exists
     assert_err!(Todo::get_by_id(&mut db, todos_reloaded[0].id).await);
@@ -100,7 +103,7 @@ pub async fn reassign_relation_required_belongs_to(test: &mut Test) -> Result<()
     let t1 = u1.todos().create().title("a todo").exec(&mut db).await?;
 
     // Associate the todo with user 2
-    u2.todos().insert(&mut db, &t1).await?;
+    u2.todos().insert(&t1).exec(&mut db).await?;
 
     // The TODO is no longer associated with user 1
     assert!(u1.todos().exec(&mut db).await?.is_empty());
@@ -127,9 +130,9 @@ pub async fn add_remove_multiple_relation_option_belongs_to(test: &mut Test) -> 
     let ids = vec![t1.id, t2.id, t3.id];
 
     // Associate the todos with the user
-    user.todos().insert(&mut db, &t1).await?;
-    user.todos().insert(&mut db, &t2).await?;
-    user.todos().insert(&mut db, &t3).await?;
+    user.todos().insert(&t1).exec(&mut db).await?;
+    user.todos().insert(&t2).exec(&mut db).await?;
+    user.todos().insert(&t3).exec(&mut db).await?;
 
     let todos_reloaded: Vec<_> = user.todos().exec(&mut db).await?;
     assert_eq!(todos_reloaded.len(), 3);

--- a/crates/toasty-driver-integration-suite/src/tests/relation_via_mutation_runtime_error.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_via_mutation_runtime_error.rs
@@ -43,11 +43,11 @@ pub async fn insert_on_multi_step_traversal_errors(test: &mut Test) -> Result<()
     // produces a query whose underlying association is two steps. `.insert`
     // requires a single-step scope, so the executor rejects it.
     let chained = user.organizations().projects();
-    let err = assert_err!(chained.insert(&mut db, &project).await);
+    let err = assert_err!(chained.insert(&project).exec(&mut db).await);
     assert!(err.to_string().to_lowercase().contains("multi-step"));
 
     let chained = user.organizations().projects();
-    let err = assert_err!(chained.remove(&mut db, &project).await);
+    let err = assert_err!(chained.remove(&project).exec(&mut db).await);
     assert!(err.to_string().to_lowercase().contains("multi-step"));
 
     Ok(())

--- a/crates/toasty-driver-integration-suite/src/tests/tx_atomic_stmt.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/tx_atomic_stmt.rs
@@ -304,7 +304,7 @@ pub async fn rmw_uses_savepoints(t: &mut Test) -> Result<()> {
     let todos: Vec<_> = user.todos().exec(&mut db).await?;
 
     t.log().clear();
-    user.todos().remove(&mut db, &todos[0]).await?;
+    user.todos().remove(&todos[0]).exec(&mut db).await?;
 
     if t.capability().cte_with_update {
         // PostgreSQL: single CTE bundles the condition + update
@@ -351,7 +351,7 @@ pub async fn rmw_condition_failure_issues_rollback_to_savepoint(t: &mut Test) ->
 
     t.log().clear();
     // Remove u2's todo via user1 — condition (user_id = user1.id) won't match
-    assert_err!(user1.todos().remove(&mut db, &u2_todos[0]).await);
+    assert_err!(user1.todos().remove(&u2_todos[0]).exec(&mut db).await);
 
     if t.capability().cte_with_update {
         // PostgreSQL: a single QuerySql; condition handled inside the CTE

--- a/crates/toasty-macros/src/model/expand/query.rs
+++ b/crates/toasty-macros/src/model/expand/query.rs
@@ -174,28 +174,22 @@ impl Expand<'_> {
                     }
                 }
 
-                /// Add an item to the relation this query was scoped from.
-                ///
-                /// Returns an error at exec time if the query is not scoped to
-                /// a single-step relation traversal.
-                #vis async fn insert(
+                /// Returns a builder that will add an item to the relation this query was scoped
+                /// from only on execution.
+                #vis fn insert(
                     self,
-                    executor: &mut dyn #toasty::Executor,
                     item: impl #toasty::IntoExpr<#model_ident>,
-                ) -> #toasty::Result<()> {
-                    #toasty::relation_insert(self.stmt, executor, item).await
+                ) -> #toasty::stmt::RelationInsert<#model_ident> {
+                    self.stmt.insert(item)
                 }
 
-                /// Remove an item from the relation this query was scoped from.
-                ///
-                /// Returns an error at exec time if the query is not scoped to
-                /// a single-step relation traversal.
-                #vis async fn remove(
+                /// Returns a builder that will remove an item from the relation this query was scoped
+                /// from only on execution.
+                #vis fn remove(
                     self,
-                    executor: &mut dyn #toasty::Executor,
                     item: impl #toasty::IntoExpr<#model_ident>,
-                ) -> #toasty::Result<()> {
-                    #toasty::relation_remove(self.stmt, executor, item).await
+                ) -> #toasty::stmt::RelationRemove<#model_ident> {
+                    self.stmt.remove(item)
                 }
 
                 #relation_methods

--- a/crates/toasty/src/codegen_support.rs
+++ b/crates/toasty/src/codegen_support.rs
@@ -21,7 +21,7 @@ pub use crate::{
         ViaPath, ViaTarget, generate_unique_id,
     },
     stmt::CreateMany,
-    stmt::{self, Assign, IntoExpr, IntoInsert, IntoStatement, List, Path},
+    stmt::{self, Assign, Expr, IntoExpr, IntoInsert, IntoStatement, List, Path},
     update_target::UpdateTarget,
 };
 #[cfg(feature = "serde")]
@@ -63,61 +63,6 @@ pub fn create_in_scope<S: Scope>(scope: S) -> S::Create {
 pub fn into_untyped_expr<T, V: IntoExpr<T>>(value: V) -> core::stmt::Expr {
     let expr: stmt::Expr<T> = value.into_expr();
     expr.into()
-}
-
-/// Insert `item` into the relation that produced this list query.
-///
-/// Generated code emits `Query<List<M>>::insert` as a one-line forward to
-/// this helper. The query must be scoped to a single-step relation
-/// traversal; multi-step traversals and unscoped queries return an
-/// `unsupported_feature` error.
-pub async fn relation_insert<M, E>(
-    mut query: stmt::Query<List<M>>,
-    executor: &mut dyn Executor,
-    item: E,
-) -> Result<()>
-where
-    M: Model,
-    E: IntoExpr<M>,
-{
-    match query.take_via_assoc() {
-        Some(untyped) if untyped.path.projection.as_slice().len() == 1 => {
-            let assoc = stmt::Association::<List<M>>::from_untyped(untyped);
-            executor.exec(assoc.insert(item)).await
-        }
-        Some(_) => Err(Error::unsupported_feature(
-            "insert is not supported on multi-step relation traversals",
-        )),
-        None => Err(Error::unsupported_feature(
-            "insert requires a relation-scoped query",
-        )),
-    }
-}
-
-/// Remove `item` from the relation that produced this list query.
-///
-/// Counterpart to [`relation_insert`]; the same scoping rules apply.
-pub async fn relation_remove<M, E>(
-    mut query: stmt::Query<List<M>>,
-    executor: &mut dyn Executor,
-    item: E,
-) -> Result<()>
-where
-    M: Model,
-    E: IntoExpr<M>,
-{
-    match query.take_via_assoc() {
-        Some(untyped) if untyped.path.projection.as_slice().len() == 1 => {
-            let assoc = stmt::Association::<List<M>>::from_untyped(untyped);
-            executor.exec(assoc.remove(item)).await
-        }
-        Some(_) => Err(Error::unsupported_feature(
-            "remove is not supported on multi-step relation traversals",
-        )),
-        None => Err(Error::unsupported_feature(
-            "remove requires a relation-scoped query",
-        )),
-    }
 }
 
 /// Continue a `has_many` traversal from `query` along `path`.

--- a/crates/toasty/src/stmt.rs
+++ b/crates/toasty/src/stmt.rs
@@ -60,6 +60,12 @@ use crate::{Executor, schema::Load};
 mod query;
 pub use query::Query;
 
+mod relation_insert;
+pub use relation_insert::RelationInsert;
+
+mod relation_remove;
+pub use relation_remove::RelationRemove;
+
 mod scope;
 pub use scope::IntoScope;
 

--- a/crates/toasty/src/stmt/query.rs
+++ b/crates/toasty/src/stmt/query.rs
@@ -1,4 +1,6 @@
-use super::{Delete, Expr, IntoExpr, IntoStatement, List, Statement, Value};
+use super::{
+    Delete, Expr, IntoExpr, IntoStatement, List, RelationInsert, RelationRemove, Statement, Value,
+};
 use crate::{
     Executor, Result,
     schema::{Load, Model},
@@ -437,6 +439,26 @@ impl<T> Query<List<T>> {
         Query {
             untyped: self.untyped,
             _p: PhantomData,
+        }
+    }
+}
+
+impl<T: Model> Query<List<T>> {
+    /// Convert this query into a [`RelationInsert`] statement that inserts `item` into the
+    /// relation that produced this list query.
+    pub fn insert(self, item: impl IntoExpr<T>) -> RelationInsert<T> {
+        RelationInsert {
+            query: self,
+            item: item.into_expr(),
+        }
+    }
+
+    /// Convert this query into a [`RelationRemove`] statement that removes `item` from the
+    /// relation that produced this list query.
+    pub fn remove(self, item: impl IntoExpr<T>) -> RelationRemove<T> {
+        RelationRemove {
+            query: self,
+            item: item.into_expr(),
         }
     }
 }

--- a/crates/toasty/src/stmt/relation_insert.rs
+++ b/crates/toasty/src/stmt/relation_insert.rs
@@ -1,0 +1,74 @@
+use crate::{
+    Error, Executor, Result,
+    schema::Model,
+    stmt::{Association, Expr, List, Query},
+};
+
+/// Deferred insert into a has-many relation. Returned by the generated
+/// `insert()` method on a relation-scoped `Query<List<M>>`. On execution
+/// this will add an item to the relation this query was scoped from.
+///
+/// # Execution
+///
+/// Call [`exec`](RelationInsert::exec) to run the insert.
+pub struct RelationInsert<M: Model> {
+    pub(crate) query: Query<List<M>>,
+    pub(crate) item: Expr<M>,
+}
+
+impl<M: Model> RelationInsert<M> {
+    /// Execute this insert statement of a relation against the given executor.
+    ///
+    /// Returns `Ok(())` on success. The given item will be inserted as a relation of the parent
+    /// object into the database.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # tokio::runtime::Runtime::new().unwrap().block_on(async {
+    /// # #[derive(Debug, toasty::Model)]
+    /// # struct User {
+    /// #     #[key]
+    /// #     #[auto]
+    /// #     id: i64,
+    /// #     name: String,
+    /// #     #[has_many]
+    /// #     todos: toasty::Deferred<Vec<Todo>>,
+    /// # }
+    /// # #[derive(Debug, toasty::Model)]
+    /// # struct Todo {
+    /// #     #[key]
+    /// #     #[auto]
+    /// #     id: i64,
+    /// #     title: String,
+    /// #     #[index]
+    /// #     user_id: Option<i64>,
+    /// #     #[belongs_to(key = user_id, references = id)]
+    /// #     user: toasty::Deferred<Option<User>>,
+    /// # }
+    /// # let driver = toasty_driver_sqlite::Sqlite::in_memory();
+    /// # let mut db = toasty::Db::builder().models(toasty::models!(User)).build(driver).await.unwrap();
+    /// # db.push_schema().await.unwrap();
+    /// let user = User::create()
+    ///     .name("John")
+    ///     .exec(&mut db)
+    ///     .await.unwrap();
+    /// let todo = Todo::create().title("dummy").exec(&mut db).await.unwrap();
+    /// user.todos().insert(&todo).exec(&mut db).await.unwrap();
+    /// # });
+    /// ```
+    pub async fn exec(mut self, executor: &mut dyn Executor) -> Result<()> {
+        match self.query.take_via_assoc() {
+            Some(untyped) if untyped.path.projection.as_slice().len() == 1 => {
+                let assoc = Association::<List<M>>::from_untyped(untyped);
+                executor.exec(assoc.insert(self.item)).await
+            }
+            Some(_) => Err(Error::unsupported_feature(
+                "insert is not supported on multi-step relation traversals",
+            )),
+            None => Err(Error::unsupported_feature(
+                "insert requires a relation-scoped query",
+            )),
+        }
+    }
+}

--- a/crates/toasty/src/stmt/relation_remove.rs
+++ b/crates/toasty/src/stmt/relation_remove.rs
@@ -1,0 +1,77 @@
+use crate::{
+    Error, Executor, Result,
+    schema::Model,
+    stmt::{Association, Expr, List, Query},
+};
+
+/// Deferred remove of a has-many relation. Returned by the generated
+/// `insert()` method on a relation-scoped `Query<List<M>>`. On execution
+/// this will remove an item from the relation this query was scoped from.
+///
+/// # Execution
+///
+/// Call [`exec`](RelationRemove::exec) to run the removal.
+pub struct RelationRemove<M: Model> {
+    pub(crate) query: Query<List<M>>,
+    pub(crate) item: Expr<M>,
+}
+
+impl<M: Model> RelationRemove<M> {
+    /// Execute this remove statement of a relation against the given executor.
+    ///
+    /// Returns `Ok(())` on success. The given item will be removed as a relation fromm the parent
+    /// object in the database.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # tokio::runtime::Runtime::new().unwrap().block_on(async {
+    /// # #[derive(Debug, toasty::Model)]
+    /// # struct User {
+    /// #     #[key]
+    /// #     #[auto]
+    /// #     id: i64,
+    /// #     name: String,
+    /// #     #[has_many]
+    /// #     todos: toasty::Deferred<Vec<Todo>>,
+    /// # }
+    /// # #[derive(Debug, toasty::Model)]
+    /// # struct Todo {
+    /// #     #[key]
+    /// #     #[auto]
+    /// #     id: i64,
+    /// #     title: String,
+    /// #     #[index]
+    /// #     user_id: Option<i64>,
+    /// #     #[belongs_to(key = user_id, references = id)]
+    /// #     user: toasty::Deferred<Option<User>>,
+    /// # }
+    /// # let driver = toasty_driver_sqlite::Sqlite::in_memory();
+    /// # let mut db = toasty::Db::builder().models(toasty::models!(User)).build(driver).await.unwrap();
+    /// # db.push_schema().await.unwrap();
+    /// let user = User::create()
+    ///     .name("John")
+    ///     .todos([Todo::create().title("dummy one")])
+    ///     .todos([Todo::create().title("dummy two")])
+    ///     .exec(&mut db)
+    ///     .await
+    ///     .unwrap();
+    /// let todos: Vec<_> = user.todos().exec(&mut db).await.unwrap();
+    /// user.todos().remove(&todos[0]).exec(&mut db).await.unwrap();
+    /// # });
+    /// ```
+    pub async fn exec(mut self, executor: &mut dyn Executor) -> Result<()> {
+        match self.query.take_via_assoc() {
+            Some(untyped) if untyped.path.projection.as_slice().len() == 1 => {
+                let assoc = Association::<List<M>>::from_untyped(untyped);
+                executor.exec(assoc.remove(self.item)).await
+            }
+            Some(_) => Err(Error::unsupported_feature(
+                "remove is not supported on multi-step relation traversals",
+            )),
+            None => Err(Error::unsupported_feature(
+                "remove requires a relation-scoped query",
+            )),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

As described in #1009 the has-many link/unlink methods generated on `Query<List<M>>` behave differently than other methods on the struct like `delete`, `update` and `select` as it takes an executor as parameter and executes immediately instead of being lazily executed by returning a builder-like struct. This PR adds a builder-like struct for the `insert` and `remove` methods of that struct called `RelationInsert` and `RelationRemove`, that offer a method `exec` for lazy execution of the statements.

## Type of change

<!-- Check one. -->

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test: 
- [ ] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`):
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [ ] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers

I implement the builder types as simple generic types in the `toasty::stmt` module instead of implementing this in the same way that `update` is implemented by returning a per-model generated struct. Because the insert/remove operation basically is a single statement that takes on item to insert/remove a relation for, we do not need the flexibility of the per-model generated struct to modify accumulated variables. So I went with the simpler approach used by `delete` and `select`.

Closes #1009 
