### PR TITLE
refactor: simplify numeric snapshot serialization

### DIFF
--- a/crates/toasty-cli/src/migration/generate.rs
+++ b/crates/toasty-cli/src/migration/generate.rs
@@ -295,7 +295,6 @@ impl GenerateCommand {
             checksum: None,
         });
 
-        let snapshot = generated.snapshot.to_toml_string()?;
         let migration = generated.migration;
         let Migration::Sql(sql) = migration;
         std::fs::write(&migration_path, format!("{sql}\n"))?;
@@ -305,7 +304,7 @@ impl GenerateCommand {
             style(format!("Created migration file: {}", migration_name)).dim()
         );
 
-        std::fs::write(&snapshot_path, snapshot)?;
+        generated.snapshot.save(&snapshot_path)?;
         println!(
             "  {} {}",
             style("✓").green().bold(),

--- a/crates/toasty-cli/src/migration/snapshot.rs
+++ b/crates/toasty-cli/src/migration/snapshot.rs
@@ -27,7 +27,7 @@ impl SnapshotCommand {
         let snapshot = Snapshot::new(toasty::schema::db::Schema::clone(&db.schema().db));
 
         // Print the snapshot with nice formatting
-        let snapshot_str = snapshot.to_toml_string()?;
+        let snapshot_str = snapshot.to_string();
         for line in snapshot_str.lines() {
             if line.starts_with('[') {
                 println!("  {}", style(line).yellow().bold());

--- a/crates/toasty-core/src/schema/db/ty.rs
+++ b/crates/toasty-core/src/schema/db/ty.rs
@@ -137,16 +137,9 @@ pub enum Type {
 
 #[cfg(feature = "serde")]
 mod numeric_serde {
-    use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as _};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum Repr {
-        Values(Vec<u32>),
-        Legacy(Option<(u32, u32)>),
-    }
-
-    pub fn serialize<S>(value: &Option<(u32, u32)>, serializer: S) -> Result<S::Ok, S::Error>
+    pub(super) fn serialize<S>(value: &Option<(u32, u32)>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
@@ -160,15 +153,15 @@ mod numeric_serde {
     where
         D: Deserializer<'de>,
     {
-        match Repr::deserialize(deserializer)? {
-            Repr::Values(values) => match values.as_slice() {
-                [] => Ok(None),
-                [precision, scale] => Ok(Some((*precision, *scale))),
-                _ => Err(D::Error::custom(
-                    "numeric storage type requires zero or two parameters",
-                )),
-            },
-            Repr::Legacy(value) => Ok(value),
+        let values = Vec::<u32>::deserialize(deserializer)?;
+
+        match values.as_slice() {
+            [] => Ok(None),
+            &[precision, scale] => Ok(Some((precision, scale))),
+            _ => Err(de::Error::invalid_length(
+                values.len(),
+                &"zero or two numeric type parameters",
+            )),
         }
     }
 }

--- a/crates/toasty/src/migration/snapshot.rs
+++ b/crates/toasty/src/migration/snapshot.rs
@@ -34,14 +34,10 @@ impl Snapshot {
         contents.parse()
     }
 
-    /// Serialize the snapshot as TOML.
-    pub fn to_toml_string(&self) -> Result<String> {
-        Ok(self.to_toml_document()?.to_string())
-    }
-
     /// Save the snapshot to a TOML file.
     pub fn save(&self, path: impl AsRef<Path>) -> Result<()> {
-        std::fs::write(path.as_ref(), self.to_toml_string()?)?;
+        let doc = self.to_toml_document()?;
+        std::fs::write(path.as_ref(), doc.to_string())?;
         Ok(())
     }
 
@@ -53,25 +49,13 @@ impl Snapshot {
             if item.is_inline_table() {
                 let mut placeholder = Item::None;
                 std::mem::swap(item, &mut placeholder);
-                let mut table = match placeholder.into_table() {
-                    Ok(table) => table,
-                    Err(original) => {
-                        *item = original;
-                        continue;
-                    }
-                };
+                let mut table = placeholder.into_table().unwrap();
 
                 for (_key, item) in table.iter_mut() {
                     if item.is_array() {
                         let mut placeholder = Item::None;
                         std::mem::swap(item, &mut placeholder);
-                        let mut array = match placeholder.into_array_of_tables() {
-                            Ok(array) => array,
-                            Err(original) => {
-                                *item = original;
-                                continue;
-                            }
-                        };
+                        let mut array = placeholder.into_array_of_tables().unwrap();
 
                         for table in array.iter_mut() {
                             for (_key, item) in table.iter_mut() {


### PR DESCRIPTION
## Summary

- follow the narrower numeric snapshot serialization approach from #1108
- encode numeric parameters only as zero- or two-element arrays
- keep serialization fallible inside `Snapshot::save` without a separate public rendering API
- retain the focused snapshot tests and reporter-shaped CLI regression coverage from #1115

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [ ] Touches a public API → no design doc; this removes the newly added `Snapshot::to_toml_string` API before release

## Notes for reviewers

This deliberately removes the legacy nullable decoder and restores the previous CLI write ordering. The regression tests added in #1115 remain unchanged and pass with the smaller implementation.