### PR TITLE
feat: support limit in includes

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/relation_preload_options.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_preload_options.rs
@@ -303,6 +303,33 @@ pub async fn preload_has_many_limit_per_parent(test: &mut Test) -> Result<()> {
     Ok(())
 }
 
+/// A bare include limit needs no SQL: truncation happens in the engine during
+/// the nested merge, so it runs on every driver. Without an order_by, *which*
+/// rows are kept is driver-dependent — assert only the per-parent counts.
+#[driver_test(id(ID), scenario(crate::scenarios::has_many_belongs_to))]
+pub async fn preload_has_many_limit_without_order(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    toasty::create!(User::[
+        { name: "alice", todos: [{ title: "a" }, { title: "b" }, { title: "c" }] },
+        { name: "bob", todos: [{ title: "x" }, { title: "y" }, { title: "z" }] },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let users: Vec<User> = User::all()
+        .include(User::fields().todos().limit(2))
+        .exec(&mut db)
+        .await?;
+
+    assert_struct!(users, [
+        _ { todos.get().len(): 2, .. },
+        _ { todos.get().len(): 2, .. },
+    ]);
+
+    Ok(())
+}
+
 /// Include filters run before the limit is applied.
 #[driver_test(id(ID), requires(sql), scenario(crate::scenarios::has_many_belongs_to))]
 pub async fn preload_has_many_limit_with_filter(test: &mut Test) -> Result<()> {

--- a/crates/toasty-driver-integration-suite/src/tests/relation_preload_options.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_preload_options.rs
@@ -254,6 +254,215 @@ pub async fn preload_has_many_repeated_ordering_last_wins(test: &mut Test) -> Re
     Ok(())
 }
 
+/// A limit on an include applies per parent record, not globally.
+#[driver_test(
+    id(ID),
+    requires(sql),
+    scenario(crate::scenarios::has_many_belongs_to_with_flags)
+)]
+pub async fn preload_has_many_limit_per_parent(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    toasty::create!(User::[
+        {
+            name: "alice",
+            todos: [
+                { title: "b", complete: false, priority: 2 },
+                { title: "a", complete: false, priority: 2 },
+                { title: "c", complete: false, priority: 1 },
+            ]
+        },
+        {
+            name: "bob",
+            todos: [
+                { title: "z", complete: false, priority: 1 },
+                { title: "y", complete: false, priority: 1 },
+                { title: "x", complete: false, priority: 3 },
+            ]
+        },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let users: Vec<User> = User::all()
+        .order_by(User::fields().name().asc())
+        .include(
+            User::fields()
+                .todos()
+                .order_by(Todo::fields().title().asc())
+                .limit(2),
+        )
+        .exec(&mut db)
+        .await?;
+
+    assert_struct!(users, [
+        { name: "alice", todos.get(): [{ title: "a" }, { title: "b" }] },
+        { name: "bob", todos.get(): [{ title: "x" }, { title: "y" }] },
+    ]);
+
+    Ok(())
+}
+
+/// Include filters run before the limit is applied.
+#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::has_many_belongs_to))]
+pub async fn preload_has_many_limit_with_filter(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user = toasty::create!(User {
+        name: "alice",
+        todos: [{ title: "a" }, { title: "c" }, { title: "b" }, { title: "d" }]
+    })
+    .exec(&mut db)
+    .await?;
+
+    let loaded = User::filter_by_id(user.id)
+        .include(
+            User::fields()
+                .todos()
+                .filter(Todo::fields().title().ne("c"))
+                .order_by(Todo::fields().title().desc())
+                .limit(2),
+        )
+        .get(&mut db)
+        .await?;
+
+    assert_struct!(loaded.todos.get(), [
+        { title: "d" },
+        { title: "b" },
+    ]);
+
+    Ok(())
+}
+
+/// A limit larger than the number of related rows returns them all; a limit of
+/// zero returns none.
+#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::has_many_belongs_to))]
+pub async fn preload_has_many_limit_bounds(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user = toasty::create!(User {
+        name: "alice",
+        todos: [{ title: "a" }, { title: "b" }]
+    })
+    .exec(&mut db)
+    .await?;
+
+    let loaded = User::filter_by_id(user.id)
+        .include(
+            User::fields()
+                .todos()
+                .order_by(Todo::fields().title().asc())
+                .limit(10),
+        )
+        .get(&mut db)
+        .await?;
+
+    assert_struct!(loaded.todos.get(), [
+        { title: "a" },
+        { title: "b" },
+    ]);
+
+    let loaded = User::filter_by_id(user.id)
+        .include(User::fields().todos().limit(0))
+        .get(&mut db)
+        .await?;
+
+    assert!(loaded.todos.get().is_empty());
+
+    Ok(())
+}
+
+/// Limits apply independently at each relation in a nested include path.
+#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::user_post_comment))]
+pub async fn preload_nested_relations_limited_at_each_level(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user = toasty::create!(User {
+        name: "alice",
+        posts: [
+            {
+                title: "a",
+                comments: [{ body: "a" }, { body: "c" }, { body: "b" }]
+            },
+            {
+                title: "b",
+                comments: [{ body: "x" }, { body: "z" }, { body: "y" }]
+            },
+            {
+                title: "c",
+                comments: [{ body: "q" }]
+            },
+        ]
+    })
+    .exec(&mut db)
+    .await?;
+
+    let loaded = User::filter_by_id(user.id)
+        .include(
+            User::fields()
+                .posts()
+                .order_by(Post::fields().title().asc())
+                .limit(2),
+        )
+        .include(
+            User::fields()
+                .posts()
+                .comments()
+                .order_by(Comment::fields().body().desc())
+                .limit(2),
+        )
+        .get(&mut db)
+        .await?;
+
+    assert_struct!(loaded.posts.get(), [
+        { title: "a", comments.get(): [{ body: "c" }, { body: "b" }] },
+        { title: "b", comments.get(): [{ body: "z" }, { body: "y" }] },
+    ]);
+
+    Ok(())
+}
+
+/// The batched child query issued for a limited include carries no
+/// database-level LIMIT — it would apply globally across all parents.
+#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::has_many_belongs_to))]
+pub async fn preload_has_many_limit_not_pushed_to_batch_query(test: &mut Test) -> Result<()> {
+    use toasty_core::{driver::Operation, stmt::Statement};
+
+    let mut db = setup(test).await;
+
+    let user = toasty::create!(User {
+        name: "alice",
+        todos: [{ title: "a" }, { title: "c" }, { title: "b" }]
+    })
+    .exec(&mut db)
+    .await?;
+
+    test.log().clear();
+
+    let loaded = User::filter_by_id(user.id)
+        .include(
+            User::fields()
+                .todos()
+                .order_by(Todo::fields().title().asc())
+                .limit(2),
+        )
+        .get(&mut db)
+        .await?;
+
+    assert_struct!(loaded.todos.get(), [
+        { title: "a" },
+        { title: "b" },
+    ]);
+
+    let _ = test.log().pop_last_op(); // transaction commit
+    assert_struct!(test.log().pop_last_op(), Operation::QuerySql({
+        stmt: Statement::Query({ limit: None, .. }),
+        ..
+    }));
+
+    Ok(())
+}
+
 /// Include ordering is rejected when the terminal relation is singular.
 #[driver_test(id(ID), scenario(crate::scenarios::has_one_optional_belongs_to))]
 pub async fn preload_has_one_ordering_rejected(test: &mut Test) -> Result<()> {
@@ -266,6 +475,23 @@ pub async fn preload_has_one_ordering_rejected(test: &mut Test) -> Result<()> {
                     .profile()
                     .order_by(Profile::fields().bio().asc()),
             )
+            .exec(&mut db)
+            .await
+    );
+
+    assert!(err.is_invalid_statement(), "unexpected error: {err}");
+
+    Ok(())
+}
+
+/// An include limit is rejected when the terminal relation is singular.
+#[driver_test(id(ID), scenario(crate::scenarios::has_one_optional_belongs_to))]
+pub async fn preload_has_one_limit_rejected(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let err = assert_err!(
+        User::all()
+            .include(User::fields().profile().limit(1))
             .exec(&mut db)
             .await
     );

--- a/crates/toasty-driver-integration-suite/src/tests/relation_preload_options.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_preload_options.rs
@@ -258,6 +258,173 @@ pub async fn preload_has_many_repeated_ordering_last_wins(test: &mut Test) -> Re
     Ok(())
 }
 
+/// A limit on an include applies per parent record, not globally.
+#[driver_test(
+    requires(sql),
+    scenario(crate::scenarios::has_many_belongs_to_with_flags)
+)]
+pub async fn preload_has_many_limit_per_parent(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    toasty::create!(User::[
+        {
+            name: "alice",
+            todos: [
+                { title: "b", complete: false, priority: 2 },
+                { title: "a", complete: false, priority: 2 },
+                { title: "c", complete: false, priority: 1 },
+            ]
+        },
+        {
+            name: "bob",
+            todos: [
+                { title: "z", complete: false, priority: 1 },
+                { title: "y", complete: false, priority: 1 },
+                { title: "x", complete: false, priority: 3 },
+            ]
+        },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let users: Vec<User> = User::all()
+        .order_by(User::fields().name().asc())
+        .include(
+            User::fields()
+                .todos()
+                .order_by(Todo::fields().title().asc())
+                .limit(2),
+        )
+        .exec(&mut db)
+        .await?;
+
+    assert_struct!(users, [
+        { name: "alice", todos.get(): [{ title: "a" }, { title: "b" }] },
+        { name: "bob", todos.get(): [{ title: "x" }, { title: "y" }] },
+    ]);
+
+    Ok(())
+}
+
+/// Include filters run before the limit is applied.
+#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::has_many_belongs_to))]
+pub async fn preload_has_many_limit_with_filter(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user = toasty::create!(User {
+        name: "alice",
+        todos: [{ title: "a" }, { title: "c" }, { title: "b" }, { title: "d" }]
+    })
+    .exec(&mut db)
+    .await?;
+
+    let loaded = User::filter_by_id(user.id)
+        .include(
+            User::fields()
+                .todos()
+                .filter(Todo::fields().title().ne("c"))
+                .order_by(Todo::fields().title().desc())
+                .limit(2),
+        )
+        .get(&mut db)
+        .await?;
+
+    assert_struct!(loaded.todos.get(), [
+        { title: "d" },
+        { title: "b" },
+    ]);
+
+    Ok(())
+}
+
+/// A limit larger than the number of related rows returns them all; a limit of
+/// zero returns none.
+#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::has_many_belongs_to))]
+pub async fn preload_has_many_limit_bounds(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user = toasty::create!(User {
+        name: "alice",
+        todos: [{ title: "a" }, { title: "b" }]
+    })
+    .exec(&mut db)
+    .await?;
+
+    let loaded = User::filter_by_id(user.id)
+        .include(
+            User::fields()
+                .todos()
+                .order_by(Todo::fields().title().asc())
+                .limit(10),
+        )
+        .get(&mut db)
+        .await?;
+
+    assert_struct!(loaded.todos.get(), [
+        { title: "a" },
+        { title: "b" },
+    ]);
+
+    let loaded = User::filter_by_id(user.id)
+        .include(User::fields().todos().limit(0))
+        .get(&mut db)
+        .await?;
+
+    assert!(loaded.todos.get().is_empty());
+
+    Ok(())
+}
+
+/// Limits apply independently at each relation in a nested include path.
+#[driver_test(requires(sql), scenario(crate::scenarios::user_post_comment))]
+pub async fn preload_nested_relations_limited_at_each_level(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let user = toasty::create!(User {
+        name: "alice",
+        posts: [
+            {
+                title: "a",
+                comments: [{ body: "a" }, { body: "c" }, { body: "b" }]
+            },
+            {
+                title: "b",
+                comments: [{ body: "x" }, { body: "z" }, { body: "y" }]
+            },
+            {
+                title: "c",
+                comments: [{ body: "q" }]
+            },
+        ]
+    })
+    .exec(&mut db)
+    .await?;
+
+    let loaded = User::filter_by_id(user.id)
+        .include(
+            User::fields()
+                .posts()
+                .order_by(Post::fields().title().asc())
+                .limit(2),
+        )
+        .include(
+            User::fields()
+                .posts()
+                .comments()
+                .order_by(Comment::fields().body().desc())
+                .limit(2),
+        )
+        .get(&mut db)
+        .await?;
+
+    assert_struct!(loaded.posts.get(), [
+        { title: "a", comments.get(): [{ body: "c" }, { body: "b" }] },
+        { title: "b", comments.get(): [{ body: "z" }, { body: "y" }] },
+    ]);
+
+    Ok(())
+}
+
 /// Include ordering is rejected when the terminal relation is singular.
 #[driver_test(scenario(crate::scenarios::has_one_optional_belongs_to::id_uuid))]
 pub async fn preload_has_one_ordering_rejected(test: &mut Test) -> Result<()> {
@@ -270,6 +437,23 @@ pub async fn preload_has_one_ordering_rejected(test: &mut Test) -> Result<()> {
                     .profile()
                     .order_by(Profile::fields().bio().asc()),
             )
+            .exec(&mut db)
+            .await
+    );
+
+    assert!(err.is_invalid_statement(), "unexpected error: {err}");
+
+    Ok(())
+}
+
+/// An include limit is rejected when the terminal relation is singular.
+#[driver_test(id(ID), scenario(crate::scenarios::has_one_optional_belongs_to))]
+pub async fn preload_has_one_limit_rejected(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    let err = assert_err!(
+        User::all()
+            .include(User::fields().profile().limit(1))
             .exec(&mut db)
             .await
     );

--- a/crates/toasty-driver-integration-suite/src/tests/relation_preload_options.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_preload_options.rs
@@ -313,12 +313,16 @@ pub async fn preload_has_many_limit_per_parent(test: &mut Test) -> Result<()> {
 pub async fn preload_has_many_limit_without_order(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
-    toasty::create!(User::[
-        { name: "alice", todos: [{ title: "a" }, { title: "b" }, { title: "c" }] },
-        { name: "bob", todos: [{ title: "x" }, { title: "y" }, { title: "z" }] },
-    ])
-    .exec(&mut db)
-    .await?;
+    // TODO: seed with a single batch create once MySQL supports returning
+    // generated IDs from a multi-row insert (the per-row fallback deferred in
+    // tokio-rs/toasty#1190).
+    for (name, titles) in [("alice", ["a", "b", "c"]), ("bob", ["x", "y", "z"])] {
+        let user = toasty::create!(User { name }).exec(&mut db).await?;
+
+        for title in titles {
+            user.todos().create().title(title).exec(&mut db).await?;
+        }
+    }
 
     let users: Vec<User> = User::all()
         .include(User::fields().todos().limit(2))
@@ -338,12 +342,16 @@ pub async fn preload_has_many_limit_without_order(test: &mut Test) -> Result<()>
 pub async fn preload_has_many_limit_with_filter(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
-    let user = toasty::create!(User {
-        name: "alice",
-        todos: [{ title: "a" }, { title: "c" }, { title: "b" }, { title: "d" }]
-    })
-    .exec(&mut db)
-    .await?;
+    // TODO: seed with a single batch create once MySQL supports returning
+    // generated IDs from a multi-row insert (the per-row fallback deferred in
+    // tokio-rs/toasty#1190).
+    let user = toasty::create!(User { name: "alice" })
+        .exec(&mut db)
+        .await?;
+
+    for title in ["a", "c", "b", "d"] {
+        user.todos().create().title(title).exec(&mut db).await?;
+    }
 
     let loaded = User::filter_by_id(user.id)
         .include(
@@ -370,12 +378,16 @@ pub async fn preload_has_many_limit_with_filter(test: &mut Test) -> Result<()> {
 pub async fn preload_has_many_limit_bounds(test: &mut Test) -> Result<()> {
     let mut db = setup(test).await;
 
-    let user = toasty::create!(User {
-        name: "alice",
-        todos: [{ title: "a" }, { title: "b" }]
-    })
-    .exec(&mut db)
-    .await?;
+    // TODO: seed with a single batch create once MySQL supports returning
+    // generated IDs from a multi-row insert (the per-row fallback deferred in
+    // tokio-rs/toasty#1190).
+    let user = toasty::create!(User { name: "alice" })
+        .exec(&mut db)
+        .await?;
+
+    for title in ["a", "b"] {
+        user.todos().create().title(title).exec(&mut db).await?;
+    }
 
     let loaded = User::filter_by_id(user.id)
         .include(

--- a/crates/toasty-driver-integration-suite/src/tests/relation_preload_options.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_preload_options.rs
@@ -306,6 +306,33 @@ pub async fn preload_has_many_limit_per_parent(test: &mut Test) -> Result<()> {
     Ok(())
 }
 
+/// A bare include limit needs no SQL: truncation happens in the engine during
+/// the nested merge, so it runs on every driver. Without an order_by, *which*
+/// rows are kept is driver-dependent — assert only the per-parent counts.
+#[driver_test(id(ID), scenario(crate::scenarios::has_many_belongs_to))]
+pub async fn preload_has_many_limit_without_order(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    toasty::create!(User::[
+        { name: "alice", todos: [{ title: "a" }, { title: "b" }, { title: "c" }] },
+        { name: "bob", todos: [{ title: "x" }, { title: "y" }, { title: "z" }] },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let users: Vec<User> = User::all()
+        .include(User::fields().todos().limit(2))
+        .exec(&mut db)
+        .await?;
+
+    assert_struct!(users, [
+        _ { todos.get().len(): 2, .. },
+        _ { todos.get().len(): 2, .. },
+    ]);
+
+    Ok(())
+}
+
 /// Include filters run before the limit is applied.
 #[driver_test(id(ID), requires(sql), scenario(crate::scenarios::has_many_belongs_to))]
 pub async fn preload_has_many_limit_with_filter(test: &mut Test) -> Result<()> {

--- a/crates/toasty-macros/src/model/expand/fields.rs
+++ b/crates/toasty-macros/src/model/expand/fields.rs
@@ -12,6 +12,7 @@ const FIELD_STRUCT_RESERVED_METHODS: &[&str] = &[
     "into_root",
     "filter",
     "order_by",
+    "limit",
     "create",
 ];
 
@@ -22,6 +23,7 @@ const FIELD_LIST_STRUCT_RESERVED_METHODS: &[&str] = &[
     "all",
     "filter",
     "order_by",
+    "limit",
     "create",
 ];
 
@@ -215,6 +217,14 @@ impl Expand<'_> {
                     self.path,
                     #toasty::stmt::Query::<#toasty::stmt::List<#model_ident>>::all(),
                 ).order_by(order_by)
+            }
+
+            /// Limits the related rows loaded by `.include(...)`, per parent record.
+            #vis fn limit(self, n: usize) -> #toasty::stmt::Include<__Origin, #target_ty> {
+                #toasty::stmt::Include::from_path_and_query(
+                    self.path,
+                    #toasty::stmt::Query::<#toasty::stmt::List<#model_ident>>::all(),
+                ).limit(n)
             }
         }
     }

--- a/crates/toasty-macros/src/model/expand/fields.rs
+++ b/crates/toasty-macros/src/model/expand/fields.rs
@@ -11,10 +11,12 @@ const FIELD_STRUCT_RESERVED_METHODS: &[&str] = &[
     "into_root",
     "filter",
     "order_by",
+    "limit",
     "create",
 ];
 
-const FIELD_LIST_STRUCT_RESERVED_METHODS: &[&str] = &["any", "all", "filter", "order_by", "create"];
+const FIELD_LIST_STRUCT_RESERVED_METHODS: &[&str] =
+    &["any", "all", "filter", "order_by", "limit", "create"];
 
 impl Expand<'_> {
     pub(super) fn expand_field_struct(&self) -> TokenStream {
@@ -260,6 +262,14 @@ impl Expand<'_> {
                     self.path,
                     #toasty::stmt::Query::<#toasty::stmt::List<#model_ident>>::all(),
                 ).order_by(order_by)
+            }
+
+            /// Limits the related rows loaded by `.include(...)`, per parent record.
+            #vis fn limit(self, n: usize) -> #toasty::stmt::Include<__Origin, #target_ty> {
+                #toasty::stmt::Include::from_path_and_query(
+                    self.path,
+                    #toasty::stmt::Query::<#toasty::stmt::List<#model_ident>>::all(),
+                ).limit(n)
             }
         }
     }

--- a/crates/toasty/src/engine/exec/nested_merge.rs
+++ b/crates/toasty/src/engine/exec/nested_merge.rs
@@ -94,6 +94,11 @@ pub(crate) struct NestedChild {
 
     /// True if single value
     pub(crate) single: bool,
+
+    /// Per-parent cap on matching rows, from `.include(...).limit(n)`. Matches
+    /// are visited in the batched query's ORDER BY order, so stopping at `n`
+    /// keeps the top-n per parent.
+    pub(crate) limit: Option<usize>,
 }
 
 /// How to filter nested records for a parent record
@@ -304,8 +309,14 @@ impl Exec<'_> {
             };
             let mut nested_rows_projected = vec![];
 
-            // Process a single matching child row: recurse and collect the result.
-            let mut process = |nested_row: &stmt::Value| -> Result<()> {
+            // Process a single matching child row: recurse and collect the
+            // result. Returns `false` once this parent's per-include limit is
+            // reached, telling the caller to stop iterating matches.
+            let limit = nested_child.limit;
+            let mut process = |nested_row: &stmt::Value| -> Result<bool> {
+                if limit.is_some_and(|limit| nested_rows_projected.len() >= limit) {
+                    return Ok(false);
+                }
                 let nested_stack = RowStack {
                     parent: Some(row_stack),
                     row: nested_row,
@@ -317,13 +328,15 @@ impl Exec<'_> {
                     inputs,
                     indices,
                 )?);
-                Ok(())
+                Ok(true)
             };
 
             match &nested_child.qualification {
                 MergeQualification::All => {
                     for row in nested_input {
-                        process(row)?;
+                        if !process(row)? {
+                            break;
+                        }
                     }
                 }
                 MergeQualification::HashLookup { index, lookup_key } => {
@@ -339,7 +352,9 @@ impl Exec<'_> {
                         std::ops::Bound::Included(key),
                         std::ops::Bound::Included(key),
                     ) {
-                        process(row)?;
+                        if !process(row)? {
+                            break;
+                        }
                     }
                 }
                 MergeQualification::Scan(func) => {
@@ -349,8 +364,8 @@ impl Exec<'_> {
                             row,
                             position: row_stack.position + 1,
                         };
-                        if func.eval_bool(&self.engine.schema, &stack)? {
-                            process(row)?;
+                        if func.eval_bool(&self.engine.schema, &stack)? && !process(row)? {
+                            break;
                         }
                     }
                 }

--- a/crates/toasty/src/engine/exec/nested_merge.rs
+++ b/crates/toasty/src/engine/exec/nested_merge.rs
@@ -50,6 +50,11 @@ pub(crate) struct NestedChild {
 
     /// True if single value
     pub(crate) single: bool,
+
+    /// Per-parent cap on matching rows, from `.include(...).limit(n)`. Matches
+    /// are visited in the batched query's ORDER BY order, so stopping at `n`
+    /// keeps the top-n per parent.
+    pub(crate) limit: Option<usize>,
 }
 
 /// How to filter nested records for a parent record
@@ -290,8 +295,14 @@ impl Exec<'_> {
             };
             let mut nested_rows_projected = vec![];
 
-            // Process a single matching child row: recurse and collect the result.
-            let mut process = |nested_row: &stmt::Value| -> Result<()> {
+            // Process a single matching child row: recurse and collect the
+            // result. Returns `false` once this parent's per-include limit is
+            // reached, telling the caller to stop iterating matches.
+            let limit = nested_child.limit;
+            let mut process = |nested_row: &stmt::Value| -> Result<bool> {
+                if limit.is_some_and(|limit| nested_rows_projected.len() >= limit) {
+                    return Ok(false);
+                }
                 let nested_stack = RowStack {
                     parent: Some(row_stack),
                     row: nested_row,
@@ -303,13 +314,15 @@ impl Exec<'_> {
                     inputs,
                     indices,
                 )?);
-                Ok(())
+                Ok(true)
             };
 
             match &nested_child.qualification {
                 MergeQualification::All => {
                     for row in nested_input {
-                        process(row)?;
+                        if !process(row)? {
+                            break;
+                        }
                     }
                 }
                 MergeQualification::HashLookup { index, lookup_key } => {
@@ -325,7 +338,9 @@ impl Exec<'_> {
                         std::ops::Bound::Included(key),
                         std::ops::Bound::Included(key),
                     ) {
-                        process(row)?;
+                        if !process(row)? {
+                            break;
+                        }
                     }
                 }
                 MergeQualification::Scan(func) => {
@@ -335,8 +350,8 @@ impl Exec<'_> {
                             row,
                             position: row_stack.position + 1,
                         };
-                        if func.eval_bool(&self.engine.schema, &stack)? {
-                            process(row)?;
+                        if func.eval_bool(&self.engine.schema, &stack)? && !process(row)? {
+                            break;
                         }
                     }
                 }

--- a/crates/toasty/src/engine/hir.rs
+++ b/crates/toasty/src/engine/hir.rs
@@ -50,6 +50,10 @@ pub(super) struct StatementInfo {
     /// Whether cursor pagination resumed this query after an earlier page.
     pub(super) has_pagination_cursor: bool,
 
+    /// Per-parent row cap from `.include(...).limit(n)`, applied by
+    /// `NestedMerge`. A `LIMIT` on [`Self::stmt`] would cap the whole batch.
+    pub(super) per_parent_limit: Option<usize>,
+
     /// Ordering edges: statements that must execute, to the degree the
     /// [`DepKind`] demands, before this one.
     ///
@@ -138,6 +142,7 @@ impl StatementInfo {
         StatementInfo {
             stmt: None,
             has_pagination_cursor: false,
+            per_parent_limit: None,
             deps,
             args: vec![],
             back_refs: HashMap::new(),

--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -1803,6 +1803,11 @@ impl<'a, 'b> LowerStatement<'a, 'b> {
         let mut stmt = Box::new(stmt);
 
         let target_id = self.scope_statement(|child| {
+            // A `LIMIT` here caps rows per parent row (`.include(...).limit(n)`),
+            // but the planner batch-loads every parent's children with one
+            // query, where a `LIMIT` would cap the whole batch. Move it off the
+            // statement before anything else can see it.
+            child.take_per_parent_limit(&mut stmt);
             // Via-association rewrite: `Source::Model { via }` becomes an
             // explicit WHERE filter so the lowering walk only sees rewritten
             // sources.  The IN-subquery lift fires next so non-walk code
@@ -1841,6 +1846,31 @@ impl<'a, 'b> LowerStatement<'a, 'b> {
         }
 
         arg
+    }
+
+    /// Moves a returning sub-statement's `LIMIT` off the statement and onto
+    /// [`hir::StatementInfo::per_parent_limit`], where `NestedMerge` applies it
+    /// per parent row while merging.
+    fn take_per_parent_limit(&mut self, stmt: &mut stmt::Statement) {
+        let stmt::Statement::Query(query) = stmt else {
+            return;
+        };
+        let Some(limit) = query.limit.take() else {
+            return;
+        };
+        let stmt::Limit::Offset(limit_offset) = limit else {
+            todo!("cursor pagination on an `.include(...)` query")
+        };
+        assert!(
+            limit_offset.offset.is_none(),
+            "include limits do not support offset"
+        );
+        let n = match &limit_offset.limit {
+            stmt::Expr::Value(stmt::Value::I64(n)) | stmt::Expr::Static(stmt::Value::I64(n)) => *n,
+            expr => panic!("include limit must be an i64 literal; got {expr:#?}"),
+        };
+        self.curr_stmt_info().per_parent_limit =
+            Some(usize::try_from(n).expect("include limit must be non-negative"));
     }
 
     fn schema(&self) -> &'b Schema {

--- a/crates/toasty/src/engine/lower/include.rs
+++ b/crates/toasty/src/engine/lower/include.rs
@@ -51,6 +51,7 @@ struct FlatInclude {
 struct IncludeQuery {
     filter: Option<stmt::Expr>,
     order_by: Option<stmt::OrderBy>,
+    limit: Option<stmt::Limit>,
 }
 
 /// The include entries that target a single field, partitioned by whether
@@ -345,6 +346,7 @@ impl LowerStatement<'_, '_> {
             // JOIN chain yet; reject rather than silently drop them.
             if top_query.filter.is_some()
                 || top_query.order_by.is_some()
+                || top_query.limit.is_some()
                 || nested.iter().any(|fi| query_has_modifiers(&fi.query))
             {
                 todo!(
@@ -410,6 +412,7 @@ impl LowerStatement<'_, '_> {
             stmt.add_filter(filter);
         }
         stmt.order_by = top_query.order_by;
+        stmt.limit = top_query.limit;
 
         // Attach each non-empty remainder as a nested include on the
         // subquery, carrying any deeper-level filter forward. Empty remainders
@@ -449,6 +452,7 @@ fn partition_includes(includes: &[FlatInclude], i: usize) -> FieldIncludes {
     let mut unfiltered_self = false;
     let mut top_filter: Option<stmt::Expr> = None;
     let mut top_order_by = None;
+    let mut top_limit = None;
     let mut sub_paths = Vec::new();
     for fi in includes {
         if let Some((first, rest)) = fi.projection.as_slice().split_first()
@@ -457,6 +461,7 @@ fn partition_includes(includes: &[FlatInclude], i: usize) -> FieldIncludes {
             if rest.is_empty() {
                 include_self = true;
                 top_order_by = fi.query.as_ref().and_then(|query| query.order_by.clone());
+                top_limit = fi.query.as_ref().and_then(|query| query.limit.clone());
                 match query_filter_expr(&fi.query) {
                     Some(f) if !unfiltered_self => {
                         top_filter = Some(match top_filter.take() {
@@ -483,6 +488,7 @@ fn partition_includes(includes: &[FlatInclude], i: usize) -> FieldIncludes {
         top_query: IncludeQuery {
             filter: top_filter,
             order_by: top_order_by,
+            limit: top_limit,
         },
         sub_paths,
     }
@@ -504,7 +510,9 @@ fn query_filter_expr(query: &Option<stmt::Query>) -> Option<stmt::Expr> {
 
 fn query_has_modifiers(query: &Option<stmt::Query>) -> bool {
     query.as_ref().is_some_and(|query| {
-        query_filter_expr(&Some(query.clone())).is_some() || query.order_by.is_some()
+        query_filter_expr(&Some(query.clone())).is_some()
+            || query.order_by.is_some()
+            || query.limit.is_some()
     })
 }
 

--- a/crates/toasty/src/engine/lower/include.rs
+++ b/crates/toasty/src/engine/lower/include.rs
@@ -51,6 +51,7 @@ struct FlatInclude {
 struct IncludeQuery {
     filter: Option<stmt::Expr>,
     order_by: Option<stmt::OrderBy>,
+    limit: Option<stmt::Limit>,
 }
 
 /// The include entries that target a single field, partitioned by whether
@@ -351,6 +352,7 @@ impl LowerStatement<'_, '_> {
             // JOIN chain yet; reject rather than silently drop them.
             if top_query.filter.is_some()
                 || top_query.order_by.is_some()
+                || top_query.limit.is_some()
                 || nested.iter().any(|fi| query_has_modifiers(&fi.query))
             {
                 todo!(
@@ -416,6 +418,7 @@ impl LowerStatement<'_, '_> {
             stmt.add_filter(filter);
         }
         stmt.order_by = top_query.order_by;
+        stmt.limit = top_query.limit;
 
         // Attach each non-empty remainder as a nested include on the
         // subquery, carrying any deeper-level filter forward. Empty remainders
@@ -455,6 +458,7 @@ fn partition_includes(includes: &[FlatInclude], i: usize) -> FieldIncludes {
     let mut unfiltered_self = false;
     let mut top_filter: Option<stmt::Expr> = None;
     let mut top_order_by = None;
+    let mut top_limit = None;
     let mut sub_paths = Vec::new();
     for fi in includes {
         if let Some((first, rest)) = fi.projection.as_slice().split_first()
@@ -463,6 +467,7 @@ fn partition_includes(includes: &[FlatInclude], i: usize) -> FieldIncludes {
             if rest.is_empty() {
                 include_self = true;
                 top_order_by = fi.query.as_ref().and_then(|query| query.order_by.clone());
+                top_limit = fi.query.as_ref().and_then(|query| query.limit.clone());
                 match query_filter_expr(&fi.query) {
                     Some(f) if !unfiltered_self => {
                         top_filter = Some(match top_filter.take() {
@@ -489,6 +494,7 @@ fn partition_includes(includes: &[FlatInclude], i: usize) -> FieldIncludes {
         top_query: IncludeQuery {
             filter: top_filter,
             order_by: top_order_by,
+            limit: top_limit,
         },
         sub_paths,
     }
@@ -510,7 +516,9 @@ fn query_filter_expr(query: &Option<stmt::Query>) -> Option<stmt::Expr> {
 
 fn query_has_modifiers(query: &Option<stmt::Query>) -> bool {
     query.as_ref().is_some_and(|query| {
-        query_filter_expr(&Some(query.clone())).is_some() || query.order_by.is_some()
+        query_filter_expr(&Some(query.clone())).is_some()
+            || query.order_by.is_some()
+            || query.limit.is_some()
     })
 }
 

--- a/crates/toasty/src/engine/plan/nested_merge.rs
+++ b/crates/toasty/src/engine/plan/nested_merge.rs
@@ -126,6 +126,18 @@ impl NestedMergePlanner<'_> {
 
         let ret = match stmt_state.stmt.as_deref().unwrap() {
             stmt::Statement::Query(query) => {
+                // Per-parent limit from `.include(...).limit(n)`. The HIR
+                // statement keeps the limit; only the batch-load clone has it
+                // stripped (see `rewrite_stmt_for_batch_load`).
+                let limit = query.limit.as_ref().map(|limit| {
+                    let stmt::Limit::Offset(lo) = limit else {
+                        todo!("cursor-based limits are not supported in includes")
+                    };
+                    assert!(lo.offset.is_none(), "include limits do not support offset");
+                    usize::try_from(super::statement::as_i64_literal(&lo.limit))
+                        .expect("include limit must be non-negative")
+                });
+
                 let filter_expr = self.build_filter_for_nested_child(stmt_id, selection, depth);
 
                 let filter_arg_tys = self.build_filter_arg_tys();
@@ -161,12 +173,14 @@ impl NestedMergePlanner<'_> {
                     level,
                     qualification,
                     single: query.single,
+                    limit,
                 }
             }
             stmt::Statement::Insert(insert) => NestedChild {
                 level,
                 qualification: MergeQualification::All,
                 single: insert.source.single,
+                limit: None,
             },
             stmt => todo!("stmt={stmt:#?}"),
         };

--- a/crates/toasty/src/engine/plan/nested_merge.rs
+++ b/crates/toasty/src/engine/plan/nested_merge.rs
@@ -121,6 +121,22 @@ impl NestedMergePlanner<'_> {
 
         let ret = match stmt_state.stmt.as_deref().unwrap() {
             stmt::Statement::Query(query) => {
+                // Per-parent limit from `.include(...).limit(n)`. The HIR
+                // statement keeps the limit; only the batch-load clone has it
+                // stripped (see `rewrite_stmt_for_batch_load`).
+                // Cursor limits are pagination applied by the batched query
+                // itself, so they are not truncated per parent here.
+                let limit = match query.limit.as_ref() {
+                    Some(stmt::Limit::Offset(lo)) => {
+                        assert!(lo.offset.is_none(), "include limits do not support offset");
+                        Some(
+                            usize::try_from(super::statement::as_i64_literal(&lo.limit))
+                                .expect("include limit must be non-negative"),
+                        )
+                    }
+                    _ => None,
+                };
+
                 let filter_expr = self.build_filter_for_nested_child(stmt_id, selection, depth);
 
                 let filter_arg_tys = self.build_filter_arg_tys();
@@ -156,12 +172,14 @@ impl NestedMergePlanner<'_> {
                     level,
                     qualification,
                     single: query.single,
+                    limit,
                 }
             }
             stmt::Statement::Insert(insert) => NestedChild {
                 level,
                 qualification: MergeQualification::All,
                 single: insert.source.single,
+                limit: None,
             },
             stmt => todo!("stmt={stmt:#?}"),
         };

--- a/crates/toasty/src/engine/plan/nested_merge.rs
+++ b/crates/toasty/src/engine/plan/nested_merge.rs
@@ -121,22 +121,6 @@ impl NestedMergePlanner<'_> {
 
         let ret = match stmt_state.stmt.as_deref().unwrap() {
             stmt::Statement::Query(query) => {
-                // Per-parent limit from `.include(...).limit(n)`. The HIR
-                // statement keeps the limit; only the batch-load clone has it
-                // stripped (see `rewrite_stmt_for_batch_load`).
-                // Cursor limits are pagination applied by the batched query
-                // itself, so they are not truncated per parent here.
-                let limit = match query.limit.as_ref() {
-                    Some(stmt::Limit::Offset(lo)) => {
-                        assert!(lo.offset.is_none(), "include limits do not support offset");
-                        Some(
-                            usize::try_from(super::statement::as_i64_literal(&lo.limit))
-                                .expect("include limit must be non-negative"),
-                        )
-                    }
-                    _ => None,
-                };
-
                 let filter_expr = self.build_filter_for_nested_child(stmt_id, selection, depth);
 
                 let filter_arg_tys = self.build_filter_arg_tys();
@@ -172,7 +156,7 @@ impl NestedMergePlanner<'_> {
                     level,
                     qualification,
                     single: query.single,
-                    limit,
+                    limit: stmt_state.per_parent_limit,
                 }
             }
             stmt::Statement::Insert(insert) => NestedChild {

--- a/crates/toasty/src/engine/plan/statement.rs
+++ b/crates/toasty/src/engine/plan/statement.rs
@@ -587,6 +587,13 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
     }
 
     fn rewrite_stmt_for_batch_load(&mut self, stmt: &mut stmt::Statement) {
+        // An include limit is per-parent, but a LIMIT on the batched query
+        // would apply globally. Strip it; NestedMerge truncates per parent
+        // instead (`plan_nested_child` reads it from the HIR statement).
+        if let stmt::Statement::Query(query) = stmt {
+            query.limit = None;
+        }
+
         if self.planner.engine.capability().sql {
             self.rewrite_stmt_query_for_batch_load_sql(stmt);
         } else {
@@ -2107,7 +2114,7 @@ fn extract_pagination(stmt: &stmt::Statement) -> Option<Pagination> {
 
 /// Extracts an `i64` from a bound or static `I64` literal expression. Panics on
 /// any other shape — an invariant violation that `verify` should have caught.
-fn as_i64_literal(expr: &stmt::Expr) -> i64 {
+pub(super) fn as_i64_literal(expr: &stmt::Expr) -> i64 {
     match expr {
         stmt::Expr::Value(stmt::Value::I64(n)) | stmt::Expr::Static(stmt::Value::I64(n)) => *n,
         _ => panic!("limit/offset must be an i64 literal; got {expr:#?}"),

--- a/crates/toasty/src/engine/plan/statement.rs
+++ b/crates/toasty/src/engine/plan/statement.rs
@@ -655,17 +655,6 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
     }
 
     fn rewrite_stmt_for_batch_load(&mut self, stmt: &mut stmt::Statement) {
-        // An include limit is per-parent, but a LIMIT on the batched query
-        // would apply globally. Strip it; NestedMerge truncates per parent
-        // instead (`plan_nested_child` reads it from the HIR statement).
-        // Cursor limits are pagination on the nested statement itself and stay
-        // on the batched query.
-        if let stmt::Statement::Query(query) = stmt
-            && matches!(query.limit, Some(stmt::Limit::Offset(_)))
-        {
-            query.limit = None;
-        }
-
         if self.planner.engine.capability().sql() {
             self.rewrite_stmt_query_for_batch_load_sql(stmt);
         } else {
@@ -2331,7 +2320,7 @@ fn extract_pagination(stmt: &stmt::Statement) -> Option<Pagination> {
 
 /// Extracts an `i64` from a bound or static `I64` literal expression. Panics on
 /// any other shape — an invariant violation that `verify` should have caught.
-pub(super) fn as_i64_literal(expr: &stmt::Expr) -> i64 {
+fn as_i64_literal(expr: &stmt::Expr) -> i64 {
     match expr {
         stmt::Expr::Value(stmt::Value::I64(n)) | stmt::Expr::Static(stmt::Value::I64(n)) => *n,
         _ => panic!("limit/offset must be an i64 literal; got {expr:#?}"),

--- a/crates/toasty/src/engine/plan/statement.rs
+++ b/crates/toasty/src/engine/plan/statement.rs
@@ -655,6 +655,17 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
     }
 
     fn rewrite_stmt_for_batch_load(&mut self, stmt: &mut stmt::Statement) {
+        // An include limit is per-parent, but a LIMIT on the batched query
+        // would apply globally. Strip it; NestedMerge truncates per parent
+        // instead (`plan_nested_child` reads it from the HIR statement).
+        // Cursor limits are pagination on the nested statement itself and stay
+        // on the batched query.
+        if let stmt::Statement::Query(query) = stmt
+            && matches!(query.limit, Some(stmt::Limit::Offset(_)))
+        {
+            query.limit = None;
+        }
+
         if self.planner.engine.capability().sql() {
             self.rewrite_stmt_query_for_batch_load_sql(stmt);
         } else {
@@ -2320,7 +2331,7 @@ fn extract_pagination(stmt: &stmt::Statement) -> Option<Pagination> {
 
 /// Extracts an `i64` from a bound or static `I64` literal expression. Panics on
 /// any other shape — an invariant violation that `verify` should have caught.
-fn as_i64_literal(expr: &stmt::Expr) -> i64 {
+pub(super) fn as_i64_literal(expr: &stmt::Expr) -> i64 {
     match expr {
         stmt::Expr::Value(stmt::Value::I64(n)) | stmt::Expr::Static(stmt::Value::I64(n)) => *n,
         _ => panic!("limit/offset must be an i64 literal; got {expr:#?}"),

--- a/crates/toasty/src/engine/verify.rs
+++ b/crates/toasty/src/engine/verify.rs
@@ -310,8 +310,9 @@ impl Verify<'_, '_> {
         }
     }
 
-    /// Reject include ordering on singular relations and preserve the existing
-    /// rule that filters are rejected only on required singular relations.
+    /// Reject include ordering and limits on singular relations and preserve
+    /// the existing rule that filters are rejected only on required singular
+    /// relations.
     /// Variant-rooted paths are not resolvable here and pass through unchecked.
     fn verify_include_modifiers(&mut self, i: &stmt::Select) {
         for include in i.returning.model_includes() {
@@ -323,7 +324,8 @@ impl Verify<'_, '_> {
                 _ => false,
             };
             let has_order_by = query.order_by.is_some();
-            if !has_filter && !has_order_by {
+            let has_limit = query.limit.is_some();
+            if !has_filter && !has_order_by && !has_limit {
                 continue;
             }
             let Some(model_id) = include.path.root.as_model() else {
@@ -347,6 +349,14 @@ impl Verify<'_, '_> {
                 self.record(Error::invalid_statement(format!(
                     "cannot order the include of singular relation `{}`; \
                      include ordering requires a many-valued relation",
+                    field.name,
+                )));
+                continue;
+            }
+            if has_limit && singular {
+                self.record(Error::invalid_statement(format!(
+                    "cannot limit the include of singular relation `{}`; \
+                     include limits require a many-valued relation",
                     field.name,
                 )));
                 continue;

--- a/crates/toasty/src/engine/verify.rs
+++ b/crates/toasty/src/engine/verify.rs
@@ -314,8 +314,9 @@ impl Verify<'_, '_> {
         }
     }
 
-    /// Reject include ordering on singular relations and preserve the existing
-    /// rule that filters are rejected only on required singular relations.
+    /// Reject include ordering and limits on singular relations and preserve
+    /// the existing rule that filters are rejected only on required singular
+    /// relations.
     /// Variant-rooted paths are not resolvable here and pass through unchecked.
     fn verify_include_modifiers(&mut self, i: &stmt::Select) {
         for include in i.returning.model_includes() {
@@ -327,7 +328,8 @@ impl Verify<'_, '_> {
                 _ => false,
             };
             let has_order_by = query.order_by.is_some();
-            if !has_filter && !has_order_by {
+            let has_limit = query.limit.is_some();
+            if !has_filter && !has_order_by && !has_limit {
                 continue;
             }
             let Some(model_id) = include.path.root.as_model() else {
@@ -351,6 +353,14 @@ impl Verify<'_, '_> {
                 self.record(Error::invalid_statement(format!(
                     "cannot order the include of singular relation `{}`; \
                      include ordering requires a many-valued relation",
+                    field.name,
+                )));
+                continue;
+            }
+            if has_limit && singular {
+                self.record(Error::invalid_statement(format!(
+                    "cannot limit the include of singular relation `{}`; \
+                     include limits require a many-valued relation",
                     field.name,
                 )));
                 continue;

--- a/crates/toasty/src/stmt/include.rs
+++ b/crates/toasty/src/stmt/include.rs
@@ -41,6 +41,18 @@ impl<Origin, T> Include<Origin, T> {
         self
     }
 
+    /// Limits the number of related rows loaded by this include, per parent
+    /// record. Combine with [`order_by`](Include::order_by) to select which
+    /// rows are kept.
+    pub fn limit(mut self, n: usize) -> Self {
+        let n = i64::try_from(n).expect("limit exceeds i64::MAX");
+        self.query_mut().limit = Some(stmt::Limit::Offset(stmt::LimitOffset {
+            limit: stmt::Value::from(n).into(),
+            offset: None,
+        }));
+        self
+    }
+
     fn query_mut(&mut self) -> &mut stmt::Query {
         self.untyped
             .query

--- a/tests/tests/ui-pass/raw_identifier_reserved_methods.rs
+++ b/tests/tests/ui-pass/raw_identifier_reserved_methods.rs
@@ -19,6 +19,7 @@ struct Comment {
 
     r#filter: i64,
     r#order_by: i64,
+    r#limit: i64,
 
     #[index]
     item_id: i64,
@@ -33,5 +34,6 @@ fn main() {
     let _ = Item::fields()
         .comments()
         .filter(Comment::fields().id().eq(1))
-        .order_by(Comment::fields().id().asc());
+        .order_by(Comment::fields().id().asc())
+        .limit(1);
 }


### PR DESCRIPTION
## Summary
This pr add support for `limit` in includes. The last bare `include` call's `limit` is used just like how `order_by` works.

We can't just emit `limit` calls in the batched child queries. Then we'd be limiting the whole query result instead of per parent. So currently we're over fetching and the engine applies the limit. In the future we should rewrite the query to use `ROW_NUMBER()` when supported (all drivers except ddb). I'm leaving that optimization for a follow-up pr.

## Type of change
- [x] Small / obvious change — bug fix, docs, internal cleanup, or test
- [ ] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`):
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers
N/A