### PR TITLE
fix: paginate with multiple order by keys

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -64,6 +64,7 @@ pub mod infra_reset_db;
 pub mod infra_sync_send;
 pub mod key_unsigned;
 pub mod lift_belongs_to_complex_filter;
+pub mod paginate_multi_column;
 pub mod query_count;
 pub mod query_in_list;
 pub mod raw_identifier_fields;

--- a/crates/toasty-driver-integration-suite/src/tests/paginate_multi_column.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/paginate_multi_column.rs
@@ -1,0 +1,76 @@
+//! Test keyset pagination over a multi-column `order_by`.
+//!
+//! The cursor must be compared lexicographically: a row that ties the cursor
+//! on a leading sort column but is beyond it on a later column belongs on the
+//! next page. These are gated on `sql` because SQL drivers rewrite the cursor
+//! into a WHERE filter; NoSQL drivers use a driver-level cursor instead.
+
+use crate::prelude::*;
+use toasty::stmt::Page;
+
+#[driver_test(requires(sql))]
+pub async fn paginate_multi_column_equal_leading_values(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        id: i64,
+        group: i64,
+    }
+
+    let mut db = test.setup_db(models!(Item)).await;
+
+    // All rows share the same leading sort value.
+    toasty::create!(Item::[
+        { id: 1, group: 1 },
+        { id: 2, group: 1 },
+        { id: 3, group: 1 },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let page: Page<Item> = Item::all()
+        .order_by((Item::fields().group().asc(), Item::fields().id().asc()))
+        .paginate(2)
+        .exec(&mut db)
+        .await?;
+    assert_struct!(page.items, [_ { id: 1, .. }, _ { id: 2, .. }]);
+
+    let page: Page<Item> = page.next(&mut db).await?.unwrap();
+    assert_struct!(page.items, [_ { id: 3, .. }]);
+
+    Ok(())
+}
+
+#[driver_test(requires(sql))]
+pub async fn paginate_multi_column_mixed_directions(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        id: i64,
+        group: i64,
+    }
+
+    let mut db = test.setup_db(models!(Item)).await;
+
+    toasty::create!(Item::[
+        { id: 1, group: 1 },
+        { id: 2, group: 1 },
+        { id: 3, group: 2 },
+        { id: 4, group: 2 },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    // group desc, id asc: 3, 4, 1, 2
+    let page: Page<Item> = Item::all()
+        .order_by((Item::fields().group().desc(), Item::fields().id().asc()))
+        .paginate(2)
+        .exec(&mut db)
+        .await?;
+    assert_struct!(page.items, [_ { id: 3, .. }, _ { id: 4, .. }]);
+
+    let page: Page<Item> = page.next(&mut db).await?.unwrap();
+    assert_struct!(page.items, [_ { id: 1, .. }, _ { id: 2, .. }]);
+
+    Ok(())
+}

--- a/crates/toasty/src/engine/lower/paginate.rs
+++ b/crates/toasty/src/engine/lower/paginate.rs
@@ -27,18 +27,37 @@ impl LowerStatement<'_, '_> {
 
         match after {
             stmt::Expr::Value(stmt::Value::Record(value)) => {
-                for (index, value) in value.fields.into_iter().enumerate() {
-                    let expr = self.rewrite_offset_after_field_as_filter(
-                        &order_by.exprs[index],
-                        value,
-                        true,
-                    );
-                    body.filter.add_filter(expr);
-                }
+                // Rows strictly beyond the cursor in lexicographic order:
+                // `e0 > v0 OR (e0 = v0 AND e1 > v1) OR ...`, flipping each
+                // comparison for descending columns. A plain conjunction of
+                // per-column comparisons would skip rows that tie the cursor
+                // on a leading column.
+                let terms = value
+                    .fields
+                    .iter()
+                    .enumerate()
+                    .map(|(index, field_value)| {
+                        let mut operands: Vec<_> = order_by.exprs[..index]
+                            .iter()
+                            .zip(value.fields.iter())
+                            .map(|(order_by, eq_value)| {
+                                stmt::Expr::eq(order_by.expr.clone(), eq_value.clone())
+                            })
+                            .collect();
+
+                        operands.push(self.rewrite_offset_after_field_as_filter(
+                            &order_by.exprs[index],
+                            field_value.clone(),
+                        ));
+
+                        stmt::Expr::and_from_vec(operands)
+                    })
+                    .collect();
+
+                body.filter.add_filter(stmt::Expr::or_from_vec(terms));
             }
             stmt::Expr::Value(value) => {
-                let expr =
-                    self.rewrite_offset_after_field_as_filter(&order_by.exprs[0], value, true);
+                let expr = self.rewrite_offset_after_field_as_filter(&order_by.exprs[0], value);
                 body.filter.add_filter(expr);
             }
             _ => todo!(),
@@ -49,13 +68,10 @@ impl LowerStatement<'_, '_> {
         &self,
         order_by: &stmt::OrderByExpr,
         value: stmt::Value,
-        last: bool,
     ) -> stmt::Expr {
-        let op = match (order_by.order, last) {
-            (Some(stmt::Direction::Desc), true) => stmt::BinaryOp::Lt,
-            (Some(stmt::Direction::Desc), false) => stmt::BinaryOp::Le,
-            (_, true) => stmt::BinaryOp::Gt,
-            (_, false) => stmt::BinaryOp::Ge,
+        let op = match order_by.order {
+            Some(stmt::Direction::Desc) => stmt::BinaryOp::Lt,
+            _ => stmt::BinaryOp::Gt,
         };
 
         stmt::Expr::binary_op(order_by.expr.clone(), op, value)


### PR DESCRIPTION
## Summary
Closes #1121

Keyset pagination over a multi-column `order_by` returned an empty next page when rows tied the cursor on a leading sort column. The SQL cursor rewrite (`rewrite_offset_after_as_filter`) translated a cursor `(group: 1, id: 2)` into a conjunction of strict per-column comparisons — `group > 1 AND id > 2` — which excludes rows such as `(group: 1, id: 3)` that tie on `group`.

The rewrite now emits the lexicographic expansion:
```sql
group > 1 OR (group = 1 AND id > 2)
```

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test
- [ ] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`):
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers
N/A