### PR TITLE
chore: release v0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,21 +74,21 @@ unsafe_code = "deny"
 
 [workspace.dependencies]
 # Toasty crates
-toasty = { version = "0.9.0", path = "crates/toasty" }
-toasty-cli = { version = "0.9.0", path = "crates/toasty-cli" }
-toasty-core = { version = "0.9.0", path = "crates/toasty-core" }
-toasty-macros = { version = "0.9.0", path = "crates/toasty-macros" }
-toasty-sql = { version = "0.9.0", path = "crates/toasty-sql" }
+toasty = { version = "0.10.0", path = "crates/toasty" }
+toasty-cli = { version = "0.10.0", path = "crates/toasty-cli" }
+toasty-core = { version = "0.10.0", path = "crates/toasty-core" }
+toasty-macros = { version = "0.10.0", path = "crates/toasty-macros" }
+toasty-sql = { version = "0.10.0", path = "crates/toasty-sql" }
 # Driver implementations
-toasty-driver-dynamodb = { version = "0.9.0", path = "crates/toasty-driver-dynamodb" }
-toasty-driver-mysql = { version = "0.9.0", path = "crates/toasty-driver-mysql", default-features = false }
-toasty-driver-postgresql = { version = "0.9.0", path = "crates/toasty-driver-postgresql" }
-toasty-driver-sqlite = { version = "0.9.0", path = "crates/toasty-driver-sqlite" }
-toasty-driver-turso = { version = "0.9.0", path = "crates/toasty-driver-turso" }
+toasty-driver-dynamodb = { version = "0.10.0", path = "crates/toasty-driver-dynamodb" }
+toasty-driver-mysql = { version = "0.10.0", path = "crates/toasty-driver-mysql", default-features = false }
+toasty-driver-postgresql = { version = "0.10.0", path = "crates/toasty-driver-postgresql" }
+toasty-driver-sqlite = { version = "0.10.0", path = "crates/toasty-driver-sqlite" }
+toasty-driver-turso = { version = "0.10.0", path = "crates/toasty-driver-turso" }
 
 # Driver integration test suite dependencies
-toasty-driver-integration-suite = { version = "0.9.0", path = "crates/toasty-driver-integration-suite" }
-toasty-driver-integration-suite-macros = { version = "0.9.0", path = "crates/toasty-driver-integration-suite-macros" }
+toasty-driver-integration-suite = { version = "0.10.0", path = "crates/toasty-driver-integration-suite" }
+toasty-driver-integration-suite-macros = { version = "0.10.0", path = "crates/toasty-driver-integration-suite-macros" }
 
 # Other crates
 assert-struct = "0.4.2"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <div align="center">
   <h3>The cozy, easy ORM for Rust</h3>
-  <a href="https://tokio-rs.github.io/toasty/0.9.0/guide/">Guide</a> •
+  <a href="https://tokio-rs.github.io/toasty/0.10.0/guide/">Guide</a> •
   <a href="https://docs.rs/toasty">API Docs</a> •
   <a href="https://crates.io/crates/toasty">Crates.io</a> •
   <a href="https://discord.gg/tokio">Discord</a>

--- a/crates/toasty-cli/CHANGELOG.md
+++ b/crates/toasty-cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/tokio-rs/toasty/compare/toasty-cli-v0.9.0...toasty-cli-v0.10.0) - 2026-08-11
+
+- Internal improvements only.
+
 ## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-cli-v0.8.0...toasty-cli-v0.9.0) - 2026-07-23
 
 ### Fixed

--- a/crates/toasty-cli/Cargo.toml
+++ b/crates/toasty-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-cli"
-version = "0.9.0"
+version = "0.10.0"
 description = "Command-line interface for Toasty schema management"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-core/CHANGELOG.md
+++ b/crates/toasty-core/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/tokio-rs/toasty/compare/toasty-core-v0.9.0...toasty-core-v0.10.0) - 2026-08-11
+
+### Added
+
+- Re-export external statement value types ([#1181])
+- Network address types ([#1178])
+- Support for `#[belongs_to]` fields in embedded types ([#1170])
+- Embed migrations in application binaries ([#1095])
+
+### Fixed
+
+- *(mysql)* [**breaking**] Make TLS features additive with SQLx ([#1147])
+- *(engine)* Cursor pagination is now deterministic ([#1142])
+
+### Changed
+
+- *(core)* [**breaking**] `Capability::sql` now names the SQL dialect ([#1155])
+- [**breaking**] Remove unused schema and statement APIs ([#1149])
+
+[#1095]: https://github.com/tokio-rs/toasty/pull/1095
+[#1142]: https://github.com/tokio-rs/toasty/pull/1142
+[#1147]: https://github.com/tokio-rs/toasty/pull/1147
+[#1149]: https://github.com/tokio-rs/toasty/pull/1149
+[#1155]: https://github.com/tokio-rs/toasty/pull/1155
+[#1170]: https://github.com/tokio-rs/toasty/pull/1170
+[#1178]: https://github.com/tokio-rs/toasty/pull/1178
+[#1181]: https://github.com/tokio-rs/toasty/pull/1181
+
 ## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-core-v0.8.0...toasty-core-v0.9.0) - 2026-07-23
 
 ### Added

--- a/crates/toasty-core/Cargo.toml
+++ b/crates/toasty-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-core"
-version = "0.9.0"
+version = "0.10.0"
 description = "Core types, schema representations, and driver interface for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-dynamodb/CHANGELOG.md
+++ b/crates/toasty-driver-dynamodb/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-dynamodb-v0.9.0...toasty-driver-dynamodb-v0.10.0) - 2026-08-11
+
+### Added
+
+- Add network address types ([#1178])
+
+### Fixed
+
+- Resolve authority-form SQLite and Turso URLs to a file path ([#1127])
+
+[#1127]: https://github.com/tokio-rs/toasty/pull/1127
+[#1178]: https://github.com/tokio-rs/toasty/pull/1178
+
 ## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-dynamodb-v0.8.0...toasty-driver-dynamodb-v0.9.0) - 2026-07-23
 
 ### Added

--- a/crates/toasty-driver-dynamodb/Cargo.toml
+++ b/crates/toasty-driver-dynamodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-dynamodb"
-version = "0.9.0"
+version = "0.10.0"
 description = "Amazon DynamoDB driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-integration-suite-macros/CHANGELOG.md
+++ b/crates/toasty-driver-integration-suite-macros/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-macros-v0.9.0...toasty-driver-integration-suite-macros-v0.10.0) - 2026-08-11
+
+### Changed
+
+- [**breaking**] `Capability::sql` now names the SQL dialect ([#1155])
+
+[#1155]: https://github.com/tokio-rs/toasty/pull/1155
+
 ## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-macros-v0.8.0...toasty-driver-integration-suite-macros-v0.9.0) - 2026-07-23
 
 - Internal improvements only.

--- a/crates/toasty-driver-integration-suite-macros/Cargo.toml
+++ b/crates/toasty-driver-integration-suite-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-integration-suite-macros"
-version = "0.9.0"
+version = "0.10.0"
 description = "Proc macros for the Toasty driver integration test suite"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-integration-suite/CHANGELOG.md
+++ b/crates/toasty-driver-integration-suite/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-v0.9.0...toasty-driver-integration-suite-v0.10.0) - 2026-08-11
+
+### Added
+
+- *(macros)* generate asc/desc on newtype embed fields ([#1180](https://github.com/tokio-rs/toasty/pull/1180))
+- add network address types ([#1178](https://github.com/tokio-rs/toasty/pull/1178))
+- *(macros)* generate ordering comparisons on newtype embed fields ([#1177](https://github.com/tokio-rs/toasty/pull/1177))
+- accept #[belongs_to] fields in embedded types ([#1170](https://github.com/tokio-rs/toasty/pull/1170))
+
+### Fixed
+
+- *(engine)* omit previous cursor on first page ([#1153](https://github.com/tokio-rs/toasty/pull/1153))
+- *(engine)* run post-lower simplify on detached IN-subquery statements ([#1138](https://github.com/tokio-rs/toasty/pull/1138))
+- *(engine)* preserve pagination cursors through includes ([#1152](https://github.com/tokio-rs/toasty/pull/1152))
+- preserve query offset when selecting one row ([#1151](https://github.com/tokio-rs/toasty/pull/1151))
+- *(engine)* exclude null foreign keys from relation subqueries ([#1148](https://github.com/tokio-rs/toasty/pull/1148))
+- *(engine)* make cursor pagination deterministic ([#1142](https://github.com/tokio-rs/toasty/pull/1142))
+- *(engine)* lower newtype foreign keys in via includes ([#1137](https://github.com/tokio-rs/toasty/pull/1137))
+- paginate with multiple order by keys ([#1124](https://github.com/tokio-rs/toasty/pull/1124))
+
+### Other
+
+- *(tests)* gate unreferenced-CTE pagination test off MySQL ([#1158](https://github.com/tokio-rs/toasty/pull/1158))
+- *(core)* [**breaking**] name the SQL dialect on `Capability::sql` ([#1155](https://github.com/tokio-rs/toasty/pull/1155))
+- *(tests)* remove redundant driver test executions ([#1144](https://github.com/tokio-rs/toasty/pull/1144))
 ## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-integration-suite-v0.8.0...toasty-driver-integration-suite-v0.9.0) - 2026-07-23
 
 ### Added

--- a/crates/toasty-driver-integration-suite/Cargo.toml
+++ b/crates/toasty-driver-integration-suite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-integration-suite"
-version = "0.9.0"
+version = "0.10.0"
 description = "Integration test suite for Toasty database drivers"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-mysql/CHANGELOG.md
+++ b/crates/toasty-driver-mysql/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-mysql-v0.9.0...toasty-driver-mysql-v0.10.0) - 2026-08-11
+
+### Added
+
+- add network address types ([#1178])
+
+### Fixed
+
+- *(mysql)* [**breaking**] make TLS features additive with SQLx ([#1147])
+
+[#1147]: https://github.com/tokio-rs/toasty/pull/1147
+[#1178]: https://github.com/tokio-rs/toasty/pull/1178
+
 ## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-mysql-v0.8.0...toasty-driver-mysql-v0.9.0) - 2026-07-23
 
 ### Added

--- a/crates/toasty-driver-mysql/Cargo.toml
+++ b/crates/toasty-driver-mysql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-mysql"
-version = "0.9.0"
+version = "0.10.0"
 description = "MySQL driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-postgresql/CHANGELOG.md
+++ b/crates/toasty-driver-postgresql/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-postgresql-v0.9.0...toasty-driver-postgresql-v0.10.0) - 2026-08-11
+
+### Added
+
+- Network address types ([#1178])
+- PostgreSQL driver now supports the options connection URL parameter ([#1156])
+
+[#1156]: https://github.com/tokio-rs/toasty/pull/1156
+[#1178]: https://github.com/tokio-rs/toasty/pull/1178
+
 ## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-postgresql-v0.8.0...toasty-driver-postgresql-v0.9.0) - 2026-07-23
 
 ### Added

--- a/crates/toasty-driver-postgresql/Cargo.toml
+++ b/crates/toasty-driver-postgresql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-postgresql"
-version = "0.9.0"
+version = "0.10.0"
 description = "PostgreSQL driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-sqlite/CHANGELOG.md
+++ b/crates/toasty-driver-sqlite/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-sqlite-v0.9.0...toasty-driver-sqlite-v0.10.0) - 2026-08-11
+
+### Added
+
+- Network address types ([#1178])
+
+### Fixed
+
+- Resolve authority-form sqlite and turso URLs to a file path ([#1127])
+
+[#1127]: https://github.com/tokio-rs/toasty/pull/1127
+[#1178]: https://github.com/tokio-rs/toasty/pull/1178
+
 ## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-sqlite-v0.8.0...toasty-driver-sqlite-v0.9.0) - 2026-07-23
 
 ### Added

--- a/crates/toasty-driver-sqlite/Cargo.toml
+++ b/crates/toasty-driver-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-sqlite"
-version = "0.9.0"
+version = "0.10.0"
 description = "SQLite driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-driver-turso/CHANGELOG.md
+++ b/crates/toasty-driver-turso/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-turso-v0.9.0...toasty-driver-turso-v0.10.0) - 2026-08-11
+
+### Added
+
+- Add network address types ([#1178])
+
+### Fixed
+
+- Fix resolution of authority-form SQLite and Turso URLs to file paths ([#1127])
+
+### Changed
+
+- [**breaking**] SQL dialect is now named on `Capability::sql` ([#1155])
+
+[#1127]: https://github.com/tokio-rs/toasty/pull/1127
+[#1155]: https://github.com/tokio-rs/toasty/pull/1155
+[#1178]: https://github.com/tokio-rs/toasty/pull/1178
+
 ## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-driver-turso-v0.8.0...toasty-driver-turso-v0.9.0) - 2026-07-23
 
 ### Added

--- a/crates/toasty-driver-turso/Cargo.toml
+++ b/crates/toasty-driver-turso/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-driver-turso"
-version = "0.9.0"
+version = "0.10.0"
 description = "Turso (SQLite-compatible) driver for Toasty"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-macros/CHANGELOG.md
+++ b/crates/toasty-macros/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/tokio-rs/toasty/compare/toasty-macros-v0.9.0...toasty-macros-v0.10.0) - 2026-08-11
+
+### Added
+
+- Re-export external statement value types ([#1181])
+- Asc/desc ordering on newtype embedded fields ([#1180])
+- Add network address types ([#1178])
+- Ordering comparisons on newtype embedded fields ([#1177])
+- Support #[belongs_to] fields in embedded types ([#1170])
+- Embed migrations in application binaries ([#1095])
+
+[#1095]: https://github.com/tokio-rs/toasty/pull/1095
+[#1170]: https://github.com/tokio-rs/toasty/pull/1170
+[#1177]: https://github.com/tokio-rs/toasty/pull/1177
+[#1178]: https://github.com/tokio-rs/toasty/pull/1178
+[#1180]: https://github.com/tokio-rs/toasty/pull/1180
+[#1181]: https://github.com/tokio-rs/toasty/pull/1181
+
 ## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-macros-v0.8.0...toasty-macros-v0.9.0) - 2026-07-23
 
 ### Added

--- a/crates/toasty-macros/Cargo.toml
+++ b/crates/toasty-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-macros"
-version = "0.9.0"
+version = "0.10.0"
 description = "Derive macros for Toasty models and embeds"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty-sql/CHANGELOG.md
+++ b/crates/toasty-sql/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/tokio-rs/toasty/compare/toasty-sql-v0.9.0...toasty-sql-v0.10.0) - 2026-08-11
+
+### Added
+
+- Network address types ([#1178])
+
+### Changed
+
+- [**breaking**] SQL dialect is now named on `Capability::sql` ([#1155])
+
+[#1155]: https://github.com/tokio-rs/toasty/pull/1155
+[#1178]: https://github.com/tokio-rs/toasty/pull/1178
+
 ## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-sql-v0.8.0...toasty-sql-v0.9.0) - 2026-07-23
 
 ### Added

--- a/crates/toasty-sql/Cargo.toml
+++ b/crates/toasty-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty-sql"
-version = "0.9.0"
+version = "0.10.0"
 description = "SQL serialization layer for Toasty database drivers"
 authors.workspace = true
 edition.workspace = true

--- a/crates/toasty/CHANGELOG.md
+++ b/crates/toasty/CHANGELOG.md
@@ -7,6 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/tokio-rs/toasty/compare/toasty-v0.9.0...toasty-v0.10.0) - 2026-08-11
+
+### Added
+
+- Re-export external statement value types ([#1181])
+- *(macros)* Generate asc/desc on newtype embed fields ([#1180])
+- Add network address types ([#1178])
+- Accept #[belongs_to] fields in embedded types ([#1170])
+- Embed migrations in application binaries ([#1095])
+
+### Fixed
+
+- Add wasm32 build support ([#1173])
+- *(mysql)* [**breaking**] Make TLS features additive with SQLx ([#1147])
+- *(engine)* Omit previous cursor on first page ([#1153])
+- *(engine)* Fix IN-subquery statement optimization ([#1138])
+- *(engine)* Preserve pagination cursors through includes ([#1152])
+- Preserve query offset when selecting one row ([#1151])
+- *(engine)* Exclude null foreign keys from relation subqueries ([#1148])
+- *(engine)* Make cursor pagination deterministic ([#1142])
+- Resolve authority-form sqlite and turso URLs to a file path ([#1127])
+- *(engine)* Fix newtype foreign keys in included relations ([#1137])
+- Support pagination with multiple order by keys ([#1124])
+
+### Changed
+
+- *(core)* [**breaking**] Name the SQL dialect on `Capability::sql` ([#1155])
+- [**breaking**] Remove unused schema and statement APIs ([#1149])
+
+[#1095]: https://github.com/tokio-rs/toasty/pull/1095
+[#1124]: https://github.com/tokio-rs/toasty/pull/1124
+[#1127]: https://github.com/tokio-rs/toasty/pull/1127
+[#1137]: https://github.com/tokio-rs/toasty/pull/1137
+[#1138]: https://github.com/tokio-rs/toasty/pull/1138
+[#1142]: https://github.com/tokio-rs/toasty/pull/1142
+[#1147]: https://github.com/tokio-rs/toasty/pull/1147
+[#1148]: https://github.com/tokio-rs/toasty/pull/1148
+[#1149]: https://github.com/tokio-rs/toasty/pull/1149
+[#1151]: https://github.com/tokio-rs/toasty/pull/1151
+[#1152]: https://github.com/tokio-rs/toasty/pull/1152
+[#1153]: https://github.com/tokio-rs/toasty/pull/1153
+[#1155]: https://github.com/tokio-rs/toasty/pull/1155
+[#1170]: https://github.com/tokio-rs/toasty/pull/1170
+[#1173]: https://github.com/tokio-rs/toasty/pull/1173
+[#1178]: https://github.com/tokio-rs/toasty/pull/1178
+[#1180]: https://github.com/tokio-rs/toasty/pull/1180
+[#1181]: https://github.com/tokio-rs/toasty/pull/1181
+
 ## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-v0.8.0...toasty-v0.9.0) - 2026-07-23
 
 ### Added

--- a/crates/toasty/Cargo.toml
+++ b/crates/toasty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toasty"
-version = "0.9.0"
+version = "0.10.0"
 description = "An async ORM for Rust supporting SQL and NoSQL databases"
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `toasty-core`: 0.9.0 -> 0.10.0 (⚠ API breaking changes)
* `toasty-driver-dynamodb`: 0.9.0 -> 0.10.0 (✓ API compatible changes)
* `toasty-sql`: 0.9.0 -> 0.10.0 (✓ API compatible changes)
* `toasty-driver-mysql`: 0.9.0 -> 0.10.0 (✓ API compatible changes)
* `toasty-driver-postgresql`: 0.9.0 -> 0.10.0 (✓ API compatible changes)
* `toasty-driver-sqlite`: 0.9.0 -> 0.10.0 (✓ API compatible changes)
* `toasty-driver-turso`: 0.9.0 -> 0.10.0 (✓ API compatible changes)
* `toasty-macros`: 0.9.0 -> 0.10.0
* `toasty`: 0.9.0 -> 0.10.0 (⚠ API breaking changes)
* `toasty-cli`: 0.9.0 -> 0.10.0 (✓ API compatible changes)
* `toasty-driver-integration-suite-macros`: 0.9.0 -> 0.10.0
* `toasty-driver-integration-suite`: 0.9.0 -> 0.10.0 (⚠ API breaking changes)

### ⚠ `toasty-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field StorageTypes.default_cidr_type in /tmp/.tmphcX0KP/toasty/crates/toasty-core/src/driver/capability.rs:440
  field StorageTypes.default_inet_type in /tmp/.tmphcX0KP/toasty/crates/toasty-core/src/driver/capability.rs:443
  field StorageTypes.default_macaddr_type in /tmp/.tmphcX0KP/toasty/crates/toasty-core/src/driver/capability.rs:446
  field StorageTypes.default_macaddr8_type in /tmp/.tmphcX0KP/toasty/crates/toasty-core/src/driver/capability.rs:449
  field Capability.native_cidr in /tmp/.tmphcX0KP/toasty/crates/toasty-core/src/driver/capability.rs:145
  field Capability.native_inet in /tmp/.tmphcX0KP/toasty/crates/toasty-core/src/driver/capability.rs:148
  field Capability.native_macaddr in /tmp/.tmphcX0KP/toasty/crates/toasty-core/src/driver/capability.rs:151
  field Capability.native_macaddr8 in /tmp/.tmphcX0KP/toasty/crates/toasty-core/src/driver/capability.rs:154
  field Capability.sql_nulls_first_on_asc in /tmp/.tmphcX0KP/toasty/crates/toasty-core/src/driver/capability.rs:294

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant Type:Cidr in /tmp/.tmphcX0KP/toasty/crates/toasty-core/src/stmt/ty.rs:178
  variant Type:Inet in /tmp/.tmphcX0KP/toasty/crates/toasty-core/src/stmt/ty.rs:183
  variant Type:MacAddr in /tmp/.tmphcX0KP/toasty/crates/toasty-core/src/stmt/ty.rs:188
  variant Type:MacAddr8 in /tmp/.tmphcX0KP/toasty/crates/toasty-core/src/stmt/ty.rs:193
  variant Type:Cidr in /tmp/.tmphcX0KP/toasty/crates/toasty-core/src/schema/db/ty.rs:110
  variant Type:Inet in /tmp/.tmphcX0KP/toasty/crates/toasty-core/src/schema/db/ty.rs:113
  variant Type:MacAddr in /tmp/.tmphcX0KP/toasty/crates/toasty-core/src/schema/db/ty.rs:116
  variant Type:MacAddr8 in /tmp/.tmphcX0KP/toasty/crates/toasty-core/src/schema/db/ty.rs:119
  variant Value:Cidr in /tmp/.tmphcX0KP/toasty/crates/toasty-core/src/stmt/value.rs:134
  variant Value:Inet in /tmp/.tmphcX0KP/toasty/crates/toasty-core/src/stmt/value.rs:138
  variant Value:MacAddr in /tmp/.tmphcX0KP/toasty/crates/toasty-core/src/stmt/value.rs:142
  variant Value:MacAddr8 in /tmp/.tmphcX0KP/toasty/crates/toasty-core/src/stmt/value.rs:146

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  Field::ty, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/app/field.rs:225
  Field::primary_key, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/app/field.rs:235
  Field::full_name, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/app/field.rs:261
  Field::relation_target, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/app/field.rs:279
  Context::rename_hints, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/diff.rs:129
  Context::previous, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/diff.rs:134
  ModelId::variant, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/app/model.rs:537
  Schema::builder, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema.rs:89
  Schema::builder, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema.rs:89
  ModelSet::iter, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/app/model.rs:89
  ForeignKeyField::source, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/app/fk.rs:61
  ForeignKeyField::target, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/app/fk.rs:66
  Embedded::target, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/app/embedded.rs:41
  Schema::variant, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/app/schema.rs:87
  Schema::column_mut, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/db/schema.rs:41
  Schema::index_mut, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/db/schema.rs:70
  Table::primary_key_column, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/db/table.rs:58
  FieldName::storage_name_unwrap, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/app/field.rs:170
  PathFieldSet::from_slice, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/stmt/path_field_set.rs:63
  PathFieldSet::len, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/stmt/path_field_set.rs:91
  Has::singular, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/app/relation/has.rs:53
  Path::is_empty, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/stmt/path.rs:110
  Path::len, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/stmt/path.rs:115
  ExprContext::expr_ref_column, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/stmt/cx.rs:626
  Name::camel_case, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/name.rs:55
  Name::upper_snake_case, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/name.rs:94
  Via::singular, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/app/relation/via.rs:92
  Via::target, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/app/relation/via.rs:97
  Index::partition_fields, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/app/index.rs:108
  Index::local_fields, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/app/index.rs:117
  RenameHints::get_table, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/diff.rs:79
  RenameHints::get_column, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/diff.rs:84
  RenameHints::get_index, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/diff.rs:89
  EntryMut::as_expr, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/stmt/entry_mut.rs:28
  EntryMut::as_expr_unwrap, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/stmt/entry_mut.rs:41
  EntryMut::as_expr_mut, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/stmt/entry_mut.rs:47
  EntryMut::as_expr_mut_unwrap, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/stmt/entry_mut.rs:60
  EntryMut::is_expr, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/stmt/entry_mut.rs:68
  EntryMut::is_statement, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/stmt/entry_mut.rs:73
  FieldTy::is_primitive, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/app/field.rs:326
  FieldTy::as_primitive_mut_unwrap, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/app/field.rs:359
  FieldTy::is_embedded, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/app/field.rs:367
  FieldTy::as_embedded, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/app/field.rs:372
  FieldTy::as_embedded_unwrap, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/app/field.rs:386
  FieldTy::as_embedded_mut_unwrap, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/app/field.rs:400
  FieldTy::is_has_n, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/app/field.rs:414
  FieldTy::as_has_unwrap, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/app/field.rs:432
  FieldTy::as_has_many_mut_unwrap, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/app/field.rs:485
  FieldTy::as_has_one_mut_unwrap, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/app/field.rs:527
  Cardinality::singular, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/app/relation/has.rs:84
  Type::diff, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/diff/ty.rs:33
  Field::as_primitive_mut, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/mapping/field.rs:96
  Model::can_be_relation_target, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/schema/app/model.rs:420
  ExprTarget::model_id, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/stmt/cx.rs:763
  ExprTarget::as_table, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/stmt/cx.rs:771
  ExprTarget::as_table_unwrap, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/stmt/cx.rs:784
  Entry::eval, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/stmt/entry.rs:46
  Entry::is_expr, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/stmt/entry.rs:112
  Entry::is_record, previously in file /tmp/.tmpnFNbSJ/toasty-core/src/stmt/entry.rs:147
```

### ⚠ `toasty` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function toasty::schema::from_macro, previously in file /tmp/.tmpnFNbSJ/toasty/src/schema.rs:55

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  Insert::from_untyped, previously in file /tmp/.tmpnFNbSJ/toasty/src/stmt/insert.rs:98
  Insert::insert, previously in file /tmp/.tmpnFNbSJ/toasty/src/stmt/insert.rs:172
  Insert::into_list_expr, previously in file /tmp/.tmpnFNbSJ/toasty/src/stmt/insert.rs:264
  CreateMany::new, previously in file /tmp/.tmpnFNbSJ/toasty/src/stmt/create_many.rs:48
  Association::untyped, previously in file /tmp/.tmpnFNbSJ/toasty/src/stmt/association.rs:28
  Association::many_via_one, previously in file /tmp/.tmpnFNbSJ/toasty/src/stmt/association.rs:142
  Update::from_untyped, previously in file /tmp/.tmpnFNbSJ/toasty/src/stmt/update.rs:77
  Update::insert, previously in file /tmp/.tmpnFNbSJ/toasty/src/stmt/update.rs:165
  Update::remove, previously in file /tmp/.tmpnFNbSJ/toasty/src/stmt/update.rs:185
  Update::set_returning_none, previously in file /tmp/.tmpnFNbSJ/toasty/src/stmt/update.rs:205

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct toasty::migration::HistoryEntry, previously in file /tmp/.tmpnFNbSJ/toasty/src/migration/history.rs:72
  struct toasty::migration::History, previously in file /tmp/.tmpnFNbSJ/toasty/src/migration/history.rs:42
```

### ⚠ `toasty-driver-integration-suite` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function toasty_driver_integration_suite::tests::crud_update_macro::update_macro_method_shorthand_clear::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_update_macro.rs:179
  function toasty_driver_integration_suite::tests::embed_enum_shared_type::shared_enum_crud::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/embed_enum_shared_type.rs:9
  function toasty_driver_integration_suite::tests::relation_has_many_composite_key::composite_assign_todo_to_user_on_update_query::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs:452
  function toasty_driver_integration_suite::tests::crud_upsert::unsupported_unique_upsert_is_reported_before_dispatch::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_upsert.rs:644
  function toasty_driver_integration_suite::tests::embed_struct::embedded_struct_with_jiff_fields::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/embed_struct.rs:1176
  function toasty_driver_integration_suite::tests::deferred_field::deferred_update_refreshes_loaded_value::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/deferred_field.rs:260
  function toasty_driver_integration_suite::tests::relation_has_many_via::scalar_via_of_via::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_via.rs:489
  function toasty_driver_integration_suite::tests::tx_interactive::delete_rolled_back::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/tx_interactive.rs:231
  function toasty_driver_integration_suite::tests::crud_basic::required_field_create_without_setting::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_basic.rs:201
  function toasty_driver_integration_suite::tests::filter_between::filter_between_empty_result::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/filter_between.rs:77
  function toasty_driver_integration_suite::tests::relation_many_to_many::filter_through_join_model::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_many_to_many.rs:52
  function toasty_driver_integration_suite::tests::type_bigdecimal::ty_bigdecimal_as_numeric_arbitrary_precision::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/type_bigdecimal.rs:68
  function toasty_driver_integration_suite::tests::relation_preload::nested_has_one_required_then_has_many::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_preload.rs:1028
  function toasty_driver_integration_suite::tests::infra_pool_config::pool_timeouts_are_accepted::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/infra_pool_config.rs:23
  function toasty_driver_integration_suite::tests::relation_preload_options::preload_has_many_ordered_per_parent::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_preload_options.rs:4
  function toasty_driver_integration_suite::tests::crud_update_macro::update_macro_value_reads_target_field::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_update_macro.rs:212
  function toasty_driver_integration_suite::tests::relation_has_many_composite_key::composite_user_batch_create_todos_one_level::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs:475
  function toasty_driver_integration_suite::tests::crud_upsert::unsupported_upsert_is_reported_before_dispatch::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_upsert.rs:664
  function toasty_driver_integration_suite::tests::embed_struct::unit_enum_in_embedded_struct::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/embed_struct.rs:1225
  function toasty_driver_integration_suite::tests::deferred_field::deferred_json_create_returns_loaded::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/deferred_field.rs:296
  function toasty_driver_integration_suite::tests::relation_has_many_via::include_via_three_step_no_intermediates::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_via.rs:557
  function toasty_driver_integration_suite::tests::tx_interactive::driver_sees_begin_commit::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/tx_interactive.rs:250
  function toasty_driver_integration_suite::tests::crud_basic::unique_index_required_field_update::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_basic.rs:209
  function toasty_driver_integration_suite::tests::filter_between::filter_between_string::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/filter_between.rs:104
  function toasty_driver_integration_suite::tests::relation_many_to_many::filter_through_via_from_both_sides::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_many_to_many.rs:97
  function toasty_driver_integration_suite::tests::type_bigdecimal::ty_bigdecimal_as_numeric_fixed_precision::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/type_bigdecimal.rs:100
  function toasty_driver_integration_suite::tests::relation_preload::nested_has_one_optional_then_has_one_optional::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_preload.rs:1112
  function toasty_driver_integration_suite::tests::relation_preload_options::preload_has_many_filter_and_order::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_preload_options.rs:67
  function toasty_driver_integration_suite::tests::record_not_found::not_found::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/record_not_found.rs:4
  function toasty_driver_integration_suite::tests::crud_update_macro::update_macro_method_shorthand_reads_target_field::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_update_macro.rs:241
  function toasty_driver_integration_suite::tests::embed_enum_string_discriminant::string_discriminant_unit_enum::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/embed_enum_string_discriminant.rs:5
  function toasty_driver_integration_suite::tests::relation_has_many_composite_key::composite_user_batch_create_two_todos_simple::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs:496
  function toasty_driver_integration_suite::tests::embed_struct::embedded_struct_with_uuid_field::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/embed_struct.rs:1283
  function toasty_driver_integration_suite::tests::deferred_field::deferred_json_default_load_leaves_unloaded::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/deferred_field.rs:324
  function toasty_driver_integration_suite::tests::field_default_and_update::default_expr_on_create::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/field_default_and_update.rs:4
  function toasty_driver_integration_suite::tests::relation_has_many_via::select_via_two_step::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_via.rs:584
  function toasty_driver_integration_suite::tests::tx_interactive::driver_sees_begin_rollback::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/tx_interactive.rs:279
  function toasty_driver_integration_suite::tests::crud_basic::unique_index_nullable_field_update::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_basic.rs:314
  function toasty_driver_integration_suite::tests::relation_many_to_many::include_from_both_sides::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_many_to_many.rs:132
  function toasty_driver_integration_suite::tests::relation_preload::nested_has_one_required_then_has_one_required::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_preload.rs:1216
  function toasty_driver_integration_suite::tests::type_decimal::ty_decimal::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/type_decimal.rs:7
  function toasty_driver_integration_suite::tests::infra_sync_send::ensure_types_sync_send::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/infra_sync_send.rs:10
  function toasty_driver_integration_suite::tests::relation_preload_options::preload_nested_relations_ordered_at_each_level::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_preload_options.rs:97
  function toasty_driver_integration_suite::tests::embed_enum_filter::filter_data_enum, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/embed_enum_filter.rs:5
  function toasty_driver_integration_suite::tests::crud_update_macro::update_macro_query_target::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_update_macro.rs:257
  function toasty_driver_integration_suite::tests::embed_enum_string_discriminant::default_string_labels::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/embed_enum_string_discriminant.rs:30
  function toasty_driver_integration_suite::tests::relation_has_many_composite_key::composite_user_batch_create_todos_with_optional_field::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs:516
  function toasty_driver_integration_suite::tests::batch_associations::batch_two_scoped_creates_same_relation::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/batch_associations.rs:7
  function toasty_driver_integration_suite::tests::deferred_field::deferred_json_include_eager_loads_value::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/deferred_field.rs:348
  function toasty_driver_integration_suite::tests::field_default_and_update::default_expr_override::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/field_default_and_update.rs:31
  function toasty_driver_integration_suite::tests::batch_query_dynamic::batch_vec_of_queries::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/batch_query_dynamic.rs:3
  function toasty_driver_integration_suite::tests::relation_has_many_via::include_via_has_one::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_via.rs:630
  function toasty_driver_integration_suite::tests::tx_interactive::nested_commit_both::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/tx_interactive.rs:311
  function toasty_driver_integration_suite::tests::crud_basic::unique_index_no_update::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_basic.rs:396
  function toasty_driver_integration_suite::tests::relation_many_to_many::mutate_link_through_join_model::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_many_to_many.rs:187
  function toasty_driver_integration_suite::tests::relation_preload::nested_has_one_optional_then_belongs_to_required::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_preload.rs:1293
  function toasty_driver_integration_suite::tests::type_decimal::ty_decimal_as_text::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/type_decimal.rs:68
  function toasty_driver_integration_suite::tests::relation_preload_options::preload_has_many_repeated_ordering_last_wins::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_preload_options.rs:201
  function toasty_driver_integration_suite::tests::crud_update_macro::update_macro_embedded_patch::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_update_macro.rs:274
  function toasty_driver_integration_suite::tests::embed_enum_string_discriminant::mixed_explicit_and_default_labels::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/embed_enum_string_discriminant.rs:65
  function toasty_driver_integration_suite::tests::relation_has_many_composite_key::composite_remove_add_single_relation_option_belongs_to::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs:567
  function toasty_driver_integration_suite::tests::deferred_embed::deferred_embed_struct::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/deferred_embed.rs:6
  function toasty_driver_integration_suite::tests::batch_associations::batch_two_scoped_queries_same_relation::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/batch_associations.rs:35
  function toasty_driver_integration_suite::tests::deferred_field::deferred_json_update_refreshes_loaded_value::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/deferred_field.rs:381
  function toasty_driver_integration_suite::tests::field_default_and_update::update_expr_on_create::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/field_default_and_update.rs:61
  function toasty_driver_integration_suite::tests::relation_has_many_link_unlink::remove_add_single_relation_option_belongs_to::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_link_unlink.rs:6
  function toasty_driver_integration_suite::tests::batch_query_dynamic::batch_array_of_queries::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/batch_query_dynamic.rs:24
  function toasty_driver_integration_suite::tests::relation_has_many_via::select_via_has_one::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_via.rs:680
  function toasty_driver_integration_suite::tests::tx_interactive::nested_rollback_inner::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/tx_interactive.rs:334
  function toasty_driver_integration_suite::tests::crud_basic::unique_index_set_same_value::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_basic.rs:423
  function toasty_driver_integration_suite::tests::relation_many_to_many::composite_join_key_prevents_duplicate_links::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_many_to_many.rs:228
  function toasty_driver_integration_suite::tests::relation_preload::nested_belongs_to_required_then_has_many::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_preload.rs:1375
  function toasty_driver_integration_suite::tests::type_decimal::ty_decimal_as_numeric_arbitrary_precision::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/type_decimal.rs:98
  function toasty_driver_integration_suite::tests::relation_preload_options::preload_has_one_ordering_rejected::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_preload_options.rs:259
  function toasty_driver_integration_suite::tests::embed_enum_filter_comparison::filter_unit_enum_ne, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/embed_enum_filter_comparison.rs:4
  function toasty_driver_integration_suite::tests::crud_update_macro::update_macro_has_many_insert::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_update_macro.rs:321
  function toasty_driver_integration_suite::tests::embed_enum_string_discriminant::string_discriminant_data_enum::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/embed_enum_string_discriminant.rs:109
  function toasty_driver_integration_suite::tests::relation_has_many_composite_key::composite_add_remove_single_relation_required_belongs_to::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs:599
  function toasty_driver_integration_suite::tests::deferred_embed::deferred_inside_embed_in_enum_variant::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/deferred_embed.rs:55
  function toasty_driver_integration_suite::tests::batch_associations::batch_scoped_update_and_delete_same_relation::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/batch_associations.rs:59
  function toasty_driver_integration_suite::tests::field_default_and_update::update_expr_on_update::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/field_default_and_update.rs:90
  function toasty_driver_integration_suite::tests::relation_has_many_link_unlink::add_remove_single_relation_required_belongs_to::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_link_unlink.rs:59
  function toasty_driver_integration_suite::tests::batch_query_dynamic::batch_vec_some_empty::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/batch_query_dynamic.rs:41
  function toasty_driver_integration_suite::tests::relation_has_many_via::query_scalar_via_returns_distinct_titles::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_via.rs:716
  function toasty_driver_integration_suite::tests::tx_interactive::nested_rollback_outer::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/tx_interactive.rs:358
  function toasty_driver_integration_suite::tests::crud_basic::update_multiple_fields::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_basic.rs:457
  function toasty_driver_integration_suite::tests::relation_many_to_many::self_referential_followers_and_following::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_many_to_many.rs:274
  function toasty_driver_integration_suite::tests::relation_preload::nested_belongs_to_required_then_has_one_optional::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_preload.rs:1460
  function toasty_driver_integration_suite::tests::type_decimal::ty_decimal_as_numeric_fixed_precision::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/type_decimal.rs:127
  function toasty_driver_integration_suite::tests::crud_update_macro::update_macro_has_many_mixed_list::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_update_macro.rs:349
  function toasty_driver_integration_suite::tests::embed_enum_string_discriminant::default_string_labels_data_enum::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/embed_enum_string_discriminant.rs:169
  function toasty_driver_integration_suite::tests::relation_has_many_composite_key::composite_add_remove_multiple_relation_option_belongs_to::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs:660
  function toasty_driver_integration_suite::tests::deferred_embed::include_deferred_inside_embed_in_enum_variant::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/deferred_embed.rs:102
  function toasty_driver_integration_suite::tests::batch_associations::batch_scoped_all_four_crud::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/batch_associations.rs:88
  function toasty_driver_integration_suite::tests::field_default_and_update::update_expr_override_on_update::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/field_default_and_update.rs:126
  function toasty_driver_integration_suite::tests::relation_has_many_link_unlink::reassign_relation_required_belongs_to::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_link_unlink.rs:95
  function toasty_driver_integration_suite::tests::batch_query_dynamic::batch_nested_tuple_with_vec::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/batch_query_dynamic.rs:59
  function toasty_driver_integration_suite::tests::relation_has_many_via::scalar_via_distinct_values_across_distinct_targets::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_via.rs:767
  function toasty_driver_integration_suite::tests::tx_interactive::nested_drop_rolls_back_savepoint::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/tx_interactive.rs:381
  function toasty_driver_integration_suite::tests::crud_basic::update_and_delete_snippets::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_basic.rs:495
  function toasty_driver_integration_suite::tests::relation_preload::nested_belongs_to_required_then_belongs_to_required::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_preload.rs:1553
  function toasty_driver_integration_suite::tests::relation_via_mutation_runtime_error::insert_on_multi_step_traversal_errors::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_via_mutation_runtime_error.rs:12
  function toasty_driver_integration_suite::tests::crud_update_arithmetic::increment_adds_one, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_update_arithmetic.rs:9
  function toasty_driver_integration_suite::tests::crud_update_macro::update_macro_mixed_shapes::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_update_macro.rs:379
  function toasty_driver_integration_suite::tests::embed_enum_string_discriminant::mixed_string_labels_data_enum::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/embed_enum_string_discriminant.rs:227
  function toasty_driver_integration_suite::tests::relation_has_many_composite_key::composite_basic_has_many_and_belongs_to_preload::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs:692
  function toasty_driver_integration_suite::tests::deferred_embed::deferred_embed_unit_enum::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/deferred_embed.rs:158
  function toasty_driver_integration_suite::tests::batch_associations::batch_scoped_with_root_statements::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/batch_associations.rs:132
  function toasty_driver_integration_suite::tests::field_default_and_update::default_and_update_on_same_field::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/field_default_and_update.rs:162
  function toasty_driver_integration_suite::tests::relation_has_many_link_unlink::add_remove_multiple_relation_option_belongs_to::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_link_unlink.rs:119
  function toasty_driver_integration_suite::tests::batch_query_dynamic::batch_vec_all_empty::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/batch_query_dynamic.rs:85
  function toasty_driver_integration_suite::tests::relation_has_many_via::query_scalar_via_two_step::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_via.rs:822
  function toasty_driver_integration_suite::tests::tx_interactive::nested_driver_sees_savepoint_ops::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/tx_interactive.rs:405
  function toasty_driver_integration_suite::tests::crud_batch_create::batch_create_empty::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_batch_create.rs:8
  function toasty_driver_integration_suite::tests::float_fields::float_fields_column_type_override::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/float_fields.rs:4
  function toasty_driver_integration_suite::tests::relation_preload::nested_belongs_to_optional_then_has_many::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_preload.rs:1582
  function toasty_driver_integration_suite::tests::type_document::vec_struct_create_get::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/type_document.rs:19
  function toasty_driver_integration_suite::tests::query_count::count_empty_table::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/query_count.rs:3
  function toasty_driver_integration_suite::tests::scan_no_index::scan_no_filter::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/scan_no_index.rs:6
  function toasty_driver_integration_suite::tests::type_jiff::ty_zoned::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/type_jiff.rs:83
  function toasty_driver_integration_suite::tests::crud_update_arithmetic::subtract_subtracts_value, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_update_arithmetic.rs:72
  function toasty_driver_integration_suite::tests::crud_upsert::upsert_by_primary_key_creates_then_updates::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_upsert.rs:3
  function toasty_driver_integration_suite::tests::relation_has_many_composite_key::composite_preload_on_empty_query::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs:760
  function toasty_driver_integration_suite::tests::deferred_embed::deferred_embed_data_enum::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/deferred_embed.rs:203
  function toasty_driver_integration_suite::tests::batch_associations::batch_scoped_across_relations::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/batch_associations.rs:159
  function toasty_driver_integration_suite::tests::field_default_and_update::auto_on_timestamp_fields::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/field_default_and_update.rs:208
  function toasty_driver_integration_suite::tests::relation_has_many_multi::crud_user_todos_categories::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_multi.rs:7
  function toasty_driver_integration_suite::tests::batch_rollback::batch_two_creates_rolls_back_on_second_failure::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/batch_rollback.rs:8
  function toasty_driver_integration_suite::tests::relation_has_many_via::include_scalar_via::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_via.rs:861
  function toasty_driver_integration_suite::tests::tx_interactive::nested_driver_sees_rollback_to_savepoint::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/tx_interactive.rs:455
  function toasty_driver_integration_suite::tests::crud_batch_create::batch_create_one::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_batch_create.rs:17
  function toasty_driver_integration_suite::tests::float_fields::float_fields_crud::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/float_fields.rs:38
  function toasty_driver_integration_suite::tests::relation_preload::nested_belongs_to_optional_then_belongs_to_optional::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_preload.rs:1671
  function toasty_driver_integration_suite::tests::type_document::vec_struct_without_attr::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/type_document.rs:67
  function toasty_driver_integration_suite::tests::query_count::count_after_inserts::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/query_count.rs:13
  function toasty_driver_integration_suite::tests::scan_no_index::scan_or_filter::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/scan_no_index.rs:38
  function toasty_driver_integration_suite::tests::type_jiff::ty_date::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/type_jiff.rs:114
  function toasty_driver_integration_suite::tests::crud_upsert::upsert_branch_overrides::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_upsert.rs:48
  function toasty_driver_integration_suite::tests::relation_has_many_composite_key::composite_preload_has_many_with_optional_belongs_to::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs:774
  function toasty_driver_integration_suite::tests::select_projection_has_many::select_has_many_basic::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/select_projection_has_many.rs:12
  function toasty_driver_integration_suite::tests::deferred_embed::deferred_embed_update_reloads::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/deferred_embed.rs:273
  function toasty_driver_integration_suite::tests::batch_associations::batch_query_across_relations::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/batch_associations.rs:181
  function toasty_driver_integration_suite::tests::batch_rollback::batch_create_and_update_rolls_back_on_update_failure::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/batch_rollback.rs:54
  function toasty_driver_integration_suite::tests::relation_has_many_via::query_chain_scalar_via::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_via.rs:927
  function toasty_driver_integration_suite::tests::tx_interactive::two_sequential_nested_transactions::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/tx_interactive.rs:502
  function toasty_driver_integration_suite::tests::crud_batch_create::batch_create_many::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_batch_create.rs:42
  function toasty_driver_integration_suite::tests::relation_preload::nested_belongs_to_required_then_has_one_required::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_preload.rs:1773
  function toasty_driver_integration_suite::tests::type_document::enum_inside_document_rejected::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/type_document.rs:112
  function toasty_driver_integration_suite::tests::query_count::count_with_filter::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/query_count.rs:31
  function toasty_driver_integration_suite::tests::scan_no_index::scan_with_limit::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/scan_no_index.rs:76
  function toasty_driver_integration_suite::tests::type_jiff::ty_time::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/type_jiff.rs:148
  function toasty_driver_integration_suite::tests::relation_belongs_to_null_fk::optional_belongs_to_null_fk::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_belongs_to_null_fk.rs:4
  function toasty_driver_integration_suite::tests::crud_update_arithmetic::set_then_arithmetic_on_one_field, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_update_arithmetic.rs:241
  function toasty_driver_integration_suite::tests::embed_enum_native_ops::native_enum_crud_lifecycle::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/embed_enum_native_ops.rs:9
  function toasty_driver_integration_suite::tests::crud_upsert::upsert_branch_overrides_are_order_independent::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_upsert.rs:77
  function toasty_driver_integration_suite::tests::relation_has_many_composite_key::composite_nested_has_many_then_belongs_to_required::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs:793
  function toasty_driver_integration_suite::tests::select_projection_has_many::select_has_many_with_filter::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/select_projection_has_many.rs:36
  function toasty_driver_integration_suite::tests::deferred_embed::deferred_embed_with_deferred_sub_field::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/deferred_embed.rs:313
  function toasty_driver_integration_suite::tests::batch_associations::batch_scoped_different_parents::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/batch_associations.rs:202
  function toasty_driver_integration_suite::tests::batch_rollback::batch_update_and_create_rolls_back_on_create_failure::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/batch_rollback.rs:107
  function toasty_driver_integration_suite::tests::relation_has_many_via::select_scalar_via::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_via.rs:963
  function toasty_driver_integration_suite::tests::tx_interactive::multi_op_inside_tx_uses_savepoints::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/tx_interactive.rs:534
  function toasty_driver_integration_suite::tests::crud_batch_create::batch_create_fails_if_any_record_missing_fields::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_batch_create.rs:74
  function toasty_driver_integration_suite::tests::relation_preload::nested_has_many_then_has_many_with_empty_leaves::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_preload.rs:1848
  function toasty_driver_integration_suite::tests::type_document::vec_struct_option_field::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/type_document.rs:155
  function toasty_driver_integration_suite::tests::query_in_list::in_list_string::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/query_in_list.rs:24
  function toasty_driver_integration_suite::tests::scan_no_index::scan_limit_with_filter_returns_correct_count::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/scan_no_index.rs:111
  function toasty_driver_integration_suite::tests::type_jiff::ty_datetime::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/type_jiff.rs:180
  function toasty_driver_integration_suite::tests::relation_belongs_to_one_way::crud_user_optional_profile_one_direction::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_belongs_to_one_way.rs:4
  function toasty_driver_integration_suite::tests::crud_update_arithmetic::filter_update_with_arithmetic, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_update_arithmetic.rs:341
  function toasty_driver_integration_suite::tests::embed_enum_native_ops::native_enum_multiple_fields::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/embed_enum_native_ops.rs:167
  function toasty_driver_integration_suite::tests::crud_upsert::upsert_single_branch_override_keeps_shared_other_branch::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_upsert.rs:106
  function toasty_driver_integration_suite::tests::embed_newtype::crud_newtype_embed::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/embed_newtype.rs:66
  function toasty_driver_integration_suite::tests::relation_has_many_composite_key::composite_crud_has_one_required::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs:822
  function toasty_driver_integration_suite::tests::select_projection_has_many::select_has_many_first::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/select_projection_has_many.rs:69
  function toasty_driver_integration_suite::tests::deferred_embed::deferred_field_inside_embed::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/deferred_embed.rs:377
  function toasty_driver_integration_suite::tests::batch_associations::batch_scoped_delete_with_root_update::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/batch_associations.rs:236
  function toasty_driver_integration_suite::tests::tx_atomic_stmt::multi_op_create_wraps_in_transaction::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/tx_atomic_stmt.rs:9
  function toasty_driver_integration_suite::tests::batch_rollback::batch_array_creates_rolls_back_on_failure::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/batch_rollback.rs:165
  function toasty_driver_integration_suite::tests::relation_has_many_via::eager_scalar_via_auto_loads::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_via.rs:1007
  function toasty_driver_integration_suite::tests::tx_interactive::builder_on_db_commit::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/tx_interactive.rs:589
  function toasty_driver_integration_suite::tests::crud_batch_create::batch_create_model_with_unique_field_index_all_unique::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_batch_create.rs:103
  function toasty_driver_integration_suite::tests::relation_preload::sibling_nested_includes_on_shared_prefix::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_preload.rs:1888
  function toasty_driver_integration_suite::tests::type_document::vec_struct_empty::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/type_document.rs:198
  function toasty_driver_integration_suite::tests::query_in_list::not_in_list_string::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/query_in_list.rs:56
  function toasty_driver_integration_suite::tests::scan_no_index::scan_paginate_multi_page::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/scan_no_index.rs:157
  function toasty_driver_integration_suite::tests::type_jiff::ty_timestamp_precision_2::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/type_jiff.rs:213
  function toasty_driver_integration_suite::tests::crud_update_field_order::update_last_field_only::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_update_field_order.rs:13
  function toasty_driver_integration_suite::tests::embed_enum_native_ops::native_enum_custom_type_name::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/embed_enum_native_ops.rs:220
  function toasty_driver_integration_suite::tests::relation_has_many_batch_create::user_batch_create_todos_one_level_basic_fk::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_batch_create.rs:4
  function toasty_driver_integration_suite::tests::crud_upsert::upsert_or_ignore_returns_option::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_upsert.rs:153
  function toasty_driver_integration_suite::tests::embed_newtype::newtype_unique_constraint::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/embed_newtype.rs:155
  function toasty_driver_integration_suite::tests::relation_has_many_composite_key::composite_filter_by_belongs_to_field::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs:872
  function toasty_driver_integration_suite::tests::deferred_embed::update_embed_by_value_with_deferred_sub_field::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/deferred_embed.rs:416
  function toasty_driver_integration_suite::tests::batch_create_statements::batch_two_creates_same_model::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/batch_create_statements.rs:9
  function toasty_driver_integration_suite::tests::relation_has_many_same_target::pair_hint_disambiguates_has_many::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_same_target.rs:9
  function toasty_driver_integration_suite::tests::tx_atomic_stmt::single_op_skips_transaction::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/tx_atomic_stmt.rs:44
  function toasty_driver_integration_suite::tests::batch_rollback::batch_different_models_rolls_back_on_failure::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/batch_rollback.rs:213
  function toasty_driver_integration_suite::tests::tx_interactive::builder_on_connection_commit::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/tx_interactive.rs:605
  function toasty_driver_integration_suite::tests::crud_batch_create::batch_create_model_with_unique_field_index_all_dups::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_batch_create.rs:134
  function toasty_driver_integration_suite::tests::relation_preload::bare_and_nested_includes_on_shared_prefix::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_preload.rs:1930
  function toasty_driver_integration_suite::tests::type_document::vec_struct_update_replace::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/type_document.rs:232
  function toasty_driver_integration_suite::tests::query_in_list::in_list_empty::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/query_in_list.rs:89
  function toasty_driver_integration_suite::tests::scan_no_index::scan_order_by_is_error::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/scan_no_index.rs:201
  function toasty_driver_integration_suite::tests::type_jiff::ty_time_precision_2::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/type_jiff.rs:249
  function toasty_driver_integration_suite::tests::crud_update_field_order::update_fields_reverse_order::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_update_field_order.rs:37
  function toasty_driver_integration_suite::tests::relation_has_many_batch_create::user_batch_create_todos_two_levels_basic_fk::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_batch_create.rs:28
  function toasty_driver_integration_suite::tests::crud_upsert::upsert_or_ignore_suppresses_only_the_selected_conflict::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_upsert.rs:181
  function toasty_driver_integration_suite::tests::embed_newtype::newtype_index::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/embed_newtype.rs:197
  function toasty_driver_integration_suite::tests::relation_has_many_composite_key::composite_filter_parent_by_child_field::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs:921
  function toasty_driver_integration_suite::tests::deferred_embed::deferred_field_inside_option_embed::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/deferred_embed.rs:463
  function toasty_driver_integration_suite::tests::field_auto::auto_uuid_v4::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/field_auto.rs:4
  function toasty_driver_integration_suite::tests::batch_create_statements::batch_two_creates_different_models::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/batch_create_statements.rs:50
  function toasty_driver_integration_suite::tests::relation_has_many_same_target::pair_hint_create_via_has_many_accessor::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_same_target.rs:61
  function toasty_driver_integration_suite::tests::tx_atomic_stmt::update_with_new_association_rolls_back_on_failure::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/tx_atomic_stmt.rs:217
  function toasty_driver_integration_suite::tests::relation_has_one_crud::crud_has_one_required_belongs_to_optional::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_one_crud.rs:95
  function toasty_driver_integration_suite::tests::tx_interactive::builder_with_isolation_level::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/tx_interactive.rs:622
  function toasty_driver_integration_suite::tests::crud_batch_create::batch_create_unique_violation_rolls_back::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_batch_create.rs:147
  function toasty_driver_integration_suite::tests::relation_preload::sibling_nested_includes_on_shared_prefix_non_sql::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_preload.rs:1968
  function toasty_driver_integration_suite::tests::type_document::vec_struct_push::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/type_document.rs:288
  function toasty_driver_integration_suite::tests::query_in_list::in_list_i64_large::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/query_in_list.rs:121
  function toasty_driver_integration_suite::tests::scan_no_index::scan_order_by_sql::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/scan_no_index.rs:238
  function toasty_driver_integration_suite::tests::type_jiff::ty_datetime_precision_2::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/type_jiff.rs:283
  function toasty_driver_integration_suite::tests::relation_chain::user_todos_category::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_chain.rs:14
  function toasty_driver_integration_suite::tests::crud_update_field_order::update_middle_field_mixed_types::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_update_field_order.rs:69
  function toasty_driver_integration_suite::tests::relation_has_many_batch_create::user_batch_create_todos_set_category_by_value::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_batch_create.rs:90
  function toasty_driver_integration_suite::tests::crud_upsert::upsert_by_unique_field::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_upsert.rs:236
  function toasty_driver_integration_suite::tests::embed_newtype::newtype_numeric::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/embed_newtype.rs:239
  function toasty_driver_integration_suite::tests::relation_has_many_composite_key::composite_select_belongs_to_basic::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs:950
  function toasty_driver_integration_suite::tests::deferred_embed::deferred_newtype_inside_option_embed::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/deferred_embed.rs:506
  function toasty_driver_integration_suite::tests::field_auto::auto_uuid_v7::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/field_auto.rs:24
  function toasty_driver_integration_suite::tests::batch_create_statements::batch_query_and_create::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/batch_create_statements.rs:85
  function toasty_driver_integration_suite::tests::relation_has_many_scoped_query::scoped_query_eq::single_id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_scoped_query.rs:7
  function toasty_driver_integration_suite::tests::tx_atomic_stmt::rmw_uses_savepoints::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/tx_atomic_stmt.rs:292
  function toasty_driver_integration_suite::tests::relation_has_one_crud::update_belongs_to_with_required_has_one_pair::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_one_crud.rs:146
  function toasty_driver_integration_suite::tests::tx_interactive::builder_with_read_only::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/tx_interactive.rs:649
  function toasty_driver_integration_suite::tests::crud_batch_create::batch_create_inside_transaction_uses_savepoints::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_batch_create.rs:178
  function toasty_driver_integration_suite::tests::crud_model_find_by_primary_key::single_column_pk::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_model_find_by_primary_key.rs:7
  function toasty_driver_integration_suite::tests::type_document::vec_struct_pop_rejected::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/type_document.rs:352
  function toasty_driver_integration_suite::tests::query_in_list::in_list_id::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/query_in_list.rs:156
  function toasty_driver_integration_suite::tests::relation_chain::chain_from_empty_source_is_empty::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_chain.rs:56
  function toasty_driver_integration_suite::tests::crud_update_field_order::query_update_non_declaration_order::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_update_field_order.rs:95
  function toasty_driver_integration_suite::tests::relation_has_many_batch_create::user_batch_create_todos_with_optional_field::id_uuid, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/relation_has_many_batch_create.rs:138
  function toasty_driver_integration_suite::tests::crud_upsert::upsert_by_composite_unique_constraint::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-integration-suite/src/tests/crud_upsert.rs:258
  function toasty_driver_integration_suite::tests::embed_newtype::nested_newtype::id_u64, previously in file /tmp/.tmpnFNbSJ/toasty-driver-in