### PR TITLE
fix: resolve authority-form sqlite and turso URLs to a file path

### DIFF
--- a/crates/toasty-driver-dynamodb/src/lib.rs
+++ b/crates/toasty-driver-dynamodb/src/lib.rs
@@ -70,6 +70,19 @@ impl DynamoDb {
     pub async fn from_env(url: String) -> Result<Self> {
         use aws_config::BehaviorVersion;
 
+        // The URL does not name the endpoint — that comes from the ambient AWS
+        // config — but validate it anyway, so a typo fails here instead of
+        // silently connecting to whatever the environment points at.
+        let parsed = url::Url::parse(&url).map_err(|err| {
+            toasty_core::Error::invalid_connection_url(format!("{err}; url={url}"))
+        })?;
+
+        if parsed.scheme() != "dynamodb" {
+            return Err(toasty_core::Error::invalid_connection_url(format!(
+                "connection URL does not have a `dynamodb` scheme; url={url}"
+            )));
+        }
+
         let sdk_config = aws_config::defaults(BehaviorVersion::latest()).load().await;
         let client = Client::new(&sdk_config);
         Ok(Self::new(url, client))

--- a/crates/toasty-driver-sqlite/Cargo.toml
+++ b/crates/toasty-driver-sqlite/Cargo.toml
@@ -25,7 +25,6 @@ toasty-sql.workspace = true
 rusqlite.workspace = true
 serde.workspace = true
 tracing.workspace = true
-url.workspace = true
 uuid.workspace = true
 percent-encoding.workspace = true
 

--- a/crates/toasty-driver-sqlite/src/lib.rs
+++ b/crates/toasty-driver-sqlite/src/lib.rs
@@ -70,6 +70,13 @@ impl Sqlite {
     /// Create a new SQLite driver with an arbitrary connection URL
     pub fn new(url: impl Into<String>) -> Result<Self> {
         let url_str = url.into();
+
+        // Not a valid WHATWG URL (an authority may not contain `:`), so
+        // match it before parsing.
+        if url_str == "sqlite://:memory:" {
+            return Ok(Self::InMemory);
+        }
+
         let url = Url::parse(&url_str).map_err(toasty_core::Error::driver_operation_failed)?;
 
         if url.scheme() != "sqlite" {
@@ -80,15 +87,25 @@ impl Sqlite {
         }
 
         if url.path() == ":memory:" {
-            Ok(Self::InMemory)
-        } else {
-            Ok(Self::File(PathBuf::from(
-                percent_encoding::percent_decode(url.path().as_bytes())
-                    .decode_utf8_lossy()
-                    .to_string()
-                    .as_str(),
-            )))
+            return Ok(Self::InMemory);
         }
+
+        // In `sqlite://name.db`, `name.db` parses as the URL host, not the
+        // path. Recombine host + path so it names the file instead of `""`,
+        // which SQLite opens as a private temporary database per connection.
+        let raw_path = format!("{}{}", url.host_str().unwrap_or(""), url.path());
+
+        if raw_path.is_empty() {
+            return Err(toasty_core::Error::invalid_connection_url(format!(
+                "connection URL does not name a database file; url={url_str}"
+            )));
+        }
+
+        Ok(Self::File(PathBuf::from(
+            percent_encoding::percent_decode(raw_path.as_bytes())
+                .decode_utf8_lossy()
+                .as_ref(),
+        )))
     }
 
     /// Create an in-memory SQLite database
@@ -505,5 +522,35 @@ mod tests {
             Sqlite::new("sqlite::memory:").unwrap(),
             Sqlite::InMemory
         ));
+        assert!(matches!(
+            Sqlite::new("sqlite://:memory:").unwrap(),
+            Sqlite::InMemory
+        ));
+    }
+
+    #[test]
+    fn new_authority_form_names_a_relative_file() {
+        // Authority-form URLs: the host component is part of the file path.
+        assert_eq!(file_path("sqlite://todos.db"), PathBuf::from("todos.db"));
+        assert_eq!(
+            file_path("sqlite://./todos.db"),
+            PathBuf::from("./todos.db")
+        );
+        assert_eq!(
+            file_path("sqlite://data/todos.db"),
+            PathBuf::from("data/todos.db")
+        );
+        // Non-special schemes have opaque hosts: case is preserved,
+        // unlike `http`.
+        assert_eq!(
+            file_path("sqlite://MyDatabase.db"),
+            PathBuf::from("MyDatabase.db")
+        );
+    }
+
+    #[test]
+    fn new_url_without_a_path_is_rejected() {
+        assert!(Sqlite::new("sqlite:").is_err());
+        assert!(Sqlite::new("sqlite://").is_err());
     }
 }

--- a/crates/toasty-driver-sqlite/src/lib.rs
+++ b/crates/toasty-driver-sqlite/src/lib.rs
@@ -41,12 +41,18 @@ use toasty_core::{
     stmt,
 };
 use toasty_sql::{self as sql};
-use url::Url;
 
 enum SqlReturn {
     Count,
     Infer,
     Types(Vec<stmt::Type>),
+}
+
+/// Strip a leading `<scheme>:` from a connection URL. Schemes are
+/// case-insensitive; returns `None` if the URL names a different scheme.
+fn strip_scheme<'a>(url: &'a str, scheme: &str) -> Option<&'a str> {
+    let (found, rest) = url.split_once(':')?;
+    found.eq_ignore_ascii_case(scheme).then_some(rest)
 }
 
 /// A SQLite [`Driver`] that opens connections to a file or in-memory database.
@@ -71,38 +77,42 @@ impl Sqlite {
     pub fn new(url: impl Into<String>) -> Result<Self> {
         let url_str = url.into();
 
-        // Not a valid WHATWG URL (an authority may not contain `:`), so
-        // match it before parsing.
-        if url_str == "sqlite://:memory:" {
-            return Ok(Self::InMemory);
-        }
-
-        let url = Url::parse(&url_str).map_err(toasty_core::Error::driver_operation_failed)?;
-
-        if url.scheme() != "sqlite" {
+        // A `sqlite:` URL is a scheme followed by a path, where `//` is an
+        // optional authority marker. It is deliberately not parsed as a WHATWG
+        // URL: that grammar rejects `sqlite://:memory:` (`:memory:` reads as an
+        // invalid port) and reads `sqlite://todos.db` as host `todos.db` with an
+        // empty path, which SQLite opens as a private temporary database.
+        let Some(rest) = strip_scheme(&url_str, "sqlite") else {
             return Err(toasty_core::Error::invalid_connection_url(format!(
-                "connection URL does not have a `sqlite` scheme; url={}",
-                url_str
+                "connection URL does not have a `sqlite` scheme; url={url_str}"
             )));
-        }
+        };
 
-        if url.path() == ":memory:" {
+        let path = rest.strip_prefix("//").unwrap_or(rest);
+
+        // A query string is not part of the file path. The driver does not
+        // support SQLite URI parameters (`?cache=shared`) — `Connection::open`
+        // treats its whole argument as a filename — so they are dropped.
+        //
+        // `#` is not special: a connection URL has no fragment, and `#` is a
+        // legal filename character, so it stays. Write `%3F` for a literal `?`.
+        let path = match path.find('?') {
+            Some(i) => &path[..i],
+            None => path,
+        };
+
+        if path == ":memory:" {
             return Ok(Self::InMemory);
         }
 
-        // In `sqlite://name.db`, `name.db` parses as the URL host, not the
-        // path. Recombine host + path so it names the file instead of `""`,
-        // which SQLite opens as a private temporary database per connection.
-        let raw_path = format!("{}{}", url.host_str().unwrap_or(""), url.path());
-
-        if raw_path.is_empty() {
+        if path.is_empty() {
             return Err(toasty_core::Error::invalid_connection_url(format!(
                 "connection URL does not name a database file; url={url_str}"
             )));
         }
 
         Ok(Self::File(PathBuf::from(
-            percent_encoding::percent_decode(raw_path.as_bytes())
+            percent_encoding::percent_decode(path.as_bytes())
                 .decode_utf8_lossy()
                 .as_ref(),
         )))
@@ -526,6 +536,15 @@ mod tests {
             Sqlite::new("sqlite://:memory:").unwrap(),
             Sqlite::InMemory
         ));
+        // Schemes are case-insensitive.
+        assert!(matches!(
+            Sqlite::new("SQLITE://:memory:").unwrap(),
+            Sqlite::InMemory
+        ));
+        assert!(matches!(
+            Sqlite::new("SQLITE::memory:").unwrap(),
+            Sqlite::InMemory
+        ));
     }
 
     #[test]
@@ -552,5 +571,37 @@ mod tests {
     fn new_url_without_a_path_is_rejected() {
         assert!(Sqlite::new("sqlite:").is_err());
         assert!(Sqlite::new("sqlite://").is_err());
+        assert!(Sqlite::new("sqlite:?cache=shared").is_err());
+    }
+
+    #[test]
+    fn new_drops_query_string() {
+        // The driver does not support SQLite URI parameters, so a query string
+        // must not end up in the filename.
+        assert_eq!(
+            file_path("sqlite:app.db?cache=shared"),
+            PathBuf::from("app.db")
+        );
+        assert_eq!(
+            file_path("sqlite://app.db?mode=ro"),
+            PathBuf::from("app.db")
+        );
+        assert!(matches!(
+            Sqlite::new("sqlite::memory:?cache=shared").unwrap(),
+            Sqlite::InMemory
+        ));
+    }
+
+    #[test]
+    fn new_keeps_hash_in_filename() {
+        // A connection URL has no fragment, and `#` is a legal filename
+        // character — truncating there would silently open the wrong file.
+        assert_eq!(file_path("sqlite:notes#1.db"), PathBuf::from("notes#1.db"));
+        assert_eq!(
+            file_path("sqlite://notes#1.db"),
+            PathBuf::from("notes#1.db")
+        );
+        // A literal `?` still has to be percent-encoded.
+        assert_eq!(file_path("sqlite:a%3Fb.db"), PathBuf::from("a?b.db"));
     }
 }

--- a/crates/toasty-driver-turso/Cargo.toml
+++ b/crates/toasty-driver-turso/Cargo.toml
@@ -28,7 +28,6 @@ serde.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 turso.workspace = true
-url.workspace = true
 uuid.workspace = true
 percent-encoding.workspace = true
 

--- a/crates/toasty-driver-turso/src/lib.rs
+++ b/crates/toasty-driver-turso/src/lib.rs
@@ -338,6 +338,13 @@ impl Turso {
     /// `turso:/path/to/db`).
     pub fn new(url: impl Into<String>) -> Result<Self> {
         let url_str = url.into();
+
+        // Not a valid WHATWG URL (an authority may not contain `:`), so
+        // match it before parsing.
+        if url_str == "turso://:memory:" {
+            return Ok(Self::with_path(TursoPath::InMemory));
+        }
+
         let url = Url::parse(&url_str).map_err(toasty_core::Error::driver_operation_failed)?;
 
         if url.scheme() != "turso" {
@@ -346,17 +353,25 @@ impl Turso {
             )));
         }
 
-        let path = if url.path() == ":memory:" {
-            TursoPath::InMemory
-        } else {
-            TursoPath::File(PathBuf::from(
-                percent_encoding::percent_decode(url.path().as_bytes())
-                    .decode_utf8_lossy()
-                    .to_string()
-                    .as_str(),
-            ))
-        };
-        Ok(Self::with_path(path))
+        if url.path() == ":memory:" {
+            return Ok(Self::with_path(TursoPath::InMemory));
+        }
+
+        // In `turso://name.db`, `name.db` parses as the URL host, not the
+        // path. Recombine host + path so it names the file instead of `""`.
+        let raw_path = format!("{}{}", url.host_str().unwrap_or(""), url.path());
+
+        if raw_path.is_empty() {
+            return Err(toasty_core::Error::invalid_connection_url(format!(
+                "connection URL does not name a database file; url={url_str}"
+            )));
+        }
+
+        Ok(Self::with_path(TursoPath::File(PathBuf::from(
+            percent_encoding::percent_decode(raw_path.as_bytes())
+                .decode_utf8_lossy()
+                .as_ref(),
+        ))))
     }
 
     /// Create an in-memory Turso database.
@@ -1048,6 +1063,33 @@ mod tests {
             Turso::new("turso::memory:").unwrap().path,
             TursoPath::InMemory
         ));
+        assert!(matches!(
+            Turso::new("turso://:memory:").unwrap().path,
+            TursoPath::InMemory
+        ));
+    }
+
+    #[test]
+    fn new_authority_form_names_a_relative_file() {
+        // Authority-form URLs: the host component is part of the file path.
+        assert_eq!(file_path("turso://todos.db"), PathBuf::from("todos.db"));
+        assert_eq!(file_path("turso://./todos.db"), PathBuf::from("./todos.db"));
+        assert_eq!(
+            file_path("turso://data/todos.db"),
+            PathBuf::from("data/todos.db")
+        );
+        // Non-special schemes have opaque hosts: case is preserved,
+        // unlike `http`.
+        assert_eq!(
+            file_path("turso://MyDatabase.db"),
+            PathBuf::from("MyDatabase.db")
+        );
+    }
+
+    #[test]
+    fn new_url_without_a_path_is_rejected() {
+        assert!(Turso::new("turso:").is_err());
+        assert!(Turso::new("turso://").is_err());
     }
 }
 

--- a/crates/toasty-driver-turso/src/lib.rs
+++ b/crates/toasty-driver-turso/src/lib.rs
@@ -72,12 +72,18 @@ use turso::sync::{AuthTokenFn, Builder, Database};
 #[cfg(not(feature = "sync"))]
 use turso::{Builder, Database};
 use turso::{Connection as TursoConn, Statement, Value as TursoValue};
-use url::Url;
 
 enum SqlReturn {
     Count,
     Infer,
     Types(Vec<stmt::Type>),
+}
+
+/// Strip a leading `<scheme>:` from a connection URL. Schemes are
+/// case-insensitive; returns `None` if the URL names a different scheme.
+fn strip_scheme<'a>(url: &'a str, scheme: &str) -> Option<&'a str> {
+    let (found, rest) = url.split_once(':')?;
+    found.eq_ignore_ascii_case(scheme).then_some(rest)
 }
 
 const CREATE_MIGRATIONS_TABLE: &str = "\
@@ -339,36 +345,41 @@ impl Turso {
     pub fn new(url: impl Into<String>) -> Result<Self> {
         let url_str = url.into();
 
-        // Not a valid WHATWG URL (an authority may not contain `:`), so
-        // match it before parsing.
-        if url_str == "turso://:memory:" {
-            return Ok(Self::with_path(TursoPath::InMemory));
-        }
-
-        let url = Url::parse(&url_str).map_err(toasty_core::Error::driver_operation_failed)?;
-
-        if url.scheme() != "turso" {
+        // A `turso:` URL is a scheme followed by a path, where `//` is an
+        // optional authority marker. It is deliberately not parsed as a WHATWG
+        // URL: that grammar rejects `turso://:memory:` (`:memory:` reads as an
+        // invalid port) and reads `turso://todos.db` as host `todos.db` with an
+        // empty path.
+        let Some(rest) = strip_scheme(&url_str, "turso") else {
             return Err(toasty_core::Error::invalid_connection_url(format!(
                 "connection URL does not have a `turso` scheme; url={url_str}"
             )));
-        }
+        };
 
-        if url.path() == ":memory:" {
+        let path = rest.strip_prefix("//").unwrap_or(rest);
+
+        // A query string is not part of the file path. The driver does not
+        // support URI parameters, so they are dropped.
+        //
+        // `#` is not special: a connection URL has no fragment, and `#` is a
+        // legal filename character, so it stays. Write `%3F` for a literal `?`.
+        let path = match path.find('?') {
+            Some(i) => &path[..i],
+            None => path,
+        };
+
+        if path == ":memory:" {
             return Ok(Self::with_path(TursoPath::InMemory));
         }
 
-        // In `turso://name.db`, `name.db` parses as the URL host, not the
-        // path. Recombine host + path so it names the file instead of `""`.
-        let raw_path = format!("{}{}", url.host_str().unwrap_or(""), url.path());
-
-        if raw_path.is_empty() {
+        if path.is_empty() {
             return Err(toasty_core::Error::invalid_connection_url(format!(
                 "connection URL does not name a database file; url={url_str}"
             )));
         }
 
         Ok(Self::with_path(TursoPath::File(PathBuf::from(
-            percent_encoding::percent_decode(raw_path.as_bytes())
+            percent_encoding::percent_decode(path.as_bytes())
                 .decode_utf8_lossy()
                 .as_ref(),
         ))))
@@ -1067,6 +1078,15 @@ mod tests {
             Turso::new("turso://:memory:").unwrap().path,
             TursoPath::InMemory
         ));
+        // Schemes are case-insensitive.
+        assert!(matches!(
+            Turso::new("TURSO://:memory:").unwrap().path,
+            TursoPath::InMemory
+        ));
+        assert!(matches!(
+            Turso::new("TURSO::memory:").unwrap().path,
+            TursoPath::InMemory
+        ));
     }
 
     #[test]
@@ -1087,9 +1107,35 @@ mod tests {
     }
 
     #[test]
+    fn new_drops_query_string() {
+        // The driver does not support URI parameters, so a query string must
+        // not end up in the filename.
+        assert_eq!(
+            file_path("turso:app.db?cache=shared"),
+            PathBuf::from("app.db")
+        );
+        assert_eq!(file_path("turso://app.db?mode=ro"), PathBuf::from("app.db"));
+        assert!(matches!(
+            Turso::new("turso::memory:?cache=shared").unwrap().path,
+            TursoPath::InMemory
+        ));
+    }
+
+    #[test]
+    fn new_keeps_hash_in_filename() {
+        // A connection URL has no fragment, and `#` is a legal filename
+        // character — truncating there would silently open the wrong file.
+        assert_eq!(file_path("turso:notes#1.db"), PathBuf::from("notes#1.db"));
+        assert_eq!(file_path("turso://notes#1.db"), PathBuf::from("notes#1.db"));
+        // A literal `?` still has to be percent-encoded.
+        assert_eq!(file_path("turso:a%3Fb.db"), PathBuf::from("a?b.db"));
+    }
+
+    #[test]
     fn new_url_without_a_path_is_rejected() {
         assert!(Turso::new("turso:").is_err());
         assert!(Turso::new("turso://").is_err());
+        assert!(Turso::new("turso:?cache=shared").is_err());
     }
 }
 

--- a/crates/toasty/Cargo.toml
+++ b/crates/toasty/Cargo.toml
@@ -78,7 +78,6 @@ tokio.workspace = true
 toml = { workspace = true, optional = true }
 toml_edit = { workspace = true, features = ["serde"], optional = true }
 tracing.workspace = true
-url.workspace = true
 
 [dev-dependencies]
 assert-struct.workspace = true

--- a/crates/toasty/src/db/builder.rs
+++ b/crates/toasty/src/db/builder.rs
@@ -248,7 +248,7 @@ impl Builder {
     /// # #[cfg(feature = "sqlite")]
     /// let db = toasty::Db::builder()
     ///     .models(toasty::models!(User))
-    ///     .connect("sqlite://memory")
+    ///     .connect("sqlite::memory:")
     ///     .await
     ///     .unwrap();
     /// # });

--- a/crates/toasty/src/db/connect.rs
+++ b/crates/toasty/src/db/connect.rs
@@ -53,9 +53,25 @@ impl Connect {
             allow(unused_variables, unreachable_code)
         )]
 
-        let url = Url::parse(url).map_err(toasty_core::Error::driver_operation_failed)?;
+        let scheme = url
+            .split_once(':')
+            .map(|(scheme, _)| scheme.to_ascii_lowercase())
+            .ok_or_else(|| {
+                toasty_core::Error::invalid_connection_url(format!(
+                    "connection URL has no scheme; url={url}"
+                ))
+            })?;
 
-        let driver: Box<dyn Driver> = match url.scheme() {
+        // `sqlite:` and `turso:` URLs name a file path rather than a network
+        // location, and their accepted forms are not valid WHATWG URLs
+        // (`sqlite://:memory:` has no parseable authority), so those drivers
+        // parse their own. Everything else is a real URL — validate it here,
+        // before a malformed one reaches a driver that never parses it.
+        if !matches!(scheme.as_str(), "sqlite" | "turso") {
+            Url::parse(url).map_err(toasty_core::Error::driver_operation_failed)?;
+        }
+
+        let driver: Box<dyn Driver> = match scheme.as_str() {
             #[cfg(feature = "dynamodb")]
             "dynamodb" => {
                 // DynamoDB driver requires async initialization to load AWS config from environment

--- a/crates/toasty/src/db/connect.rs
+++ b/crates/toasty/src/db/connect.rs
@@ -8,8 +8,6 @@ use toasty_core::{
     schema::{db::Migration, diff},
 };
 
-use url::Url;
-
 /// A connection to a database, wrapping the specific driver implementation.
 pub struct Connect {
     driver: Box<dyn Driver>,
@@ -53,6 +51,10 @@ impl Connect {
             allow(unused_variables, unreachable_code)
         )]
 
+        // Dispatch on the scheme alone — each driver parses and validates the
+        // full URL itself. Schemes are case-insensitive, and some accepted
+        // forms (`sqlite://:memory:`) are not valid WHATWG URLs, so the string
+        // must not be parsed as one here.
         let scheme = url
             .split_once(':')
             .map(|(scheme, _)| scheme.to_ascii_lowercase())
@@ -61,15 +63,6 @@ impl Connect {
                     "connection URL has no scheme; url={url}"
                 ))
             })?;
-
-        // `sqlite:` and `turso:` URLs name a file path rather than a network
-        // location, and their accepted forms are not valid WHATWG URLs
-        // (`sqlite://:memory:` has no parseable authority), so those drivers
-        // parse their own. Everything else is a real URL — validate it here,
-        // before a malformed one reaches a driver that never parses it.
-        if !matches!(scheme.as_str(), "sqlite" | "turso") {
-            Url::parse(url).map_err(toasty_core::Error::driver_operation_failed)?;
-        }
 
         let driver: Box<dyn Driver> = match scheme.as_str() {
             #[cfg(feature = "dynamodb")]

--- a/tests/tests/connect_memory_url.rs
+++ b/tests/tests/connect_memory_url.rs
@@ -1,0 +1,10 @@
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn connect_sqlite_in_memory_urls() {
+    for url in ["sqlite::memory:", "sqlite://:memory:", "SQLITE://:memory:"] {
+        toasty::Db::builder()
+            .connect(url)
+            .await
+            .unwrap_or_else(|err| panic!("connecting with `{url}` should succeed: {err}"));
+    }
+}


### PR DESCRIPTION
## Summary
Closes #1125

`sqlite://name.db` parsed `name.db` as the URL *host*, leaving the path empty, so the driver became `Sqlite::File("")` — SQLite opens an empty path as a private temporary database per connection.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test
- [ ] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`):
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers
N/A