### PR TITLE
feat: let a read-only plan run without a transaction when the driver has none

### DIFF
--- a/crates/toasty-core/CHANGELOG.md
+++ b/crates/toasty-core/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Capability::snapshot_reads`, letting a driver whose backend has no
+  transactions run read-only plans unwrapped instead of refusing them.
+
 ## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-core-v0.8.0...toasty-core-v0.9.0) - 2026-07-23
 
 ### Added

--- a/crates/toasty-core/src/driver/capability.rs
+++ b/crates/toasty-core/src/driver/capability.rs
@@ -243,6 +243,21 @@ pub struct Capability {
     /// [`Error::unsupported_feature`](crate::Error::unsupported_feature).
     pub transaction_lock_mode: bool,
 
+    /// Whether a multi-statement read can be given a consistent snapshot by
+    /// wrapping it in a transaction.
+    ///
+    /// SQL backends set this `true`, so a read-only plan of several
+    /// statements — an eager load, say — runs inside `BEGIN`/`COMMIT` and its
+    /// statements cannot straddle a concurrent write.
+    ///
+    /// A driver whose backend has no transactions at all sets it `false`.
+    /// Read-only plans then run unwrapped, trading that snapshot for being
+    /// able to run at all: the alternative is the engine asking for a
+    /// transaction the driver must refuse. Plans that *write* are unaffected
+    /// — they still request a transaction, so a driver that cannot provide
+    /// one still rejects them rather than silently writing non-atomically.
+    pub snapshot_reads: bool,
+
     /// Whether the backend can walk a paginated query in reverse from a
     /// cursor.
     ///
@@ -638,6 +653,7 @@ impl Capability {
         // SQLite exposes `BEGIN DEFERRED|IMMEDIATE|EXCLUSIVE` for
         // lock-acquisition policy.
         transaction_lock_mode: true,
+        snapshot_reads: true,
 
         backward_pagination: true,
         sql_nulls_first_on_asc: true,
@@ -713,6 +729,7 @@ impl Capability {
         // PostgreSQL has no SQLite-style lock-mode keyword on BEGIN.
         transaction_lock_mode: false,
         sql_nulls_first_on_asc: false,
+        snapshot_reads: true,
 
         // PostgreSQL accepts a single array-valued bind param and supports
         // `expr <op> ANY(array)` / `<op> ALL(array)` predicates.
@@ -771,6 +788,7 @@ impl Capability {
 
         // MySQL has no SQLite-style lock-mode keyword on START TRANSACTION.
         transaction_lock_mode: false,
+        snapshot_reads: true,
 
         // `Vec<scalar>` model fields land in a `JSON` column. The driver
         // serializes `Value::List` to a JSON string at bind time, so the
@@ -864,6 +882,7 @@ impl Capability {
 
         // DynamoDB rejects `Operation::Transaction` wholesale.
         transaction_lock_mode: false,
+        snapshot_reads: false,
 
         backward_pagination: false,
         sql_nulls_first_on_asc: false,

--- a/crates/toasty/CHANGELOG.md
+++ b/crates/toasty/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- A read-only plan runs without a transaction when the driver reports it
+  cannot offer a snapshot. Plans that write are unaffected, as are drivers
+  that leave the capability at its default.
+
 ## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-v0.8.0...toasty-v0.9.0) - 2026-07-23
 
 ### Added

--- a/crates/toasty/src/engine/exec/action.rs
+++ b/crates/toasty/src/engine/exec/action.rs
@@ -2,6 +2,7 @@ use crate::engine::exec::{
     DeleteByKey, Eval, ExecStatement, Filter, FindPkByIndex, GetByKey, Guard, NestedMerge, Project,
     QueryPk, ReadModifyWrite, Scan, SetVar, UpdateByKey, Upsert,
 };
+use toasty_core::stmt;
 
 use std::fmt;
 
@@ -75,6 +76,33 @@ impl Action {
             Action::SetVar(_) => "set_var",
             Action::UpdateByKey(_) => "update_by_key",
             Action::Upsert(_) => "upsert",
+        }
+    }
+
+    /// Returns true if this action can modify the database.
+    ///
+    /// A plan built only from actions that return `false` here reads without
+    /// writing, which is what lets the planner decide whether wrapping it in a
+    /// transaction is about atomicity or only about snapshot consistency.
+    pub(crate) fn is_write(&self) -> bool {
+        match self {
+            Action::DeleteByKey(_)
+            | Action::ReadModifyWrite(_)
+            | Action::UpdateByKey(_)
+            | Action::Upsert(_) => true,
+
+            Action::ExecStatement(exec) => !matches!(exec.stmt, stmt::Statement::Query(_)),
+
+            Action::Eval(_)
+            | Action::Filter(_)
+            | Action::FindPkByIndex(_)
+            | Action::GetByKey(_)
+            | Action::Guard(_)
+            | Action::NestedMerge(_)
+            | Action::Project(_)
+            | Action::QueryPk(_)
+            | Action::Scan(_)
+            | Action::SetVar(_) => false,
         }
     }
 

--- a/crates/toasty/src/engine/plan.rs
+++ b/crates/toasty/src/engine/plan.rs
@@ -30,6 +30,7 @@ struct ExecPlanner<'a> {
     var_decls: VarDecls,
     actions: Vec<exec::Action>,
     use_transactions: bool,
+    snapshot_reads: bool,
     schema: Arc<Schema>,
 }
 
@@ -53,6 +54,7 @@ impl Engine {
             var_decls: VarDecls::default(),
             actions: vec![],
             use_transactions: self.capability().sql,
+            snapshot_reads: self.capability().snapshot_reads,
             schema: self.schema.clone(),
         }
         .plan_execution()

--- a/crates/toasty/src/engine/plan/execution.rs
+++ b/crates/toasty/src/engine/plan/execution.rs
@@ -13,8 +13,15 @@ impl ExecPlanner<'_> {
 
         let returning = self.logical_plan.completion().var.get();
 
+        // A plan touching several statements is wrapped in a transaction for
+        // one of two reasons: so its writes commit together, or so its reads
+        // see one snapshot. Only the second is optional — a driver whose
+        // backend has no transactions still needs its reads to run, whereas
+        // letting its writes proceed unwrapped would drop atomicity silently.
+        let db_ops = self.actions.iter().filter(|a| a.is_db_op()).count();
+        let writes = self.actions.iter().any(|action| action.is_write());
         let needs_transaction =
-            self.use_transactions && self.actions.iter().filter(|a| a.is_db_op()).count() > 1;
+            self.use_transactions && db_ops > 1 && (writes || self.snapshot_reads);
 
         ExecPlan {
             vars: VarStore::new(self.var_decls, self.schema),

--- a/tests/tests/capability_dispatch.rs
+++ b/tests/tests/capability_dispatch.rs
@@ -1,0 +1,236 @@
+#![cfg(feature = "sqlite")]
+
+//! Tests that the engine decides whether a plan needs a transaction from what
+//! the driver says it can do, via [`Capability::snapshot_reads`].
+//!
+//! Each test wraps the SQLite driver in one that reports different
+//! capabilities and records what it is asked to do, so the assertions are
+//! about the engine's choices rather than any backend's behaviour.
+
+use std::sync::{Arc, Mutex, OnceLock};
+
+use async_trait::async_trait;
+use toasty_core::{
+    Schema,
+    driver::{Capability, ConnectContext, Driver, ExecResponse, Operation},
+    schema::{
+        db::{AppliedMigration, Migration},
+        diff,
+    },
+};
+
+#[derive(Debug, toasty::Model)]
+struct Author {
+    #[key]
+    #[auto]
+    id: u64,
+
+    #[index]
+    name: String,
+
+    #[has_many]
+    books: toasty::Deferred<Vec<Book>>,
+}
+
+#[derive(Debug, toasty::Model)]
+struct Book {
+    #[key]
+    #[auto]
+    id: u64,
+
+    #[index]
+    title: String,
+
+    #[index]
+    author_id: u64,
+
+    #[belongs_to(key = author_id, references = id)]
+    author: toasty::Deferred<Author>,
+}
+
+/// What the engine asked the driver to do, in order.
+#[derive(Debug, PartialEq, Eq)]
+enum Call {
+    Transaction,
+    Statement,
+}
+
+type Log = Arc<Mutex<Vec<Call>>>;
+
+/// Wraps the SQLite driver, reporting chosen capabilities and recording the
+/// calls the engine makes.
+#[derive(Debug)]
+struct Probe {
+    inner: toasty_driver_sqlite::Sqlite,
+    capability: &'static Capability,
+    log: Log,
+}
+
+impl Probe {
+    /// Capabilities of a SQL backend that cannot open a transaction, so its
+    /// reads get no snapshot.
+    fn without_transactions() -> &'static Capability {
+        static CAPABILITY: OnceLock<Capability> = OnceLock::new();
+        CAPABILITY.get_or_init(|| Capability {
+            snapshot_reads: false,
+            ..Capability::SQLITE
+        })
+    }
+}
+
+#[async_trait]
+impl Driver for Probe {
+    fn url(&self) -> std::borrow::Cow<'_, str> {
+        self.inner.url()
+    }
+
+    fn capability(&self) -> &'static Capability {
+        self.capability
+    }
+
+    async fn connect(
+        &self,
+        cx: &ConnectContext,
+    ) -> toasty_core::Result<Box<dyn toasty_core::Connection>> {
+        Ok(Box::new(ProbeConnection {
+            inner: self.inner.connect(cx).await?,
+            log: self.log.clone(),
+        }))
+    }
+
+    fn max_connections(&self) -> Option<usize> {
+        self.inner.max_connections()
+    }
+
+    fn generate_migration(&self, schema_diff: &diff::Schema<'_>) -> Migration {
+        self.inner.generate_migration(schema_diff)
+    }
+
+    async fn reset_db(&self) -> toasty_core::Result<()> {
+        self.inner.reset_db().await
+    }
+}
+
+#[derive(Debug)]
+struct ProbeConnection {
+    inner: Box<dyn toasty_core::Connection>,
+    log: Log,
+}
+
+#[async_trait]
+impl toasty_core::driver::Connection for ProbeConnection {
+    async fn exec(
+        &mut self,
+        schema: &Arc<Schema>,
+        op: Operation,
+    ) -> toasty_core::Result<ExecResponse> {
+        self.log.lock().unwrap().push(match op {
+            Operation::Transaction(_) => Call::Transaction,
+            _ => Call::Statement,
+        });
+        self.inner.exec(schema, op).await
+    }
+
+    async fn push_schema(&mut self, schema: &Schema) -> toasty_core::Result<()> {
+        self.inner.push_schema(schema).await
+    }
+
+    async fn applied_migrations(&mut self) -> toasty_core::Result<Vec<AppliedMigration>> {
+        self.inner.applied_migrations().await
+    }
+
+    async fn apply_migration(
+        &mut self,
+        id: u64,
+        name: &str,
+        migration: &Migration,
+    ) -> toasty_core::Result<()> {
+        self.inner.apply_migration(id, name, migration).await
+    }
+}
+
+async fn setup(capability: &'static Capability) -> (toasty::Db, Log) {
+    let log: Log = Arc::new(Mutex::new(vec![]));
+    let mut builder = toasty::Db::builder();
+    builder.models(toasty::models!(Author, Book));
+    let db = builder
+        .build(Probe {
+            inner: toasty_driver_sqlite::Sqlite::in_memory(),
+            capability,
+            log: log.clone(),
+        })
+        .await
+        .unwrap();
+    db.push_schema().await.unwrap();
+    (db, log)
+}
+
+/// Clears the calls made while seeding, so an assertion sees only the
+/// statement under test.
+fn take(log: &Log) -> Vec<Call> {
+    std::mem::take(&mut *log.lock().unwrap())
+}
+
+async fn seed(db: &toasty::Db) -> u64 {
+    let mut handle = db.clone();
+    let author = Author::create()
+        .name("Alice")
+        .exec(&mut handle)
+        .await
+        .unwrap();
+    for title in ["Alpha", "Beta"] {
+        Book::create()
+            .title(title)
+            .author_id(author.id)
+            .exec(&mut handle)
+            .await
+            .unwrap();
+    }
+    author.id
+}
+
+/// The default: an eager load reads under a transaction so both statements
+/// see one snapshot.
+#[tokio::test]
+async fn read_only_plan_takes_a_transaction_by_default() {
+    let (db, log) = setup(&Capability::SQLITE).await;
+    let author_id = seed(&db).await;
+    take(&log);
+
+    let mut handle = db.clone();
+    let author = Author::filter_by_id(author_id)
+        .include(Author::fields().books())
+        .get(&mut handle)
+        .await
+        .unwrap();
+    assert_eq!(author.books.get().len(), 2);
+
+    let calls = take(&log);
+    assert!(
+        calls.contains(&Call::Transaction),
+        "expected a transaction, got {calls:?}"
+    );
+}
+
+/// A driver that cannot offer a snapshot gets the same reads without one,
+/// rather than a transaction it would have to refuse.
+#[tokio::test]
+async fn read_only_plan_skips_the_transaction_without_snapshot_reads() {
+    let (db, log) = setup(Probe::without_transactions()).await;
+    let author_id = seed(&db).await;
+    take(&log);
+
+    let mut handle = db.clone();
+    let author = Author::filter_by_id(author_id)
+        .include(Author::fields().books())
+        .get(&mut handle)
+        .await
+        .unwrap();
+    assert_eq!(author.books.get().len(), 2, "the eager load still resolves");
+
+    let calls = take(&log);
+    assert!(
+        !calls.contains(&Call::Transaction),
+        "expected no transaction, got {calls:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Implements the read half of #1128, per the design in #1131. **Blocked on that design being accepted** — opened early because the work was already done; happy to close and resubmit if the design changes shape.

A plan with more than one database operation is wrapped in a transaction whenever the driver reports `sql`, regardless of what those operations do. An eager load is two SELECTs, so it takes a transaction purely for the snapshot — and a backend without transactions cannot run it at all, despite having no trouble with either statement.

`Capability` gains `snapshot_reads`. The planner then asks for a transaction when the plan writes, or when the driver can offer a snapshot:

```rust
let needs_transaction =
    self.use_transactions && db_ops > 1 && (writes || self.snapshot_reads);
```

Shipped drivers set it `true`, where `writes || true` leaves the condition exactly as it was. Plans that write are untouched, so a driver that cannot provide a transaction still receives one for them and still rejects it, rather than being allowed to write non-atomically by silence.

## Type of change

- [ ] Small / obvious change — bug fix, docs, internal cleanup, or test
- [x] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`):
      [`transaction-less-backends.md`](https://github.com/tokio-rs/toasty/blob/main/docs/dev/design/transaction-less-backends.md) — proposed in #1131, **not yet merged**
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers

The behavioural question is what a driver gives up by setting `snapshot_reads: false`: its two reads can straddle a concurrent write. The rows returned are always real, but they are not one point in time. That is why it is the driver's declaration rather than a blanket change — the design doc's *Edge cases* section covers it.

`tests/tests/capability_dispatch.rs` wraps the SQLite driver in one reporting chosen capabilities and recording what the engine asks of it, so it asserts the engine's decision rather than any backend's behaviour, and runs in CI without a backend that actually lacks transactions. Both directions are covered: a read-only plan takes a transaction by default, and skips it without `snapshot_reads` while still resolving the eager load.

Verified locally against the CI steps: `fmt --all --check`, `check --workspace --all-features`, `clippy --workspace --all-features` (clean), `test --no-default-features --features sqlite` (the sqlite suite holds at 1352), MSRV 1.95, and `cargo hack check --feature-powerset` for `toasty` and `toasty-core`.

Measured against live Cloudflare D1 through [toasty-driver-d1](https://github.com/hirunefu/toasty-driver-d1): `include()` goes from failing outright to returning the correct rows.
