### PR TITLE
feat: hand a plan's writes to the driver as one atomic set

### DIFF
--- a/crates/toasty-core/CHANGELOG.md
+++ b/crates/toasty-core/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Capability::snapshot_reads`, letting a driver whose backend has no
+  transactions run read-only plans unwrapped instead of refusing them.
+
 ## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-core-v0.8.0...toasty-core-v0.9.0) - 2026-07-23
 
 ### Added

--- a/crates/toasty-core/CHANGELOG.md
+++ b/crates/toasty-core/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Capability::snapshot_reads`, letting a driver whose backend has no
   transactions run read-only plans unwrapped instead of refusing them.
+- `Capability::atomic_write_batch` and `Connection::exec_batch`, for a backend
+  that commits a set of writes submitted together rather than under an
+  engine-controlled `BEGIN`/`COMMIT`.
 
 ## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-core-v0.8.0...toasty-core-v0.9.0) - 2026-07-23
 

--- a/crates/toasty-core/src/driver.rs
+++ b/crates/toasty-core/src/driver.rs
@@ -182,6 +182,30 @@ pub trait Connection: Debug + Send + 'static {
     /// typed by the structural `Type::Object`.
     async fn exec(&mut self, schema: &Arc<Schema>, plan: Operation) -> crate::Result<ExecResponse>;
 
+    /// Executes several write operations as one atomic unit, returning one
+    /// response per operation, in order.
+    ///
+    /// The engine calls this instead of [`exec`](Self::exec) when the driver
+    /// reports [`Capability::atomic_write_batch`] and a plan performs more
+    /// than one write. It exists for backends that cannot hold a transaction
+    /// open across calls but can commit a set of statements submitted
+    /// together — Cloudflare D1, whose HTTP API rejects `BEGIN` yet runs a
+    /// multi-statement request atomically, is the motivating case.
+    ///
+    /// Implementations must apply every operation or none of them. The
+    /// default returns [`Error::unsupported_feature`](crate::Error::unsupported_feature),
+    /// which is correct for any driver that leaves the capability off, since
+    /// the engine then never calls this.
+    async fn exec_batch(
+        &mut self,
+        _schema: &Arc<Schema>,
+        _ops: Vec<Operation>,
+    ) -> crate::Result<Vec<ExecResponse>> {
+        Err(crate::Error::unsupported_feature(
+            "this driver does not execute write batches atomically",
+        ))
+    }
+
     /// Cheap, synchronous, local check that the driver's client object
     /// still considers the connection open.
     ///

--- a/crates/toasty-core/src/driver/capability.rs
+++ b/crates/toasty-core/src/driver/capability.rs
@@ -258,6 +258,22 @@ pub struct Capability {
     /// one still rejects them rather than silently writing non-atomically.
     pub snapshot_reads: bool,
 
+    /// Whether the driver commits a set of writes handed to it together,
+    /// rather than under an engine-controlled `BEGIN`/`COMMIT`.
+    ///
+    /// SQL backends leave this `false`: the engine streams their writes
+    /// inside a transaction, which also lets a later write read an earlier
+    /// one's effect. A backend that cannot hold a transaction open across
+    /// calls but can commit statements submitted in one request — Cloudflare
+    /// D1 — sets it `true`, and the engine hands the whole set to
+    /// [`Connection::exec_batch`](super::Connection::exec_batch) instead.
+    ///
+    /// The engine only takes that route when no write in the set depends on
+    /// another's output, since a batch is submitted before any of it runs.
+    /// A set that fails the check falls back to the streamed path, where a
+    /// driver without transactions rejects it.
+    pub atomic_write_batch: bool,
+
     /// Whether the backend can walk a paginated query in reverse from a
     /// cursor.
     ///
@@ -654,6 +670,7 @@ impl Capability {
         // lock-acquisition policy.
         transaction_lock_mode: true,
         snapshot_reads: true,
+        atomic_write_batch: false,
 
         backward_pagination: true,
         sql_nulls_first_on_asc: true,
@@ -730,6 +747,7 @@ impl Capability {
         transaction_lock_mode: false,
         sql_nulls_first_on_asc: false,
         snapshot_reads: true,
+        atomic_write_batch: false,
 
         // PostgreSQL accepts a single array-valued bind param and supports
         // `expr <op> ANY(array)` / `<op> ALL(array)` predicates.
@@ -789,6 +807,7 @@ impl Capability {
         // MySQL has no SQLite-style lock-mode keyword on START TRANSACTION.
         transaction_lock_mode: false,
         snapshot_reads: true,
+        atomic_write_batch: false,
 
         // `Vec<scalar>` model fields land in a `JSON` column. The driver
         // serializes `Value::List` to a JSON string at bind time, so the
@@ -883,6 +902,7 @@ impl Capability {
         // DynamoDB rejects `Operation::Transaction` wholesale.
         transaction_lock_mode: false,
         snapshot_reads: false,
+        atomic_write_batch: false,
 
         backward_pagination: false,
         sql_nulls_first_on_asc: false,

--- a/crates/toasty-core/src/driver/capability.rs
+++ b/crates/toasty-core/src/driver/capability.rs
@@ -243,6 +243,21 @@ pub struct Capability {
     /// [`Error::unsupported_feature`](crate::Error::unsupported_feature).
     pub transaction_lock_mode: bool,
 
+    /// Whether a multi-statement read can be given a consistent snapshot by
+    /// wrapping it in a transaction.
+    ///
+    /// SQL backends set this `true`, so a read-only plan of several
+    /// statements — an eager load, say — runs inside `BEGIN`/`COMMIT` and its
+    /// statements cannot straddle a concurrent write.
+    ///
+    /// A driver whose backend has no transactions at all sets it `false`.
+    /// Read-only plans then run unwrapped, trading that snapshot for being
+    /// able to run at all: the alternative is the engine asking for a
+    /// transaction the driver must refuse. Plans that *write* are unaffected
+    /// — they still request a transaction, so a driver that cannot provide
+    /// one still rejects them rather than silently writing non-atomically.
+    pub snapshot_reads: bool,
+
     /// Whether the backend can walk a paginated query in reverse from a
     /// cursor.
     ///
@@ -638,6 +653,7 @@ impl Capability {
         // SQLite exposes `BEGIN DEFERRED|IMMEDIATE|EXCLUSIVE` for
         // lock-acquisition policy.
         transaction_lock_mode: true,
+        snapshot_reads: true,
 
         backward_pagination: true,
         sql_nulls_first_on_asc: true,
@@ -713,6 +729,7 @@ impl Capability {
         // PostgreSQL has no SQLite-style lock-mode keyword on BEGIN.
         transaction_lock_mode: false,
         sql_nulls_first_on_asc: false,
+        snapshot_reads: true,
 
         // PostgreSQL accepts a single array-valued bind param and supports
         // `expr <op> ANY(array)` / `<op> ALL(array)` predicates.
@@ -771,6 +788,7 @@ impl Capability {
 
         // MySQL has no SQLite-style lock-mode keyword on START TRANSACTION.
         transaction_lock_mode: false,
+        snapshot_reads: true,
 
         // `Vec<scalar>` model fields land in a `JSON` column. The driver
         // serializes `Value::List` to a JSON string at bind time, so the
@@ -864,6 +882,7 @@ impl Capability {
 
         // DynamoDB rejects `Operation::Transaction` wholesale.
         transaction_lock_mode: false,
+        snapshot_reads: false,
 
         backward_pagination: false,
         sql_nulls_first_on_asc: false,

--- a/crates/toasty-driver-integration-suite/src/instrumented_driver.rs
+++ b/crates/toasty-driver-integration-suite/src/instrumented_driver.rs
@@ -244,6 +244,57 @@ impl Connection for InstrumentedConnection {
         Ok(response)
     }
 
+    async fn exec_batch(
+        &mut self,
+        schema: &Arc<Schema>,
+        ops: Vec<Operation>,
+    ) -> Result<Vec<ExecResponse>> {
+        // One injected fault fails the batch, matching what the underlying
+        // driver would do: a batch applies wholly or not at all.
+        let fault = self
+            .handle
+            .inner
+            .faults
+            .lock()
+            .expect("Failed to acquire faults lock")
+            .pop_front();
+        if let Some(fault) = fault {
+            match fault {
+                Fault::OperationFailed => {
+                    return Err(toasty_core::Error::driver_operation_failed(
+                        std::io::Error::other("injected operation failure"),
+                    ));
+                }
+                Fault::ConnectionLost => {
+                    self.valid.store(false, Ordering::Release);
+                    return Err(toasty_core::Error::connection_lost(std::io::Error::other(
+                        "injected connection-lost fault",
+                    )));
+                }
+            }
+        }
+
+        let operations = ops.clone();
+        let mut responses = self.inner.exec_batch(schema, ops).await?;
+
+        // Log each statement separately, so assertions over the operation log
+        // read the same whether the driver batched or streamed the writes.
+        for (operation, response) in operations.into_iter().zip(responses.iter_mut()) {
+            let duplicated_response = duplicate_response_mut(response).await?;
+            self.handle
+                .inner
+                .ops_log
+                .lock()
+                .expect("Failed to acquire ops log lock")
+                .push(DriverOp {
+                    operation,
+                    response: duplicated_response,
+                });
+        }
+
+        Ok(responses)
+    }
+
     async fn push_schema(&mut self, schema: &Schema) -> Result<()> {
         self.inner.push_schema(schema).await
     }

--- a/crates/toasty/CHANGELOG.md
+++ b/crates/toasty/CHANGELOG.md
@@ -9,9 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- A read-only plan runs without a transaction when the driver reports it
-  cannot offer a snapshot. Plans that write are unaffected, as are drivers
-  that leave the capability at its default.
+- Plans are dispatched by what the driver reports it can do: a read-only plan
+  runs without a transaction when the driver cannot offer a snapshot, and a
+  plan's independent writes are handed over as one set when the driver commits
+  them together. Drivers reporting neither capability are unaffected.
 
 ## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-v0.8.0...toasty-v0.9.0) - 2026-07-23
 

--- a/crates/toasty/CHANGELOG.md
+++ b/crates/toasty/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- A read-only plan runs without a transaction when the driver reports it
+  cannot offer a snapshot. Plans that write are unaffected, as are drivers
+  that leave the capability at its default.
+
 ## [0.9.0](https://github.com/tokio-rs/toasty/compare/toasty-v0.8.0...toasty-v0.9.0) - 2026-07-23
 
 ### Added

--- a/crates/toasty/src/engine/exec.rs
+++ b/crates/toasty/src/engine/exec.rs
@@ -111,20 +111,29 @@ impl Engine {
             )
         };
 
-        if plan.needs_transaction {
+        // A driver that commits a set of writes handed to it takes that route
+        // rather than a transaction, when the plan's writes qualify.
+        let batched = self.capability().atomic_write_batch
+            && plan.needs_transaction
+            && exec.exec_write_batch(&plan.actions).await?;
+
+        if plan.needs_transaction && !batched {
             tracing::trace!("beginning plan transaction");
             exec.connection.exec(&self.schema, begin.into()).await?;
             exec.in_transaction = true;
         }
 
         for (i, step) in plan.actions.iter().enumerate() {
+            if batched && step.is_batchable_write() {
+                continue;
+            }
             tracing::trace!(step = i, action = %step.name(), "executing action");
             // Debug, not error: the failure propagates to the caller, who
             // decides whether it is an application error. A handled unique
             // violation should not error-spam production logs.
             if let Err(e) = exec.exec_step(step).await {
                 tracing::debug!(step = i, action = %step.name(), error = %e, "action failed");
-                if plan.needs_transaction {
+                if plan.needs_transaction && !batched {
                     tracing::trace!("rolling back plan transaction due to error");
                     // Best effort: ignore rollback errors so the original error is returned
                     let _ = exec.connection.exec(&self.schema, rollback.into()).await;
@@ -133,7 +142,7 @@ impl Engine {
             }
         }
 
-        if plan.needs_transaction {
+        if plan.needs_transaction && !batched {
             tracing::trace!("committing plan transaction");
             exec.connection.exec(&self.schema, commit.into()).await?;
         }
@@ -164,6 +173,62 @@ impl Engine {
 }
 
 impl Exec<'_> {
+    /// Sends the plan's writes to the driver as one atomic set.
+    ///
+    /// Returns `false` without touching the database when the plan does not
+    /// qualify — fewer than two writes, or a write that reads a variable and
+    /// so cannot be submitted before the rest of the batch has run. The
+    /// caller then falls back to the streamed path.
+    ///
+    /// The writes are hoisted ahead of the actions between them, which is
+    /// sound precisely because none of them takes an input.
+    async fn exec_write_batch(&mut self, actions: &[Action]) -> Result<bool> {
+        let writes: Vec<&ExecStatement> = actions
+            .iter()
+            .filter_map(|action| match action {
+                Action::ExecStatement(exec) if action.is_batchable_write() => Some(&**exec),
+                _ => None,
+            })
+            .collect();
+
+        let all_writes_batchable = actions
+            .iter()
+            .filter(|action| action.is_write())
+            .all(Action::is_batchable_write);
+
+        if writes.len() < 2 || !all_writes_batchable {
+            return Ok(false);
+        }
+
+        let mut ops = Vec::with_capacity(writes.len());
+        let mut pending = Vec::with_capacity(writes.len());
+        for action in &writes {
+            if let Some(op) = self.prepare_exec_statement(action).await? {
+                ops.push(op.into());
+                pending.push(*action);
+            }
+        }
+
+        if ops.is_empty() {
+            return Ok(true);
+        }
+
+        tracing::trace!(writes = ops.len(), "executing write batch");
+        let responses = self.connection.exec_batch(&self.engine.schema, ops).await?;
+
+        if responses.len() != pending.len() {
+            return Err(toasty_core::Error::invalid_result(
+                "driver returned the wrong number of batch responses",
+            ));
+        }
+
+        for (action, res) in pending.into_iter().zip(responses) {
+            self.finish_batched_statement(action, res).await?;
+        }
+
+        Ok(true)
+    }
+
     async fn exec_step(&mut self, action: &Action) -> Result<()> {
         match action {
             Action::DeleteByKey(action) => self.action_delete_by_key(action).await,

--- a/crates/toasty/src/engine/exec/action.rs
+++ b/crates/toasty/src/engine/exec/action.rs
@@ -106,6 +106,21 @@ impl Action {
         }
     }
 
+    /// Returns true if this action is a write that can be handed to
+    /// [`Connection::exec_batch`](toasty_core::driver::Connection::exec_batch).
+    ///
+    /// A batch is submitted before any of it runs, so a statement that reads
+    /// a variable is excluded: whatever produced that variable may itself be
+    /// in the batch, and would not have run yet.
+    pub(crate) fn is_batchable_write(&self) -> bool {
+        match self {
+            Action::ExecStatement(exec) => {
+                !matches!(exec.stmt, stmt::Statement::Query(_)) && exec.input.is_empty()
+            }
+            _ => false,
+        }
+    }
+
     /// Returns true if this action issues a database operation.
     ///
     /// Used to determine whether a plan needs to be wrapped in a transaction.

--- a/crates/toasty/src/engine/exec/action.rs
+++ b/crates/toasty/src/engine/exec/action.rs
@@ -2,6 +2,7 @@ use crate::engine::exec::{
     DeleteByKey, Eval, ExecStatement, Filter, FindPkByIndex, GetByKey, Guard, NestedMerge, Project,
     QueryPk, ReadModifyWrite, Scan, SetVar, UpdateByKey, Upsert,
 };
+use toasty_core::stmt;
 
 use std::fmt;
 
@@ -75,6 +76,33 @@ impl Action {
             Action::SetVar(_) => "set_var",
             Action::UpdateByKey(_) => "update_by_key",
             Action::Upsert(_) => "upsert",
+        }
+    }
+
+    /// Returns true if this action can modify the database.
+    ///
+    /// A plan built only from actions that return `false` here reads without
+    /// writing, which is what lets the planner decide whether wrapping it in a
+    /// transaction is about atomicity or only about snapshot consistency.
+    pub(crate) fn is_write(&self) -> bool {
+        match self {
+            Action::DeleteByKey(_)
+            | Action::ReadModifyWrite(_)
+            | Action::UpdateByKey(_)
+            | Action::Upsert(_) => true,
+
+            Action::ExecStatement(exec) => !matches!(exec.stmt, stmt::Statement::Query(_)),
+
+            Action::Eval(_)
+            | Action::Filter(_)
+            | Action::FindPkByIndex(_)
+            | Action::GetByKey(_)
+            | Action::Guard(_)
+            | Action::NestedMerge(_)
+            | Action::Project(_)
+            | Action::QueryPk(_)
+            | Action::Scan(_)
+            | Action::SetVar(_) => false,
         }
     }
 

--- a/crates/toasty/src/engine/exec/exec_statement.rs
+++ b/crates/toasty/src/engine/exec/exec_statement.rs
@@ -197,8 +197,86 @@ impl Exec<'_> {
             last_insert_id_hack: mysql_insert_returning.as_ref().map(|info| info.num_rows),
         };
 
-        let mut res = self.connection.exec(&self.engine.schema, op.into()).await?;
+        let res = self.connection.exec(&self.engine.schema, op.into()).await?;
 
+        self.finish_exec_statement(action, res, mysql_insert_returning, mysql_update_returning)
+            .await
+    }
+
+    /// Readies a statement for the driver without sending it.
+    ///
+    /// Returns `None` when the action resolved without touching the database,
+    /// having already stored its result. Only called for actions that
+    /// [`is_batchable`](ExecStatement::is_batchable) accepted, so the MySQL
+    /// `RETURNING` fixups cannot apply here.
+    pub(super) async fn prepare_exec_statement(
+        &mut self,
+        action: &ExecStatement,
+    ) -> Result<Option<operation::QuerySql>> {
+        let mut stmt = action.stmt.clone();
+        debug_assert!(action.input.is_empty(), "batched statement takes no input");
+
+        if let stmt::Statement::Query(query) = &stmt
+            && let stmt::ExprSet::Values(values) = &query.body
+            && values.is_empty()
+        {
+            let rows = if action.output.ty.is_some() {
+                Rows::Stream(stmt::ValueStream::default())
+            } else {
+                Rows::Count(0)
+            };
+            self.vars.store(
+                action.output.output.var,
+                action.output.output.num_uses,
+                ExecResponse::from_rows(rows),
+            );
+            return Ok(None);
+        }
+
+        let params = self.engine.prepare_for_driver(&mut stmt);
+
+        let ret = match action.conditional {
+            ConditionalOutput::Count => Some(vec![stmt::Type::I64, stmt::Type::I64]),
+            ConditionalOutput::Returning => {
+                let mut tys = vec![stmt::Type::I64, stmt::Type::I64];
+                tys.extend(
+                    action
+                        .output
+                        .ty
+                        .clone()
+                        .expect("conditional write with RETURNING has output columns"),
+                );
+                Some(tys)
+            }
+            ConditionalOutput::None => action.output.ty.clone(),
+        };
+
+        Ok(Some(operation::QuerySql {
+            stmt,
+            params,
+            ret,
+            last_insert_id_hack: None,
+        }))
+    }
+
+    /// Interprets a batched statement's response. The MySQL `RETURNING`
+    /// fixups never apply: they belong to a driver that streams its writes.
+    pub(super) async fn finish_batched_statement(
+        &mut self,
+        action: &ExecStatement,
+        res: ExecResponse,
+    ) -> Result<()> {
+        self.finish_exec_statement(action, res, None, None).await
+    }
+
+    /// Interprets a statement's response and stores it in the output variable.
+    async fn finish_exec_statement(
+        &mut self,
+        action: &ExecStatement,
+        mut res: ExecResponse,
+        mysql_insert_returning: Option<MySQLInsertReturning>,
+        mysql_update_returning: Option<MySQLUpdateReturning>,
+    ) -> Result<()> {
         match action.conditional {
             ConditionalOutput::None => {
                 if let Some(mysql_info) = mysql_insert_returning {

--- a/crates/toasty/src/engine/plan.rs
+++ b/crates/toasty/src/engine/plan.rs
@@ -30,6 +30,7 @@ struct ExecPlanner<'a> {
     var_decls: VarDecls,
     actions: Vec<exec::Action>,
     use_transactions: bool,
+    snapshot_reads: bool,
     schema: Arc<Schema>,
 }
 
@@ -53,6 +54,7 @@ impl Engine {
             var_decls: VarDecls::default(),
             actions: vec![],
             use_transactions: self.capability().sql,
+            snapshot_reads: self.capability().snapshot_reads,
             schema: self.schema.clone(),
         }
         .plan_execution()

--- a/crates/toasty/src/engine/plan/execution.rs
+++ b/crates/toasty/src/engine/plan/execution.rs
@@ -13,8 +13,15 @@ impl ExecPlanner<'_> {
 
         let returning = self.logical_plan.completion().var.get();
 
+        // A plan touching several statements is wrapped in a transaction for
+        // one of two reasons: so its writes commit together, or so its reads
+        // see one snapshot. Only the second is optional — a driver whose
+        // backend has no transactions still needs its reads to run, whereas
+        // letting its writes proceed unwrapped would drop atomicity silently.
+        let db_ops = self.actions.iter().filter(|a| a.is_db_op()).count();
+        let writes = self.actions.iter().any(|action| action.is_write());
         let needs_transaction =
-            self.use_transactions && self.actions.iter().filter(|a| a.is_db_op()).count() > 1;
+            self.use_transactions && db_ops > 1 && (writes || self.snapshot_reads);
 
         ExecPlan {
             vars: VarStore::new(self.var_decls, self.schema),

--- a/tests/tests/capability_dispatch.rs
+++ b/tests/tests/capability_dispatch.rs
@@ -1,0 +1,236 @@
+#![cfg(feature = "sqlite")]
+
+//! Tests that the engine decides whether a plan needs a transaction from what
+//! the driver says it can do, via [`Capability::snapshot_reads`].
+//!
+//! Each test wraps the SQLite driver in one that reports different
+//! capabilities and records what it is asked to do, so the assertions are
+//! about the engine's choices rather than any backend's behaviour.
+
+use std::sync::{Arc, Mutex, OnceLock};
+
+use async_trait::async_trait;
+use toasty_core::{
+    Schema,
+    driver::{Capability, ConnectContext, Driver, ExecResponse, Operation},
+    schema::{
+        db::{AppliedMigration, Migration},
+        diff,
+    },
+};
+
+#[derive(Debug, toasty::Model)]
+struct Author {
+    #[key]
+    #[auto]
+    id: u64,
+
+    #[index]
+    name: String,
+
+    #[has_many]
+    books: toasty::Deferred<Vec<Book>>,
+}
+
+#[derive(Debug, toasty::Model)]
+struct Book {
+    #[key]
+    #[auto]
+    id: u64,
+
+    #[index]
+    title: String,
+
+    #[index]
+    author_id: u64,
+
+    #[belongs_to(key = author_id, references = id)]
+    author: toasty::Deferred<Author>,
+}
+
+/// What the engine asked the driver to do, in order.
+#[derive(Debug, PartialEq, Eq)]
+enum Call {
+    Transaction,
+    Statement,
+}
+
+type Log = Arc<Mutex<Vec<Call>>>;
+
+/// Wraps the SQLite driver, reporting chosen capabilities and recording the
+/// calls the engine makes.
+#[derive(Debug)]
+struct Probe {
+    inner: toasty_driver_sqlite::Sqlite,
+    capability: &'static Capability,
+    log: Log,
+}
+
+impl Probe {
+    /// Capabilities of a SQL backend that cannot open a transaction, so its
+    /// reads get no snapshot.
+    fn without_transactions() -> &'static Capability {
+        static CAPABILITY: OnceLock<Capability> = OnceLock::new();
+        CAPABILITY.get_or_init(|| Capability {
+            snapshot_reads: false,
+            ..Capability::SQLITE
+        })
+    }
+}
+
+#[async_trait]
+impl Driver for Probe {
+    fn url(&self) -> std::borrow::Cow<'_, str> {
+        self.inner.url()
+    }
+
+    fn capability(&self) -> &'static Capability {
+        self.capability
+    }
+
+    async fn connect(
+        &self,
+        cx: &ConnectContext,
+    ) -> toasty_core::Result<Box<dyn toasty_core::Connection>> {
+        Ok(Box::new(ProbeConnection {
+            inner: self.inner.connect(cx).await?,
+            log: self.log.clone(),
+        }))
+    }
+
+    fn max_connections(&self) -> Option<usize> {
+        self.inner.max_connections()
+    }
+
+    fn generate_migration(&self, schema_diff: &diff::Schema<'_>) -> Migration {
+        self.inner.generate_migration(schema_diff)
+    }
+
+    async fn reset_db(&self) -> toasty_core::Result<()> {
+        self.inner.reset_db().await
+    }
+}
+
+#[derive(Debug)]
+struct ProbeConnection {
+    inner: Box<dyn toasty_core::Connection>,
+    log: Log,
+}
+
+#[async_trait]
+impl toasty_core::driver::Connection for ProbeConnection {
+    async fn exec(
+        &mut self,
+        schema: &Arc<Schema>,
+        op: Operation,
+    ) -> toasty_core::Result<ExecResponse> {
+        self.log.lock().unwrap().push(match op {
+            Operation::Transaction(_) => Call::Transaction,
+            _ => Call::Statement,
+        });
+        self.inner.exec(schema, op).await
+    }
+
+    async fn push_schema(&mut self, schema: &Schema) -> toasty_core::Result<()> {
+        self.inner.push_schema(schema).await
+    }
+
+    async fn applied_migrations(&mut self) -> toasty_core::Result<Vec<AppliedMigration>> {
+        self.inner.applied_migrations().await
+    }
+
+    async fn apply_migration(
+        &mut self,
+        id: u64,
+        name: &str,
+        migration: &Migration,
+    ) -> toasty_core::Result<()> {
+        self.inner.apply_migration(id, name, migration).await
+    }
+}
+
+async fn setup(capability: &'static Capability) -> (toasty::Db, Log) {
+    let log: Log = Arc::new(Mutex::new(vec![]));
+    let mut builder = toasty::Db::builder();
+    builder.models(toasty::models!(Author, Book));
+    let db = builder
+        .build(Probe {
+            inner: toasty_driver_sqlite::Sqlite::in_memory(),
+            capability,
+            log: log.clone(),
+        })
+        .await
+        .unwrap();
+    db.push_schema().await.unwrap();
+    (db, log)
+}
+
+/// Clears the calls made while seeding, so an assertion sees only the
+/// statement under test.
+fn take(log: &Log) -> Vec<Call> {
+    std::mem::take(&mut *log.lock().unwrap())
+}
+
+async fn seed(db: &toasty::Db) -> u64 {
+    let mut handle = db.clone();
+    let author = Author::create()
+        .name("Alice")
+        .exec(&mut handle)
+        .await
+        .unwrap();
+    for title in ["Alpha", "Beta"] {
+        Book::create()
+            .title(title)
+            .author_id(author.id)
+            .exec(&mut handle)
+            .await
+            .unwrap();
+    }
+    author.id
+}
+
+/// The default: an eager load reads under a transaction so both statements
+/// see one snapshot.
+#[tokio::test]
+async fn read_only_plan_takes_a_transaction_by_default() {
+    let (db, log) = setup(&Capability::SQLITE).await;
+    let author_id = seed(&db).await;
+    take(&log);
+
+    let mut handle = db.clone();
+    let author = Author::filter_by_id(author_id)
+        .include(Author::fields().books())
+        .get(&mut handle)
+        .await
+        .unwrap();
+    assert_eq!(author.books.get().len(), 2);
+
+    let calls = take(&log);
+    assert!(
+        calls.contains(&Call::Transaction),
+        "expected a transaction, got {calls:?}"
+    );
+}
+
+/// A driver that cannot offer a snapshot gets the same reads without one,
+/// rather than a transaction it would have to refuse.
+#[tokio::test]
+async fn read_only_plan_skips_the_transaction_without_snapshot_reads() {
+    let (db, log) = setup(Probe::without_transactions()).await;
+    let author_id = seed(&db).await;
+    take(&log);
+
+    let mut handle = db.clone();
+    let author = Author::filter_by_id(author_id)
+        .include(Author::fields().books())
+        .get(&mut handle)
+        .await
+        .unwrap();
+    assert_eq!(author.books.get().len(), 2, "the eager load still resolves");
+
+    let calls = take(&log);
+    assert!(
+        !calls.contains(&Call::Transaction),
+        "expected no transaction, got {calls:?}"
+    );
+}

--- a/tests/tests/capability_dispatch.rs
+++ b/tests/tests/capability_dispatch.rs
@@ -1,7 +1,8 @@
 #![cfg(feature = "sqlite")]
 
-//! Tests that the engine decides whether a plan needs a transaction from what
-//! the driver says it can do, via [`Capability::snapshot_reads`].
+//! Tests that the engine dispatches a plan according to what the driver says
+//! it can do, for the two capabilities a backend without transactions needs:
+//! [`Capability::snapshot_reads`] and [`Capability::atomic_write_batch`].
 //!
 //! Each test wraps the SQLite driver in one that reports different
 //! capabilities and records what it is asked to do, so the assertions are
@@ -53,6 +54,8 @@ struct Book {
 enum Call {
     Transaction,
     Statement,
+    /// A write set handed over together, with how many statements it held.
+    Batch(usize),
 }
 
 type Log = Arc<Mutex<Vec<Call>>>;
@@ -67,9 +70,19 @@ struct Probe {
 }
 
 impl Probe {
-    /// Capabilities of a SQL backend that cannot open a transaction, so its
-    /// reads get no snapshot.
+    /// Capabilities of a SQL backend that cannot open a transaction: reads
+    /// get no snapshot, writes arrive as a set.
     fn without_transactions() -> &'static Capability {
+        static CAPABILITY: OnceLock<Capability> = OnceLock::new();
+        CAPABILITY.get_or_init(|| Capability {
+            snapshot_reads: false,
+            atomic_write_batch: true,
+            ..Capability::SQLITE
+        })
+    }
+
+    /// As above, but declining batches, so writes take the streamed path.
+    fn without_transactions_or_batching() -> &'static Capability {
         static CAPABILITY: OnceLock<Capability> = OnceLock::new();
         CAPABILITY.get_or_init(|| Capability {
             snapshot_reads: false,
@@ -129,6 +142,23 @@ impl toasty_core::driver::Connection for ProbeConnection {
             _ => Call::Statement,
         });
         self.inner.exec(schema, op).await
+    }
+
+    async fn exec_batch(
+        &mut self,
+        schema: &Arc<Schema>,
+        ops: Vec<Operation>,
+    ) -> toasty_core::Result<Vec<ExecResponse>> {
+        self.log.lock().unwrap().push(Call::Batch(ops.len()));
+
+        // SQLite has real transactions; a driver reaching for this API would
+        // not. Running the statements one at a time is enough to check what
+        // the engine dispatched and that the results come back in order.
+        let mut responses = Vec::with_capacity(ops.len());
+        for op in ops {
+            responses.push(self.inner.exec(schema, op).await?);
+        }
+        Ok(responses)
     }
 
     async fn push_schema(&mut self, schema: &Schema) -> toasty_core::Result<()> {
@@ -232,5 +262,86 @@ async fn read_only_plan_skips_the_transaction_without_snapshot_reads() {
     assert!(
         !calls.contains(&Call::Transaction),
         "expected no transaction, got {calls:?}"
+    );
+}
+
+/// Several independent writes are handed over as one set.
+#[tokio::test]
+async fn writes_are_batched_when_the_driver_takes_them_together() {
+    let (db, log) = setup(Probe::without_transactions()).await;
+    let author_id = seed(&db).await;
+    take(&log);
+
+    let mut handle = db.clone();
+    let books = toasty::create!(Book::[
+        { title: "One", author_id: author_id },
+        { title: "Two", author_id: author_id },
+    ])
+    .exec(&mut handle)
+    .await
+    .unwrap();
+
+    assert_eq!(books.len(), 2);
+    assert!(books.iter().all(|book| book.id > 0), "ids: {books:?}");
+
+    let calls = take(&log);
+    assert!(
+        calls.contains(&Call::Batch(2)),
+        "expected one batch of two, got {calls:?}"
+    );
+    assert!(
+        !calls.contains(&Call::Transaction),
+        "a batched plan opens no transaction, got {calls:?}"
+    );
+}
+
+/// Without the capability the same plan streams its writes under a
+/// transaction, exactly as before.
+#[tokio::test]
+async fn writes_stream_under_a_transaction_without_the_capability() {
+    let (db, log) = setup(Probe::without_transactions_or_batching()).await;
+    let author_id = seed(&db).await;
+    take(&log);
+
+    let mut handle = db.clone();
+    toasty::create!(Book::[
+        { title: "One", author_id: author_id },
+        { title: "Two", author_id: author_id },
+    ])
+    .exec(&mut handle)
+    .await
+    .unwrap();
+
+    let calls = take(&log);
+    assert!(
+        calls.contains(&Call::Transaction),
+        "expected a transaction, got {calls:?}"
+    );
+    assert!(
+        !calls.iter().any(|call| matches!(call, Call::Batch(_))),
+        "expected no batch, got {calls:?}"
+    );
+}
+
+/// A single write is not a set, so it needs neither a batch nor a
+/// transaction.
+#[tokio::test]
+async fn a_lone_write_is_not_batched() {
+    let (db, log) = setup(Probe::without_transactions()).await;
+    let author_id = seed(&db).await;
+    take(&log);
+
+    let mut handle = db.clone();
+    Book::create()
+        .title("Only")
+        .author_id(author_id)
+        .exec(&mut handle)
+        .await
+        .unwrap();
+
+    let calls = take(&log);
+    assert!(
+        !calls.iter().any(|call| matches!(call, Call::Batch(_))),
+        "expected no batch, got {calls:?}"
     );
 }


### PR DESCRIPTION
## Summary

Implements the write half of #1128, per the design in #1131. **Blocked on that design being accepted**, and specifically on its first open question — whether this should fold into `transaction_delivery` from [`atomic-batches.md`](https://github.com/tokio-rs/toasty/blob/main/docs/dev/design/atomic-batches.md). Opened early because the work was already done; happy to close and resubmit in that shape.

**Stacked on #1129** — review that one first; this branch contains its commit.

A backend can lack interactive transactions yet still commit statements submitted together. Cloudflare D1 rejects `BEGIN` outright, but applies a multi-statement request atomically: send `INSERT (3,'c'); INSERT (4,NULL);` where the second violates `NOT NULL`, and the request fails with row 3 absent. Such a driver had no way to say so, so every multi-write plan died on the transaction the engine opened.

`Connection` gains `exec_batch`, defaulting to `unsupported_feature`, and `Capability` gains `atomic_write_batch`. A driver setting it receives the plan's writes together instead of a transaction; the engine hoists them ahead of the actions between them and distributes the responses after.

## Type of change

- [ ] Small / obvious change — bug fix, docs, internal cleanup, or test
- [x] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`):
      [`transaction-less-backends.md`](https://github.com/tokio-rs/toasty/blob/main/docs/dev/design/transaction-less-backends.md) — proposed in #1131, **not yet merged**
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers

**Why only some plans batch.** Hoisting is sound only because a batch is submitted before any of it runs. A write that reads a variable might depend on another write in the same batch, which would not have run yet — so those plans keep the streamed path, where a driver without transactions still rejects them. `Action::is_batchable_write` is the check.

That is conservative: a `create!` of independent records batches, while a plan whose second write consumes the first's returned id does not. 184 suite tests still fail on D1 for that reason. Whether such plans should be rejected outright — as `atomic-batches.md` does for `WriteSet` drivers — is an open question in the design doc.

**Changes worth a close look:**

- `action_exec_statement` is split into a prepare half and a finish half, so a batched statement can be readied without being sent. The MySQL `RETURNING` fixups stay on the streamed path only; a batching driver asserts they do not apply.
- The integration suite's instrumented connection forwards `exec_batch` and logs each statement separately, so operation-log assertions read the same either way. Missing that override silently routes to the default — worth noting for any other wrapping driver.

**Testing.** The capability probe from #1129 is extended: independent writes arrive as one set with the capability, stream under a transaction without it, and a lone write is never batched. Verified locally against the CI steps, including `cargo hack check --feature-powerset`; the sqlite suite holds at 1352.

Against live D1 through [toasty-driver-d1](https://github.com/hirunefu/toasty-driver-d1): a multi-record `create!` returns both records with their ids, and a batch whose second statement fails leaves no rows behind. The integration suite goes from 720 to 1138 passing.
