### PR TITLE
Cloudflare D1 Database support + wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,28 @@ jobs:
       - name: doc-tests
         run: cargo test -p tests --doc
 
+  test-d1:
+    needs: check
+    name: Run tests for Cloudflare D1
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE_VERSION }}
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Install worker-build
+        run: cargo install worker-build --version 0.8.5 --locked
+      - name: Build D1 Worker
+        working-directory: tests/d1-worker
+        run: worker-build --release --panic-unwind
+      - name: Run D1 Worker tests
+        run: node tests/d1-worker/run.mjs
+
   test-mysql:
     needs: check
     name: Run tests for MySQL

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,7 @@ toml = "1.1.0"
 toml_edit = "0.25.8"
 tempfile = "3.27"
 proptest = "1"
-tokio = { version = "1.50", features = ["full"] }
+tokio = "1.50"
 tokio-postgres = "0.7.17"
 tokio-postgres-rustls = { version = "0.14.0", default-features = false }
 rustls = { version = "0.23", default-features = false, features = ["std", "ring"] }
@@ -149,7 +149,7 @@ turso = "0.7"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 trybuild = { version = "1.0.116", features = ["diff"] }
 url = "2.5.8"
-uuid = { version = "1.23.0", features = ["v4", "v7", "fast-rng"] }
+uuid = { version = "1.23.0", features = ["v4", "v7", "fast-rng", "js"] }
 
 [profile.dev]
 debug = "line-tables-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/toasty-sql",
 
     # Driver implementations
+    "crates/toasty-driver-d1",
     "crates/toasty-driver-dynamodb",
     "crates/toasty-driver-mysql",
     "crates/toasty-driver-postgresql",
@@ -78,6 +79,7 @@ toasty-core = { version = "0.9.0", path = "crates/toasty-core" }
 toasty-macros = { version = "0.9.0", path = "crates/toasty-macros" }
 toasty-sql = { version = "0.9.0", path = "crates/toasty-sql" }
 # Driver implementations
+toasty-driver-d1 = { version = "0.9.0", path = "crates/toasty-driver-d1" }
 toasty-driver-dynamodb = { version = "0.9.0", path = "crates/toasty-driver-dynamodb" }
 toasty-driver-mysql = { version = "0.9.0", path = "crates/toasty-driver-mysql" }
 toasty-driver-postgresql = { version = "0.9.0", path = "crates/toasty-driver-postgresql" }
@@ -150,6 +152,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 trybuild = { version = "1.0.116", features = ["diff"] }
 url = "2.5.8"
 uuid = { version = "1.23.0", features = ["v4", "v7", "fast-rng", "js"] }
+worker = "0.8.5"
 
 [profile.dev]
 debug = "line-tables-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
 
     # Tests
     "tests",
+    "tests/d1-worker",
     "tests/tests/fixtures/post",
     "tests/tests/fixtures/user",
 ]
@@ -105,6 +106,7 @@ console = "0.16"
 deadpool = { version = "0.13", features = ["rt_tokio_1"] }
 dialoguer = "0.12"
 expect-test = "1.5"
+getrandom = "0.4.3"
 hashbrown = "0.17"
 heck = "0.5.0"
 indexmap = "2.13.0"

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@
 [discord-badge]: https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=flat-square
 [discord-url]: https://discord.gg/tokio
 
-Toasty supports SQL databases (SQLite/Turso, PostgreSQL, MySQL) and DynamoDB.
-It does not hide database capabilities — it exposes features based on the
-target database.
+Toasty supports SQL databases (SQLite/Turso, Cloudflare D1, PostgreSQL, MySQL)
+and DynamoDB. It does not hide database capabilities — it exposes features
+based on the target database.
 
 ## Using Toasty
 
@@ -100,9 +100,10 @@ for todo in &todos {
 ## SQL and NoSQL
 
 Toasty supports both SQL and NoSQL databases. Current drivers are SQLite,
-Turso, PostgreSQL, MySQL, and DynamoDB. However, it does not aim to abstract
-the database. Instead, Toasty leans into the target database's capabilities
-and aims to help the user avoid issuing inefficient queries for that database.
+Turso, Cloudflare D1, PostgreSQL, MySQL, and DynamoDB. However, it does not aim
+to abstract the database. Instead, Toasty leans into the target database's
+capabilities and aims to help the user avoid issuing inefficient queries for
+that database.
 
 When targeting both SQL and NoSQL databases, Toasty generates query methods
 (e.g. `get_by_id` only for access patterns that are indexed). When targeting a

--- a/crates/toasty-core/src/driver.rs
+++ b/crates/toasty-core/src/driver.rs
@@ -197,6 +197,20 @@ pub trait Connection: Debug + Send + 'static {
     /// typed by the structural `Type::Object`.
     async fn exec(&mut self, schema: &Arc<Schema>, plan: Operation) -> crate::Result<ExecResponse>;
 
+    /// Executes generated SQL statements as one atomic backend batch.
+    ///
+    /// The default deliberately rejects the operation. A sequential fallback
+    /// would violate the caller's atomicity requirement.
+    async fn exec_atomic_batch(
+        &mut self,
+        _schema: &Arc<Schema>,
+        _batch: operation::AtomicSqlBatch,
+    ) -> crate::Result<Vec<ExecResponse>> {
+        Err(crate::Error::unsupported_feature(
+            "driver does not support atomic SQL batches",
+        ))
+    }
+
     /// Cheap, synchronous, local check that the driver's client object
     /// still considers the connection open.
     ///

--- a/crates/toasty-core/src/driver.rs
+++ b/crates/toasty-core/src/driver.rs
@@ -96,6 +96,18 @@ pub struct ConnectContext {
     pub query_log: QueryLogConfig,
 }
 
+/// Selects how a database handle obtains connections from a driver.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConnectionStrategy {
+    /// Create connections on demand and return them to a pool after use.
+    Pooled,
+
+    /// Create one connection when the database handle is built and serialize
+    /// all access to it. Direct connections do not start background tasks or
+    /// timers.
+    Direct,
+}
+
 /// Factory for database connections and provider of driver-level metadata.
 ///
 /// Each database backend (SQLite, PostgreSQL, MySQL, DynamoDB) implements this
@@ -124,10 +136,16 @@ pub trait Driver: Debug + Send + Sync + 'static {
     /// Describes the driver's capability, which informs the query planner.
     fn capability(&self) -> &'static Capability;
 
+    /// Returns how Toasty should own connections created by this driver.
+    fn connection_strategy(&self) -> ConnectionStrategy {
+        ConnectionStrategy::Pooled
+    }
+
     /// Creates a new connection to the database.
     ///
-    /// This method is called by the [`Pool`] whenever a [`Connection`] is requested while none is
-    /// available and there is room to create a new [`Connection`]. The [`ConnectContext`] carries
+    /// Pooled drivers are called whenever no idle connection is available and
+    /// the pool has room for another. Direct drivers are called exactly once
+    /// while the database handle is built. The [`ConnectContext`] carries
     /// per-connection configuration the driver applies at construction time.
     async fn connect(&self, cx: &ConnectContext) -> crate::Result<Box<dyn Connection>>;
 

--- a/crates/toasty-core/src/driver.rs
+++ b/crates/toasty-core/src/driver.rs
@@ -79,10 +79,10 @@ use std::{borrow::Cow, fmt::Debug, sync::Arc};
 
 /// Per-connection configuration passed to [`Driver::connect`].
 ///
-/// The connection pool builds one from the values set on `Db::builder()` and
+/// The connection source builds one from the values set on `Db::builder()` and
 /// hands it to the driver every time a new connection is created, so drivers
 /// can apply configuration at construction time rather than through separate
-/// setters. Callers connecting outside a pool use
+/// setters. Callers connecting outside a `Db` use
 /// [`ConnectContext::default()`].
 ///
 /// The struct is non-exhaustive: construct it with `default()` and assign the
@@ -110,9 +110,9 @@ pub enum ConnectionStrategy {
 
 /// Factory for database connections and provider of driver-level metadata.
 ///
-/// Each database backend (SQLite, PostgreSQL, MySQL, DynamoDB) implements this
-/// trait to tell Toasty what the backend supports ([`Capability`]) and to
-/// create [`Connection`] instances on demand.
+/// Each database backend (SQLite, Turso, Cloudflare D1, PostgreSQL, MySQL,
+/// DynamoDB) implements this trait to tell Toasty what the backend supports
+/// ([`Capability`]) and to create [`Connection`] instances on demand.
 ///
 /// # Examples
 ///
@@ -166,9 +166,10 @@ pub trait Driver: Debug + Send + Sync + 'static {
 
 /// A live database session that can execute [`Operation`]s.
 ///
-/// Connections are obtained from [`Driver::connect`] and are managed by the
-/// connection pool. All query execution flows through [`Connection::exec`],
-/// which accepts an [`Operation`] and returns an [`ExecResponse`].
+/// Connections are obtained from [`Driver::connect`] and are managed by a
+/// pooled or direct connection source. All query execution flows through
+/// [`Connection::exec`], which accepts an [`Operation`] and returns an
+/// [`ExecResponse`].
 ///
 /// # Examples
 ///

--- a/crates/toasty-core/src/driver/capability.rs
+++ b/crates/toasty-core/src/driver/capability.rs
@@ -52,6 +52,10 @@ pub struct Capability {
     /// Whether the driver can reset the complete database.
     pub reset_database: bool,
 
+    /// Whether table rebuild migrations must defer foreign-key checks instead
+    /// of disabling enforcement.
+    pub defer_foreign_keys_during_rebuild: bool,
+
     /// Column storage types supported by the database.
     pub storage_types: StorageTypes,
 
@@ -639,6 +643,7 @@ impl Capability {
         max_bind_parameters: None,
         runtime_migrations: true,
         reset_database: true,
+        defer_foreign_keys_during_rebuild: false,
         storage_types: StorageTypes::SQLITE,
         schema_mutations: SchemaMutations::SQLITE,
         cte_with_update: false,
@@ -875,6 +880,7 @@ impl Capability {
         max_bind_parameters: None,
         runtime_migrations: true,
         reset_database: true,
+        defer_foreign_keys_during_rebuild: false,
         storage_types: StorageTypes::DYNAMODB,
         schema_mutations: SchemaMutations::DYNAMODB,
         cte_with_update: false,
@@ -968,6 +974,7 @@ impl Capability {
         max_bind_parameters: Some(100),
         runtime_migrations: false,
         reset_database: false,
+        defer_foreign_keys_during_rebuild: true,
         test_connection_pool: false,
         transaction_lock_mode: false,
         ..Self::SQLITE

--- a/crates/toasty-core/src/driver/capability.rs
+++ b/crates/toasty-core/src/driver/capability.rs
@@ -35,6 +35,23 @@ pub struct Capability {
     /// SQL drivers set this to `Some`. Non-SQL drivers set this to `None`.
     pub sql_placeholder: Option<SqlPlaceholder>,
 
+    /// Whether callers can begin, commit, and roll back an interactive
+    /// transaction on one connection.
+    pub interactive_transactions: bool,
+
+    /// Whether the driver can execute a prevalidated group of SQL statements
+    /// as one atomic batch.
+    pub atomic_batch: bool,
+
+    /// Maximum number of bind parameters accepted by one statement.
+    pub max_bind_parameters: Option<usize>,
+
+    /// Whether the driver can apply Toasty migrations at runtime.
+    pub runtime_migrations: bool,
+
+    /// Whether the driver can reset the complete database.
+    pub reset_database: bool,
+
     /// Column storage types supported by the database.
     pub storage_types: StorageTypes,
 
@@ -414,6 +431,14 @@ pub struct StorageTypes {
     /// Maximum value for unsigned integers. When `Some`, unsigned integers
     /// are limited to this value. When `None`, full u64 range is supported.
     pub max_unsigned_integer: Option<u64>,
+
+    /// Minimum value accepted for signed integers. `None` means the full i64
+    /// range is supported.
+    pub min_signed_integer: Option<i64>,
+
+    /// Maximum value accepted for signed integers. `None` means the full i64
+    /// range is supported.
+    pub max_signed_integer: Option<i64>,
 }
 
 /// The database's capabilities to mutate the schema (tables, columns, indices).
@@ -531,6 +556,40 @@ impl Capability {
             ));
         }
 
+        if self.interactive_transactions && !self.sql {
+            return Err(crate::Error::invalid_driver_configuration(
+                "interactive_transactions is true but sql is false",
+            ));
+        }
+
+        if self.atomic_batch && !self.sql {
+            return Err(crate::Error::invalid_driver_configuration(
+                "atomic_batch is true but sql is false",
+            ));
+        }
+
+        if self.max_bind_parameters.is_some() && !self.sql {
+            return Err(crate::Error::invalid_driver_configuration(
+                "max_bind_parameters is set but sql is false",
+            ));
+        }
+
+        if self.transaction_lock_mode && !self.interactive_transactions {
+            return Err(crate::Error::invalid_driver_configuration(
+                "transaction_lock_mode is true but interactive_transactions is false",
+            ));
+        }
+
+        if let (Some(min), Some(max)) = (
+            self.storage_types.min_signed_integer,
+            self.storage_types.max_signed_integer,
+        ) && min > max
+        {
+            return Err(crate::Error::invalid_driver_configuration(
+                "storage_types.min_signed_integer exceeds max_signed_integer",
+            ));
+        }
+
         Ok(())
     }
 
@@ -575,6 +634,11 @@ impl Capability {
         driver_name: "SQLite",
         sql: true,
         sql_placeholder: Some(SqlPlaceholder::NumberedQuestionMark),
+        interactive_transactions: true,
+        atomic_batch: false,
+        max_bind_parameters: None,
+        runtime_migrations: true,
+        reset_database: true,
         storage_types: StorageTypes::SQLITE,
         schema_mutations: SchemaMutations::SQLITE,
         cte_with_update: false,
@@ -806,6 +870,11 @@ impl Capability {
         driver_name: "DynamoDB",
         sql: false,
         sql_placeholder: None,
+        interactive_transactions: false,
+        atomic_batch: false,
+        max_bind_parameters: None,
+        runtime_migrations: true,
+        reset_database: true,
         storage_types: StorageTypes::DYNAMODB,
         schema_mutations: SchemaMutations::DYNAMODB,
         cte_with_update: false,
@@ -888,6 +957,21 @@ impl Capability {
         vec_pop: false,
         vec_remove_at: false,
     };
+
+    /// Cloudflare D1 capabilities.
+    pub const D1: Self = Self {
+        driver_name: "D1",
+        storage_types: StorageTypes::D1,
+        schema_mutations: SchemaMutations::D1,
+        interactive_transactions: false,
+        atomic_batch: true,
+        max_bind_parameters: Some(100),
+        runtime_migrations: false,
+        reset_database: false,
+        test_connection_pool: false,
+        transaction_lock_mode: false,
+        ..Self::SQLITE
+    };
 }
 
 impl StorageTypes {
@@ -925,6 +1009,8 @@ impl StorageTypes {
         // SQLite INTEGER is a signed 64-bit integer, so unsigned integers
         // are limited to i64::MAX to prevent overflow
         max_unsigned_integer: Some(i64::MAX as u64),
+        min_signed_integer: None,
+        max_signed_integer: None,
     };
 
     /// PostgreSQL storage types.
@@ -957,6 +1043,8 @@ impl StorageTypes {
         // to i64::MAX. While NUMERIC could theoretically support larger values,
         // we prefer explicit limits over implicit type switching.
         max_unsigned_integer: Some(i64::MAX as u64),
+        min_signed_integer: None,
+        max_signed_integer: None,
     };
 
     /// MySQL storage types.
@@ -993,6 +1081,8 @@ impl StorageTypes {
 
         // MySQL supports full u64 range via BIGINT UNSIGNED
         max_unsigned_integer: None,
+        min_signed_integer: None,
+        max_signed_integer: None,
     };
 
     /// DynamoDB storage types.
@@ -1019,6 +1109,17 @@ impl StorageTypes {
 
         // DynamoDB supports full u64 range (numbers stored as strings)
         max_unsigned_integer: None,
+        min_signed_integer: None,
+        max_signed_integer: None,
+    };
+
+    /// Cloudflare D1 storage types.
+    pub const D1: StorageTypes = StorageTypes {
+        default_uuid_type: db::Type::Text,
+        max_unsigned_integer: Some(9_007_199_254_740_991),
+        min_signed_integer: Some(-9_007_199_254_740_991),
+        max_signed_integer: Some(9_007_199_254_740_991),
+        ..Self::SQLITE
     };
 }
 
@@ -1045,6 +1146,12 @@ impl SchemaMutations {
 
     /// DynamoDB schema mutation capabilities. Migrations are not currently supported.
     pub const DYNAMODB: Self = Self {
+        alter_column_type: false,
+        alter_column_properties_atomic: false,
+    };
+
+    /// D1 schema mutation capabilities.
+    pub const D1: Self = Self {
         alter_column_type: false,
         alter_column_properties_atomic: false,
     };
@@ -1076,6 +1183,48 @@ mod tests {
     fn test_validate_dynamodb_capability() {
         // DynamoDB has native_varchar=false and varchar=None, should pass
         assert!(Capability::DYNAMODB.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_d1_capability() {
+        assert!(Capability::D1.validate().is_ok());
+        const {
+            assert!(!Capability::D1.interactive_transactions);
+            assert!(Capability::D1.atomic_batch);
+        }
+        assert_eq!(Capability::D1.max_bind_parameters, Some(100));
+        assert_eq!(
+            Capability::D1.storage_types.max_signed_integer,
+            Some(9_007_199_254_740_991)
+        );
+        assert_eq!(
+            Capability::D1.storage_types.min_signed_integer,
+            Some(-9_007_199_254_740_991)
+        );
+        assert!(matches!(
+            Capability::D1.storage_types.default_uuid_type,
+            db::Type::Text
+        ));
+    }
+
+    #[test]
+    fn test_validate_rejects_atomic_batch_for_non_sql_driver() {
+        let invalid = Capability {
+            atomic_batch: true,
+            ..Capability::DYNAMODB
+        };
+
+        assert!(invalid.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_rejects_lock_modes_without_interactive_transactions() {
+        let invalid = Capability {
+            interactive_transactions: false,
+            ..Capability::SQLITE
+        };
+
+        assert!(invalid.validate().is_err());
     }
 
     #[test]

--- a/crates/toasty-core/src/driver/capability.rs
+++ b/crates/toasty-core/src/driver/capability.rs
@@ -9,7 +9,8 @@ use crate::{schema::db, stmt};
 ///
 /// Pre-built configurations are available as associated constants:
 /// [`SQLITE`](Self::SQLITE), [`POSTGRESQL`](Self::POSTGRESQL),
-/// [`MYSQL`](Self::MYSQL), and [`DYNAMODB`](Self::DYNAMODB).
+/// [`MYSQL`](Self::MYSQL), [`DYNAMODB`](Self::DYNAMODB), and
+/// [`D1`](Self::D1).
 ///
 /// # Examples
 ///
@@ -128,7 +129,7 @@ pub struct Capability {
     ///
     /// - MySQL: `Some(64)` — hard error on longer names
     /// - PostgreSQL: `Some(63)` — silently truncates, risking collisions
-    /// - SQLite / DynamoDB: `None` — no enforced limit
+    /// - SQLite / D1 / DynamoDB: `None` — no enforced identifier limit
     pub max_identifier_length: Option<usize>,
 
     /// Whether the database supports `VARCHAR(n)` column types natively.
@@ -187,7 +188,7 @@ pub struct Capability {
     /// When false, the decimal type requires fixed precision and scale to be specified upfront.
     /// - PostgreSQL: true (NUMERIC supports arbitrary precision)
     /// - MySQL: false (DECIMAL requires fixed precision/scale)
-    /// - SQLite/DynamoDB: false (no native decimal support, stored as TEXT)
+    /// - SQLite/D1/DynamoDB: false (no native decimal support, stored as TEXT)
     pub decimal_arbitrary_precision: bool,
 
     /// Whether OR is supported in index key conditions (e.g. DynamoDB KeyConditionExpression).
@@ -318,7 +319,8 @@ pub struct Capability {
     /// array-valued parameter.
     ///
     /// When `false`, `Vec<T>` model fields use whatever fallback the backend
-    /// provides (JSON column on MySQL/SQLite, native List `L` on DynamoDB).
+    /// provides (JSON on MySQL, JSON text on SQLite/D1, native List `L` on
+    /// DynamoDB).
     /// See [`Self::vec_scalar`] for the schema-build gate.
     pub native_array: bool,
 

--- a/crates/toasty-core/src/driver/log.rs
+++ b/crates/toasty-core/src/driver/log.rs
@@ -15,7 +15,10 @@ use crate::driver::{ExecResponse, Rows};
 use crate::stmt::Value;
 
 use std::fmt::Write;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Instant;
 
 /// The tracing target of the per-query event, shared by all drivers.
 pub const TARGET: &str = "toasty::query";
@@ -69,6 +72,7 @@ pub struct QueryLog<'a> {
     collection: Option<&'a str>,
     params: Option<String>,
     rows: Option<u64>,
+    #[cfg(not(target_arch = "wasm32"))]
     start: Instant,
 }
 
@@ -88,6 +92,7 @@ impl<'a> QueryLog<'a> {
             collection: None,
             params: render_params(config, params),
             rows: None,
+            #[cfg(not(target_arch = "wasm32"))]
             start: Instant::now(),
         }
     }
@@ -107,6 +112,7 @@ impl<'a> QueryLog<'a> {
             collection,
             params: None,
             rows: None,
+            #[cfg(not(target_arch = "wasm32"))]
             start: Instant::now(),
         }
     }
@@ -120,7 +126,13 @@ impl<'a> QueryLog<'a> {
 
     /// Emits the `toasty::query` event describing `result`.
     pub fn finish(self, result: &crate::Result<ExecResponse>) {
+        #[cfg(not(target_arch = "wasm32"))]
         let elapsed = self.start.elapsed();
+        // `std::time::Instant` panics on `wasm32-unknown-unknown`. Workers do
+        // not currently provide a platform-neutral monotonic clock through
+        // Toasty's shared crates, so D1 query events omit meaningful timing.
+        #[cfg(target_arch = "wasm32")]
+        let elapsed = Duration::ZERO;
         let duration_ms = elapsed.as_secs_f64() * 1e3;
         let rows = self.rows.or(match result {
             Ok(response) => match &response.values {

--- a/crates/toasty-core/src/driver/operation.rs
+++ b/crates/toasty-core/src/driver/operation.rs
@@ -5,8 +5,11 @@
 //! SQL drivers handle [`QuerySql`], [`RawSql`], and [`Insert`]; key-value
 //! drivers handle [`GetByKey`], [`QueryPk`], [`DeleteByKey`],
 //! [`FindPkByIndex`], [`UpdateByKey`], and (when
-//! [`Capability::scan`](super::Capability::scan) is `true`) [`Scan`]. Both
-//! driver types handle [`Transaction`] operations.
+//! [`Capability::scan`](super::Capability::scan) is `true`) [`Scan`].
+//! Drivers with interactive transaction support also handle [`Transaction`]
+//! operations. Drivers with atomic batch support receive
+//! [`AtomicSqlBatch`] through
+//! [`Connection::exec_atomic_batch`](super::Connection::exec_atomic_batch).
 
 mod atomic_sql_batch;
 pub use atomic_sql_batch::AtomicSqlBatch;

--- a/crates/toasty-core/src/driver/operation.rs
+++ b/crates/toasty-core/src/driver/operation.rs
@@ -8,6 +8,9 @@
 //! [`Capability::scan`](super::Capability::scan) is `true`) [`Scan`]. Both
 //! driver types handle [`Transaction`] operations.
 
+mod atomic_sql_batch;
+pub use atomic_sql_batch::AtomicSqlBatch;
+
 mod delete_by_key;
 pub use delete_by_key::DeleteByKey;
 

--- a/crates/toasty-core/src/driver/operation/atomic_sql_batch.rs
+++ b/crates/toasty-core/src/driver/operation/atomic_sql_batch.rs
@@ -1,0 +1,19 @@
+use super::QuerySql;
+
+/// An ordered group of generated SQL statements that must execute atomically.
+///
+/// Drivers must either execute the complete group as one backend atomic unit
+/// or return an error without executing any statement. Raw SQL and non-SQL
+/// operations are deliberately excluded.
+#[derive(Debug, Clone)]
+pub struct AtomicSqlBatch {
+    /// Generated SQL operations in execution order.
+    pub operations: Vec<QuerySql>,
+}
+
+impl AtomicSqlBatch {
+    /// Creates an atomic batch from ordered generated SQL operations.
+    pub fn new(operations: Vec<QuerySql>) -> Self {
+        Self { operations }
+    }
+}

--- a/crates/toasty-driver-d1/Cargo.toml
+++ b/crates/toasty-driver-d1/Cargo.toml
@@ -25,6 +25,7 @@ tracing.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 async-trait.workspace = true
+serde_json.workspace = true
 worker = { workspace = true, features = ["d1"] }
 
 [lints]

--- a/crates/toasty-driver-d1/Cargo.toml
+++ b/crates/toasty-driver-d1/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "toasty-driver-d1"
+version = "0.9.0"
+description = "Cloudflare D1 driver for Toasty"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+categories.workspace = true
+readme.workspace = true
+documentation = "https://docs.rs/toasty-driver-d1"
+
+[features]
+rust_decimal = ["toasty-core/rust_decimal", "toasty-sql/rust_decimal"]
+bigdecimal = ["toasty-core/bigdecimal", "toasty-sql/bigdecimal"]
+jiff = ["toasty-core/jiff", "toasty-sql/jiff"]
+
+[dependencies]
+toasty-core.workspace = true
+toasty-sql.workspace = true
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+async-trait.workspace = true
+worker = { workspace = true, features = ["d1"] }
+
+[lints]
+workspace = true

--- a/crates/toasty-driver-d1/Cargo.toml
+++ b/crates/toasty-driver-d1/Cargo.toml
@@ -21,6 +21,7 @@ jiff = ["toasty-core/jiff", "toasty-sql/jiff"]
 [dependencies]
 toasty-core.workspace = true
 toasty-sql.workspace = true
+tracing.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 async-trait.workspace = true

--- a/crates/toasty-driver-d1/Cargo.toml
+++ b/crates/toasty-driver-d1/Cargo.toml
@@ -13,6 +13,10 @@ categories.workspace = true
 readme.workspace = true
 documentation = "https://docs.rs/toasty-driver-d1"
 
+[package.metadata.docs.rs]
+default-target = "wasm32-unknown-unknown"
+targets = []
+
 [features]
 rust_decimal = ["toasty-core/rust_decimal", "toasty-sql/rust_decimal"]
 bigdecimal = ["toasty-core/bigdecimal", "toasty-sql/bigdecimal"]

--- a/crates/toasty-driver-d1/src/connection.rs
+++ b/crates/toasty-driver-d1/src/connection.rs
@@ -3,17 +3,29 @@ use std::{fmt, sync::Arc};
 use async_trait::async_trait;
 use toasty_core::{
     Schema,
-    driver::{ExecResponse, QueryLogConfig, operation::Operation},
+    driver::{
+        ExecResponse, QueryLogConfig,
+        log::QueryLog,
+        operation::{Operation, QuerySql, RawSql, RawSqlRet, TypedValue},
+    },
     schema::db::{AppliedMigration, Migration},
+    stmt,
 };
-use worker::{D1Database, send::SendWrapper};
+use worker::{
+    D1Database, D1PreparedStatement,
+    send::{IntoSendFuture, SendWrapper},
+};
 
-use crate::error;
+use crate::{error, value::wasm as value};
+
+enum SqlReturn {
+    Count,
+    Infer,
+    Types(Vec<stmt::Type>),
+}
 
 pub(crate) struct Connection {
-    #[allow(dead_code)]
     database: SendWrapper<D1Database>,
-    #[allow(dead_code)]
     query_log: QueryLogConfig,
 }
 
@@ -24,6 +36,84 @@ impl Connection {
             query_log,
         }
     }
+
+    async fn exec_query_sql(
+        &self,
+        schema: &Schema,
+        operation: QuerySql,
+    ) -> toasty_core::Result<ExecResponse> {
+        if operation.last_insert_id_hack.is_some() {
+            return Err(error::unsupported("MySQL last-insert-id workaround"));
+        }
+
+        let statement = toasty_sql::Statement::from(operation.stmt);
+        let sql = toasty_sql::Serializer::sqlite(&schema.db).serialize(&statement);
+        let ret = operation
+            .ret
+            .map(SqlReturn::Types)
+            .unwrap_or(SqlReturn::Count);
+        self.exec_sql(&sql, operation.params, ret, "query_sql")
+            .await
+    }
+
+    async fn exec_raw_sql(&self, operation: RawSql) -> toasty_core::Result<ExecResponse> {
+        let ret = match operation.ret {
+            RawSqlRet::None => SqlReturn::Count,
+            RawSqlRet::Infer => SqlReturn::Infer,
+            RawSqlRet::Types(types) => SqlReturn::Types(types),
+        };
+        self.exec_sql(&operation.sql, operation.params, ret, "raw_sql")
+            .await
+    }
+
+    async fn exec_sql(
+        &self,
+        sql: &str,
+        params: Vec<TypedValue>,
+        ret: SqlReturn,
+        operation: &str,
+    ) -> toasty_core::Result<ExecResponse> {
+        if params.len() > 100 {
+            return Err(toasty_core::Error::validation_failed(format!(
+                "D1 statement has {} bind parameters; maximum is 100",
+                params.len()
+            )));
+        }
+
+        let log = QueryLog::sql(
+            &self.query_log,
+            "d1",
+            sql,
+            params.iter().map(|param| &param.value),
+        );
+        let result = self.exec_sql_inner(sql, params, ret, operation).await;
+        log.finish(&result);
+        result
+    }
+
+    async fn exec_sql_inner(
+        &self,
+        sql: &str,
+        params: Vec<TypedValue>,
+        ret: SqlReturn,
+        operation: &str,
+    ) -> toasty_core::Result<ExecResponse> {
+        let values = params
+            .into_iter()
+            .map(|param| value::bind(param.value))
+            .collect::<toasty_core::Result<Vec<_>>>()?;
+        let statement = self
+            .database
+            .prepare(sql)
+            .bind(&values)
+            .map_err(|error| error::worker(operation, error))?;
+
+        match ret {
+            SqlReturn::Count => execute_count(&statement, operation).await,
+            SqlReturn::Infer => execute_rows(&statement, None, operation).await,
+            SqlReturn::Types(types) => execute_rows(&statement, Some(&types), operation).await,
+        }
+    }
 }
 
 impl fmt::Debug for Connection {
@@ -32,16 +122,85 @@ impl fmt::Debug for Connection {
     }
 }
 
+async fn execute_count(
+    statement: &D1PreparedStatement,
+    operation: &str,
+) -> toasty_core::Result<ExecResponse> {
+    let result = statement
+        .run()
+        .into_send()
+        .await
+        .map_err(|error| error::worker(operation, error))?;
+    ensure_success(&result, operation)?;
+    let changes = result
+        .meta()
+        .map_err(|error| error::worker(operation, error))?
+        .and_then(|meta| meta.changes)
+        .unwrap_or(0);
+    Ok(ExecResponse::count(changes as u64))
+}
+
+async fn execute_rows(
+    statement: &D1PreparedStatement,
+    types: Option<&[stmt::Type]>,
+    operation: &str,
+) -> toasty_core::Result<ExecResponse> {
+    let rows = statement
+        .raw_js_value()
+        .into_send()
+        .await
+        .map_err(|error| error::worker(operation, error))?;
+    let mut decoded = Vec::with_capacity(rows.len());
+    for row in rows {
+        let row = value::row(row)?;
+        if let Some(types) = types
+            && row.length() as usize != types.len()
+        {
+            return Err(toasty_core::Error::invalid_result(format!(
+                "D1 row has {} columns; expected {}",
+                row.length(),
+                types.len()
+            )));
+        }
+
+        let values = row
+            .iter()
+            .enumerate()
+            .map(|(index, item)| match types {
+                Some(types) => value::decode_typed(item, &types[index], index),
+                None => value::decode_infer(item, index),
+            })
+            .collect::<toasty_core::Result<Vec<_>>>()?;
+        decoded.push(stmt::ValueRecord::from_vec(values).into());
+    }
+
+    Ok(ExecResponse::value_stream(stmt::ValueStream::from_vec(
+        decoded,
+    )))
+}
+
+fn ensure_success(result: &worker::D1Result, operation: &str) -> toasty_core::Result<()> {
+    if result.success() {
+        Ok(())
+    } else {
+        Err(error::result(
+            operation,
+            result.error().unwrap_or_else(|| "unknown D1 error".into()),
+        ))
+    }
+}
+
 #[async_trait]
 impl toasty_core::Connection for Connection {
     async fn exec(
         &mut self,
-        _schema: &Arc<Schema>,
+        schema: &Arc<Schema>,
         operation: Operation,
     ) -> toasty_core::Result<ExecResponse> {
+        tracing::trace!(driver = "d1", op = %operation.name(), "driver exec");
         match operation {
-            Operation::QuerySql(_) => Err(error::unsupported("query_sql")),
-            Operation::RawSql(_) => Err(error::unsupported("raw_sql")),
+            Operation::QuerySql(operation) => self.exec_query_sql(schema, operation).await,
+            Operation::RawSql(operation) => self.exec_raw_sql(operation).await,
             Operation::Transaction(_) => Err(error::unsupported("transaction")),
             operation => Err(error::unsupported(operation.name())),
         }

--- a/crates/toasty-driver-d1/src/connection.rs
+++ b/crates/toasty-driver-d1/src/connection.rs
@@ -6,7 +6,7 @@ use toasty_core::{
     driver::{
         ExecResponse, QueryLogConfig,
         log::QueryLog,
-        operation::{Operation, QuerySql, RawSql, RawSqlRet, TypedValue},
+        operation::{AtomicSqlBatch, Operation, QuerySql, RawSql, RawSqlRet, TypedValue},
     },
     schema::db::{AppliedMigration, Migration},
     stmt,
@@ -190,6 +190,51 @@ fn ensure_success(result: &worker::D1Result, operation: &str) -> toasty_core::Re
     }
 }
 
+fn decode_batch_result(
+    result: &worker::D1Result,
+    types: Option<&[stmt::Type]>,
+    statement_index: usize,
+) -> toasty_core::Result<ExecResponse> {
+    ensure_success(result, &format!("batch statement {statement_index}"))?;
+    let Some(types) = types else {
+        let changes = result
+            .meta()
+            .map_err(|error| error::worker("batch metadata", error))?
+            .and_then(|meta| meta.changes)
+            .unwrap_or(0);
+        return Ok(ExecResponse::count(changes as u64));
+    };
+
+    let rows: Vec<serde_json::Value> = result
+        .results()
+        .map_err(|error| error::worker("batch results", error))?;
+    let mut decoded = Vec::with_capacity(rows.len());
+    for row in rows {
+        let serde_json::Value::Object(mut row) = row else {
+            return Err(toasty_core::Error::invalid_result(format!(
+                "D1 batch statement {statement_index} returned a non-object row"
+            )));
+        };
+        let mut values = Vec::with_capacity(types.len());
+        for (column_index, ty) in types.iter().enumerate() {
+            let alias = format!("column{}", column_index + 1);
+            let item = row.remove(&alias).ok_or_else(|| {
+                toasty_core::Error::invalid_result(format!(
+                    "D1 batch statement {statement_index} row is missing alias {alias}"
+                ))
+            })?;
+            let item = worker::d1::serde_wasm_bindgen::to_value(&item)
+                .map_err(|error| error::worker("batch value conversion", error.into()))?;
+            values.push(value::decode_typed(item, ty, column_index)?);
+        }
+        decoded.push(stmt::ValueRecord::from_vec(values).into());
+    }
+
+    Ok(ExecResponse::value_stream(stmt::ValueStream::from_vec(
+        decoded,
+    )))
+}
+
 #[async_trait]
 impl toasty_core::Connection for Connection {
     async fn exec(
@@ -204,6 +249,67 @@ impl toasty_core::Connection for Connection {
             Operation::Transaction(_) => Err(error::unsupported("transaction")),
             operation => Err(error::unsupported(operation.name())),
         }
+    }
+
+    async fn exec_atomic_batch(
+        &mut self,
+        schema: &Arc<Schema>,
+        batch: AtomicSqlBatch,
+    ) -> toasty_core::Result<Vec<ExecResponse>> {
+        let mut statements = Vec::with_capacity(batch.operations.len());
+        let mut returns = Vec::with_capacity(batch.operations.len());
+
+        for (index, operation) in batch.operations.into_iter().enumerate() {
+            if operation.last_insert_id_hack.is_some() {
+                return Err(error::unsupported("MySQL last-insert-id workaround"));
+            }
+            if operation.params.len() > 100 {
+                return Err(toasty_core::Error::validation_failed(format!(
+                    "D1 batch statement {index} has {} bind parameters; maximum is 100",
+                    operation.params.len()
+                )));
+            }
+
+            let statement = toasty_sql::Statement::from(operation.stmt);
+            let sql = toasty_sql::Serializer::sqlite(&schema.db).serialize(&statement);
+            let values = operation
+                .params
+                .into_iter()
+                .map(|param| value::bind(param.value))
+                .collect::<toasty_core::Result<Vec<_>>>()?;
+            let statement =
+                self.database.prepare(sql).bind(&values).map_err(|error| {
+                    error::worker(&format!("batch statement {index} bind"), error)
+                })?;
+            statements.push(statement);
+            returns.push(operation.ret);
+        }
+
+        tracing::trace!(
+            driver = "d1",
+            statements = statements.len(),
+            "executing atomic SQL batch"
+        );
+        let results = self
+            .database
+            .batch(statements)
+            .into_send()
+            .await
+            .map_err(|error| error::worker("atomic batch", error))?;
+        if results.len() != returns.len() {
+            return Err(toasty_core::Error::invalid_result(format!(
+                "D1 atomic batch returned {} results for {} statements",
+                results.len(),
+                returns.len()
+            )));
+        }
+
+        results
+            .iter()
+            .zip(&returns)
+            .enumerate()
+            .map(|(index, (result, types))| decode_batch_result(result, types.as_deref(), index))
+            .collect()
     }
 
     async fn push_schema(&mut self, _schema: &Schema) -> toasty_core::Result<()> {

--- a/crates/toasty-driver-d1/src/connection.rs
+++ b/crates/toasty-driver-d1/src/connection.rs
@@ -1,0 +1,66 @@
+use std::{fmt, sync::Arc};
+
+use async_trait::async_trait;
+use toasty_core::{
+    Schema,
+    driver::{ExecResponse, QueryLogConfig, operation::Operation},
+    schema::db::{AppliedMigration, Migration},
+};
+use worker::{D1Database, send::SendWrapper};
+
+use crate::error;
+
+pub(crate) struct Connection {
+    #[allow(dead_code)]
+    database: SendWrapper<D1Database>,
+    #[allow(dead_code)]
+    query_log: QueryLogConfig,
+}
+
+impl Connection {
+    pub(crate) fn new(database: SendWrapper<D1Database>, query_log: QueryLogConfig) -> Self {
+        Self {
+            database,
+            query_log,
+        }
+    }
+}
+
+impl fmt::Debug for Connection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Connection").finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl toasty_core::Connection for Connection {
+    async fn exec(
+        &mut self,
+        _schema: &Arc<Schema>,
+        operation: Operation,
+    ) -> toasty_core::Result<ExecResponse> {
+        match operation {
+            Operation::QuerySql(_) => Err(error::unsupported("query_sql")),
+            Operation::RawSql(_) => Err(error::unsupported("raw_sql")),
+            Operation::Transaction(_) => Err(error::unsupported("transaction")),
+            operation => Err(error::unsupported(operation.name())),
+        }
+    }
+
+    async fn push_schema(&mut self, _schema: &Schema) -> toasty_core::Result<()> {
+        Err(error::unsupported("push schema"))
+    }
+
+    async fn applied_migrations(&mut self) -> toasty_core::Result<Vec<AppliedMigration>> {
+        Err(error::unsupported("read applied migrations"))
+    }
+
+    async fn apply_migration(
+        &mut self,
+        _id: u64,
+        _name: &str,
+        _migration: &Migration,
+    ) -> toasty_core::Result<()> {
+        Err(error::unsupported("apply migration"))
+    }
+}

--- a/crates/toasty-driver-d1/src/connection.rs
+++ b/crates/toasty-driver-d1/src/connection.rs
@@ -373,12 +373,19 @@ impl toasty_core::Connection for Connection {
         if statements.is_empty() {
             return Ok(());
         }
+        let statement_count = statements.len();
         let results = self
             .database
             .batch(statements)
             .into_send()
             .await
             .map_err(|error| error::worker("push schema", error))?;
+        if results.len() != statement_count {
+            return Err(toasty_core::Error::invalid_result(format!(
+                "D1 schema batch returned {} results for {statement_count} statements",
+                results.len()
+            )));
+        }
         for (index, result) in results.iter().enumerate() {
             ensure_success(result, &format!("push schema statement {index}"))?;
         }

--- a/crates/toasty-driver-d1/src/connection.rs
+++ b/crates/toasty-driver-d1/src/connection.rs
@@ -16,7 +16,10 @@ use worker::{
     send::{IntoSendFuture, SendWrapper},
 };
 
-use crate::{error, value::wasm as value};
+use crate::{
+    error,
+    value::{self, wasm as codec},
+};
 
 enum SqlReturn {
     Count,
@@ -46,6 +49,8 @@ impl Connection {
             return Err(error::unsupported("MySQL last-insert-id workaround"));
         }
 
+        validate_patterns(&operation.stmt, &operation.params)?;
+
         let statement = toasty_sql::Statement::from(operation.stmt);
         let sql = toasty_sql::Serializer::sqlite(&schema.db).serialize(&statement);
         let ret = operation
@@ -73,12 +78,8 @@ impl Connection {
         ret: SqlReturn,
         operation: &str,
     ) -> toasty_core::Result<ExecResponse> {
-        if params.len() > 100 {
-            return Err(toasty_core::Error::validation_failed(format!(
-                "D1 statement has {} bind parameters; maximum is 100",
-                params.len()
-            )));
-        }
+        value::validate_sql(sql)?;
+        value::validate_parameter_count(params.len())?;
 
         let log = QueryLog::sql(
             &self.query_log,
@@ -100,7 +101,7 @@ impl Connection {
     ) -> toasty_core::Result<ExecResponse> {
         let values = params
             .into_iter()
-            .map(|param| value::bind(param.value))
+            .map(|param| codec::bind(param.value))
             .collect::<toasty_core::Result<Vec<_>>>()?;
         let statement = self
             .database
@@ -152,7 +153,7 @@ async fn execute_rows(
         .map_err(|error| error::worker(operation, error))?;
     let mut decoded = Vec::with_capacity(rows.len());
     for row in rows {
-        let row = value::row(row)?;
+        let row = codec::row(row)?;
         if let Some(types) = types
             && row.length() as usize != types.len()
         {
@@ -167,8 +168,8 @@ async fn execute_rows(
             .iter()
             .enumerate()
             .map(|(index, item)| match types {
-                Some(types) => value::decode_typed(item, &types[index], index),
-                None => value::decode_infer(item, index),
+                Some(types) => codec::decode_typed(item, &types[index], index),
+                None => codec::decode_infer(item, index),
             })
             .collect::<toasty_core::Result<Vec<_>>>()?;
         decoded.push(stmt::ValueRecord::from_vec(values).into());
@@ -188,6 +189,34 @@ fn ensure_success(result: &worker::D1Result, operation: &str) -> toasty_core::Re
             result.error().unwrap_or_else(|| "unknown D1 error".into()),
         ))
     }
+}
+
+fn validate_patterns(
+    statement: &stmt::Statement,
+    params: &[TypedValue],
+) -> toasty_core::Result<()> {
+    let mut validation = Ok(());
+    stmt::visit::for_each_expr(statement, |expression| {
+        if validation.is_err() {
+            return;
+        }
+        let pattern = match expression {
+            stmt::Expr::Like(expression) => expression.pattern.as_ref(),
+            stmt::Expr::StartsWith(expression) => expression.prefix.as_ref(),
+            _ => return,
+        };
+        let value = match pattern {
+            stmt::Expr::Arg(argument) if argument.nesting == 0 => {
+                params.get(argument.position).map(|param| &param.value)
+            }
+            stmt::Expr::Value(value) | stmt::Expr::Static(value) => Some(value),
+            _ => None,
+        };
+        if let Some(stmt::Value::String(pattern)) = value {
+            validation = value::validate_pattern(pattern);
+        }
+    });
+    validation
 }
 
 fn decode_batch_result(
@@ -225,7 +254,7 @@ fn decode_batch_result(
             })?;
             let item = worker::d1::serde_wasm_bindgen::to_value(&item)
                 .map_err(|error| error::worker("batch value conversion", error.into()))?;
-            values.push(value::decode_typed(item, ty, column_index)?);
+            values.push(codec::decode_typed(item, ty, column_index)?);
         }
         decoded.push(stmt::ValueRecord::from_vec(values).into());
     }
@@ -263,19 +292,20 @@ impl toasty_core::Connection for Connection {
             if operation.last_insert_id_hack.is_some() {
                 return Err(error::unsupported("MySQL last-insert-id workaround"));
             }
-            if operation.params.len() > 100 {
-                return Err(toasty_core::Error::validation_failed(format!(
-                    "D1 batch statement {index} has {} bind parameters; maximum is 100",
-                    operation.params.len()
-                )));
-            }
+            value::validate_parameter_count(operation.params.len()).map_err(|error| {
+                error.context(toasty_core::Error::from_args(format_args!(
+                    "D1 batch statement {index} is invalid"
+                )))
+            })?;
+            validate_patterns(&operation.stmt, &operation.params)?;
 
             let statement = toasty_sql::Statement::from(operation.stmt);
             let sql = toasty_sql::Serializer::sqlite(&schema.db).serialize(&statement);
+            value::validate_sql(&sql)?;
             let values = operation
                 .params
                 .into_iter()
-                .map(|param| value::bind(param.value))
+                .map(|param| codec::bind(param.value))
                 .collect::<toasty_core::Result<Vec<_>>>()?;
             let statement =
                 self.database.prepare(sql).bind(&values).map_err(|error| {
@@ -312,8 +342,47 @@ impl toasty_core::Connection for Connection {
             .collect()
     }
 
-    async fn push_schema(&mut self, _schema: &Schema) -> toasty_core::Result<()> {
-        Err(error::unsupported("push schema"))
+    async fn push_schema(&mut self, schema: &Schema) -> toasty_core::Result<()> {
+        let serializer = toasty_sql::Serializer::sqlite(&schema.db);
+        let mut statements = Vec::new();
+        for table in &schema.db.tables {
+            if table.columns.len() > 100 {
+                return Err(toasty_core::Error::validation_failed(format!(
+                    "D1 table {} has {} columns; maximum is 100",
+                    table.name,
+                    table.columns.len()
+                )));
+            }
+
+            let sql = serializer.serialize(&toasty_sql::Statement::create_table(
+                table,
+                &toasty_core::driver::Capability::D1,
+            ));
+            value::validate_sql(&sql)?;
+            statements.push(self.database.prepare(sql));
+            for index in &table.indices {
+                if index.primary_key {
+                    continue;
+                }
+                let sql = serializer.serialize(&toasty_sql::Statement::create_index(index));
+                value::validate_sql(&sql)?;
+                statements.push(self.database.prepare(sql));
+            }
+        }
+
+        if statements.is_empty() {
+            return Ok(());
+        }
+        let results = self
+            .database
+            .batch(statements)
+            .into_send()
+            .await
+            .map_err(|error| error::worker("push schema", error))?;
+        for (index, result) in results.iter().enumerate() {
+            ensure_success(result, &format!("push schema statement {index}"))?;
+        }
+        Ok(())
     }
 
     async fn applied_migrations(&mut self) -> toasty_core::Result<Vec<AppliedMigration>> {

--- a/crates/toasty-driver-d1/src/driver.rs
+++ b/crates/toasty-driver-d1/src/driver.rs
@@ -1,0 +1,79 @@
+use std::{borrow::Cow, fmt, sync::Mutex};
+
+use async_trait::async_trait;
+use toasty_core::{
+    driver::{Capability, ConnectContext, ConnectionStrategy, Driver},
+    schema::{db::Migration, diff},
+};
+use worker::{D1Database, send::SendWrapper};
+
+use crate::{connection::Connection, error, migration};
+
+/// A request-local Cloudflare D1 driver.
+pub struct D1 {
+    binding_name: String,
+    database: Mutex<Option<SendWrapper<D1Database>>>,
+}
+
+impl D1 {
+    /// Creates a driver from a Worker D1 binding.
+    pub fn new(binding_name: impl Into<String>, database: D1Database) -> Self {
+        Self {
+            binding_name: binding_name.into(),
+            database: Mutex::new(Some(SendWrapper::new(database))),
+        }
+    }
+}
+
+impl fmt::Debug for D1 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("D1")
+            .field("binding_name", &self.binding_name)
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl Driver for D1 {
+    fn url(&self) -> Cow<'_, str> {
+        Cow::Owned(format!("d1:{}", self.binding_name))
+    }
+
+    fn capability(&self) -> &'static Capability {
+        &Capability::D1
+    }
+
+    fn connection_strategy(&self) -> ConnectionStrategy {
+        ConnectionStrategy::Direct
+    }
+
+    async fn connect(
+        &self,
+        cx: &ConnectContext,
+    ) -> toasty_core::Result<Box<dyn toasty_core::Connection>> {
+        let database = self
+            .database
+            .lock()
+            .map_err(|_| {
+                toasty_core::Error::invalid_driver_configuration(
+                    "D1 binding ownership lock was poisoned",
+                )
+            })?
+            .take()
+            .ok_or_else(|| {
+                toasty_core::Error::invalid_driver_configuration(
+                    "D1 drivers can create only one direct connection",
+                )
+            })?;
+
+        Ok(Box::new(Connection::new(database, cx.query_log)))
+    }
+
+    fn generate_migration(&self, schema_diff: &diff::Schema<'_>) -> Migration {
+        migration::generate_migration(schema_diff)
+    }
+
+    async fn reset_db(&self) -> toasty_core::Result<()> {
+        Err(error::unsupported("reset database"))
+    }
+}

--- a/crates/toasty-driver-d1/src/error.rs
+++ b/crates/toasty-driver-d1/src/error.rs
@@ -1,0 +1,5 @@
+pub(crate) fn unsupported(operation: &str) -> toasty_core::Error {
+    toasty_core::Error::unsupported_feature(format!(
+        "D1 does not support the {operation} operation"
+    ))
+}

--- a/crates/toasty-driver-d1/src/error.rs
+++ b/crates/toasty-driver-d1/src/error.rs
@@ -3,3 +3,19 @@ pub(crate) fn unsupported(operation: &str) -> toasty_core::Error {
         "D1 does not support the {operation} operation"
     ))
 }
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn worker(operation: &str, error: worker::Error) -> toasty_core::Error {
+    let error = std::io::Error::other(error.to_string());
+    toasty_core::Error::driver_operation_failed(error).context(toasty_core::Error::from_args(
+        format_args!("D1 {operation} failed"),
+    ))
+}
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn result(operation: &str, message: String) -> toasty_core::Error {
+    let error = std::io::Error::other(message);
+    toasty_core::Error::driver_operation_failed(error).context(toasty_core::Error::from_args(
+        format_args!("D1 {operation} failed"),
+    ))
+}

--- a/crates/toasty-driver-d1/src/lib.rs
+++ b/crates/toasty-driver-d1/src/lib.rs
@@ -5,14 +5,16 @@
 //! D1 drivers are constructed from a request-local Worker binding and use a
 //! direct connection rather than a connection pool.
 
-mod error;
 mod migration;
-mod value;
 
 #[cfg(target_arch = "wasm32")]
 mod connection;
 #[cfg(target_arch = "wasm32")]
 mod driver;
+#[cfg(target_arch = "wasm32")]
+mod error;
+#[cfg(any(target_arch = "wasm32", test))]
+mod value;
 
 pub use migration::generate_migration;
 

--- a/crates/toasty-driver-d1/src/lib.rs
+++ b/crates/toasty-driver-d1/src/lib.rs
@@ -1,0 +1,20 @@
+#![warn(missing_docs)]
+
+//! Toasty driver for [Cloudflare D1](https://developers.cloudflare.com/d1/).
+//!
+//! D1 drivers are constructed from a request-local Worker binding and use a
+//! direct connection rather than a connection pool.
+
+mod error;
+mod migration;
+mod value;
+
+#[cfg(target_arch = "wasm32")]
+mod connection;
+#[cfg(target_arch = "wasm32")]
+mod driver;
+
+pub use migration::generate_migration;
+
+#[cfg(target_arch = "wasm32")]
+pub use driver::D1;

--- a/crates/toasty-driver-d1/src/migration.rs
+++ b/crates/toasty-driver-d1/src/migration.rs
@@ -1,0 +1,20 @@
+use toasty_core::{
+    driver::Capability,
+    schema::{db::Migration, diff},
+};
+
+/// Generates D1-compatible SQL for a schema difference.
+///
+/// The returned statements are intended to be written to a Wrangler migration
+/// file and applied by Wrangler rather than through a live D1 binding.
+pub fn generate_migration(schema_diff: &diff::Schema<'_>) -> Migration {
+    let statements = toasty_sql::MigrationStatement::from_diff(schema_diff, &Capability::D1);
+    let sql = statements
+        .iter()
+        .map(|statement| {
+            toasty_sql::Serializer::sqlite(statement.schema()).serialize(statement.statement())
+        })
+        .collect::<Vec<_>>();
+
+    Migration::new_sql_with_breakpoints(&sql)
+}

--- a/crates/toasty-driver-d1/src/value.rs
+++ b/crates/toasty-driver-d1/src/value.rs
@@ -1,13 +1,373 @@
+use toasty_core::stmt::Value;
+
+#[cfg(target_arch = "wasm32")]
+use toasty_core::stmt;
+
 pub(crate) const MIN_SAFE_INTEGER: i64 = -9_007_199_254_740_991;
 pub(crate) const MAX_SAFE_INTEGER: i64 = 9_007_199_254_740_991;
+pub(crate) const MAX_SAFE_UNSIGNED_INTEGER: u64 = MAX_SAFE_INTEGER as u64;
+pub(crate) const MAX_VALUE_BYTES: usize = 2_000_000;
+
+fn invalid_value(message: impl Into<String>) -> toasty_core::Error {
+    toasty_core::Error::validation_failed(message)
+}
 
 pub(crate) fn validate_i64(value: i64) -> toasty_core::Result<()> {
     if (MIN_SAFE_INTEGER..=MAX_SAFE_INTEGER).contains(&value) {
         Ok(())
     } else {
-        Err(toasty_core::Error::validation_failed(format!(
-            "D1 integer is outside JavaScript's safe range ({MIN_SAFE_INTEGER}..={MAX_SAFE_INTEGER})"
+        Err(invalid_value(format!(
+            "D1 signed integer exceeds JavaScript's safe range ({MIN_SAFE_INTEGER}..={MAX_SAFE_INTEGER})"
         )))
+    }
+}
+
+pub(crate) fn validate_u64(value: u64) -> toasty_core::Result<()> {
+    if value <= MAX_SAFE_UNSIGNED_INTEGER {
+        Ok(())
+    } else {
+        Err(invalid_value(format!(
+            "D1 unsigned integer exceeds JavaScript's safe maximum ({MAX_SAFE_UNSIGNED_INTEGER})"
+        )))
+    }
+}
+
+pub(crate) fn validate_f64(value: f64, ty: &str) -> toasty_core::Result<()> {
+    if value.is_finite() {
+        Ok(())
+    } else {
+        Err(invalid_value(format!("D1 {ty} values must be finite")))
+    }
+}
+
+fn validate_bytes(len: usize, ty: &str) -> toasty_core::Result<()> {
+    if len <= MAX_VALUE_BYTES {
+        Ok(())
+    } else {
+        Err(invalid_value(format!(
+            "D1 {ty} exceeds the {MAX_VALUE_BYTES}-byte value limit"
+        )))
+    }
+}
+
+fn text_value(value: &Value) -> toasty_core::Result<Option<String>> {
+    Ok(match value {
+        Value::List(_) | Value::Object(_) => Some(
+            toasty_sql::json::to_string(value)
+                .map_err(|error| invalid_value(format!("D1 JSON serialization failed: {error}")))?,
+        ),
+        #[cfg(feature = "rust_decimal")]
+        Value::Decimal(value) => Some(value.to_string()),
+        #[cfg(feature = "bigdecimal")]
+        Value::BigDecimal(value) => Some(value.to_string()),
+        #[cfg(feature = "jiff")]
+        Value::Timestamp(value) => Some(value.to_string()),
+        #[cfg(feature = "jiff")]
+        Value::Zoned(value) => Some(value.to_string()),
+        #[cfg(feature = "jiff")]
+        Value::Date(value) => Some(value.to_string()),
+        #[cfg(feature = "jiff")]
+        Value::Time(value) => Some(value.to_string()),
+        #[cfg(feature = "jiff")]
+        Value::DateTime(value) => Some(value.to_string()),
+        _ => None,
+    })
+}
+
+pub(crate) fn validate(value: &Value) -> toasty_core::Result<()> {
+    match value {
+        Value::I8(value) => validate_i64(i64::from(*value)),
+        Value::I16(value) => validate_i64(i64::from(*value)),
+        Value::I32(value) => validate_i64(i64::from(*value)),
+        Value::I64(value) => validate_i64(*value),
+        Value::U8(value) => validate_u64(u64::from(*value)),
+        Value::U16(value) => validate_u64(u64::from(*value)),
+        Value::U32(value) => validate_u64(u64::from(*value)),
+        Value::U64(value) => validate_u64(*value),
+        Value::F32(value) => validate_f64(f64::from(*value), "f32"),
+        Value::F64(value) => validate_f64(*value, "f64"),
+        Value::String(value) => validate_bytes(value.len(), "string"),
+        Value::Bytes(value) => validate_bytes(value.len(), "BLOB"),
+        Value::Uuid(value) => {
+            let text = value.hyphenated().to_string();
+            if text.len() == 36 {
+                Ok(())
+            } else {
+                Err(invalid_value("D1 UUID is not in canonical text form"))
+            }
+        }
+        Value::Null | Value::Bool(_) => Ok(()),
+        value if text_value(value)?.is_some() => {
+            let text = text_value(value)?.expect("checked above");
+            validate_bytes(text.len(), "text-encoded value")
+        }
+        value => Err(invalid_value(format!(
+            "D1 cannot bind Toasty value type {:?}",
+            value.infer_ty()
+        ))),
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) mod wasm {
+    use super::*;
+    use worker::{
+        js_sys::{Array, Uint8Array},
+        wasm_bindgen::{JsCast, JsValue},
+    };
+
+    pub(crate) fn bind(value: Value) -> toasty_core::Result<JsValue> {
+        validate(&value)?;
+
+        Ok(match value {
+            Value::Null => JsValue::null(),
+            Value::Bool(value) => JsValue::from_bool(value),
+            Value::I8(value) => JsValue::from_f64(f64::from(value)),
+            Value::I16(value) => JsValue::from_f64(f64::from(value)),
+            Value::I32(value) => JsValue::from_f64(f64::from(value)),
+            Value::I64(value) => JsValue::from_f64(value as f64),
+            Value::U8(value) => JsValue::from_f64(f64::from(value)),
+            Value::U16(value) => JsValue::from_f64(f64::from(value)),
+            Value::U32(value) => JsValue::from_f64(f64::from(value)),
+            Value::U64(value) => JsValue::from_f64(value as f64),
+            Value::F32(value) => JsValue::from_f64(f64::from(value)),
+            Value::F64(value) => JsValue::from_f64(value),
+            Value::String(value) => JsValue::from_str(&value),
+            Value::Bytes(value) => Uint8Array::from(value.as_slice()).into(),
+            Value::Uuid(value) => JsValue::from_str(&value.hyphenated().to_string()),
+            value => JsValue::from_str(
+                &text_value(&value)?
+                    .ok_or_else(|| invalid_value("D1 value has no supported text encoding"))?,
+            ),
+        })
+    }
+
+    pub(crate) fn decode_typed(
+        value: JsValue,
+        ty: &stmt::Type,
+        index: usize,
+    ) -> toasty_core::Result<Value> {
+        if value.is_null() || value.is_undefined() {
+            return Ok(Value::Null);
+        }
+
+        let invalid = || {
+            toasty_core::Error::invalid_result(format!(
+                "D1 column {index} expected {ty:?}, received {}",
+                category(&value)
+            ))
+        };
+
+        match ty {
+            stmt::Type::Bool => {
+                if let Some(value) = value.as_bool() {
+                    return Ok(Value::Bool(value));
+                }
+                match value.as_f64() {
+                    Some(0.0) => Ok(Value::Bool(false)),
+                    Some(1.0) => Ok(Value::Bool(true)),
+                    _ => Err(invalid()),
+                }
+            }
+            stmt::Type::I8 => integer(&value, index)
+                .and_then(|value| i8::try_from(value).map(Value::I8).map_err(|_| invalid())),
+            stmt::Type::I16 => integer(&value, index)
+                .and_then(|value| i16::try_from(value).map(Value::I16).map_err(|_| invalid())),
+            stmt::Type::I32 => integer(&value, index)
+                .and_then(|value| i32::try_from(value).map(Value::I32).map_err(|_| invalid())),
+            stmt::Type::I64 => integer(&value, index).map(Value::I64),
+            stmt::Type::U8 => integer(&value, index)
+                .and_then(|value| u8::try_from(value).map(Value::U8).map_err(|_| invalid())),
+            stmt::Type::U16 => integer(&value, index)
+                .and_then(|value| u16::try_from(value).map(Value::U16).map_err(|_| invalid())),
+            stmt::Type::U32 => integer(&value, index)
+                .and_then(|value| u32::try_from(value).map(Value::U32).map_err(|_| invalid())),
+            stmt::Type::U64 => integer(&value, index)
+                .and_then(|value| u64::try_from(value).map(Value::U64).map_err(|_| invalid())),
+            stmt::Type::F32 => finite_number(&value, index).map(|value| Value::F32(value as f32)),
+            stmt::Type::F64 => finite_number(&value, index).map(Value::F64),
+            stmt::Type::String => value.as_string().map(Value::String).ok_or_else(invalid),
+            stmt::Type::Uuid => value
+                .as_string()
+                .ok_or_else(&invalid)?
+                .parse()
+                .map(Value::Uuid)
+                .map_err(|_| invalid()),
+            stmt::Type::Bytes => decode_bytes(value, index).map(Value::Bytes),
+            stmt::Type::List(elem) => {
+                let text = value.as_string().ok_or_else(&invalid)?;
+                toasty_sql::json::list_from_str(&text, elem).map_err(|error| {
+                    toasty_core::Error::invalid_result(format!(
+                        "D1 column {index} contains invalid JSON: {error}"
+                    ))
+                })
+            }
+            stmt::Type::Object => {
+                let text = value.as_string().ok_or_else(&invalid)?;
+                toasty_sql::json::from_str(&text, ty).map_err(|error| {
+                    toasty_core::Error::invalid_result(format!(
+                        "D1 column {index} contains invalid JSON: {error}"
+                    ))
+                })
+            }
+            #[cfg(feature = "rust_decimal")]
+            stmt::Type::Decimal => parse_text(value, index, "Decimal").map(Value::Decimal),
+            #[cfg(feature = "bigdecimal")]
+            stmt::Type::BigDecimal => parse_text(value, index, "BigDecimal").map(Value::BigDecimal),
+            #[cfg(feature = "jiff")]
+            stmt::Type::Timestamp => parse_text(value, index, "Timestamp").map(Value::Timestamp),
+            #[cfg(feature = "jiff")]
+            stmt::Type::Zoned => parse_text(value, index, "Zoned").map(Value::Zoned),
+            #[cfg(feature = "jiff")]
+            stmt::Type::Date => parse_text(value, index, "Date").map(Value::Date),
+            #[cfg(feature = "jiff")]
+            stmt::Type::Time => parse_text(value, index, "Time").map(Value::Time),
+            #[cfg(feature = "jiff")]
+            stmt::Type::DateTime => parse_text(value, index, "DateTime").map(Value::DateTime),
+            _ => Err(invalid()),
+        }
+    }
+
+    pub(crate) fn decode_infer(value: JsValue, index: usize) -> toasty_core::Result<Value> {
+        if value.is_null() || value.is_undefined() {
+            return Ok(Value::Null);
+        }
+        if let Some(value) = value.as_string() {
+            return Ok(Value::String(value));
+        }
+        if let Some(value) = value.as_bool() {
+            return Ok(Value::Bool(value));
+        }
+        if value.is_instance_of::<Uint8Array>() || Array::is_array(&value) {
+            return decode_bytes(value, index).map(Value::Bytes);
+        }
+        if let Some(value) = value.as_f64() {
+            validate_f64(value, "raw numeric result").map_err(|_| {
+                toasty_core::Error::invalid_result(format!(
+                    "D1 column {index} contains a non-finite number"
+                ))
+            })?;
+            if value.fract() == 0.0
+                && value >= MIN_SAFE_INTEGER as f64
+                && value <= MAX_SAFE_INTEGER as f64
+            {
+                return Ok(Value::I64(value as i64));
+            }
+            return Ok(Value::F64(value));
+        }
+
+        Err(toasty_core::Error::invalid_result(format!(
+            "D1 column {index} has unsupported raw value category {}",
+            category(&value)
+        )))
+    }
+
+    pub(crate) fn row(value: JsValue) -> toasty_core::Result<Array> {
+        value.dyn_into::<Array>().map_err(|value| {
+            toasty_core::Error::invalid_result(format!(
+                "D1 raw query returned {}, expected an array row",
+                category(&value)
+            ))
+        })
+    }
+
+    fn finite_number(value: &JsValue, index: usize) -> toasty_core::Result<f64> {
+        let value = value.as_f64().ok_or_else(|| {
+            toasty_core::Error::invalid_result(format!(
+                "D1 column {index} expected a number, received {}",
+                category(value)
+            ))
+        })?;
+        if value.is_finite() {
+            Ok(value)
+        } else {
+            Err(toasty_core::Error::invalid_result(format!(
+                "D1 column {index} contains a non-finite number"
+            )))
+        }
+    }
+
+    fn integer(value: &JsValue, index: usize) -> toasty_core::Result<i64> {
+        let value = finite_number(value, index)?;
+        if value.fract() != 0.0
+            || value < MIN_SAFE_INTEGER as f64
+            || value > MAX_SAFE_INTEGER as f64
+        {
+            return Err(toasty_core::Error::invalid_result(format!(
+                "D1 column {index} expected a safe integral number"
+            )));
+        }
+        Ok(value as i64)
+    }
+
+    fn decode_bytes(value: JsValue, index: usize) -> toasty_core::Result<Vec<u8>> {
+        if value.is_instance_of::<Uint8Array>() {
+            return Ok(Uint8Array::new(&value).to_vec());
+        }
+        if Array::is_array(&value) {
+            let array = Array::from(&value);
+            let mut bytes = Vec::with_capacity(array.length() as usize);
+            for item in array.iter() {
+                let number = item.as_f64().ok_or_else(|| {
+                    toasty_core::Error::invalid_result(format!(
+                        "D1 column {index} BLOB contains a non-number"
+                    ))
+                })?;
+                if number.fract() != 0.0 || !(0.0..=255.0).contains(&number) {
+                    return Err(toasty_core::Error::invalid_result(format!(
+                        "D1 column {index} BLOB contains a byte outside 0..=255"
+                    )));
+                }
+                bytes.push(number as u8);
+            }
+            return Ok(bytes);
+        }
+        Err(toasty_core::Error::invalid_result(format!(
+            "D1 column {index} expected a BLOB, received {}",
+            category(&value)
+        )))
+    }
+
+    #[cfg(any(feature = "rust_decimal", feature = "bigdecimal", feature = "jiff"))]
+    fn parse_text<T: std::str::FromStr>(
+        value: JsValue,
+        index: usize,
+        ty: &str,
+    ) -> toasty_core::Result<T> {
+        value
+            .as_string()
+            .ok_or_else(|| {
+                toasty_core::Error::invalid_result(format!(
+                    "D1 column {index} expected {ty} text, received {}",
+                    category(&value)
+                ))
+            })?
+            .parse()
+            .map_err(|_| {
+                toasty_core::Error::invalid_result(format!(
+                    "D1 column {index} contains invalid {ty} text"
+                ))
+            })
+    }
+
+    fn category(value: &JsValue) -> &'static str {
+        if value.is_null() {
+            "null"
+        } else if value.is_undefined() {
+            "undefined"
+        } else if value.is_string() {
+            "string"
+        } else if value.as_bool().is_some() {
+            "boolean"
+        } else if value.as_f64().is_some() {
+            "number"
+        } else if value.is_instance_of::<Uint8Array>() {
+            "Uint8Array"
+        } else if Array::is_array(value) {
+            "array"
+        } else {
+            "object"
+        }
     }
 }
 
@@ -21,5 +381,45 @@ mod tests {
         assert!(validate_i64(MAX_SAFE_INTEGER).is_ok());
         assert!(validate_i64(MIN_SAFE_INTEGER - 1).is_err());
         assert!(validate_i64(MAX_SAFE_INTEGER + 1).is_err());
+        assert!(validate_u64(MAX_SAFE_UNSIGNED_INTEGER).is_ok());
+        assert!(validate_u64(MAX_SAFE_UNSIGNED_INTEGER + 1).is_err());
+    }
+
+    #[test]
+    fn validates_every_integer_width() {
+        assert!(validate(&Value::I8(i8::MIN)).is_ok());
+        assert!(validate(&Value::I16(i16::MIN)).is_ok());
+        assert!(validate(&Value::I32(i32::MIN)).is_ok());
+        assert!(validate(&Value::I64(MAX_SAFE_INTEGER)).is_ok());
+        assert!(validate(&Value::U8(u8::MAX)).is_ok());
+        assert!(validate(&Value::U16(u16::MAX)).is_ok());
+        assert!(validate(&Value::U32(u32::MAX)).is_ok());
+        assert!(validate(&Value::U64(MAX_SAFE_UNSIGNED_INTEGER)).is_ok());
+    }
+
+    #[test]
+    fn rejects_non_finite_floats() {
+        assert!(validate(&Value::F32(1.5)).is_ok());
+        assert!(validate(&Value::F64(-2.5)).is_ok());
+        assert!(validate(&Value::F32(f32::NAN)).is_err());
+        assert!(validate(&Value::F64(f64::INFINITY)).is_err());
+        assert!(validate(&Value::F64(f64::NEG_INFINITY)).is_err());
+    }
+
+    #[test]
+    fn validates_string_and_blob_limits() {
+        assert!(validate(&Value::String(String::new())).is_ok());
+        assert!(validate(&Value::String("ok".into())).is_ok());
+        assert!(validate(&Value::String("x".repeat(MAX_VALUE_BYTES))).is_ok());
+        assert!(validate(&Value::String("x".repeat(MAX_VALUE_BYTES + 1))).is_err());
+        assert!(validate(&Value::Bytes(vec![0; MAX_VALUE_BYTES])).is_ok());
+        assert!(validate(&Value::Bytes(vec![0; MAX_VALUE_BYTES + 1])).is_err());
+    }
+
+    #[test]
+    fn validates_uuid_and_json_text() {
+        let uuid = "67e55044-10b1-426f-9247-bb680e5fe0c8".parse().unwrap();
+        assert!(validate(&Value::Uuid(uuid)).is_ok());
+        assert!(validate(&Value::List(vec![Value::I64(1)])).is_ok());
     }
 }

--- a/crates/toasty-driver-d1/src/value.rs
+++ b/crates/toasty-driver-d1/src/value.rs
@@ -1,0 +1,25 @@
+pub(crate) const MIN_SAFE_INTEGER: i64 = -9_007_199_254_740_991;
+pub(crate) const MAX_SAFE_INTEGER: i64 = 9_007_199_254_740_991;
+
+pub(crate) fn validate_i64(value: i64) -> toasty_core::Result<()> {
+    if (MIN_SAFE_INTEGER..=MAX_SAFE_INTEGER).contains(&value) {
+        Ok(())
+    } else {
+        Err(toasty_core::Error::validation_failed(format!(
+            "D1 integer is outside JavaScript's safe range ({MIN_SAFE_INTEGER}..={MAX_SAFE_INTEGER})"
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_javascript_safe_integer_bounds() {
+        assert!(validate_i64(MIN_SAFE_INTEGER).is_ok());
+        assert!(validate_i64(MAX_SAFE_INTEGER).is_ok());
+        assert!(validate_i64(MIN_SAFE_INTEGER - 1).is_err());
+        assert!(validate_i64(MAX_SAFE_INTEGER + 1).is_err());
+    }
+}

--- a/crates/toasty-driver-d1/src/value.rs
+++ b/crates/toasty-driver-d1/src/value.rs
@@ -7,6 +7,9 @@ pub(crate) const MIN_SAFE_INTEGER: i64 = -9_007_199_254_740_991;
 pub(crate) const MAX_SAFE_INTEGER: i64 = 9_007_199_254_740_991;
 pub(crate) const MAX_SAFE_UNSIGNED_INTEGER: u64 = MAX_SAFE_INTEGER as u64;
 pub(crate) const MAX_VALUE_BYTES: usize = 2_000_000;
+pub(crate) const MAX_BIND_PARAMETERS: usize = 100;
+pub(crate) const MAX_PATTERN_BYTES: usize = 50;
+pub(crate) const MAX_SQL_BYTES: usize = 100_000;
 
 fn invalid_value(message: impl Into<String>) -> toasty_core::Error {
     toasty_core::Error::validation_failed(message)
@@ -46,6 +49,38 @@ fn validate_bytes(len: usize, ty: &str) -> toasty_core::Result<()> {
     } else {
         Err(invalid_value(format!(
             "D1 {ty} exceeds the {MAX_VALUE_BYTES}-byte value limit"
+        )))
+    }
+}
+
+pub(crate) fn validate_parameter_count(count: usize) -> toasty_core::Result<()> {
+    if count <= MAX_BIND_PARAMETERS {
+        Ok(())
+    } else {
+        Err(invalid_value(format!(
+            "D1 statement has {count} bind parameters; maximum is {MAX_BIND_PARAMETERS}"
+        )))
+    }
+}
+
+pub(crate) fn validate_pattern(pattern: &str) -> toasty_core::Result<()> {
+    if pattern.len() <= MAX_PATTERN_BYTES {
+        Ok(())
+    } else {
+        Err(invalid_value(format!(
+            "D1 LIKE/GLOB pattern is {} bytes; maximum is {MAX_PATTERN_BYTES}",
+            pattern.len()
+        )))
+    }
+}
+
+pub(crate) fn validate_sql(sql: &str) -> toasty_core::Result<()> {
+    if sql.len() <= MAX_SQL_BYTES {
+        Ok(())
+    } else {
+        Err(invalid_value(format!(
+            "D1 SQL statement is {} bytes; maximum is {MAX_SQL_BYTES}",
+            sql.len()
         )))
     }
 }
@@ -414,6 +449,16 @@ mod tests {
         assert!(validate(&Value::String("x".repeat(MAX_VALUE_BYTES + 1))).is_err());
         assert!(validate(&Value::Bytes(vec![0; MAX_VALUE_BYTES])).is_ok());
         assert!(validate(&Value::Bytes(vec![0; MAX_VALUE_BYTES + 1])).is_err());
+    }
+
+    #[test]
+    fn validates_statement_and_pattern_limits() {
+        assert!(validate_parameter_count(MAX_BIND_PARAMETERS).is_ok());
+        assert!(validate_parameter_count(MAX_BIND_PARAMETERS + 1).is_err());
+        assert!(validate_pattern(&"x".repeat(MAX_PATTERN_BYTES)).is_ok());
+        assert!(validate_pattern(&"x".repeat(MAX_PATTERN_BYTES + 1)).is_err());
+        assert!(validate_sql(&"x".repeat(MAX_SQL_BYTES)).is_ok());
+        assert!(validate_sql(&"x".repeat(MAX_SQL_BYTES + 1)).is_err());
     }
 
     #[test]

--- a/crates/toasty-driver-integration-suite/Cargo.toml
+++ b/crates/toasty-driver-integration-suite/Cargo.toml
@@ -26,7 +26,7 @@ toasty = { workspace = true, features = ["rust_decimal", "bigdecimal", "jiff", "
 toasty-core = { workspace = true, features = ["assert-struct"] }
 toasty-macros.workspace = true
 toasty-driver-integration-suite-macros.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }
 rand.workspace = true
 uuid.workspace = true
 

--- a/crates/toasty-driver-integration-suite/src/instrumented_driver.rs
+++ b/crates/toasty-driver-integration-suite/src/instrumented_driver.rs
@@ -157,6 +157,10 @@ impl Driver for InstrumentedDriver {
         self.inner.capability()
     }
 
+    fn connection_strategy(&self) -> toasty_core::driver::ConnectionStrategy {
+        self.inner.connection_strategy()
+    }
+
     async fn connect(&self, cx: &ConnectContext) -> Result<Box<dyn Connection>> {
         Ok(Box::new(InstrumentedConnection {
             inner: self.inner.connect(cx).await?,

--- a/crates/toasty-driver-integration-suite/src/instrumented_driver.rs
+++ b/crates/toasty-driver-integration-suite/src/instrumented_driver.rs
@@ -10,7 +10,10 @@ use std::{
 };
 use toasty_core::{
     Result, Schema,
-    driver::{Capability, ConnectContext, Connection, Driver, ExecResponse, Operation, Rows},
+    driver::{
+        Capability, ConnectContext, Connection, Driver, ExecResponse, Operation, Rows,
+        operation::AtomicSqlBatch,
+    },
     schema::{
         db::{AppliedMigration, Migration},
         diff,
@@ -246,6 +249,36 @@ impl Connection for InstrumentedConnection {
             .push(driver_op);
 
         Ok(response)
+    }
+
+    async fn exec_atomic_batch(
+        &mut self,
+        schema: &Arc<Schema>,
+        batch: AtomicSqlBatch,
+    ) -> Result<Vec<ExecResponse>> {
+        let operations = batch.operations.clone();
+        let mut responses = self.inner.exec_atomic_batch(schema, batch).await?;
+        if operations.len() != responses.len() {
+            return Err(toasty_core::Error::invalid_result(format!(
+                "instrumented atomic batch received {} responses for {} operations",
+                responses.len(),
+                operations.len()
+            )));
+        }
+
+        for (operation, response) in operations.into_iter().zip(&mut responses) {
+            let duplicated_response = duplicate_response_mut(response).await?;
+            self.handle
+                .inner
+                .ops_log
+                .lock()
+                .expect("Failed to acquire ops log lock")
+                .push(DriverOp {
+                    operation: operation.into(),
+                    response: duplicated_response,
+                });
+        }
+        Ok(responses)
     }
 
     async fn push_schema(&mut self, schema: &Schema) -> Result<()> {

--- a/crates/toasty-driver-integration-suite/src/isolate.rs
+++ b/crates/toasty-driver-integration-suite/src/isolate.rs
@@ -29,7 +29,15 @@ impl Isolate {
     }
 
     /// Generate a process ID using the OS process ID.
+    #[cfg(not(target_arch = "wasm32"))]
     fn generate_process_id() -> u32 {
         std::process::id()
+    }
+
+    /// Workers have no process identifier. The per-isolate counter remains
+    /// unique within one Worker instance.
+    #[cfg(target_arch = "wasm32")]
+    fn generate_process_id() -> u32 {
+        0
     }
 }

--- a/crates/toasty-driver-integration-suite/src/setup.rs
+++ b/crates/toasty-driver-integration-suite/src/setup.rs
@@ -8,4 +8,14 @@ pub trait Setup: Send + Sync + 'static {
     /// Delete the table with the specified name. This is used by the test
     /// runner to cleanup after itself.
     async fn delete_table(&self, name: &str);
+
+    /// Delete a test table and report cleanup failures to async runners.
+    ///
+    /// Native test setups can keep implementing [`delete_table`](Self::delete_table);
+    /// request-driven runners override this method when cleanup errors must be
+    /// returned to a host process.
+    async fn try_delete_table(&self, name: &str) -> toasty::Result<()> {
+        self.delete_table(name).await;
+        Ok(())
+    }
 }

--- a/crates/toasty-driver-integration-suite/src/test.rs
+++ b/crates/toasty-driver-integration-suite/src/test.rs
@@ -1,9 +1,10 @@
-use std::{
-    error::Error,
-    sync::{Arc, RwLock},
-};
+use std::{error::Error, sync::Arc};
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::RwLock;
 
 use toasty::{Db, schema::ModelSet};
+#[cfg(not(target_arch = "wasm32"))]
 use tokio::runtime::Runtime;
 
 use crate::{Fault, InstrumentedDriver, InstrumentedHandle, Isolate, Setup};
@@ -11,6 +12,7 @@ use crate::{Fault, InstrumentedDriver, InstrumentedHandle, Isolate, Setup};
 /// Global lock for coordinating serial vs parallel tests.
 /// Normal tests acquire a read lock (allowing parallelism).
 /// Serial tests acquire a write lock (exclusive access).
+#[cfg(not(target_arch = "wasm32"))]
 static TEST_LOCK: RwLock<()> = RwLock::new(());
 
 /// Wraps the Tokio runtime and ensures cleanup happens.
@@ -24,6 +26,7 @@ pub struct Test {
     isolate: Isolate,
 
     /// Tokio runtime used by the test
+    #[cfg(not(target_arch = "wasm32"))]
     runtime: Option<Runtime>,
 
     /// Single handle controlling the instrumented driver test middleware:
@@ -39,6 +42,7 @@ pub struct Test {
 }
 
 impl Test {
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn new(setup: Arc<dyn Setup>) -> Self {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -49,6 +53,22 @@ impl Test {
             setup,
             isolate: Isolate::new(),
             runtime: Some(runtime),
+            handle: InstrumentedHandle::default(),
+            tables: vec![],
+            serial: false,
+        }
+    }
+
+    /// Create a test harness for an existing async runtime.
+    ///
+    /// Worker handlers use this constructor and [`run_async`](Self::run_async)
+    /// instead of creating or blocking a Tokio runtime.
+    pub fn new_async(setup: Arc<dyn Setup>) -> Self {
+        Test {
+            setup,
+            isolate: Isolate::new(),
+            #[cfg(not(target_arch = "wasm32"))]
+            runtime: None,
             handle: InstrumentedHandle::default(),
             tables: vec![],
             serial: false,
@@ -131,6 +151,7 @@ impl Test {
     }
 
     /// Run an async test function using the internal runtime
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn run<R>(&mut self, f: impl AsyncFn(&mut Test) -> R)
     where
         R: Into<TestResult>,
@@ -145,19 +166,42 @@ impl Test {
 
         // Temporarily take the runtime to avoid borrow checker issues
         let runtime = self.runtime.take().expect("runtime already consumed");
-        let f: std::pin::Pin<Box<dyn std::future::Future<Output = R>>> = Box::pin(f(self));
-        let result = runtime.block_on(f).into();
+        let result = runtime.block_on(self.run_async(f));
 
-        // now, wut
-        for table in &self.tables {
-            runtime.block_on(self.setup.delete_table(table));
-        }
-
-        if let Some(error) = result.error {
-            panic!("Driver test returned an error: {error}");
+        if let Err(error) = result {
+            panic!("Driver test failed: {error}");
         }
 
         self.runtime = Some(runtime);
+    }
+
+    /// Run one test body and clean up every table it created.
+    ///
+    /// This entry point is executor-neutral: it awaits the caller's runtime and
+    /// never blocks a thread or creates a Tokio runtime. It returns test and
+    /// cleanup failures as strings so a Worker can send them to its host.
+    pub async fn run_async<R>(&mut self, f: impl AsyncFn(&mut Test) -> R) -> Result<(), String>
+    where
+        R: Into<TestResult>,
+    {
+        let result: TestResult = f(self).await.into();
+        let tables = std::mem::take(&mut self.tables);
+        let mut cleanup_errors = Vec::new();
+        for table in tables {
+            if let Err(error) = self.setup.try_delete_table(&table).await {
+                cleanup_errors.push(format!("{table}: {error}"));
+            }
+        }
+
+        match (result.error, cleanup_errors.is_empty()) {
+            (None, true) => Ok(()),
+            (Some(error), true) => Err(error.to_string()),
+            (None, false) => Err(format!("cleanup failed: {}", cleanup_errors.join("; "))),
+            (Some(error), false) => Err(format!(
+                "{error}; cleanup failed: {}",
+                cleanup_errors.join("; ")
+            )),
+        }
     }
 }
 

--- a/crates/toasty-driver-integration-suite/src/tests/batch_create_statements.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/batch_create_statements.rs
@@ -6,7 +6,11 @@ use toasty_core::{
 };
 
 /// Batch two creates of the same model.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn batch_two_creates_same_model(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -47,7 +51,11 @@ pub async fn batch_two_creates_same_model(t: &mut Test) -> Result<()> {
 }
 
 /// Batch creates of two different models.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn batch_two_creates_different_models(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -82,7 +90,11 @@ pub async fn batch_two_creates_different_models(t: &mut Test) -> Result<()> {
 }
 
 /// Batch mixing a query first and a create second.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn batch_query_and_create(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -119,7 +131,11 @@ pub async fn batch_query_and_create(t: &mut Test) -> Result<()> {
 }
 
 /// Batch mixing a create first and a query second.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn batch_create_then_query(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
     User::create().name("Alice").exec(&mut db).await?;
@@ -155,7 +171,11 @@ pub async fn batch_create_then_query(t: &mut Test) -> Result<()> {
 }
 
 /// Three-element batch: create, query, create.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn batch_create_query_create(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
     User::create().name("Alice").exec(&mut db).await?;
@@ -198,7 +218,11 @@ pub async fn batch_create_query_create(t: &mut Test) -> Result<()> {
 }
 
 /// Batch creates via an array of create builders.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn batch_creates_from_array(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -240,7 +264,11 @@ pub async fn batch_creates_from_array(t: &mut Test) -> Result<()> {
 }
 
 /// Batch creates via a Vec of create builders.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn batch_creates_from_vec(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 

--- a/crates/toasty-driver-integration-suite/src/tests/batch_rollback.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/batch_rollback.rs
@@ -5,11 +5,7 @@ use toasty_core::driver::{Operation, operation::Transaction};
 /// When a batch of two creates fails on the second INSERT (unique constraint
 /// violation), the entire batch is rolled back — the first INSERT must not
 /// persist.
-#[driver_test(
-    id(ID),
-    requires(interactive_transactions),
-    scenario(crate::scenarios::user_unique_email)
-)]
+#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::user_unique_email))]
 pub async fn batch_two_creates_rolls_back_on_second_failure(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -29,20 +25,24 @@ pub async fn batch_two_creates_rolls_back_on_second_failure(t: &mut Test) -> Res
         .await
     );
 
-    // BEGIN → INSERT (succeeds) → INSERT (fails, not logged) → ROLLBACK
-    assert_struct!(
-        t.log().pop_op(),
-        Operation::Transaction(Transaction::Start {
-            isolation: None,
-            read_only: false,
-            ..
-        })
-    );
-    assert_struct!(t.log().pop_op(), Operation::QuerySql(_)); // first INSERT
-    assert_struct!(
-        t.log().pop_op(),
-        Operation::Transaction(Transaction::Rollback)
-    );
+    if t.capability().interactive_transactions {
+        // BEGIN → INSERT (succeeds) → INSERT (fails, not logged) → ROLLBACK
+        assert_struct!(
+            t.log().pop_op(),
+            Operation::Transaction(Transaction::Start {
+                isolation: None,
+                read_only: false,
+                ..
+            })
+        );
+        assert_struct!(t.log().pop_op(), Operation::QuerySql(_)); // first INSERT
+        assert_struct!(
+            t.log().pop_op(),
+            Operation::Transaction(Transaction::Rollback)
+        );
+    }
+    // Atomic-batch drivers return the failing batch before the middleware can
+    // log any successful child operation.
     assert!(t.log().is_empty());
 
     // Only the seeded user remains — "new@example.com" was rolled back

--- a/crates/toasty-driver-integration-suite/src/tests/batch_rollback.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/batch_rollback.rs
@@ -5,7 +5,11 @@ use toasty_core::driver::{Operation, operation::Transaction};
 /// When a batch of two creates fails on the second INSERT (unique constraint
 /// violation), the entire batch is rolled back — the first INSERT must not
 /// persist.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::user_unique_email))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::user_unique_email)
+)]
 pub async fn batch_two_creates_rolls_back_on_second_failure(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -51,7 +55,11 @@ pub async fn batch_two_creates_rolls_back_on_second_failure(t: &mut Test) -> Res
 
 /// When a batch of a create + update fails on the update (unique constraint),
 /// the successful create is rolled back.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::user_unique_email))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::user_unique_email)
+)]
 pub async fn batch_create_and_update_rolls_back_on_update_failure(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -104,7 +112,11 @@ pub async fn batch_create_and_update_rolls_back_on_update_failure(t: &mut Test) 
 
 /// When a batch of an update + create fails on the create (unique constraint),
 /// the successful update is rolled back.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::user_unique_email))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::user_unique_email)
+)]
 pub async fn batch_update_and_create_rolls_back_on_create_failure(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -162,7 +174,11 @@ pub async fn batch_update_and_create_rolls_back_on_create_failure(t: &mut Test) 
 
 /// When a batch of array creates fails on one element (unique constraint),
 /// all prior successful creates are rolled back.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::user_unique_email))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::user_unique_email)
+)]
 pub async fn batch_array_creates_rolls_back_on_failure(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -212,7 +228,7 @@ pub async fn batch_array_creates_rolls_back_on_failure(t: &mut Test) -> Result<(
 /// model's create is rolled back too.
 #[driver_test(
     id(ID),
-    requires(sql),
+    requires(interactive_transactions),
     scenario(crate::scenarios::two_models_unique_title)
 )]
 pub async fn batch_different_models_rolls_back_on_failure(t: &mut Test) -> Result<()> {

--- a/crates/toasty-driver-integration-suite/src/tests/infra_connection_per_clone.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/infra_connection_per_clone.rs
@@ -10,7 +10,7 @@ pub async fn db_does_not_hold_connection(t: &mut Test) -> Result<()> {
 
     // Db is stateless — after setup_db, the connection used for push_schema has
     // been returned to the pool, so it should be available.
-    let status = db.pool().status();
+    let status = db.pool().unwrap().status();
     assert_eq!(
         status.size, 1,
         "setup_db should have created one connection"
@@ -23,7 +23,7 @@ pub async fn db_does_not_hold_connection(t: &mut Test) -> Result<()> {
     // Execute an operation — it acquires a connection, runs, and returns it.
     User::create().name("dummy").exec(&mut db).await?;
 
-    let status = db.pool().status();
+    let status = db.pool().unwrap().status();
     assert_eq!(
         status.available, 1,
         "connection should be returned after operation"
@@ -33,7 +33,7 @@ pub async fn db_does_not_hold_connection(t: &mut Test) -> Result<()> {
     let mut db2 = db.clone();
     User::create().name("dummy").exec(&mut db2).await?;
 
-    let status = db.pool().status();
+    let status = db.pool().unwrap().status();
     assert_eq!(
         status.available, status.size,
         "all connections should be available after operations"
@@ -56,13 +56,13 @@ pub async fn dedicated_connection_holds_pool_slot(t: &mut Test) -> Result<()> {
     let db = setup(t).await;
 
     // All connections available since Db is stateless.
-    let status = db.pool().status();
+    let status = db.pool().unwrap().status();
     assert_eq!(status.available, status.size);
 
     // Acquire a dedicated connection — it should be held from the pool.
     let mut conn = db.connection().await?;
 
-    let status = db.pool().status();
+    let status = db.pool().unwrap().status();
     assert_eq!(
         status.available,
         status.size - 1,
@@ -73,7 +73,7 @@ pub async fn dedicated_connection_holds_pool_slot(t: &mut Test) -> Result<()> {
     User::create().name("dummy").exec(&mut conn).await?;
 
     // Connection is still held.
-    let status = db.pool().status();
+    let status = db.pool().unwrap().status();
     assert_eq!(
         status.available,
         status.size - 1,
@@ -86,7 +86,7 @@ pub async fn dedicated_connection_holds_pool_slot(t: &mut Test) -> Result<()> {
     // The background task needs a moment to notice the channel closed and exit.
     tokio::task::yield_now().await;
 
-    let status = db.pool().status();
+    let status = db.pool().unwrap().status();
     assert_eq!(
         status.available, status.size,
         "connection should be returned after drop"

--- a/crates/toasty-driver-integration-suite/src/tests/infra_pool_config.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/infra_pool_config.rs
@@ -14,7 +14,7 @@ pub async fn max_pool_size_is_applied(t: &mut Test) -> Result<()> {
         })
         .await;
 
-    assert_eq!(db.pool().status().max_size, 7);
+    assert_eq!(db.pool().unwrap().status().max_size, 7);
 
     Ok(())
 }

--- a/crates/toasty-driver-integration-suite/src/tests/infra_reset_db.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/infra_reset_db.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 
-#[driver_test(serial)]
+#[driver_test(serial, requires(reset_database))]
 pub async fn reset_db_and_recreate(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     struct User {

--- a/crates/toasty-driver-integration-suite/src/tests/tx_atomic_stmt.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/tx_atomic_stmt.rs
@@ -6,7 +6,11 @@ use toasty_core::driver::{Operation, operation::Transaction};
 
 /// A multi-op create (user + associated todo) should be wrapped in
 /// BEGIN ... COMMIT so the driver sees all three transaction operations.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::has_many_belongs_to))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::has_many_belongs_to)
+)]
 pub async fn multi_op_create_wraps_in_transaction(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -66,7 +70,7 @@ pub async fn single_op_skips_transaction(t: &mut Test) -> Result<()> {
 /// explicit transaction wrapping is exercised. With uuid::Uuid IDs the engine
 /// reorders execution (INSERT todo before INSERT user due to the Const
 /// optimization), which produces a different but equally valid log pattern.
-#[driver_test(requires(and(sql, auto_increment)))]
+#[driver_test(requires(and(interactive_transactions, auto_increment)))]
 pub async fn create_with_has_many_rolls_back_on_failure(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     struct User {
@@ -141,7 +145,7 @@ pub async fn create_with_has_many_rolls_back_on_failure(t: &mut Test) -> Result<
 /// explicit transaction wrapping is exercised. With uuid::Uuid IDs the engine
 /// can combine both inserts into a single atomic SQL statement, which provides
 /// atomicity without an explicit transaction.
-#[driver_test(requires(and(sql, auto_increment)))]
+#[driver_test(requires(and(interactive_transactions, auto_increment)))]
 pub async fn create_with_has_one_rolls_back_on_failure(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     struct User {
@@ -214,7 +218,7 @@ pub async fn create_with_has_one_rolls_back_on_failure(t: &mut Test) -> Result<(
 /// a dependency of the UPDATE's returning clause). So the collision is placed
 /// on the User's name field (not the Todo), ensuring the INSERT succeeds first
 /// and is then rolled back when the subsequent UPDATE fails.
-#[driver_test(id(ID), requires(sql))]
+#[driver_test(id(ID), requires(interactive_transactions))]
 pub async fn update_with_new_association_rolls_back_on_failure(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     struct User {
@@ -291,7 +295,7 @@ pub async fn update_with_new_association_rolls_back_on_failure(t: &mut Test) -> 
 /// instead. On PostgreSQL the same operation is a single CTE-based QuerySql.
 #[driver_test(
     id(ID),
-    requires(sql),
+    requires(interactive_transactions),
     scenario(crate::scenarios::has_many_nullable_fk)
 )]
 pub async fn rmw_uses_savepoints(t: &mut Test) -> Result<()> {
@@ -336,7 +340,7 @@ pub async fn rmw_uses_savepoints(t: &mut Test) -> Result<()> {
 /// On PostgreSQL the CTE handles this in a single statement.
 #[driver_test(
     id(ID),
-    requires(sql),
+    requires(interactive_transactions),
     scenario(crate::scenarios::has_many_nullable_fk)
 )]
 pub async fn rmw_condition_failure_issues_rollback_to_savepoint(t: &mut Test) -> Result<()> {

--- a/crates/toasty-driver-integration-suite/src/tests/tx_interactive.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/tx_interactive.rs
@@ -6,7 +6,11 @@ use toasty_core::driver::{Operation, operation::IsolationLevel, operation::Trans
 // ===== Basic commit / rollback =====
 
 /// Data created inside a committed transaction is visible afterwards.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn commit_persists_data(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -22,7 +26,11 @@ pub async fn commit_persists_data(t: &mut Test) -> Result<()> {
 }
 
 /// Data created inside a rolled-back transaction is not visible.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn rollback_discards_data(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -37,7 +45,11 @@ pub async fn rollback_discards_data(t: &mut Test) -> Result<()> {
 }
 
 /// Dropping a transaction without commit or rollback automatically rolls back.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn drop_without_finalize_rolls_back(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -54,7 +66,7 @@ pub async fn drop_without_finalize_rolls_back(t: &mut Test) -> Result<()> {
 }
 
 /// A failed commit rolls back before the connection returns to the pool.
-#[driver_test(requires(sql))]
+#[driver_test(requires(interactive_transactions))]
 pub async fn commit_failure_rolls_back_before_connection_reuse(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     struct Item {
@@ -104,7 +116,7 @@ pub async fn commit_failure_rolls_back_before_connection_reuse(t: &mut Test) -> 
 }
 
 /// A failed rollback is retried before the connection returns to the pool.
-#[driver_test(requires(sql))]
+#[driver_test(requires(interactive_transactions))]
 pub async fn rollback_failure_retries_before_connection_reuse(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     struct Item {
@@ -126,7 +138,7 @@ pub async fn rollback_failure_retries_before_connection_reuse(t: &mut Test) -> R
 }
 
 /// Cancelling a queued commit keeps the connection reusable.
-#[driver_test(requires(sql))]
+#[driver_test(requires(interactive_transactions))]
 pub async fn cancel_queued_commit_keeps_connection_reusable(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     struct Item {
@@ -159,7 +171,11 @@ pub async fn cancel_queued_commit_keeps_connection_reusable(t: &mut Test) -> Res
 }
 
 /// Multiple operations inside a single transaction are all committed together.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn multiple_ops_in_transaction(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -177,7 +193,11 @@ pub async fn multiple_ops_in_transaction(t: &mut Test) -> Result<()> {
 
 /// Read-your-writes: data created inside a transaction is visible within it
 /// before commit.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn read_your_writes(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -194,7 +214,11 @@ pub async fn read_your_writes(t: &mut Test) -> Result<()> {
 }
 
 /// Updates inside a transaction are committed.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn update_inside_transaction(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -211,7 +235,11 @@ pub async fn update_inside_transaction(t: &mut Test) -> Result<()> {
 }
 
 /// Updates inside a rolled-back transaction are discarded.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn update_rolled_back(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -228,7 +256,11 @@ pub async fn update_rolled_back(t: &mut Test) -> Result<()> {
 }
 
 /// Deletes inside a rolled-back transaction are discarded.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn delete_rolled_back(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -247,7 +279,11 @@ pub async fn delete_rolled_back(t: &mut Test) -> Result<()> {
 // ===== Driver operation log =====
 
 /// Verify the driver receives BEGIN, statements, and COMMIT in the right order.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn driver_sees_begin_commit(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -276,7 +312,11 @@ pub async fn driver_sees_begin_commit(t: &mut Test) -> Result<()> {
 }
 
 /// Verify the driver receives BEGIN and ROLLBACK when rolled back.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn driver_sees_begin_rollback(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -308,7 +348,11 @@ pub async fn driver_sees_begin_rollback(t: &mut Test) -> Result<()> {
 
 /// A committed nested transaction (savepoint) persists when the outer
 /// transaction also commits.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn nested_commit_both(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -331,7 +375,11 @@ pub async fn nested_commit_both(t: &mut Test) -> Result<()> {
 
 /// Rolling back a nested transaction discards only its changes; the outer
 /// transaction can still commit its own.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn nested_rollback_inner(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -355,7 +403,11 @@ pub async fn nested_rollback_inner(t: &mut Test) -> Result<()> {
 
 /// Rolling back the outer transaction discards everything, including changes
 /// from an already-committed nested transaction.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn nested_rollback_outer(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -378,7 +430,11 @@ pub async fn nested_rollback_outer(t: &mut Test) -> Result<()> {
 
 /// Dropping a nested transaction without finalize rolls back just that
 /// savepoint.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn nested_drop_rolls_back_savepoint(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -402,7 +458,11 @@ pub async fn nested_drop_rolls_back_savepoint(t: &mut Test) -> Result<()> {
 
 /// Verify the driver log for a nested transaction shows SAVEPOINT / RELEASE
 /// SAVEPOINT around the inner work.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn nested_driver_sees_savepoint_ops(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -452,7 +512,11 @@ pub async fn nested_driver_sees_savepoint_ops(t: &mut Test) -> Result<()> {
 
 /// Verify the driver log when a nested transaction is rolled back shows
 /// ROLLBACK TO SAVEPOINT.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn nested_driver_sees_rollback_to_savepoint(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -499,7 +563,11 @@ pub async fn nested_driver_sees_rollback_to_savepoint(t: &mut Test) -> Result<()
 
 /// Two sequential nested transactions: first committed, second rolled back.
 /// Only data from the first survives.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn two_sequential_nested_transactions(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -531,7 +599,11 @@ pub async fn two_sequential_nested_transactions(t: &mut Test) -> Result<()> {
 /// When a multi-op statement (e.g. create with association) runs inside an
 /// interactive transaction, the engine wraps it in SAVEPOINT/RELEASE instead
 /// of BEGIN/COMMIT.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::has_many_belongs_to))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::has_many_belongs_to)
+)]
 pub async fn multi_op_inside_tx_uses_savepoints(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -586,7 +658,11 @@ pub async fn multi_op_inside_tx_uses_savepoints(t: &mut Test) -> Result<()> {
 // ===== TransactionBuilder API =====
 
 /// TransactionBuilder from Db commits data like a regular transaction.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn builder_on_db_commit(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -602,7 +678,11 @@ pub async fn builder_on_db_commit(t: &mut Test) -> Result<()> {
 }
 
 /// TransactionBuilder from Connection commits data like a regular transaction.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn builder_on_connection_commit(t: &mut Test) -> Result<()> {
     let db = setup(t).await;
     let mut conn = db.connection().await?;
@@ -619,7 +699,11 @@ pub async fn builder_on_connection_commit(t: &mut Test) -> Result<()> {
 }
 
 /// TransactionBuilder with isolation level sends the correct option to the driver.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn builder_with_isolation_level(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -646,7 +730,11 @@ pub async fn builder_with_isolation_level(t: &mut Test) -> Result<()> {
 }
 
 /// TransactionBuilder with read_only sends the correct option to the driver.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn builder_with_read_only(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -668,7 +756,11 @@ pub async fn builder_with_read_only(t: &mut Test) -> Result<()> {
 }
 
 /// TransactionBuilder with both isolation and read_only sends both options.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn builder_with_all_options(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -695,7 +787,11 @@ pub async fn builder_with_all_options(t: &mut Test) -> Result<()> {
 }
 
 /// TransactionBuilder auto-rolls back on drop just like a regular transaction.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn builder_drop_rolls_back(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 
@@ -711,7 +807,11 @@ pub async fn builder_drop_rolls_back(t: &mut Test) -> Result<()> {
 }
 
 /// Calling `.transaction()` through `&mut dyn Executor` works.
-#[driver_test(id(ID), requires(sql), scenario(crate::scenarios::two_models))]
+#[driver_test(
+    id(ID),
+    requires(interactive_transactions),
+    scenario(crate::scenarios::two_models)
+)]
 pub async fn transaction_via_dyn_executor(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 

--- a/crates/toasty-driver-integration-suite/src/tests/type_primitives.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/type_primitives.rs
@@ -23,14 +23,20 @@ macro_rules! num_ty_test_body {
         let mut db = test.setup_db(models!(Item)).await;
         let mut test_values: Vec<$ty> = (*$test_values).to_vec();
 
-        // Filter test values based on database capabilities for unsigned integers
-        // Unsigned types have MIN == 0, signed types have MIN < 0
+        // Filter test values against the backend's integer range.
         if <$ty>::MIN == 0 {
             if let Some(max_unsigned) = test.capability().storage_types.max_unsigned_integer {
                 test_values.retain(|&val| {
                     let val_as_u64 = val as u64;
                     val_as_u64 <= max_unsigned
                 });
+            }
+        } else {
+            if let Some(min_signed) = test.capability().storage_types.min_signed_integer {
+                test_values.retain(|&val| (val as i128) >= i128::from(min_signed));
+            }
+            if let Some(max_signed) = test.capability().storage_types.max_signed_integer {
+                test_values.retain(|&val| (val as i128) <= i128::from(max_signed));
             }
         }
 
@@ -168,12 +174,12 @@ pub async fn ty_isize(test: &mut Test) -> Result<()> {
         isize,
         &[
             isize::MIN,
-            -1000000000000,
+            -1000000,
             -1,
             0,
             1,
-            1000000000000,
-            4611686018427387903,
+            1000000,
+            1073741823,
             isize::MAX
         ]
     )
@@ -224,9 +230,9 @@ pub async fn ty_usize(test: &mut Test) -> Result<()> {
             usize::MIN,
             0,
             1,
-            1000000000000,
-            9223372036854775807,
-            10000000000000000000,
+            1000000,
+            2147483647,
+            4000000000,
             usize::MAX
         ]
     )

--- a/crates/toasty-driver-mysql/Cargo.toml
+++ b/crates/toasty-driver-mysql/Cargo.toml
@@ -26,7 +26,7 @@ rust_decimal = { workspace = true, optional = true }
 bigdecimal = { workspace = true, optional = true }
 jiff = { workspace = true, optional = true }
 mysql_async.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["net", "rt", "time"] }
 tracing.workspace = true
 url.workspace = true
 uuid.workspace = true

--- a/crates/toasty-driver-postgresql/Cargo.toml
+++ b/crates/toasty-driver-postgresql/Cargo.toml
@@ -40,7 +40,7 @@ percent-encoding.workspace = true
 postgres-protocol.workspace = true
 postgres-types.workspace = true
 fallible-iterator.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
 tokio-postgres.workspace = true
 uuid.workspace = true
 url.workspace = true

--- a/crates/toasty-driver-turso/Cargo.toml
+++ b/crates/toasty-driver-turso/Cargo.toml
@@ -25,7 +25,7 @@ async-trait.workspace = true
 toasty-core.workspace = true
 toasty-sql.workspace = true
 serde.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
 tracing.workspace = true
 turso.workspace = true
 url.workspace = true

--- a/crates/toasty-sql/src/migration.rs
+++ b/crates/toasty-sql/src/migration.rs
@@ -219,9 +219,15 @@ impl<'a> MigrationStatement<'a> {
         let current_name = schema.table(previous.id).name.clone();
         let temp_name = format!("_toasty_new_{}", current_name);
 
-        // 1. PRAGMA foreign_keys = OFF
+        // D1 migrations run inside a Wrangler-owned transaction and forbid
+        // disabling foreign-key enforcement. SQLite's connected migration
+        // path retains its existing disable/enable pair.
         result.push(Self::new(
-            Statement::pragma_disable_foreign_keys(),
+            if capability.defer_foreign_keys_during_rebuild {
+                Statement::pragma_defer_foreign_keys()
+            } else {
+                Statement::pragma_disable_foreign_keys()
+            },
             schema.clone(),
         ));
 
@@ -297,11 +303,12 @@ impl<'a> MigrationStatement<'a> {
             schema.clone(),
         ));
 
-        // 6. PRAGMA foreign_keys = ON
-        result.push(Self::new(
-            Statement::pragma_enable_foreign_keys(),
-            schema.clone(),
-        ));
+        if !capability.defer_foreign_keys_during_rebuild {
+            result.push(Self::new(
+                Statement::pragma_enable_foreign_keys(),
+                schema.clone(),
+            ));
+        }
     }
 
     fn emit_column_changes(

--- a/crates/toasty-sql/src/stmt/pragma.rs
+++ b/crates/toasty-sql/src/stmt/pragma.rs
@@ -29,6 +29,15 @@ impl Statement {
         .into()
     }
 
+    /// Defers foreign-key validation until the surrounding transaction ends.
+    pub fn pragma_defer_foreign_keys() -> Self {
+        Pragma {
+            name: "defer_foreign_keys".to_string(),
+            value: Some("ON".to_string()),
+        }
+        .into()
+    }
+
     /// Creates a PRAGMA statement with the given name and value.
     pub fn pragma(name: impl Into<String>, value: impl Into<String>) -> Self {
         Pragma {

--- a/crates/toasty-sql/tests/migration_alter_column.rs
+++ b/crates/toasty-sql/tests/migration_alter_column.rs
@@ -667,6 +667,38 @@ fn alter_column_change_nullability_sqlite() {
 }
 
 #[test]
+fn alter_column_change_nullability_d1_defers_foreign_keys() {
+    let mut email = make_column(0, 1, "email", Type::Text);
+    email.nullable = true;
+    let from = Schema {
+        tables: vec![make_table(
+            0,
+            "users",
+            vec![make_column(0, 0, "id", Type::Integer(8)), email],
+        )],
+    };
+    let to = Schema {
+        tables: vec![make_table(
+            0,
+            "users",
+            vec![
+                make_column(0, 0, "id", Type::Integer(8)),
+                make_column(0, 1, "email", Type::Text),
+            ],
+        )],
+    };
+
+    let hints = diff::RenameHints::new();
+    let diff = diff::Schema::from(&from, &to, &hints);
+    let statements = MigrationStatement::from_diff(&diff, &Capability::D1);
+    let sql = serialize_migration(&statements, "sqlite");
+
+    assert_eq!(sql.first().unwrap(), "PRAGMA defer_foreign_keys = ON;");
+    assert!(!sql.iter().any(|sql| sql.contains("foreign_keys = OFF")));
+    assert!(!sql.iter().any(|sql| sql == "BEGIN;" || sql == "COMMIT;"));
+}
+
+#[test]
 fn alter_column_change_type_sqlite() {
     // value: Integer(4) → Text requires table recreation
     let from = Schema {

--- a/crates/toasty/Cargo.toml
+++ b/crates/toasty/Cargo.toml
@@ -74,7 +74,7 @@ indexmap.workspace = true
 index_vec.workspace = true
 inventory.workspace = true
 serde = { workspace = true, optional = true }
-tokio.workspace = true
+tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }
 toml = { workspace = true, optional = true }
 toml_edit = { workspace = true, features = ["serde"], optional = true }
 tracing.workspace = true
@@ -84,7 +84,7 @@ url.workspace = true
 assert-struct.workspace = true
 proptest.workspace = true
 tempfile.workspace = true
-tokio = { workspace = true, features = ["test-util"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 toasty-driver-sqlite = { workspace = true }
 
 [lints]

--- a/crates/toasty/src/db.rs
+++ b/crates/toasty/src/db.rs
@@ -112,6 +112,12 @@ impl Db {
 
     /// Drops the entire database and recreates an empty one without applying migrations.
     pub async fn reset_db(&self) -> Result<()> {
+        if !self.capability().reset_database {
+            return Err(toasty_core::Error::unsupported_feature(format!(
+                "{} does not support resetting the database",
+                self.capability().driver_name
+            )));
+        }
         self.shared.source.driver().reset_db().await
     }
 
@@ -174,6 +180,7 @@ impl std::fmt::Debug for Db {
 #[async_trait]
 impl Executor for Db {
     async fn transaction(&mut self) -> Result<Transaction<'_>> {
+        require_interactive_transactions(self.capability())?;
         let conn = self.connection().await?;
         Transaction::begin(ConnRef::owned(conn)).await
     }
@@ -193,5 +200,16 @@ impl Executor for Db {
 
     fn schema(&mut self) -> &Arc<Schema> {
         Db::schema(self)
+    }
+}
+
+pub(crate) fn require_interactive_transactions(capability: &Capability) -> Result<()> {
+    if capability.interactive_transactions {
+        Ok(())
+    } else {
+        Err(toasty_core::Error::unsupported_feature(format!(
+            "{} does not support interactive transactions",
+            capability.driver_name
+        )))
     }
 }

--- a/crates/toasty/src/db.rs
+++ b/crates/toasty/src/db.rs
@@ -2,8 +2,10 @@ mod builder;
 mod connect;
 mod connection;
 mod connection_task;
+mod direct;
 mod executor;
 mod pool;
+mod source;
 mod tx;
 
 pub use builder::Builder;
@@ -11,7 +13,9 @@ pub use connect::Connect;
 pub use connection::Connection;
 pub use executor::Executor;
 pub use pool::{Pool, PoolStatus};
-pub use toasty_core::driver::{Capability, ConnectContext, Driver, SqlPlaceholder};
+pub use toasty_core::driver::{
+    Capability, ConnectContext, ConnectionStrategy, Driver, SqlPlaceholder,
+};
 pub use tx::{Transaction, TransactionBuilder};
 
 /// Response from executing a statement, including pagination metadata.
@@ -30,17 +34,17 @@ use std::sync::Arc;
 /// Shared state between all `Db` clones.
 pub(crate) struct Shared {
     pub(crate) engine: Engine,
-    pub(crate) pool: Pool,
+    pub(crate) source: source::ConnectionSource,
 }
 
-/// A database handle backed by a connection pool.
+/// A database handle backed by a pooled or direct connection source.
 ///
 /// Each operation acquires a connection from the pool, executes, and returns
 /// the connection. Use [`Db::connection`] to obtain a dedicated
 /// [`Connection`] when you need multiple statements to share the same
 /// physical connection (e.g. temporary tables or session-level state).
 ///
-/// Cloning a `Db` is cheap — it shares the underlying pool.
+/// Cloning a `Db` is cheap. Clones share the same pool or direct connection.
 pub struct Db {
     shared: Arc<Shared>,
 }
@@ -78,16 +82,17 @@ impl Db {
         Builder::default()
     }
 
-    /// Acquire a dedicated connection from the pool.
+    /// Acquire a dedicated database connection.
     ///
     /// The returned [`Connection`] implements [`Executor`] and pins all
     /// operations to the same physical connection. This is useful when
     /// multiple statements must share connection-level state such as
     /// temporary tables or session variables.
     ///
-    /// When the `Connection` is dropped it is returned to the pool for reuse.
+    /// Pooled connections return to the pool when dropped. Direct connections
+    /// release the shared request-local connection for the next operation.
     pub async fn connection(&self) -> Result<Connection> {
-        self.shared.pool.get(self.shared.clone()).await
+        self.shared.source.get(self.shared.clone()).await
     }
 
     pub(crate) async fn exec_stmt(
@@ -95,24 +100,24 @@ impl Db {
         stmt: stmt::Statement,
         in_transaction: bool,
     ) -> Result<ExecResponse> {
-        let conn = self.connection().await?;
+        let mut conn = self.connection().await?;
         conn.exec_stmt(stmt, in_transaction).await
     }
 
     /// Creates tables and indices defined in the schema on the database.
     pub async fn push_schema(&self) -> Result<()> {
-        let conn = self.connection().await?;
+        let mut conn = self.connection().await?;
         conn.push_schema().await
     }
 
     /// Drops the entire database and recreates an empty one without applying migrations.
     pub async fn reset_db(&self) -> Result<()> {
-        self.shared.pool.driver().reset_db().await
+        self.shared.source.driver().reset_db().await
     }
 
     /// Returns a reference to the underlying database driver.
     pub fn driver(&self) -> &dyn Driver {
-        self.shared.pool.driver()
+        self.shared.source.driver()
     }
 
     /// Returns the compiled schema used by this database handle.
@@ -128,7 +133,7 @@ impl Db {
         self.shared.engine.capability()
     }
 
-    /// Begin a transaction, acquiring a connection from the pool.
+    /// Begin a transaction, acquiring a connection from the configured source.
     ///
     /// Takes `&mut self` so the `Db` handle is exclusively borrowed while the
     /// transaction is open. This prevents accidentally running a statement
@@ -151,10 +156,10 @@ impl Db {
         TransactionBuilder::new(tx::TxSource::Db(self))
     }
 
-    /// Returns a reference to the connection pool backing this handle.
+    /// Returns the connection pool backing this handle, if the driver uses one.
     #[doc(hidden)]
-    pub fn pool(&self) -> &Pool {
-        &self.shared.pool
+    pub fn pool(&self) -> Option<&Pool> {
+        self.shared.source.pool()
     }
 }
 
@@ -178,7 +183,7 @@ impl Executor for Db {
     }
 
     async fn exec_raw_sql(&mut self, raw: RawSql) -> Result<ExecResponse> {
-        let conn = self.connection().await?;
+        let mut conn = self.connection().await?;
         conn.exec_raw_sql(raw).await
     }
 

--- a/crates/toasty/src/db.rs
+++ b/crates/toasty/src/db.rs
@@ -39,10 +39,11 @@ pub(crate) struct Shared {
 
 /// A database handle backed by a pooled or direct connection source.
 ///
-/// Each operation acquires a connection from the pool, executes, and returns
-/// the connection. Use [`Db::connection`] to obtain a dedicated
-/// [`Connection`] when you need multiple statements to share the same
-/// physical connection (e.g. temporary tables or session-level state).
+/// With a pooled driver, each operation acquires a connection from the pool,
+/// executes, and returns the connection. A direct driver serializes operations
+/// through one request-local connection. Use [`Db::connection`] to obtain a
+/// dedicated [`Connection`] when you need multiple statements to share the
+/// same physical connection (e.g. temporary tables or session-level state).
 ///
 /// Cloning a `Db` is cheap. Clones share the same pool or direct connection.
 pub struct Db {

--- a/crates/toasty/src/db/builder.rs
+++ b/crates/toasty/src/db/builder.rs
@@ -1,6 +1,6 @@
 use crate::{
     Db, Result,
-    db::{Connect, Pool, Shared, pool::PoolConfig},
+    db::{Connect, ConnectionStrategy, Shared, pool::PoolConfig, source::ConnectionSource},
     engine::Engine,
 };
 
@@ -296,13 +296,25 @@ impl Builder {
         tracing::info!(tables = schema.db.tables.len(), "schema built successfully");
 
         let engine = Engine::new(Arc::new(schema), capability);
-        let pool = Pool::new(driver, engine.clone(), self.pool.clone())?;
+        let source = match driver.connection_strategy() {
+            ConnectionStrategy::Pooled => {
+                ConnectionSource::pooled(driver, engine.clone(), self.pool.clone())?
+            }
+            ConnectionStrategy::Direct => {
+                self.pool.validate_direct()?;
+                ConnectionSource::direct(driver, &self.pool).await?
+            }
+        };
 
-        let shared = Arc::new(Shared { engine, pool });
+        let shared = Arc::new(Shared { engine, source });
 
-        // see if we're able to acquire a valid connection
-        let conn = shared.pool.get(shared.clone()).await?;
-        std::mem::drop(conn);
+        // Pooled sources open their first connection lazily, so acquire one
+        // here to preserve build-time connection validation. Direct sources
+        // connected exactly once while they were constructed above.
+        if shared.source.pool().is_some() {
+            let conn = shared.source.get(shared.clone()).await?;
+            std::mem::drop(conn);
+        }
 
         tracing::info!("database ready");
         Ok(Db { shared })

--- a/crates/toasty/src/db/connect.rs
+++ b/crates/toasty/src/db/connect.rs
@@ -128,6 +128,10 @@ impl Driver for Connect {
         self.driver.capability()
     }
 
+    fn connection_strategy(&self) -> toasty_core::driver::ConnectionStrategy {
+        self.driver.connection_strategy()
+    }
+
     async fn connect(&self, cx: &ConnectContext) -> Result<Box<dyn Connection>> {
         self.driver.connect(cx).await
     }

--- a/crates/toasty/src/db/connection.rs
+++ b/crates/toasty/src/db/connection.rs
@@ -197,6 +197,7 @@ impl Connection {
 #[async_trait]
 impl super::Executor for Connection {
     async fn transaction(&mut self) -> crate::Result<Transaction<'_>> {
+        super::require_interactive_transactions(self.shared.engine.capability())?;
         Transaction::begin(ConnRef::Borrowed(self)).await
     }
 

--- a/crates/toasty/src/db/connection.rs
+++ b/crates/toasty/src/db/connection.rs
@@ -16,22 +16,31 @@ use toasty_core::{
 use tokio::sync::oneshot;
 use tracing::Instrument;
 
-/// A dedicated database connection retrieved from a pool.
+/// A dedicated connection acquired from a database handle.
 ///
 /// Holding a `Connection` guarantees that all operations are executed on the
 /// same physical connection. This is useful when multiple statements must
 /// share connection-level state such as temporary tables or session variables.
 ///
-/// When dropped, the connection is returned to the pool for reuse.
+/// When dropped, the connection returns to its pool or releases a direct
+/// connection for the next caller.
 pub struct Connection {
-    pub(super) inner: deadpool::managed::Object<Manager>,
+    pub(super) inner: ConnectionInner,
     pub(super) shared: Arc<super::Shared>,
+}
+
+pub(super) enum ConnectionInner {
+    Pooled(deadpool::managed::Object<Manager>),
+    Direct(tokio::sync::Mutex<tokio::sync::OwnedMutexGuard<Box<dyn toasty_core::Connection>>>),
 }
 
 impl Connection {
     /// Access the underlying connection handle.
-    pub(crate) fn handle(&self) -> &ConnectionHandle {
-        &self.inner
+    pub(crate) fn handle(&self) -> Option<&ConnectionHandle> {
+        match &self.inner {
+            ConnectionInner::Pooled(inner) => Some(inner),
+            ConnectionInner::Direct(_) => None,
+        }
     }
 
     /// Returns the compiled schema used by this connection.
@@ -40,7 +49,7 @@ impl Connection {
     }
 
     pub(crate) async fn exec_stmt(
-        &self,
+        &mut self,
         stmt: stmt::Statement,
         in_transaction: bool,
     ) -> crate::Result<ExecResponse> {
@@ -48,51 +57,79 @@ impl Connection {
         // current span; the worker task enters it while executing.
         let span = crate::instrument::query_span(&self.shared.engine.schema, &stmt);
 
-        let (tx, rx) = oneshot::channel();
-
-        self.handle()
-            .in_tx
-            .send(ConnectionOperation::ExecStatement {
-                stmt: Box::new(stmt),
-                in_transaction,
-                span: span.clone(),
-                tx,
-            })
-            .unwrap();
-
-        rx.instrument(span).await.unwrap()
+        match &mut self.inner {
+            ConnectionInner::Pooled(inner) => {
+                let (tx, rx) = oneshot::channel();
+                inner
+                    .in_tx
+                    .send(ConnectionOperation::ExecStatement {
+                        stmt: Box::new(stmt),
+                        in_transaction,
+                        span: span.clone(),
+                        tx,
+                    })
+                    .unwrap();
+                rx.instrument(span).await.unwrap()
+            }
+            ConnectionInner::Direct(inner) => {
+                self.shared
+                    .engine
+                    .exec_buffered(&mut ***inner.get_mut(), stmt, in_transaction)
+                    .instrument(span)
+                    .await
+            }
+        }
     }
 
-    pub(crate) async fn exec_operation(&self, operation: Operation) -> crate::Result<ExecResponse> {
-        let (tx, rx) = oneshot::channel();
-
-        self.handle()
-            .in_tx
-            .send(ConnectionOperation::ExecOperation {
-                operation: Box::new(operation),
-                span: tracing::Span::current(),
-                tx,
-            })
-            .unwrap();
-
-        rx.await.unwrap()
+    pub(crate) async fn exec_operation(
+        &mut self,
+        operation: Operation,
+    ) -> crate::Result<ExecResponse> {
+        match &mut self.inner {
+            ConnectionInner::Pooled(inner) => {
+                let (tx, rx) = oneshot::channel();
+                inner
+                    .in_tx
+                    .send(ConnectionOperation::ExecOperation {
+                        operation: Box::new(operation),
+                        span: tracing::Span::current(),
+                        tx,
+                    })
+                    .unwrap();
+                rx.await.unwrap()
+            }
+            ConnectionInner::Direct(inner) => {
+                inner
+                    .get_mut()
+                    .exec(&self.shared.engine.schema, operation)
+                    .await
+            }
+        }
     }
 
-    pub(crate) async fn exec_raw_sql(&self, raw: RawSql) -> crate::Result<ExecResponse> {
+    pub(crate) async fn exec_raw_sql(&mut self, raw: RawSql) -> crate::Result<ExecResponse> {
         let span = crate::instrument::raw_sql_span();
-
-        let (tx, rx) = oneshot::channel();
-
-        self.handle()
-            .in_tx
-            .send(ConnectionOperation::ExecRawSql {
-                raw: Box::new(raw),
-                span: span.clone(),
-                tx,
-            })
-            .unwrap();
-
-        rx.instrument(span).await.unwrap()
+        match &mut self.inner {
+            ConnectionInner::Pooled(inner) => {
+                let (tx, rx) = oneshot::channel();
+                inner
+                    .in_tx
+                    .send(ConnectionOperation::ExecRawSql {
+                        raw: Box::new(raw),
+                        span: span.clone(),
+                        tx,
+                    })
+                    .unwrap();
+                rx.instrument(span).await.unwrap()
+            }
+            ConnectionInner::Direct(inner) => {
+                self.shared
+                    .engine
+                    .exec_raw_sql(&mut ***inner.get_mut(), raw)
+                    .instrument(span)
+                    .await
+            }
+        }
     }
 
     /// Begin a transaction on this connection.
@@ -115,17 +152,45 @@ impl Connection {
     }
 
     /// Creates tables and indices defined in the schema on the database.
-    pub async fn push_schema(&self) -> crate::Result<()> {
+    pub async fn push_schema(&mut self) -> crate::Result<()> {
         tracing::info!("pushing schema to database");
-        let (tx, rx) = oneshot::channel();
-        self.handle()
-            .in_tx
-            .send(ConnectionOperation::PushSchema {
-                span: tracing::Span::current(),
-                tx,
-            })
-            .unwrap();
-        rx.await.unwrap()
+        match &mut self.inner {
+            ConnectionInner::Pooled(inner) => {
+                let (tx, rx) = oneshot::channel();
+                inner
+                    .in_tx
+                    .send(ConnectionOperation::PushSchema {
+                        span: tracing::Span::current(),
+                        tx,
+                    })
+                    .unwrap();
+                rx.await.unwrap()
+            }
+            ConnectionInner::Direct(inner) => {
+                inner
+                    .get_mut()
+                    .push_schema(&self.shared.engine.schema)
+                    .await
+            }
+        }
+    }
+
+    /// Checks whether this connection can reach its database.
+    pub async fn ping(&mut self) -> crate::Result<()> {
+        match &mut self.inner {
+            ConnectionInner::Pooled(inner) => {
+                let (tx, rx) = oneshot::channel();
+                inner
+                    .in_tx
+                    .send(ConnectionOperation::Ping {
+                        span: tracing::Span::current(),
+                        tx,
+                    })
+                    .unwrap();
+                rx.await.unwrap()
+            }
+            ConnectionInner::Direct(inner) => inner.get_mut().ping().await,
+        }
     }
 }
 
@@ -157,8 +222,12 @@ impl super::Executor for Connection {
 
 impl std::fmt::Debug for Connection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let strategy = match &self.inner {
+            ConnectionInner::Pooled(_) => "pooled",
+            ConnectionInner::Direct(_) => "direct",
+        };
         f.debug_struct("Connection")
-            .field("handle", &*self.inner)
-            .finish()
+            .field("strategy", &strategy)
+            .finish_non_exhaustive()
     }
 }

--- a/crates/toasty/src/db/connection_task.rs
+++ b/crates/toasty/src/db/connection_task.rs
@@ -10,9 +10,8 @@
 
 use std::sync::Arc;
 
+use toasty_core::driver::Connection;
 use toasty_core::driver::operation::RawSql;
-use toasty_core::driver::{Connection, Rows};
-use toasty_core::stmt::Value;
 use tokio::{
     sync::{mpsc, oneshot},
     task::JoinHandle,
@@ -186,26 +185,9 @@ impl ConnectionTask {
         stmt: toasty_core::stmt::Statement,
         in_transaction: bool,
     ) -> crate::Result<toasty_core::driver::ExecResponse> {
-        let single = stmt.is_single();
-        let mut response = self
-            .engine
-            .exec(&mut *self.connection, stmt, in_transaction)
-            .await?;
-        response.values.buffer().await?;
-
-        if single {
-            let Rows::Value(Value::List(mut items)) = response.values else {
-                unreachable!()
-            };
-            assert!(
-                items.len() <= 1,
-                "expected at most 1 row for single statement, got {}",
-                items.len()
-            );
-            response.values = Rows::Value(items.pop().unwrap_or(Value::Null));
-        }
-
-        Ok(response)
+        self.engine
+            .exec_buffered(&mut *self.connection, stmt, in_transaction)
+            .await
     }
 
     /// Send `result` to the caller, but if the connection reported

--- a/crates/toasty/src/db/direct.rs
+++ b/crates/toasty/src/db/direct.rs
@@ -1,0 +1,45 @@
+use std::sync::Arc;
+
+use toasty_core::driver::{ConnectContext, Connection as CoreConnection, Driver};
+use tokio::sync::Mutex;
+
+use super::{Connection, connection::ConnectionInner, pool::PoolConfig};
+
+/// One request-local connection shared by every clone of a direct [`Db`](crate::Db).
+pub(crate) struct Direct {
+    driver: Box<dyn Driver>,
+    connection: Arc<Mutex<Box<dyn CoreConnection>>>,
+}
+
+impl Direct {
+    pub(crate) async fn new(driver: impl Driver, config: &PoolConfig) -> crate::Result<Self> {
+        let mut cx = ConnectContext::default();
+        cx.query_log = config.query_log;
+        let connection = driver.connect(&cx).await?;
+
+        Ok(Self {
+            driver: Box::new(driver),
+            connection: Arc::new(Mutex::new(connection)),
+        })
+    }
+
+    pub(crate) async fn get(&self, shared: Arc<super::Shared>) -> Connection {
+        let inner = self.connection.clone().lock_owned().await;
+        Connection {
+            inner: ConnectionInner::Direct(Mutex::new(inner)),
+            shared,
+        }
+    }
+
+    pub(crate) fn driver(&self) -> &dyn Driver {
+        self.driver.as_ref()
+    }
+}
+
+impl std::fmt::Debug for Direct {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Direct")
+            .field("driver", &self.driver)
+            .finish_non_exhaustive()
+    }
+}

--- a/crates/toasty/src/db/pool.rs
+++ b/crates/toasty/src/db/pool.rs
@@ -105,7 +105,9 @@ impl Pool {
             engine,
             sweep_waker: sweep_waker.clone(),
             pre_ping: config.pre_ping,
+            #[cfg(not(target_arch = "wasm32"))]
             max_connection_lifetime: config.max_connection_lifetime,
+            #[cfg(not(target_arch = "wasm32"))]
             max_connection_idle_time: config.max_connection_idle_time,
             connect_cx,
         })
@@ -175,7 +177,9 @@ pub(super) struct Manager {
     engine: Engine,
     sweep_waker: Arc<SweepWaker>,
     pre_ping: bool,
+    #[cfg(not(target_arch = "wasm32"))]
     max_connection_lifetime: Option<Duration>,
+    #[cfg(not(target_arch = "wasm32"))]
     max_connection_idle_time: Option<Duration>,
     /// Per-connection configuration handed to `Driver::connect` for every
     /// connection the pool creates.
@@ -215,22 +219,30 @@ impl deadpool::managed::Manager for Manager {
         obj: &mut Self::Type,
         metrics: &deadpool::managed::Metrics,
     ) -> deadpool::managed::RecycleResult<Self::Error> {
-        if let Some(max) = self.max_connection_lifetime
-            && metrics.age() >= max
+        // deadpool omits its `Instant`-based metrics on wasm. D1 uses a direct
+        // connection, so these pooled lifetime checks are native-only.
+        #[cfg(not(target_arch = "wasm32"))]
         {
-            tracing::debug!(?max, "discarding pooled connection past max lifetime");
-            return Err(deadpool::managed::RecycleError::message(
-                "connection exceeded max lifetime",
-            ));
+            if let Some(max) = self.max_connection_lifetime
+                && metrics.age() >= max
+            {
+                tracing::debug!(?max, "discarding pooled connection past max lifetime");
+                return Err(deadpool::managed::RecycleError::message(
+                    "connection exceeded max lifetime",
+                ));
+            }
+            if let Some(max) = self.max_connection_idle_time
+                && metrics.last_used() >= max
+            {
+                tracing::debug!(?max, "discarding pooled connection past max idle time");
+                return Err(deadpool::managed::RecycleError::message(
+                    "connection exceeded max idle time",
+                ));
+            }
         }
-        if let Some(max) = self.max_connection_idle_time
-            && metrics.last_used() >= max
-        {
-            tracing::debug!(?max, "discarding pooled connection past max idle time");
-            return Err(deadpool::managed::RecycleError::message(
-                "connection exceeded max idle time",
-            ));
-        }
+
+        #[cfg(target_arch = "wasm32")]
+        let _ = metrics;
         if obj.in_tx.is_closed() || obj.is_finished() {
             tracing::debug!("discarding dead pooled connection");
             return Err(deadpool::managed::RecycleError::message(

--- a/crates/toasty/src/db/pool.rs
+++ b/crates/toasty/src/db/pool.rs
@@ -54,6 +54,47 @@ impl Default for PoolConfig {
     }
 }
 
+impl PoolConfig {
+    pub(crate) fn validate_direct(&self) -> crate::Result<()> {
+        let default = Self::default();
+        let mut configured = Vec::new();
+
+        if self.max_size != default.max_size {
+            configured.push("max_pool_size");
+        }
+        if self.timeouts.wait != default.timeouts.wait {
+            configured.push("pool_wait_timeout");
+        }
+        if self.timeouts.create != default.timeouts.create {
+            configured.push("pool_create_timeout");
+        }
+        if self.timeouts.recycle != default.timeouts.recycle {
+            configured.push("pool_recycle_timeout");
+        }
+        if self.health_check_interval != default.health_check_interval {
+            configured.push("pool_health_check_interval");
+        }
+        if self.pre_ping != default.pre_ping {
+            configured.push("pool_pre_ping");
+        }
+        if self.max_connection_lifetime != default.max_connection_lifetime {
+            configured.push("pool_max_connection_lifetime");
+        }
+        if self.max_connection_idle_time != default.max_connection_idle_time {
+            configured.push("pool_max_connection_idle_time");
+        }
+
+        if configured.is_empty() {
+            Ok(())
+        } else {
+            Err(toasty_core::Error::invalid_driver_configuration(format!(
+                "direct connections do not support pool configuration: {}",
+                configured.join(", ")
+            )))
+        }
+    }
+}
+
 /// A connection pool that manages database connections with background tasks.
 #[derive(Debug)]
 pub struct Pool {
@@ -144,7 +185,7 @@ impl Pool {
             toasty_core::Error::connection_pool(e)
         })?;
         Ok(super::Connection {
-            inner: connection,
+            inner: super::connection::ConnectionInner::Pooled(connection),
             shared,
         })
     }

--- a/crates/toasty/src/db/source.rs
+++ b/crates/toasty/src/db/source.rs
@@ -1,0 +1,47 @@
+use std::sync::Arc;
+
+use toasty_core::driver::Driver;
+
+use super::{Connection, Pool, direct::Direct, pool::PoolConfig};
+use crate::engine::Engine;
+
+#[derive(Debug)]
+pub(crate) enum ConnectionSource {
+    Pooled(Pool),
+    Direct(Direct),
+}
+
+impl ConnectionSource {
+    pub(crate) fn pooled(
+        driver: impl Driver,
+        engine: Engine,
+        config: PoolConfig,
+    ) -> crate::Result<Self> {
+        Ok(Self::Pooled(Pool::new(driver, engine, config)?))
+    }
+
+    pub(crate) async fn direct(driver: impl Driver, config: &PoolConfig) -> crate::Result<Self> {
+        Ok(Self::Direct(Direct::new(driver, config).await?))
+    }
+
+    pub(crate) async fn get(&self, shared: Arc<super::Shared>) -> crate::Result<Connection> {
+        match self {
+            Self::Pooled(pool) => pool.get(shared).await,
+            Self::Direct(direct) => Ok(direct.get(shared).await),
+        }
+    }
+
+    pub(crate) fn driver(&self) -> &dyn Driver {
+        match self {
+            Self::Pooled(pool) => pool.driver(),
+            Self::Direct(direct) => direct.driver(),
+        }
+    }
+
+    pub(crate) fn pool(&self) -> Option<&Pool> {
+        match self {
+            Self::Pooled(pool) => Some(pool),
+            Self::Direct(_) => None,
+        }
+    }
+}

--- a/crates/toasty/src/db/tx.rs
+++ b/crates/toasty/src/db/tx.rs
@@ -70,6 +70,12 @@ impl<'a> TransactionBuilder<'a> {
     /// its configured source. The returned [`Transaction`] owns the
     /// connection until it completes or is dropped.
     pub async fn begin(self) -> Result<Transaction<'a>> {
+        let capability = match &self.source {
+            TxSource::Db(db) => super::Db::capability(db),
+            TxSource::Connection(conn) => conn.shared.engine.capability(),
+        };
+        super::require_interactive_transactions(capability)?;
+
         let conn = match self.source {
             TxSource::Db(db) => ConnRef::owned(db.connection().await?),
             TxSource::Connection(conn) => ConnRef::Borrowed(conn),

--- a/crates/toasty/src/db/tx.rs
+++ b/crates/toasty/src/db/tx.rs
@@ -67,8 +67,8 @@ impl<'a> TransactionBuilder<'a> {
     /// Begin the transaction.
     ///
     /// When built from a [`Db`](super::Db), this acquires a connection from
-    /// the pool. The connection is owned by the returned [`Transaction`] and
-    /// will be returned to the pool when the transaction is dropped.
+    /// its configured source. The returned [`Transaction`] owns the
+    /// connection until it completes or is dropped.
     pub async fn begin(self) -> Result<Transaction<'a>> {
         let conn = match self.source {
             TxSource::Db(db) => ConnRef::owned(db.connection().await?),
@@ -150,7 +150,7 @@ impl<'a> Transaction<'a> {
         // We're creating the Transaction struct before actually starting the transaction. If the
         // future is cancelled while waiting on the response of the start command, the transaction
         // is still rolled back.
-        let tx = Transaction {
+        let mut tx = Transaction {
             conn,
             finalized: false,
             savepoint: None,
@@ -182,15 +182,11 @@ impl<'a> Transaction<'a> {
     /// Commit the transaction.
     pub async fn commit(mut self) -> Result<()> {
         tracing::debug!("committing transaction");
-        match self.savepoint {
-            Some(_) => self
-                .conn
-                .exec_operation(operation::Transaction::ReleaseSavepoint(self.savepoint()).into()),
-            None => self
-                .conn
-                .exec_operation(operation::Transaction::Commit.into()),
-        }
-        .await?;
+        let operation = match self.savepoint {
+            Some(_) => operation::Transaction::ReleaseSavepoint(self.savepoint()),
+            None => operation::Transaction::Commit,
+        };
+        self.conn.exec_operation(operation.into()).await?;
         self.finalized = true;
         Ok(())
     }
@@ -198,15 +194,11 @@ impl<'a> Transaction<'a> {
     /// Roll back the transaction.
     pub async fn rollback(mut self) -> Result<()> {
         tracing::debug!("rolling back transaction");
-        match self.savepoint {
-            Some(_) => self.conn.exec_operation(
-                operation::Transaction::RollbackToSavepoint(self.savepoint()).into(),
-            ),
-            None => self
-                .conn
-                .exec_operation(operation::Transaction::Rollback.into()),
-        }
-        .await?;
+        let operation = match self.savepoint {
+            Some(_) => operation::Transaction::RollbackToSavepoint(self.savepoint()),
+            None => operation::Transaction::Rollback,
+        };
+        self.conn.exec_operation(operation.into()).await?;
         self.finalized = true;
         Ok(())
     }
@@ -227,15 +219,13 @@ impl Drop for Transaction<'_> {
             // Fire-and-forget rollback: send the operation to the background
             // connection task without awaiting the response.
             let (tx, _rx) = oneshot::channel();
-            let _ = self
-                .conn
-                .handle()
-                .in_tx
-                .send(ConnectionOperation::ExecOperation {
+            if let Some(handle) = self.conn.handle() {
+                let _ = handle.in_tx.send(ConnectionOperation::ExecOperation {
                     operation: Box::new(op.into()),
                     span: tracing::Span::current(),
                     tx,
                 });
+            }
         }
     }
 }
@@ -249,15 +239,16 @@ impl<'a> Executor for Transaction<'a> {
         };
         tracing::debug!(depth = depth, "creating nested transaction (savepoint)");
 
-        let transaction = Transaction {
+        let mut transaction = Transaction {
             conn: ConnRef::Borrowed(&mut self.conn),
             finalized: false,
             savepoint: Some(depth),
         };
 
+        let savepoint = transaction.savepoint();
         transaction
             .conn
-            .exec_operation(operation::Transaction::Savepoint(transaction.savepoint()).into())
+            .exec_operation(operation::Transaction::Savepoint(savepoint).into())
             .await?;
 
         Ok(transaction)

--- a/crates/toasty/src/engine.rs
+++ b/crates/toasty/src/engine.rs
@@ -30,8 +30,8 @@ use crate::Result;
 use std::sync::Arc;
 use toasty_core::{
     Connection, Schema,
-    driver::{Capability, operation::RawSql},
-    stmt::{self, Statement},
+    driver::{Capability, Rows, operation::RawSql},
+    stmt::{self, Statement, Value},
 };
 
 /// The query execution engine.
@@ -100,6 +100,31 @@ impl Engine {
         // The plan is called once (single entry record stream) with no arguments
         // (empty record).
         self.exec_plan(connection, plan, in_transaction).await
+    }
+
+    pub(crate) async fn exec_buffered(
+        &self,
+        connection: &mut dyn Connection,
+        stmt: Statement,
+        in_transaction: bool,
+    ) -> Result<toasty_core::driver::ExecResponse> {
+        let single = stmt.is_single();
+        let mut response = self.exec(connection, stmt, in_transaction).await?;
+        response.values.buffer().await?;
+
+        if single {
+            let Rows::Value(Value::List(mut items)) = response.values else {
+                unreachable!()
+            };
+            assert!(
+                items.len() <= 1,
+                "expected at most 1 row for single statement, got {}",
+                items.len()
+            );
+            response.values = Rows::Value(items.pop().unwrap_or(Value::Null));
+        }
+
+        Ok(response)
     }
 
     /// Executes user-authored SQL through the driver SQL path.

--- a/crates/toasty/src/engine.rs
+++ b/crates/toasty/src/engine.rs
@@ -93,7 +93,7 @@ impl Engine {
 
         tracing::trace!(
             actions = plan.actions.len(),
-            needs_transaction = plan.needs_transaction,
+            atomicity = ?plan.atomicity,
             "execution plan ready"
         );
 

--- a/crates/toasty/src/engine/exec.rs
+++ b/crates/toasty/src/engine/exec.rs
@@ -64,7 +64,10 @@ pub(crate) use var::{VarDecls, VarId, VarStore};
 use crate::{Result, engine::Engine};
 use toasty_core::{
     Connection,
-    driver::{ExecResponse, Rows, operation::Transaction},
+    driver::{
+        ExecResponse, Rows,
+        operation::{AtomicSqlBatch, QuerySql, Transaction},
+    },
     stmt::{self, ValueStream},
 };
 
@@ -111,11 +114,9 @@ impl Engine {
             )
         };
 
-        if plan.atomicity == Atomicity::AtomicBatch {
-            return Err(toasty_core::Error::unsupported_feature(format!(
-                "{} atomic batch execution is not implemented",
-                self.capability.driver_name
-            )));
+        let atomic_batch = plan.atomicity == Atomicity::AtomicBatch;
+        if atomic_batch {
+            exec.exec_atomic_batch(&plan.actions).await?;
         }
 
         let interactive = plan.atomicity == Atomicity::InteractiveTransaction;
@@ -127,6 +128,9 @@ impl Engine {
         }
 
         for (i, step) in plan.actions.iter().enumerate() {
+            if atomic_batch && step.is_db_op() {
+                continue;
+            }
             tracing::trace!(step = i, action = %step.name(), "executing action");
             // Debug, not error: the failure propagates to the caller, who
             // decides whether it is an application error. A handled unique
@@ -173,6 +177,57 @@ impl Engine {
 }
 
 impl Exec<'_> {
+    async fn exec_atomic_batch(&mut self, actions: &[Action]) -> Result<()> {
+        let mut operations = Vec::new();
+        let mut outputs = Vec::new();
+
+        for action in actions {
+            if !action.is_db_op() {
+                continue;
+            }
+            let Action::ExecStatement(action) = action else {
+                return Err(toasty_core::Error::unsupported_feature(
+                    "atomic SQL batches require generated SQL statements",
+                ));
+            };
+            if !action.input.is_empty()
+                || action.conditional != ConditionalOutput::None
+                || action.pagination.is_some()
+            {
+                return Err(toasty_core::Error::unsupported_feature(
+                    "atomic SQL batch statement depends on an earlier database result",
+                ));
+            }
+
+            let mut statement = action.stmt.clone();
+            let params = self.engine.prepare_for_driver(&mut statement);
+            operations.push(QuerySql {
+                stmt: statement,
+                params,
+                ret: action.output.ty.clone(),
+                last_insert_id_hack: None,
+            });
+            outputs.push(action.output.output.clone());
+        }
+
+        let responses = self
+            .connection
+            .exec_atomic_batch(&self.engine.schema, AtomicSqlBatch::new(operations))
+            .await?;
+        if responses.len() != outputs.len() {
+            return Err(toasty_core::Error::invalid_result(format!(
+                "atomic SQL batch returned {} responses for {} statements",
+                responses.len(),
+                outputs.len()
+            )));
+        }
+
+        for (output, response) in outputs.into_iter().zip(responses) {
+            self.vars.store(output.var, output.num_uses, response);
+        }
+        Ok(())
+    }
+
     async fn exec_step(&mut self, action: &Action) -> Result<()> {
         match action {
             Action::DeleteByKey(action) => self.action_delete_by_key(action).await,

--- a/crates/toasty/src/engine/exec.rs
+++ b/crates/toasty/src/engine/exec.rs
@@ -35,7 +35,7 @@ mod output;
 pub(crate) use output::Output;
 
 mod plan;
-pub(crate) use plan::ExecPlan;
+pub(crate) use plan::{Atomicity, ExecPlan};
 
 mod project;
 pub(crate) use project::Project;
@@ -111,7 +111,16 @@ impl Engine {
             )
         };
 
-        if plan.needs_transaction {
+        if plan.atomicity == Atomicity::AtomicBatch {
+            return Err(toasty_core::Error::unsupported_feature(format!(
+                "{} atomic batch execution is not implemented",
+                self.capability.driver_name
+            )));
+        }
+
+        let interactive = plan.atomicity == Atomicity::InteractiveTransaction;
+
+        if interactive {
             tracing::trace!("beginning plan transaction");
             exec.connection.exec(&self.schema, begin.into()).await?;
             exec.in_transaction = true;
@@ -124,7 +133,7 @@ impl Engine {
             // violation should not error-spam production logs.
             if let Err(e) = exec.exec_step(step).await {
                 tracing::debug!(step = i, action = %step.name(), error = %e, "action failed");
-                if plan.needs_transaction {
+                if interactive {
                     tracing::trace!("rolling back plan transaction due to error");
                     // Best effort: ignore rollback errors so the original error is returned
                     let _ = exec.connection.exec(&self.schema, rollback.into()).await;
@@ -133,7 +142,7 @@ impl Engine {
             }
         }
 
-        if plan.needs_transaction {
+        if interactive {
             tracing::trace!("committing plan transaction");
             exec.connection.exec(&self.schema, commit.into()).await?;
         }

--- a/crates/toasty/src/engine/exec/action.rs
+++ b/crates/toasty/src/engine/exec/action.rs
@@ -106,6 +106,19 @@ impl Action {
     pub(crate) fn requires_interactive_transaction(&self) -> bool {
         matches!(self, Action::ReadModifyWrite(_))
     }
+
+    /// Whether this database action can be fully materialized before a D1
+    /// atomic batch is dispatched.
+    pub(crate) fn is_atomic_batch_eligible(&self) -> bool {
+        match self {
+            Action::ExecStatement(action) => {
+                action.input.is_empty()
+                    && action.conditional == crate::engine::exec::ConditionalOutput::None
+                    && action.pagination.is_none()
+            }
+            action => !action.is_db_op(),
+        }
+    }
 }
 
 impl fmt::Debug for Action {

--- a/crates/toasty/src/engine/exec/action.rs
+++ b/crates/toasty/src/engine/exec/action.rs
@@ -102,6 +102,10 @@ impl Action {
             | Action::SetVar(_) => false,
         }
     }
+
+    pub(crate) fn requires_interactive_transaction(&self) -> bool {
+        matches!(self, Action::ReadModifyWrite(_))
+    }
 }
 
 impl fmt::Debug for Action {

--- a/crates/toasty/src/engine/exec/plan.rs
+++ b/crates/toasty/src/engine/exec/plan.rs
@@ -1,5 +1,12 @@
 use crate::engine::exec::{Action, VarId, VarStore};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Atomicity {
+    None,
+    InteractiveTransaction,
+    AtomicBatch,
+}
+
 #[derive(Debug)]
 pub(crate) struct ExecPlan {
     /// Arguments seeding the plan
@@ -13,6 +20,6 @@ pub(crate) struct ExecPlan {
     /// When `None`, nothing is returned
     pub(crate) returning: Option<VarId>,
 
-    /// When true, the executor wraps the entire plan in a transaction.
-    pub(crate) needs_transaction: bool,
+    /// How database operations in this plan must be committed atomically.
+    pub(crate) atomicity: Atomicity,
 }

--- a/crates/toasty/src/engine/plan.rs
+++ b/crates/toasty/src/engine/plan.rs
@@ -29,7 +29,7 @@ struct ExecPlanner<'a> {
     logical_plan: &'a LogicalPlan,
     var_decls: VarDecls,
     actions: Vec<exec::Action>,
-    use_transactions: bool,
+    capability: &'static toasty_core::driver::Capability,
     schema: Arc<Schema>,
 }
 
@@ -44,15 +44,15 @@ impl Engine {
         .build_logical_plan()?;
 
         // Build the execution plan from the logical plan
-        Ok(self.plan_execution(logical_plan))
+        self.plan_execution(logical_plan)
     }
 
-    fn plan_execution(&self, logical_plan: mir::LogicalPlan) -> ExecPlan {
+    fn plan_execution(&self, logical_plan: mir::LogicalPlan) -> Result<ExecPlan> {
         ExecPlanner {
             logical_plan: &logical_plan,
             var_decls: VarDecls::default(),
             actions: vec![],
-            use_transactions: self.capability().sql,
+            capability: self.capability,
             schema: self.schema.clone(),
         }
         .plan_execution()

--- a/crates/toasty/src/engine/plan/execution.rs
+++ b/crates/toasty/src/engine/plan/execution.rs
@@ -1,10 +1,11 @@
 use crate::engine::{
-    exec::{ExecPlan, VarStore},
+    exec::{Action, Atomicity, ExecPlan, VarStore},
     plan::ExecPlanner,
 };
+use toasty_core::driver::Capability;
 
 impl ExecPlanner<'_> {
-    pub(super) fn plan_execution(mut self) -> ExecPlan {
+    pub(super) fn plan_execution(mut self) -> crate::Result<ExecPlan> {
         // Convert each node in execution order
         for node in self.logical_plan.operations() {
             let action = node.to_exec(self.logical_plan, &mut self.var_decls);
@@ -13,14 +14,94 @@ impl ExecPlanner<'_> {
 
         let returning = self.logical_plan.completion().var.get();
 
-        let needs_transaction =
-            self.use_transactions && self.actions.iter().filter(|a| a.is_db_op()).count() > 1;
+        let atomicity = plan_atomicity(self.capability, &self.actions)?;
 
-        ExecPlan {
+        Ok(ExecPlan {
             vars: VarStore::new(self.var_decls, self.schema),
             actions: self.actions,
             returning,
-            needs_transaction,
-        }
+            atomicity,
+        })
+    }
+}
+
+fn plan_atomicity(capability: &Capability, actions: &[Action]) -> crate::Result<Atomicity> {
+    let requires_interactive = actions.iter().any(Action::requires_interactive_transaction);
+    let database_operations = actions.iter().filter(|action| action.is_db_op()).count();
+    select_atomicity(capability, database_operations, requires_interactive)
+}
+
+fn select_atomicity(
+    capability: &Capability,
+    database_operations: usize,
+    requires_interactive: bool,
+) -> crate::Result<Atomicity> {
+    if requires_interactive && !capability.interactive_transactions {
+        return Err(toasty_core::Error::unsupported_feature(format!(
+            "{} does not support read-modify-write operations because they require interactive transactions",
+            capability.driver_name
+        )));
+    }
+
+    if database_operations <= 1 || !capability.sql {
+        return Ok(Atomicity::None);
+    }
+
+    if capability.interactive_transactions {
+        Ok(Atomicity::InteractiveTransaction)
+    } else if capability.atomic_batch {
+        Ok(Atomicity::AtomicBatch)
+    } else {
+        Err(toasty_core::Error::unsupported_feature(format!(
+            "{} cannot execute a {database_operations}-operation plan atomically",
+            capability.driver_name
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_operation_needs_no_atomic_wrapper() {
+        assert_eq!(
+            select_atomicity(&Capability::SQLITE, 1, false).unwrap(),
+            Atomicity::None
+        );
+    }
+
+    #[test]
+    fn existing_sql_drivers_use_interactive_transactions() {
+        assert_eq!(
+            select_atomicity(&Capability::POSTGRESQL, 2, false).unwrap(),
+            Atomicity::InteractiveTransaction
+        );
+    }
+
+    #[test]
+    fn d1_multi_operation_plans_require_atomic_batches() {
+        assert_eq!(
+            select_atomicity(&Capability::D1, 2, false).unwrap(),
+            Atomicity::AtomicBatch
+        );
+    }
+
+    #[test]
+    fn d1_rejects_read_modify_write_plans() {
+        let error = select_atomicity(&Capability::D1, 1, true).unwrap_err();
+        assert!(error.is_unsupported_feature());
+    }
+
+    #[test]
+    fn sql_driver_without_atomic_mechanism_is_rejected() {
+        let capability = Capability {
+            interactive_transactions: false,
+            atomic_batch: false,
+            transaction_lock_mode: false,
+            ..Capability::SQLITE
+        };
+        let error = select_atomicity(&capability, 2, false).unwrap_err();
+        assert!(error.is_unsupported_feature());
     }
 }

--- a/crates/toasty/src/engine/plan/execution.rs
+++ b/crates/toasty/src/engine/plan/execution.rs
@@ -28,7 +28,18 @@ impl ExecPlanner<'_> {
 fn plan_atomicity(capability: &Capability, actions: &[Action]) -> crate::Result<Atomicity> {
     let requires_interactive = actions.iter().any(Action::requires_interactive_transaction);
     let database_operations = actions.iter().filter(|action| action.is_db_op()).count();
-    select_atomicity(capability, database_operations, requires_interactive)
+    let atomicity = select_atomicity(capability, database_operations, requires_interactive)?;
+    if atomicity == Atomicity::AtomicBatch
+        && actions
+            .iter()
+            .any(|action| !action.is_atomic_batch_eligible())
+    {
+        return Err(toasty_core::Error::unsupported_feature(format!(
+            "{} cannot atomically batch a plan with database result dependencies or non-generated SQL operations",
+            capability.driver_name
+        )));
+    }
+    Ok(atomicity)
 }
 
 fn select_atomicity(

--- a/crates/toasty/src/lib.rs
+++ b/crates/toasty/src/lib.rs
@@ -125,7 +125,8 @@ pub use stmt::{Batch, batch};
 /// Database handle, connection pool, executor trait, and transaction support.
 pub mod db;
 pub use db::{
-    Capability, Connection, Db, Executor, SqlPlaceholder, Transaction, TransactionBuilder,
+    Capability, Connection, ConnectionStrategy, Db, Executor, SqlPlaceholder, Transaction,
+    TransactionBuilder,
 };
 
 mod engine;

--- a/crates/toasty/src/lib.rs
+++ b/crates/toasty/src/lib.rs
@@ -1,6 +1,6 @@
 #![warn(missing_docs)]
-//! Toasty is an async ORM for Rust supporting both SQL (SQLite, PostgreSQL,
-//! MySQL) and NoSQL (DynamoDB) databases.
+//! Toasty is an async ORM for Rust supporting SQL (SQLite, Turso, Cloudflare
+//! D1, PostgreSQL, MySQL) and NoSQL (DynamoDB) databases.
 //!
 //! This crate is the user-facing API. It contains the database handle,
 //! query execution traits, and the types that generated code builds on. For
@@ -10,11 +10,12 @@
 //!
 //! # Modules
 //!
-//! ## [`db`] — database handle and connection pool
+//! ## [`db`] — database handle and connections
 //!
-//! The [`Db`] type is the entry point for all database interaction. It owns
-//! a connection pool and provides [`Db::builder`] for configuration. The
-//! module also contains [`Builder`](db::Builder) and the pool internals.
+//! The [`Db`] type is the entry point for all database interaction. It owns a
+//! pooled or direct connection source and provides [`Db::builder`] for
+//! configuration. The module also contains [`Builder`](db::Builder) and the
+//! connection internals.
 //!
 //! ## [`schema`] — model, relation, and schema inspection
 //!
@@ -99,6 +100,9 @@
 //! | `dynamodb`     | `toasty-driver-dynamodb`     |
 //! | `turso`        | `toasty-driver-turso`        |
 //!
+//! Cloudflare D1 uses the separate `toasty-driver-d1` crate rather than a
+//! feature here because Workers provide D1 as a request-local binding.
+//!
 //! Additional feature flags: `rust_decimal`, `bigdecimal`, `jiff` (date/time
 //! via the `jiff` crate), and `serde` (JSON serialization support).
 //!
@@ -122,7 +126,7 @@ pub use update_target::UpdateTarget;
 // `Batch`, `batch()`, and `CreateMany` live in `stmt`.
 pub use stmt::{Batch, batch};
 
-/// Database handle, connection pool, executor trait, and transaction support.
+/// Database handle, connection sources, executor trait, and transaction support.
 pub mod db;
 pub use db::{
     Capability, Connection, ConnectionStrategy, Db, Executor, SqlPlaceholder, Transaction,

--- a/crates/toasty/tests/direct_connection.rs
+++ b/crates/toasty/tests/direct_connection.rs
@@ -45,6 +45,7 @@ struct State {
 #[derive(Debug)]
 struct DirectDriver {
     inner: toasty_driver_sqlite::Sqlite,
+    capability: &'static Capability,
     state: Arc<State>,
     _tempdir: TempDir,
 }
@@ -55,6 +56,7 @@ impl DirectDriver {
         let inner = toasty_driver_sqlite::Sqlite::open(tempdir.path().join("direct.db"));
         Self {
             inner,
+            capability: &Capability::SQLITE,
             state: Arc::new(State::default()),
             _tempdir: tempdir,
         }
@@ -62,6 +64,11 @@ impl DirectDriver {
 
     fn state(&self) -> Arc<State> {
         self.state.clone()
+    }
+
+    fn d1_like(mut self) -> Self {
+        self.capability = &Capability::D1;
+        self
     }
 }
 
@@ -78,7 +85,7 @@ impl Driver for DirectDriver {
     }
 
     fn capability(&self) -> &'static Capability {
-        self.inner.capability()
+        self.capability
     }
 
     fn connection_strategy(&self) -> ConnectionStrategy {
@@ -272,4 +279,50 @@ async fn direct_source_rejects_pool_configuration() {
 
     assert!(error.is_invalid_driver_configuration());
     assert!(error.to_string().contains("max_pool_size"));
+}
+
+#[tokio::test]
+async fn unsupported_transactions_fail_before_connection_use() {
+    let driver = DirectDriver::new().d1_like();
+    let state = driver.state();
+    let mut db = toasty::Db::builder().build(driver).await.unwrap();
+
+    let Err(error) = db.transaction().await else {
+        panic!("transaction unexpectedly succeeded");
+    };
+    assert!(error.is_unsupported_feature());
+    assert_eq!(state.connects.load(Ordering::Relaxed), 1);
+    assert_eq!(state.execs.load(Ordering::Relaxed), 0);
+
+    let Err(error) = db.transaction_builder().begin().await else {
+        panic!("transaction builder unexpectedly succeeded");
+    };
+    assert!(error.is_unsupported_feature());
+    assert_eq!(state.execs.load(Ordering::Relaxed), 0);
+
+    let mut connection = db.connection().await.unwrap();
+    let Err(error) = connection.transaction().await else {
+        panic!("connection transaction unexpectedly succeeded");
+    };
+    assert!(error.is_unsupported_feature());
+    assert_eq!(state.execs.load(Ordering::Relaxed), 0);
+}
+
+#[tokio::test]
+async fn atomic_batch_plan_fails_before_dispatch_until_batch_support_lands() {
+    let driver = DirectDriver::new().d1_like();
+    let state = driver.state();
+    let mut db = toasty::Db::builder()
+        .models(toasty::models!(User))
+        .build(driver)
+        .await
+        .unwrap();
+    db.push_schema().await.unwrap();
+
+    let error = toasty::batch((User::create().name("a"), User::create().name("b")))
+        .exec(&mut db)
+        .await
+        .unwrap_err();
+    assert!(error.is_unsupported_feature());
+    assert_eq!(state.execs.load(Ordering::Relaxed), 0);
 }

--- a/crates/toasty/tests/direct_connection.rs
+++ b/crates/toasty/tests/direct_connection.rs
@@ -15,7 +15,9 @@ use tempfile::TempDir;
 use toasty_core::{
     Result, Schema,
     driver::{
-        Capability, ConnectContext, Connection, ConnectionStrategy, Driver, ExecResponse, Operation,
+        Capability, ConnectContext, Connection, ConnectionStrategy, Driver, ExecResponse,
+        Operation,
+        operation::{AtomicSqlBatch, Transaction},
     },
     schema::{
         db::{AppliedMigration, Migration},
@@ -35,6 +37,7 @@ struct User {
 struct State {
     connects: AtomicU32,
     execs: AtomicU32,
+    batches: AtomicU32,
     active: AtomicU32,
     max_active: AtomicU32,
     connection_drops: AtomicU32,
@@ -137,6 +140,27 @@ impl Connection for DirectConnection {
         let result = self.inner.exec(schema, op).await;
         self.state.active.fetch_sub(1, Ordering::SeqCst);
         result
+    }
+
+    async fn exec_atomic_batch(
+        &mut self,
+        schema: &Arc<Schema>,
+        batch: AtomicSqlBatch,
+    ) -> Result<Vec<ExecResponse>> {
+        self.state.batches.fetch_add(1, Ordering::Relaxed);
+        self.inner.exec(schema, Transaction::start().into()).await?;
+        let mut responses = Vec::with_capacity(batch.operations.len());
+        for operation in batch.operations {
+            match self.inner.exec(schema, operation.into()).await {
+                Ok(response) => responses.push(response),
+                Err(error) => {
+                    let _ = self.inner.exec(schema, Transaction::Rollback.into()).await;
+                    return Err(error);
+                }
+            }
+        }
+        self.inner.exec(schema, Transaction::Commit.into()).await?;
+        Ok(responses)
     }
 
     async fn ping(&mut self) -> Result<()> {
@@ -309,7 +333,7 @@ async fn unsupported_transactions_fail_before_connection_use() {
 }
 
 #[tokio::test]
-async fn atomic_batch_plan_fails_before_dispatch_until_batch_support_lands() {
+async fn atomic_batch_plan_dispatches_once() {
     let driver = DirectDriver::new().d1_like();
     let state = driver.state();
     let mut db = toasty::Db::builder()
@@ -319,10 +343,12 @@ async fn atomic_batch_plan_fails_before_dispatch_until_batch_support_lands() {
         .unwrap();
     db.push_schema().await.unwrap();
 
-    let error = toasty::batch((User::create().name("a"), User::create().name("b")))
+    let (a, b): (User, User) = toasty::batch((User::create().name("a"), User::create().name("b")))
         .exec(&mut db)
         .await
-        .unwrap_err();
-    assert!(error.is_unsupported_feature());
+        .unwrap();
+    assert_eq!(a.name, "a");
+    assert_eq!(b.name, "b");
+    assert_eq!(state.batches.load(Ordering::Relaxed), 1);
     assert_eq!(state.execs.load(Ordering::Relaxed), 0);
 }

--- a/crates/toasty/tests/direct_connection.rs
+++ b/crates/toasty/tests/direct_connection.rs
@@ -1,0 +1,275 @@
+use std::{
+    borrow::Cow,
+    future::Future,
+    pin::pin,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU32, Ordering},
+    },
+    task::{Context, Poll, Wake, Waker},
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use tempfile::TempDir;
+use toasty_core::{
+    Result, Schema,
+    driver::{
+        Capability, ConnectContext, Connection, ConnectionStrategy, Driver, ExecResponse, Operation,
+    },
+    schema::{
+        db::{AppliedMigration, Migration},
+        diff,
+    },
+};
+
+#[derive(Debug, toasty::Model)]
+struct User {
+    #[key]
+    #[auto]
+    id: u64,
+    name: String,
+}
+
+#[derive(Debug, Default)]
+struct State {
+    connects: AtomicU32,
+    execs: AtomicU32,
+    active: AtomicU32,
+    max_active: AtomicU32,
+    connection_drops: AtomicU32,
+    driver_drops: AtomicU32,
+    fail_next: AtomicBool,
+}
+
+#[derive(Debug)]
+struct DirectDriver {
+    inner: toasty_driver_sqlite::Sqlite,
+    state: Arc<State>,
+    _tempdir: TempDir,
+}
+
+impl DirectDriver {
+    fn new() -> Self {
+        let tempdir = TempDir::new().unwrap();
+        let inner = toasty_driver_sqlite::Sqlite::open(tempdir.path().join("direct.db"));
+        Self {
+            inner,
+            state: Arc::new(State::default()),
+            _tempdir: tempdir,
+        }
+    }
+
+    fn state(&self) -> Arc<State> {
+        self.state.clone()
+    }
+}
+
+impl Drop for DirectDriver {
+    fn drop(&mut self) {
+        self.state.driver_drops.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+#[async_trait]
+impl Driver for DirectDriver {
+    fn url(&self) -> Cow<'_, str> {
+        Cow::Borrowed("direct:test")
+    }
+
+    fn capability(&self) -> &'static Capability {
+        self.inner.capability()
+    }
+
+    fn connection_strategy(&self) -> ConnectionStrategy {
+        ConnectionStrategy::Direct
+    }
+
+    async fn connect(&self, cx: &ConnectContext) -> Result<Box<dyn Connection>> {
+        self.state.connects.fetch_add(1, Ordering::Relaxed);
+        Ok(Box::new(DirectConnection {
+            inner: self.inner.connect(cx).await?,
+            state: self.state.clone(),
+        }))
+    }
+
+    fn generate_migration(&self, diff: &diff::Schema<'_>) -> Migration {
+        self.inner.generate_migration(diff)
+    }
+
+    async fn reset_db(&self) -> Result<()> {
+        self.inner.reset_db().await
+    }
+}
+
+#[derive(Debug)]
+struct DirectConnection {
+    inner: Box<dyn Connection>,
+    state: Arc<State>,
+}
+
+impl Drop for DirectConnection {
+    fn drop(&mut self) {
+        self.state.connection_drops.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+#[async_trait]
+impl Connection for DirectConnection {
+    async fn exec(&mut self, schema: &Arc<Schema>, op: Operation) -> Result<ExecResponse> {
+        if self.state.fail_next.swap(false, Ordering::Relaxed) {
+            return Err(toasty_core::Error::unsupported_feature(
+                "injected direct error",
+            ));
+        }
+
+        self.state.execs.fetch_add(1, Ordering::Relaxed);
+        let active = self.state.active.fetch_add(1, Ordering::SeqCst) + 1;
+        self.state.max_active.fetch_max(active, Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        let result = self.inner.exec(schema, op).await;
+        self.state.active.fetch_sub(1, Ordering::SeqCst);
+        result
+    }
+
+    async fn ping(&mut self) -> Result<()> {
+        self.inner.ping().await
+    }
+
+    async fn push_schema(&mut self, schema: &Schema) -> Result<()> {
+        self.inner.push_schema(schema).await
+    }
+
+    async fn applied_migrations(&mut self) -> Result<Vec<AppliedMigration>> {
+        self.inner.applied_migrations().await
+    }
+
+    async fn apply_migration(&mut self, id: u64, name: &str, migration: &Migration) -> Result<()> {
+        self.inner.apply_migration(id, name, migration).await
+    }
+}
+
+async fn build_db() -> (toasty::Db, Arc<State>) {
+    let driver = DirectDriver::new();
+    let state = driver.state();
+    let db = toasty::Db::builder()
+        .models(toasty::models!(User))
+        .build(driver)
+        .await
+        .unwrap();
+    db.push_schema().await.unwrap();
+    (db, state)
+}
+
+fn block_on<F: Future>(future: F) -> F::Output {
+    struct ThreadWake(std::thread::Thread);
+
+    impl Wake for ThreadWake {
+        fn wake(self: Arc<Self>) {
+            self.0.unpark();
+        }
+    }
+
+    let waker = Waker::from(Arc::new(ThreadWake(std::thread::current())));
+    let mut cx = Context::from_waker(&waker);
+    let mut future = pin!(future);
+
+    loop {
+        match future.as_mut().poll(&mut cx) {
+            Poll::Ready(output) => return output,
+            Poll::Pending => std::thread::park(),
+        }
+    }
+}
+
+#[test]
+fn direct_build_does_not_require_tokio_runtime() {
+    let driver = DirectDriver::new();
+    let state = driver.state();
+    let db = block_on(toasty::Db::builder().build(driver)).unwrap();
+
+    assert_eq!(state.connects.load(Ordering::Relaxed), 1);
+    assert!(db.pool().is_none());
+}
+
+#[tokio::test]
+async fn direct_source_reuses_one_connection() {
+    let (mut db, state) = build_db().await;
+
+    toasty::sql::statement("DELETE FROM users")
+        .exec(&mut db)
+        .await
+        .unwrap();
+    toasty::sql::statement("DELETE FROM users")
+        .exec(&mut db)
+        .await
+        .unwrap();
+
+    assert_eq!(state.connects.load(Ordering::Relaxed), 1);
+    assert_eq!(state.execs.load(Ordering::Relaxed), 2);
+    assert!(db.pool().is_none());
+}
+
+#[tokio::test]
+async fn cloned_handles_serialize_direct_operations() {
+    let (mut db1, state) = build_db().await;
+    let mut db2 = db1.clone();
+
+    let (first, second) = tokio::join!(
+        toasty::sql::statement("DELETE FROM users").exec(&mut db1),
+        toasty::sql::statement("DELETE FROM users").exec(&mut db2),
+    );
+    first.unwrap();
+    second.unwrap();
+
+    assert_eq!(state.max_active.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn direct_errors_propagate_without_discarding_connection() {
+    let (mut db, state) = build_db().await;
+    state.fail_next.store(true, Ordering::Relaxed);
+
+    let error = toasty::sql::statement("DELETE FROM users")
+        .exec(&mut db)
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "unsupported feature: injected direct error"
+    );
+
+    toasty::sql::statement("DELETE FROM users")
+        .exec(&mut db)
+        .await
+        .unwrap();
+    assert_eq!(state.connects.load(Ordering::Relaxed), 1);
+}
+
+#[tokio::test]
+async fn final_handle_drops_direct_driver_and_connection() {
+    let (db, state) = build_db().await;
+    let clone = db.clone();
+
+    drop(db);
+    assert_eq!(state.connection_drops.load(Ordering::Relaxed), 0);
+    assert_eq!(state.driver_drops.load(Ordering::Relaxed), 0);
+
+    drop(clone);
+    assert_eq!(state.connection_drops.load(Ordering::Relaxed), 1);
+    assert_eq!(state.driver_drops.load(Ordering::Relaxed), 1);
+}
+
+#[tokio::test]
+async fn direct_source_rejects_pool_configuration() {
+    let driver = DirectDriver::new();
+    let error = toasty::Db::builder()
+        .models(toasty::models!(User))
+        .max_pool_size(2)
+        .build(driver)
+        .await
+        .unwrap_err();
+
+    assert!(error.is_invalid_driver_configuration());
+    assert!(error.to_string().contains("max_pool_size"));
+}

--- a/crates/toasty/tests/pool_sweep.rs
+++ b/crates/toasty/tests/pool_sweep.rs
@@ -222,7 +222,7 @@ async fn sweep_evicts_dead_idle_connection() {
     .exec(&mut db)
     .await
     .unwrap();
-    assert_eq!(db.pool().status().size, 1);
+    assert_eq!(db.pool().unwrap().status().size, 1);
 
     state.ping_fail_tokens.store(1, Ordering::Relaxed);
 
@@ -230,7 +230,7 @@ async fn sweep_evicts_dead_idle_connection() {
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     assert_eq!(
-        db.pool().status().size,
+        db.pool().unwrap().status().size,
         0,
         "sweep did not evict the dead idle connection",
     );
@@ -259,7 +259,7 @@ async fn eager_escalation_after_observed_loss() {
     let c2 = db.connection().await.unwrap();
     let c3 = db.connection().await.unwrap();
     drop((c1, c2, c3));
-    assert_eq!(db.pool().status().size, 3);
+    assert_eq!(db.pool().unwrap().status().size, 3);
 
     // One fault for the user query, two for the sweep's escalation
     // pings over the remaining idle connections.
@@ -323,7 +323,7 @@ async fn periodic_failure_does_not_redundantly_escalate() {
     let c2 = db.connection().await.unwrap();
     let c3 = db.connection().await.unwrap();
     drop((c1, c2, c3));
-    assert_eq!(db.pool().status().size, 3);
+    assert_eq!(db.pool().unwrap().status().size, 3);
 
     state.ping_fail_tokens.store(1, Ordering::Relaxed);
 
@@ -355,7 +355,7 @@ async fn pre_ping_evicts_silently_broken_idle_connection() {
     .exec(&mut db)
     .await
     .unwrap();
-    assert_eq!(db.pool().status().size, 1);
+    assert_eq!(db.pool().unwrap().status().size, 1);
 
     let pings_before = state.pings.load(Ordering::Relaxed);
     state.ping_fail_tokens.store(1, Ordering::Relaxed);
@@ -372,7 +372,7 @@ async fn pre_ping_evicts_silently_broken_idle_connection() {
 
     assert_eq!(state.pings.load(Ordering::Relaxed) - pings_before, 1);
     assert_eq!(state.ping_fail_tokens.load(Ordering::Relaxed), 0);
-    assert_eq!(db.pool().status().size, 1);
+    assert_eq!(db.pool().unwrap().status().size, 1);
 }
 
 /// Pre-ping issues a round-trip on every checkout. The first query
@@ -459,7 +459,7 @@ async fn lifetime_cap_evicts_aged_connection() {
         1,
         "recycle did not replace the over-lifetime connection",
     );
-    assert_eq!(db.pool().status().size, 1);
+    assert_eq!(db.pool().unwrap().status().size, 1);
 }
 
 /// Idle-time cap: a connection that has been sitting unused for longer
@@ -506,7 +506,7 @@ async fn idle_time_cap_evicts_long_idle_connection() {
         1,
         "recycle did not replace the over-idle connection",
     );
-    assert_eq!(db.pool().status().size, 1);
+    assert_eq!(db.pool().unwrap().status().size, 1);
 }
 
 /// A connection within both caps is reused — `recycle` must not evict

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -25,6 +25,7 @@ Guide-level design documents for specific features. Use
 [`_template.md`](./design/_template.md) when starting a new one.
 
 - [Design Overview](./design/README.md)
+- [Cloudflare D1 Driver](./design/cloudflare-d1.md)
 - [Per-Call Column Projection](./design/column-projection.md)
 - [DynamoDB Driver Error-Handling Convention](./design/ddb-error-handling.md)
 - [DynamoDB Scan Support](./design/ddb-scan.md)

--- a/docs/dev/design/cloudflare-d1.md
+++ b/docs/dev/design/cloudflare-d1.md
@@ -1,0 +1,242 @@
+# Cloudflare D1 Driver
+
+## Summary
+
+Toasty adds a Cloudflare D1 driver for Rust applications running in a
+Cloudflare Worker. Applications construct the driver from a request-local D1
+binding. Toasty uses D1's SQLite-compatible SQL interface, executes eligible
+multi-statement plans through D1's atomic batch API, and rejects operations
+that require an interactive transaction.
+
+## Motivation
+
+D1 exposes a relational database to Workers through a runtime binding rather
+than a connection URL. The binding does not create independent connections and
+cannot remain valid beyond the Worker request that supplied it. D1 also differs
+from connected SQLite in two ways that affect Toasty's execution model:
+
+- Workers cannot hold an interactive SQL transaction across calls.
+- D1 can execute a fixed list of prepared statements as one atomic batch.
+
+Treating D1 as a pooled SQLite connection would start pool machinery that the
+binding does not need and would send transaction operations that D1 does not
+support. A D1 driver needs request-local connection ownership and an explicit
+atomic-batch contract.
+
+## User-facing API
+
+Add Toasty, the D1 driver, and the Workers SDK to the Worker crate:
+
+```toml
+[dependencies]
+toasty = "0.9"
+toasty-driver-d1 = "0.9"
+worker = { version = "0.8", features = ["d1"] }
+```
+
+Read the binding from the Worker environment and build one `Db` for the
+request:
+
+```rust
+use toasty_driver_d1::D1;
+use worker::{Context, Env, Request, Response, Result, event};
+
+#[event(fetch)]
+pub async fn fetch(
+    _request: Request,
+    env: Env,
+    _context: Context,
+) -> Result<Response> {
+    let driver = D1::new("DB", env.d1("DB")?);
+    let mut db = toasty::Db::builder()
+        .models(toasty::models!(crate::*))
+        .build(driver)
+        .await
+        .map_err(|error| worker::Error::RustError(error.to_string()))?;
+
+    // Use `db` before the request returns.
+    Response::ok("ready")
+}
+```
+
+The driver lives in `toasty-driver-d1` rather than behind a feature on
+`toasty`. A feature could re-export the driver, but it could not construct one:
+the application must still read the request-local binding from `Env` and pass
+it to `D1::new`.
+
+Pool settings do not apply to D1. `Db::builder()` rejects settings such as
+`max_pool_size` and `pool_pre_ping` when building a direct driver.
+
+### Batches and transactions
+
+Call `toasty::batch()` when every statement can be prepared before the batch
+starts:
+
+```rust
+let (user, post) = toasty::batch((
+    User::create().name("Alice"),
+    Post::create().title("Hello"),
+))
+.exec(&mut db)
+.await?;
+```
+
+Toasty sends eligible multi-statement plans through D1's atomic batch API. D1
+executes the statements in order and rolls back the group if a statement
+fails.
+
+`db.transaction()` is not available. A plan that must read one database result
+before constructing a later statement also returns
+`Error::UnsupportedFeature`. The application must express the work as one SQL
+statement, split it into separate non-atomic operations, or use a database that
+supports interactive transactions.
+
+### Schema management
+
+`db.push_schema()` creates tables and indexes through one D1 atomic batch. It
+is suitable for local development and disposable databases.
+
+Production schema changes use Wrangler migrations. The D1 migration generator
+emits SQLite-compatible SQL, including deferred foreign-key checking for table
+rebuilds, but Toasty does not apply or track those migrations at runtime.
+
+## Behavior
+
+The driver serializes generated statements with Toasty's SQLite serializer and
+uses numbered question-mark parameters. Generated queries, raw SQL, inserts,
+updates, deletes, result projections, and supported relation queries retain
+their SQLite SQL behavior.
+
+D1 values cross a JavaScript API boundary. The driver rejects integers outside
+JavaScript's safe integer range and non-finite floating-point values rather
+than changing their values during conversion. UUID values use canonical text
+because D1's binding API cannot carry Toasty's SQLite UUID blob representation.
+Document values, scalar lists, decimal values, and date/time values use their
+existing text encodings.
+
+The driver validates D1 limits that can be determined before dispatch,
+including parameter count, SQL length, pattern length, column count, and
+individual string or blob size. D1 remains responsible for aggregate limits
+such as final row size.
+
+A single database operation executes directly. For a plan with multiple
+database operations, the engine selects one of these forms from the driver's
+capabilities:
+
+- An interactive transaction streams operations between `BEGIN` and `COMMIT`.
+- An atomic SQL batch sends an ordered list of generated statements at once.
+- A driver supporting neither form rejects the plan before dispatch.
+
+For D1, every database operation in an atomic plan must be a generated SQL
+statement with no dependency on an earlier database result. The driver returns
+one result for each input statement in the same order. A missing, extra, or
+malformed result returns `Error::InvalidResult`.
+
+Errors from the Workers SDK or D1 result objects become Toasty driver-operation
+errors. Unsupported operations, including interactive transactions, runtime
+migrations, and database reset, return `Error::UnsupportedFeature`.
+
+## Edge cases
+
+**Request lifetime.** A `D1` value can create one direct Toasty connection.
+Cloned `Db` handles share that connection, and access is serialized. The
+application must not retain the `Db` after its Worker request ends.
+
+**Empty schemas.** `push_schema()` returns successfully without sending an
+empty D1 batch.
+
+**Atomic dependencies.** Pagination, conditional output, raw SQL operations,
+and statements whose inputs depend on earlier database results are not
+eligible for an atomic SQL batch. Toasty rejects the complete plan before
+sending its first statement.
+
+**Integer representation.** Signed and unsigned integer fields share
+JavaScript's safe integer ceiling even though SQLite can store the full signed
+64-bit range. Model validation and value binding report the same range.
+
+**Query timing.** `std::time::Instant` is unavailable on
+`wasm32-unknown-unknown`. D1 query events retain their SQL, parameters, result,
+and row metadata but report zero duration.
+
+**Migration table rebuilds.** D1 enforces foreign keys inside its implicit
+transactions. Rebuild migrations use `PRAGMA defer_foreign_keys = ON` instead
+of disabling foreign keys. Connected SQLite keeps its existing behavior.
+
+## Driver integration
+
+`Driver::connection_strategy()` tells `Db` how to own connections. Its default
+is `ConnectionStrategy::Pooled`, so existing drivers and out-of-tree drivers do
+not need to implement it. A direct driver returns
+`ConnectionStrategy::Direct`; `Db` then calls `Driver::connect()` once and
+serializes all access to that connection without starting pool background
+tasks.
+
+`Capability` describes transaction delivery separately from whether the
+backend uses SQL:
+
+- `interactive_transactions` allows `Transaction` operations.
+- `atomic_batch` allows a fixed group of generated SQL statements.
+- `max_bind_parameters` reports the backend ceiling; the D1 driver rejects
+  oversized statements before dispatch.
+- `runtime_migrations` and `reset_database` describe administrative support.
+- `defer_foreign_keys_during_rebuild` selects D1-compatible rebuild SQL.
+
+The additional `Capability` fields require out-of-tree drivers that construct
+the struct directly to select values when updating Toasty. Existing shipped
+drivers retain their previous transaction and administration behavior.
+
+`Connection::exec_atomic_batch()` accepts an ordered `AtomicSqlBatch` and
+returns one `ExecResponse` per statement. Its default implementation returns
+`Error::UnsupportedFeature`; a sequential fallback is invalid because it would
+weaken the requested atomicity. Implementors must commit the complete list or
+return an error without committing a prefix.
+
+SQL drivers that support interactive transactions continue to receive
+individual `Operation` values through `Connection::exec()`. They do not need
+to implement the atomic-batch method.
+
+## Alternatives considered
+
+**Use the existing connection pool with a maximum size of one.** This still
+models the binding as a factory, permits reconnect attempts after its one value
+has been consumed, and retains pool timers and background tasks. A direct
+connection represents the binding's ownership and lifetime explicitly.
+
+**Expose D1 through `Db::connect()`.** D1 has no connection URL, and only the
+Worker environment can supply the binding. A URL form would hide a value that
+the application must provide.
+
+**Emulate interactive transactions by buffering operations.** The engine may
+need an earlier result to construct a later operation, so buffering cannot
+preserve interactive transaction behavior. Toasty rejects those plans instead
+of changing their semantics.
+
+**Execute multi-statement plans sequentially.** This can leave partial state
+after an error and breaks Toasty's atomic batch guarantee. Toasty uses D1's
+batch API or rejects the plan.
+
+**Put D1 behind a `toasty` feature.** A feature would only re-export the driver;
+it would not remove the need to depend on the Workers SDK and read the binding.
+Keeping the driver separate isolates its Wasm-only dependencies and runtime
+API.
+
+## Open questions
+
+No open questions remain for this implementation. Adding D1 Sessions for read
+replication can be designed independently without changing the binding-based
+construction API.
+
+## Out of scope
+
+- **Interactive transactions and savepoints.** The Worker binding does not
+  expose them.
+- **Runtime migration tracking.** Wrangler owns D1 migration files and the
+  `d1_migrations` ledger.
+- **Database reset.** D1 does not expose Toasty's connected-database reset
+  workflow through the binding driver.
+- **D1 Sessions and read replication.** The initial driver executes against the
+  binding without a session API.
+- **Automatic retries.** Retrying a write after an ambiguous failure could
+  apply it twice.
+- **Using D1 outside a Worker.** The driver targets the Workers binding API, not
+  the Cloudflare REST API.

--- a/docs/dev/roadmap.md
+++ b/docs/dev/roadmap.md
@@ -118,6 +118,7 @@ the entry lands here.
 
 ## Drivers
 
+- Cloudflare D1 ([design](design/cloudflare-d1.md))
 - DynamoDB Scan support ([design](design/ddb-scan.md), [#741])
 - Connection pooling improvements ([#384])
 - Retry-safe transparent recovery from connection loss ([design](design/retry-safe-recovery.md), [#863])

--- a/docs/guide/src/SUMMARY.md
+++ b/docs/guide/src/SUMMARY.md
@@ -55,4 +55,5 @@
 - [MySQL](./mysql.md)
 - [SQLite](./sqlite.md)
 - [Turso](./turso.md)
+- [Cloudflare D1](./d1.md)
 - [DynamoDB](./dynamodb.md)

--- a/docs/guide/src/batch-operations.md
+++ b/docs/guide/src/batch-operations.md
@@ -14,6 +14,11 @@ execute each statement, and commit. In many cases, batch operations are
 sufficient. Reach for interactive transactions only when you need to read data
 and make decisions based on those reads within the same atomic scope.
 
+On Cloudflare D1, Toasty sends multi-statement plans through D1's atomic batch
+API when every statement can be prepared up front. A plan whose later database
+operation depends on an earlier database result is rejected instead of losing
+atomicity. See [Cloudflare D1](./d1.md#atomic-batches-and-transactions).
+
 ## Batching queries with tuples
 
 Pass a tuple of queries to `toasty::batch()`. The return type matches the tuple

--- a/docs/guide/src/d1.md
+++ b/docs/guide/src/d1.md
@@ -1,0 +1,162 @@
+# Cloudflare D1
+
+Toasty's [Cloudflare D1] driver runs inside a Cloudflare Worker and uses the D1
+binding provided for the current request. D1 speaks SQLite-compatible SQL, so
+the driver shares Toasty's SQLite serializer while preserving D1's runtime and
+platform limits.
+
+## Enabling the driver
+
+Add Toasty, the D1 driver, and `worker` to the Worker crate:
+
+```toml
+[dependencies]
+toasty = "{{toasty_version}}"
+toasty-driver-d1 = "{{toasty_version}}"
+worker = { version = "0.8", features = ["d1"] }
+```
+
+The `D1` driver type is available only for `wasm32` targets. Migration
+generation remains available on native targets so build tooling can produce
+SQL without loading a Worker binding.
+
+Add the binding and migration directory to `wrangler.toml`:
+
+```toml
+[[d1_databases]]
+binding = "DB"
+database_name = "my-database"
+database_id = "00000000-0000-0000-0000-000000000000"
+migrations_dir = "migrations"
+```
+
+## Creating a request-local `Db`
+
+Read the binding from `Env`, construct the driver, and pass it to
+`Db::builder().build()`:
+
+```rust,ignore
+use toasty_driver_d1::D1;
+use worker::{Context, Env, Request, Response, Result, event};
+
+#[event(fetch)]
+pub async fn fetch(
+    _request: Request,
+    env: Env,
+    _context: Context,
+) -> Result<Response> {
+    let binding = env.d1("DB")?;
+    let driver = D1::new("DB", binding);
+    let mut db = toasty::Db::builder()
+        .models(toasty::models!(crate::*))
+        .build(driver)
+        .await
+        .map_err(|error| worker::Error::RustError(error.to_string()))?;
+
+    // Run queries with `&mut db` before the request returns.
+    Response::ok("ready")
+}
+```
+
+Create one `Db` per Worker request. The binding is already managed by the
+Workers runtime, so the driver uses one direct connection and does not create a
+Toasty connection pool. Cloned `Db` handles share that request-local
+connection. Pool settings such as `max_pool_size` and `pool_pre_ping` are
+rejected when building a direct driver.
+
+There is no D1 connection URL and no D1 feature on the `toasty` crate. Depend
+on `toasty-driver-d1` directly and pass the Worker binding to `D1::new`.
+
+## Type mapping
+
+D1 values cross a JavaScript API boundary. Toasty validates values before
+dispatch so conversions do not silently lose information.
+
+| Rust value | D1 representation | Notes |
+|---|---|---|
+| `bool` | `BOOLEAN` | Typed results also accept SQLite's `0` and `1`. |
+| Signed and unsigned integers | `INTEGER` | Must be in JavaScript's safe integer range, `-9,007,199,254,740,991` through `9,007,199,254,740,991`. |
+| `f32`, `f64` | `REAL` | `NaN` and infinities are rejected. |
+| `String` | `TEXT` | Limited to 2,000,000 UTF-8 bytes. |
+| `Vec<u8>` | `BLOB` | Limited to 2,000,000 bytes. |
+| `uuid::Uuid` | `TEXT` | Stored as canonical hyphenated text, unlike the SQLite driver's BLOB representation. |
+| Decimal and date/time feature types | `TEXT` | Encoded in their canonical string form. |
+| `Vec<scalar>` and `#[document]` values | `TEXT` | JSON encoded. |
+
+For raw SQL, untyped result inference maps integral JavaScript numbers to
+`Value::I64`, non-integral numbers to `Value::F64`, strings to
+`Value::String`, and byte arrays to `Value::Bytes`. Use
+[`column_types`](./raw-sql.md#decoding-query-results) when a numeric result is
+a Boolean, unsigned integer, or narrower integer, or when a string represents
+a UUID or another typed value.
+
+## Queries and D1 limits
+
+The driver enforces limits it can determine before dispatch, and D1 enforces
+the rest:
+
+| Limit | Maximum |
+|---|---:|
+| Bound parameters | 100 |
+| Columns per table | 100 |
+| SQL statement size | 100,000 bytes |
+| String, BLOB, or row size | 2,000,000 bytes |
+| `LIKE` or `GLOB` pattern | 50 bytes |
+
+The value checks cover individual string and BLOB parameters. D1 remains the
+source of truth for aggregate row size and other service limits that depend on
+the final encoded statement or row.
+
+D1 keeps SQLite's operator behavior:
+
+- `.like()` uses D1's native `LIKE`, including SQLite's ASCII case folding.
+- `.ilike()` returns `Error::UnsupportedFeature`; D1 has no `ILIKE` operator.
+- `.starts_with()` uses a case-sensitive `GLOB` expression and escapes GLOB
+  metacharacters in the prefix.
+
+The driver sends each operation once. It does not retry writes, because retrying
+a write after an ambiguous failure could apply it twice.
+
+## Atomic batches and transactions
+
+D1 does not let a Worker hold an interactive SQL transaction across calls.
+`db.transaction()`, savepoints, and read-modify-write plans therefore return
+`Error::UnsupportedFeature` before any database operation is sent.
+
+For a multi-statement Toasty plan, the engine uses D1's atomic batch API when
+all SQL statements can be generated before dispatch. D1 executes those
+statements in order and rolls the complete batch back if one statement fails.
+Results are returned in the same order as their input statements.
+
+A plan is rejected before dispatch when a later statement needs an earlier
+database result, uses conditional output, or requires an operation other than
+generated SQL. Split independent work into a batch. If application logic must
+read a value and choose a later write, redesign it as one native SQL statement
+or accept separate, non-atomic operations.
+
+## Schema setup
+
+`db.push_schema()` creates every table and secondary index in one D1 atomic
+batch. It is useful for disposable local databases and tests. It does not track
+schema history and should not replace production migrations.
+
+## Migrations
+
+D1 migrations belong to Wrangler. Put SQL files in the configured
+`migrations_dir`, then apply them with Wrangler:
+
+```bash
+npx wrangler d1 migrations apply my-database --local
+npx wrangler d1 migrations apply my-database --remote
+```
+
+Toasty's D1 migration generator emits SQLite-compatible DDL. Column changes
+that SQLite cannot express with `ALTER COLUMN` use a table rebuild. Those
+rebuilds begin with `PRAGMA defer_foreign_keys = ON`, which is safe inside
+Wrangler's transaction wrapper; they do not disable foreign-key enforcement.
+
+The D1 driver intentionally does not implement Toasty's runtime migration
+ledger, `migration apply`, or database reset. Do not mix Toasty's
+`__toasty_migrations` ledger with Wrangler's `d1_migrations` ledger.
+
+[`Cloudflare D1`]: https://developers.cloudflare.com/d1/

--- a/docs/guide/src/database-setup.md
+++ b/docs/guide/src/database-setup.md
@@ -75,6 +75,10 @@ For per-backend details — URL query parameters, TLS, type mapping,
 and per-driver behavior — see the
 [Database Backends](./postgresql.md) chapters.
 
+Cloudflare D1 is the exception to URL-based setup. A Worker receives a D1
+binding from its `Env`, so construct `toasty_driver_d1::D1` from that binding
+and use `build()`. See [Cloudflare D1](./d1.md) for the complete setup.
+
 ## Using a driver directly
 
 If you need more control over the driver configuration, construct the driver
@@ -90,10 +94,13 @@ let mut db = toasty::Db::builder()
 
 ## Connection pool
 
-`Db` owns a connection pool. Each query checks out a connection from the
-pool for the duration of the call and returns it when finished. The pool
-defaults work for typical applications; the builder exposes knobs for
+With a pooled driver, `Db` owns a connection pool. Each query checks out a
+connection for the duration of the call and returns it when finished. The
+pool defaults work for typical applications; the builder exposes knobs for
 tuning size, timeouts, and broken-connection recovery.
+
+D1 uses one request-local direct connection instead. Pool configuration is
+rejected for direct drivers because there is no pool to configure.
 
 ```rust,ignore
 use std::time::Duration;

--- a/docs/guide/src/defining-models.md
+++ b/docs/guide/src/defining-models.md
@@ -43,7 +43,7 @@ Toasty supports these Rust types as model fields:
 | `f32`, `f64` | Floating point |
 | `uuid::Uuid` | UUID |
 | `Vec<u8>` | Binary / Blob |
-| `Vec<T>` (T scalar, not `u8`) | Native array column on PostgreSQL (`text[]`, `int8[]`, …); JSON on MySQL / SQLite; List `L` on DynamoDB. See [`Vec<scalar>` Fields](./vec-scalar-fields.md). |
+| `Vec<T>` (T scalar, not `u8`) | Native array column on PostgreSQL (`text[]`, `int8[]`, …); JSON on MySQL; JSON text on SQLite, Turso, and D1; List `L` on DynamoDB. See [`Vec<scalar>` Fields](./vec-scalar-fields.md). |
 | `Option<T>` | Nullable version of `T` |
 | Embedded types (`#[derive(toasty::Embed)]`) | Flattened into parent table columns (see [Embedded Types](./embedded-types.md)) |
 | Document fields (`#[document]`) | One structured column whose scalar leaves remain queryable (see [`#[document]` Fields](./document-fields.md)) |

--- a/docs/guide/src/document-fields.md
+++ b/docs/guide/src/document-fields.md
@@ -108,8 +108,8 @@ let users = User::filter(
 
 The query engine lowers `address().city()` to the backend's document
 path operation. PostgreSQL extracts a JSONB path, MySQL uses its JSON
-functions, SQLite and Turso use JSON1, and DynamoDB uses a document path
-expression.
+functions, SQLite, Turso, and Cloudflare D1 use JSON1, and DynamoDB uses a
+document path expression.
 
 Equality, ordering, and optional-field checks work on supported scalar
 leaves. Comparing the entire document to an `Address` value is not yet
@@ -156,8 +156,8 @@ struct Order {
 }
 ```
 
-PostgreSQL, MySQL, SQLite, and Turso encode the field as an array of JSON
-objects. DynamoDB stores it as a List (`L`) of Map (`M`) values.
+PostgreSQL, MySQL, SQLite, Turso, and Cloudflare D1 encode the field as an array
+of JSON objects. DynamoDB stores it as a List (`L`) of Map (`M`) values.
 
 Whole-value create, read, and replacement work for document
 collections. `stmt::push` appends one embedded value. Element predicates

--- a/docs/guide/src/filtering-with-expressions.md
+++ b/docs/guide/src/filtering-with-expressions.md
@@ -473,8 +473,8 @@ match — it works across all drivers.
 
 `.ilike()` is the case-insensitive form of `.like()` and maps to PostgreSQL's
 `ILIKE` operator. **PostgreSQL only.** Toasty does not emulate `ILIKE` on
-backends that lack it: on MySQL, SQLite, and DynamoDB the query is rejected with
-an `unsupported_feature` error.
+backends that lack it: on MySQL, SQLite, Turso, Cloudflare D1, and DynamoDB the
+query is rejected with an `unsupported_feature` error.
 
 PostgreSQL's `LIKE` is case-sensitive, so PostgreSQL provides `ILIKE` for
 case-insensitive matching. The other backends have no operator with matching

--- a/docs/guide/src/getting-started.md
+++ b/docs/guide/src/getting-started.md
@@ -20,7 +20,9 @@ tokio = { version = "1", features = ["full"] }
 
 The `sqlite` feature enables the SQLite driver. Toasty also supports
 `postgresql`, `mysql`, `turso`, and `dynamodb` — swap the feature flag to use
-a different database.
+a different database. Cloudflare D1 uses the separate `toasty-driver-d1`
+crate because a Worker supplies the database binding directly; see
+[Cloudflare D1](./d1.md).
 
 ## Define a model
 

--- a/docs/guide/src/indexes-and-unique-constraints.md
+++ b/docs/guide/src/indexes-and-unique-constraints.md
@@ -7,9 +7,10 @@ generated.
 ## Unique fields
 
 Add `#[unique]` to a field to create a unique index. Toasty enforces uniqueness
-on all supported databases. SQL databases (SQLite/Turso, PostgreSQL, MySQL) use a
-native unique index. DynamoDB uses a separate index table keyed on the unique
-attribute; inserts and updates write to both tables in a single
+on all supported databases. SQL databases (SQLite/Turso, Cloudflare D1,
+PostgreSQL, MySQL) use a native unique index. DynamoDB uses a separate index
+table keyed on the unique attribute; inserts and updates write to both tables
+in a single
 `TransactWriteItems` call with an `attribute_not_exists` condition that rejects
 duplicates.
 

--- a/docs/guide/src/introduction.md
+++ b/docs/guide/src/introduction.md
@@ -1,7 +1,7 @@
 # Introduction
 
-Toasty is an async ORM for Rust. It supports both SQL databases (SQLite/Turso,
-PostgreSQL, MySQL) and NoSQL databases (DynamoDB).
+Toasty is an async ORM for Rust. It supports SQL databases (SQLite/Turso,
+Cloudflare D1, PostgreSQL, MySQL) and NoSQL databases (DynamoDB).
 
 You define your models as Rust structs and annotate them with
 `#[derive(toasty::Model)]`. Toasty infers the database schema from your

--- a/docs/guide/src/json-encoding.md
+++ b/docs/guide/src/json-encoding.md
@@ -83,9 +83,9 @@ JSON fields accept these column types:
 | `json` | Native JSON on PostgreSQL and MySQL |
 | `jsonb` | Native binary JSON on PostgreSQL |
 
-Use `text` on SQLite, Turso, DynamoDB, or any backend where the database
-does not provide a native JSON column. Toasty's serializer still emits
-valid JSON, but a text column does not ask the database to validate
+Use `text` on SQLite, Turso, Cloudflare D1, DynamoDB, or any backend where the
+database does not provide a native JSON column. Toasty's serializer still
+emits valid JSON, but a text column does not ask the database to validate
 external writes.
 
 Use `json` when PostgreSQL or MySQL should validate the stored value as

--- a/docs/guide/src/keys-and-auto-generation.md
+++ b/docs/guide/src/keys-and-auto-generation.md
@@ -243,8 +243,8 @@ println!("post id: {}", post.id); // 1, 2, 3, ...
 # }
 ```
 
-Auto-increment requires database support. SQLite, Turso, PostgreSQL, and MySQL
-all support auto-incrementing columns. DynamoDB does not.
+Auto-increment requires database support. SQLite, Turso, Cloudflare D1,
+PostgreSQL, and MySQL all support auto-incrementing columns. DynamoDB does not.
 
 ## Composite keys
 

--- a/docs/guide/src/many-to-many.md
+++ b/docs/guide/src/many-to-many.md
@@ -271,8 +271,9 @@ incoming rows reach followers.
 
 Queries that traverse `has_many(via = ...)`, including relation accessors,
 `.any()`, `.include()`, and `.select()`, require a SQL backend. They are supported
-on SQLite, PostgreSQL, and MySQL and are not available on DynamoDB. Creating,
-updating, querying, and deleting the join model use its ordinary model APIs.
+on SQLite, Turso, Cloudflare D1, PostgreSQL, and MySQL and are not available on
+DynamoDB. Creating, updating, querying, and deleting the join model use its
+ordinary model APIs.
 
 See [HasMany](./has-many.md#multi-step-relations-via) for the general `via`
 rules, [Filtering with Expressions](./filtering-with-expressions.md#filtering-on-associations)

--- a/docs/guide/src/postgresql.md
+++ b/docs/guide/src/postgresql.md
@@ -153,9 +153,10 @@ which the migration generator handles.
 
 **Row-level locking.** Generated [transactions](./transactions.md) can
 use `SELECT ... FOR UPDATE` to lock rows for the duration of a
-transaction. SQLite, Turso, Cloudflare D1, and DynamoDB do not have row-level
-locking; Toasty's transaction layer falls back to serializable transaction
-isolation on those backends.
+transaction. SQLite and Turso do not have row-level locking; Toasty's
+transaction layer uses serializable transaction isolation on those backends.
+Cloudflare D1 and DynamoDB do not expose interactive transactions through
+Toasty.
 
 **Backward pagination.**
 [`.paginate(per_page).prev(&db)`](./sorting-limits-and-pagination.md#navigating-pages)

--- a/docs/guide/src/postgresql.md
+++ b/docs/guide/src/postgresql.md
@@ -153,8 +153,8 @@ which the migration generator handles.
 
 **Row-level locking.** Generated [transactions](./transactions.md) can
 use `SELECT ... FOR UPDATE` to lock rows for the duration of a
-transaction. SQLite and DynamoDB do not have row-level locking;
-Toasty's transaction layer falls back to serializable transaction
+transaction. SQLite, Turso, Cloudflare D1, and DynamoDB do not have row-level
+locking; Toasty's transaction layer falls back to serializable transaction
 isolation on those backends.
 
 **Backward pagination.**

--- a/docs/guide/src/preloading-associations.md
+++ b/docs/guide/src/preloading-associations.md
@@ -314,8 +314,8 @@ collapsed, so an article a user commented on twice appears once. A
 list.
 
 Preloading a `via` relation with `.include()` (and projecting one with
-`.select()`) is supported on SQL backends (SQLite, PostgreSQL, MySQL). It is
-not yet available on DynamoDB.
+`.select()`) is supported on SQL backends (SQLite, Turso, Cloudflare D1,
+PostgreSQL, MySQL). It is not yet available on DynamoDB.
 
 ## Multiple includes
 

--- a/docs/guide/src/raw-sql.md
+++ b/docs/guide/src/raw-sql.md
@@ -3,8 +3,8 @@
 Raw SQL runs backend SQL through Toasty's database handles. Use it when you need
 a database feature that Toasty's query builders do not expose.
 
-Raw SQL is available on SQL backends: SQLite, Turso, PostgreSQL, and MySQL.
-DynamoDB returns an `unsupported_feature` error.
+Raw SQL is available on SQL backends: SQLite, Turso, Cloudflare D1,
+PostgreSQL, and MySQL. DynamoDB returns an `unsupported_feature` error.
 
 ## Statements
 
@@ -57,6 +57,7 @@ reported by `db.capability().sql_placeholder` for the active backend:
 |---|---|---|
 | SQLite | `NumberedQuestionMark` | `?1`, `?2`, ... |
 | Turso | `NumberedQuestionMark` | `?1`, `?2`, ... |
+| Cloudflare D1 | `NumberedQuestionMark` | `?1`, `?2`, ... |
 | PostgreSQL | `DollarNumber` | `$1`, `$2`, ... |
 | MySQL | `QuestionMark` | `?`, `?`, ... |
 

--- a/docs/guide/src/schema-management.md
+++ b/docs/guide/src/schema-management.md
@@ -3,6 +3,10 @@
 Toasty provides two ways to manage your database schema: `push_schema` for
 quick development, and a migration system for production databases.
 
+Cloudflare D1 uses Wrangler's migration files and migration ledger instead of
+Toasty's runtime migration commands. See
+[Cloudflare D1 migrations](./d1.md#migrations) before setting up a D1 project.
+
 ## Quick setup with `push_schema`
 
 `db.push_schema()` creates all tables and indexes based on your registered

--- a/docs/guide/src/tracing.md
+++ b/docs/guide/src/tracing.md
@@ -52,14 +52,18 @@ The event's fields:
 
 | Field | Meaning |
 |---|---|
-| `db.system` | Backend that ran the operation: `sqlite`, `turso`, `postgresql`, `mysql`, or `dynamodb`. |
-| `db.statement` | The serialized SQL, with `?N` (SQLite, Turso, MySQL) or `$N` (PostgreSQL) placeholders. SQL drivers only. |
+| `db.system` | Backend that ran the operation: `sqlite`, `turso`, `d1`, `postgresql`, `mysql`, or `dynamodb`. |
+| `db.statement` | The serialized SQL, with `?N` (SQLite, Turso, D1), `?` (MySQL), or `$N` (PostgreSQL) placeholders. SQL drivers only. |
 | `db.operation` | The operation name (`get_by_key`, `query_pk`, `scan`, …). Key-value drivers only. |
 | `db.collection` | The table the operation targets. Key-value drivers only. |
 | `db.params` | Bound parameter values. Only present when enabled — see [Parameter values](#parameter-values). |
 | `duration_ms` | Elapsed execution time in milliseconds. |
 | `rows` | Rows returned or affected, when the driver knows the count. |
 | `error` | The error, when the operation failed. |
+
+D1 reports `duration_ms` as `0`. Rust's standard monotonic clock is not
+available in this Worker environment, so query logging omits timing rather
+than risking a runtime panic.
 
 The field names follow [OpenTelemetry's database semantic conventions], so
 subscribers that understand those conventions (for example, an OTLP

--- a/docs/guide/src/transactions.md
+++ b/docs/guide/src/transactions.md
@@ -4,6 +4,11 @@ A transaction groups multiple database operations so they either all succeed or
 all fail. Toasty supports interactive transactions on SQL databases
 (SQLite/Turso, PostgreSQL, MySQL).
 
+Cloudflare D1 does not expose interactive transactions to Workers. Calling
+`db.transaction()` with the D1 driver returns `Error::UnsupportedFeature`.
+Use an eligible [batch operation](./batch-operations.md) when all statements
+can be prepared before any result is available.
+
 > **Tip:** If you just need multiple operations to execute atomically, consider
 > using [batch operations](./batch-operations.md) first. Batch operations are
 > atomic and more efficient — they can be sent as a single statement, avoiding

--- a/docs/guide/src/vec-scalar-fields.md
+++ b/docs/guide/src/vec-scalar-fields.md
@@ -16,10 +16,10 @@ Storage depends on the driver:
 |---|---|
 | PostgreSQL | Native array column (`text[]`, `int8[]`, `double precision[]`, …) |
 | MySQL | `JSON` column |
-| SQLite, Turso | JSON-encoded text |
+| SQLite, Turso, Cloudflare D1 | JSON-encoded text |
 | DynamoDB | List `L` attribute |
 
-All five built-in drivers support `Vec<scalar>` fields. A driver that
+All six built-in drivers support `Vec<scalar>` fields. A driver that
 does not will reject the model at schema build with an error naming the
 unsupported field rather than mis-storing it. The incremental update
 builders have narrower support — see [Driver support](#driver-support).
@@ -371,7 +371,7 @@ replacement and the appending builders — `set`, `push`, `extend`,
 
 The element-removal builders are narrower:
 
-| Operation | PostgreSQL | MySQL | SQLite | DynamoDB |
+| Operation | PostgreSQL | MySQL | SQLite/Turso/D1 | DynamoDB |
 |---|---|---|---|---|
 | Define field, create, read | ✓ | ✓ | ✓ | ✓ |
 | `contains`, `len`, `is_empty` | ✓ | ✓ | ✓ | ✓ |

--- a/examples/cms-article-fields/Cargo.toml
+++ b/examples/cms-article-fields/Cargo.toml
@@ -15,7 +15,7 @@ sqlite = [ "toasty/sqlite" ]
 
 [dependencies]
 toasty = { workspace = true, features = [ "jiff", "serde" ] }
-tokio.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 uuid.workspace = true
 serde.workspace = true
 jiff.workspace = true

--- a/examples/crm-embedded/Cargo.toml
+++ b/examples/crm-embedded/Cargo.toml
@@ -15,7 +15,7 @@ sqlite = [ "toasty/sqlite" ]
 
 [dependencies]
 toasty.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 uuid.workspace = true
 
 [lints]

--- a/examples/forum-relationships/Cargo.toml
+++ b/examples/forum-relationships/Cargo.toml
@@ -15,7 +15,7 @@ sqlite = [ "toasty/sqlite" ]
 
 [dependencies]
 toasty.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 uuid.workspace = true
 
 [lints]

--- a/examples/product-search/Cargo.toml
+++ b/examples/product-search/Cargo.toml
@@ -15,7 +15,7 @@ sqlite = [ "toasty/sqlite" ]
 
 [dependencies]
 toasty.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 uuid.workspace = true
 
 [lints]

--- a/examples/quickstart-blog/Cargo.toml
+++ b/examples/quickstart-blog/Cargo.toml
@@ -15,7 +15,7 @@ sqlite = [ "toasty/sqlite" ]
 
 [dependencies]
 toasty.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 uuid.workspace = true
 
 [lints]

--- a/examples/service-ops/Cargo.toml
+++ b/examples/service-ops/Cargo.toml
@@ -17,7 +17,7 @@ sqlite = [ "toasty/sqlite" ]
 [dependencies]
 toasty.workspace = true
 toasty-cli.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 uuid.workspace = true
 anyhow = "1"
 tracing-subscriber.workspace = true

--- a/examples/store-operations/Cargo.toml
+++ b/examples/store-operations/Cargo.toml
@@ -16,7 +16,7 @@ sqlite = [ "toasty/sqlite" ]
 [dependencies]
 toasty.workspace = true
 toasty-core.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 uuid.workspace = true
 
 [lints]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -35,6 +35,10 @@ name = "toasty-sql"
 version_group = "toasty"
 
 [[package]]
+name = "toasty-driver-d1"
+version_group = "toasty"
+
+[[package]]
 name = "toasty-driver-dynamodb"
 version_group = "toasty"
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -30,7 +30,7 @@ toasty = { workspace = true, features = ["rust_decimal", "bigdecimal", "jiff", "
 toasty-cli.workspace = true
 toasty-core.workspace = true
 toasty-macros.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
 
 # Integration test suite
 toasty-driver-integration-suite.workspace = true

--- a/tests/d1-worker/.gitignore
+++ b/tests/d1-worker/.gitignore
@@ -1,0 +1,2 @@
+/build/
+/.wrangler/

--- a/tests/d1-worker/Cargo.toml
+++ b/tests/d1-worker/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "toasty-d1-worker-tests"
+version = "0.0.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+async-trait.workspace = true
+getrandom = { workspace = true, features = ["wasm_js"] }
+serde = { workspace = true, features = ["derive"] }
+toasty.workspace = true
+toasty-core.workspace = true
+toasty-driver-d1.workspace = true
+toasty-driver-integration-suite.workspace = true
+worker = { workspace = true, features = ["d1"] }
+
+[lints]
+workspace = true

--- a/tests/d1-worker/build.sh
+++ b/tests/d1-worker/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+worker-build --release --panic-unwind

--- a/tests/d1-worker/build.sh
+++ b/tests/d1-worker/build.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-worker-build --release --panic-unwind

--- a/tests/d1-worker/run.mjs
+++ b/tests/d1-worker/run.mjs
@@ -1,0 +1,71 @@
+import { spawn } from "node:child_process";
+
+const address = "http://127.0.0.1:8791";
+const wrangler = spawn(
+  "npx",
+  ["--yes", "wrangler@4.114.0", "dev", "--local", "--port", "8791"],
+  { cwd: import.meta.dirname, stdio: ["ignore", "pipe", "pipe"] },
+);
+
+let output = "";
+for (const stream of [wrangler.stdout, wrangler.stderr]) {
+  stream.on("data", (chunk) => {
+    output += chunk.toString();
+    process.stderr.write(chunk);
+  });
+}
+
+async function waitUntilReady() {
+  for (let attempt = 0; attempt < 600; attempt += 1) {
+    if (wrangler.exitCode !== null) {
+      throw new Error(`Wrangler exited before becoming ready\n${output}`);
+    }
+    try {
+      const response = await fetch(`${address}/tests`);
+      if (response.ok) return response.json();
+    } catch {
+      // The Worker is still building.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(`Timed out waiting for Wrangler\n${output}`);
+}
+
+async function stopWrangler() {
+  if (wrangler.exitCode !== null) return;
+  wrangler.kill("SIGTERM");
+  await new Promise((resolve) => wrangler.once("exit", resolve));
+}
+
+async function main() {
+  const manifest = await waitUntilReady();
+  const tests = manifest.tests;
+  console.log(`compatibility date: ${manifest.compatibility_date}`);
+  let failed = 0;
+  for (const name of tests) {
+    const response = await fetch(
+      `${address}/run?name=${encodeURIComponent(name)}`,
+    );
+    if (!response.ok) {
+      failed += 1;
+      console.error(`FAILED ${name}: HTTP ${response.status}`);
+      continue;
+    }
+    const result = await response.json();
+    if (result.status === "passed") {
+      console.log(`ok ${name}`);
+    } else {
+      failed += 1;
+      console.error(`FAILED ${name}: ${result.error}`);
+      console.error(result.operations);
+    }
+  }
+  console.log(`${tests.length - failed} passed; ${failed} failed`);
+  if (failed !== 0) process.exitCode = 1;
+}
+
+try {
+  await main();
+} finally {
+  await stopWrangler();
+}

--- a/tests/d1-worker/run.mjs
+++ b/tests/d1-worker/run.mjs
@@ -1,10 +1,21 @@
 import { spawn } from "node:child_process";
+import { join } from "node:path";
 
 const address = "http://127.0.0.1:8791";
+const wranglerState = join(import.meta.dirname, ".wrangler");
 const wrangler = spawn(
   "npx",
   ["--yes", "wrangler@4.114.0", "dev", "--local", "--port", "8791"],
-  { cwd: import.meta.dirname, stdio: ["ignore", "pipe", "pipe"] },
+  {
+    cwd: import.meta.dirname,
+    env: {
+      ...process.env,
+      npm_config_cache: join(wranglerState, "npm-cache"),
+      XDG_CACHE_HOME: join(wranglerState, "cache"),
+      XDG_CONFIG_HOME: join(wranglerState, "config"),
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  },
 );
 
 let output = "";

--- a/tests/d1-worker/src/lib.rs
+++ b/tests/d1-worker/src/lib.rs
@@ -4,24 +4,45 @@ use std::sync::Arc;
 
 use serde::Serialize;
 use toasty_core::driver::Driver;
-use toasty_driver_integration_suite::{Setup, Test};
+use toasty_driver_integration_suite::{Setup, Test, tests};
 use worker::{Context, Env, Request, Response, send::IntoSendFuture};
 
-const TESTS: &[&str] = &[
-    "crud_basic::crud_one_string::id_uuid",
-    "type_primitives::ty_i64",
-    "type_primitives::ty_u64",
-    "type_primitives::ty_uuid",
-    "raw_sql::statement_and_query_on_db",
-    "select_projection::select_tuple",
-    "filter_like::like_basic",
-    "starts_with::starts_with_case_sensitive",
-    "crud_upsert::upsert_by_primary_key_creates_then_updates::id_uuid",
-    "type_document::vec_struct_create_get::id_uuid",
-    "batch_query::batch_same_model::id_uuid",
-    "batch_rollback::batch_two_creates_rolls_back_on_second_failure::id_uuid",
-];
 const COMPATIBILITY_DATE: &str = "2026-07-25";
+
+macro_rules! d1_tests {
+    ($($name:literal => $test:path),+ $(,)?) => {
+        const TESTS: &[&str] = &[$($name),+];
+
+        async fn run_test(name: &str, test: &mut Test) -> Result<(), String> {
+            match name {
+                $(
+                    $name => test
+                        .run_async(async move |test| $test(test).await)
+                        .await,
+                )+
+                _ => Err(format!("unknown test: {name}")),
+            }
+        }
+    };
+}
+
+d1_tests! {
+    "crud_basic::crud_one_string::id_uuid" => tests::crud_basic::crud_one_string::id_uuid,
+    "type_primitives::ty_i64" => tests::type_primitives::ty_i64,
+    "type_primitives::ty_u64" => tests::type_primitives::ty_u64,
+    "type_primitives::ty_uuid" => tests::type_primitives::ty_uuid,
+    "raw_sql::statement_and_query_on_db" => tests::raw_sql::statement_and_query_on_db,
+    "select_projection::select_tuple" => tests::select_projection::select_tuple,
+    "filter_like::like_basic" => tests::filter_like::like_basic,
+    "starts_with::starts_with_case_sensitive" => tests::starts_with::starts_with_case_sensitive,
+    "crud_upsert::upsert_by_primary_key_creates_then_updates::id_uuid" =>
+        tests::crud_upsert::upsert_by_primary_key_creates_then_updates::id_uuid,
+    "type_document::vec_struct_create_get::id_uuid" =>
+        tests::type_document::vec_struct_create_get::id_uuid,
+    "batch_query::batch_same_model::id_uuid" => tests::batch_query::batch_same_model::id_uuid,
+    "batch_rollback::batch_two_creates_rolls_back_on_second_failure::id_uuid" =>
+        tests::batch_rollback::batch_two_creates_rolls_back_on_second_failure::id_uuid,
+}
 
 #[derive(Clone)]
 struct D1Setup {
@@ -125,74 +146,9 @@ struct TestOutcome {
 }
 
 async fn run(name: &str, env: Env) -> TestOutcome {
-    use toasty_driver_integration_suite::tests;
-
     let setup = Arc::new(D1Setup { env });
     let mut test = Test::new_async(setup);
-    let result = match name {
-        "crud_basic::crud_one_string::id_uuid" => {
-            test.run_async(async move |test| {
-                tests::crud_basic::crud_one_string::id_uuid(test).await
-            })
-            .await
-        }
-        "type_primitives::ty_i64" => {
-            test.run_async(async move |test| tests::type_primitives::ty_i64(test).await)
-                .await
-        }
-        "type_primitives::ty_u64" => {
-            test.run_async(async move |test| tests::type_primitives::ty_u64(test).await)
-                .await
-        }
-        "type_primitives::ty_uuid" => {
-            test.run_async(async move |test| tests::type_primitives::ty_uuid(test).await)
-                .await
-        }
-        "raw_sql::statement_and_query_on_db" => {
-            test.run_async(async move |test| tests::raw_sql::statement_and_query_on_db(test).await)
-                .await
-        }
-        "select_projection::select_tuple" => {
-            test.run_async(async move |test| tests::select_projection::select_tuple(test).await)
-                .await
-        }
-        "filter_like::like_basic" => {
-            test.run_async(async move |test| tests::filter_like::like_basic(test).await)
-                .await
-        }
-        "starts_with::starts_with_case_sensitive" => {
-            test.run_async(async move |test| {
-                tests::starts_with::starts_with_case_sensitive(test).await
-            })
-            .await
-        }
-        "crud_upsert::upsert_by_primary_key_creates_then_updates::id_uuid" => {
-            test.run_async(async move |test| {
-                tests::crud_upsert::upsert_by_primary_key_creates_then_updates::id_uuid(test).await
-            })
-            .await
-        }
-        "type_document::vec_struct_create_get::id_uuid" => {
-            test.run_async(async move |test| {
-                tests::type_document::vec_struct_create_get::id_uuid(test).await
-            })
-            .await
-        }
-        "batch_query::batch_same_model::id_uuid" => {
-            test.run_async(async move |test| {
-                tests::batch_query::batch_same_model::id_uuid(test).await
-            })
-            .await
-        }
-        "batch_rollback::batch_two_creates_rolls_back_on_second_failure::id_uuid" => {
-            test.run_async(async move |test| {
-                tests::batch_rollback::batch_two_creates_rolls_back_on_second_failure::id_uuid(test)
-                    .await
-            })
-            .await
-        }
-        _ => Err(format!("unknown test: {name}")),
-    };
+    let result = run_test(name, &mut test).await;
     TestOutcome {
         result,
         operations: format!("{:?}", test.log()),

--- a/tests/d1-worker/src/lib.rs
+++ b/tests/d1-worker/src/lib.rs
@@ -1,0 +1,200 @@
+#![cfg(target_arch = "wasm32")]
+
+use std::sync::Arc;
+
+use serde::Serialize;
+use toasty_core::driver::Driver;
+use toasty_driver_integration_suite::{Setup, Test};
+use worker::{Context, Env, Request, Response, send::IntoSendFuture};
+
+const TESTS: &[&str] = &[
+    "crud_basic::crud_one_string::id_uuid",
+    "type_primitives::ty_i64",
+    "type_primitives::ty_u64",
+    "type_primitives::ty_uuid",
+    "raw_sql::statement_and_query_on_db",
+    "select_projection::select_tuple",
+    "filter_like::like_basic",
+    "starts_with::starts_with_case_sensitive",
+    "crud_upsert::upsert_by_primary_key_creates_then_updates::id_uuid",
+    "type_document::vec_struct_create_get::id_uuid",
+    "batch_query::batch_same_model::id_uuid",
+    "batch_rollback::batch_two_creates_rolls_back_on_second_failure::id_uuid",
+];
+const COMPATIBILITY_DATE: &str = "2026-07-25";
+
+#[derive(Clone)]
+struct D1Setup {
+    env: Env,
+}
+
+#[async_trait::async_trait]
+impl Setup for D1Setup {
+    fn driver(&self) -> Box<dyn Driver> {
+        let database = self.env.d1("DB").expect("DB binding is configured");
+        Box::new(toasty_driver_d1::D1::new("DB", database))
+    }
+
+    async fn delete_table(&self, name: &str) {
+        self.try_delete_table(name)
+            .await
+            .expect("D1 test table cleanup failed");
+    }
+
+    async fn try_delete_table(&self, name: &str) -> toasty::Result<()> {
+        let database = self
+            .env
+            .d1("DB")
+            .map_err(|error| driver_error("read DB binding", error))?;
+        let quoted = name.replace('"', "\"\"");
+        let result = database
+            .prepare(format!("DROP TABLE IF EXISTS \"{quoted}\""))
+            .run()
+            .into_send()
+            .await
+            .map_err(|error| driver_error("drop test table", error))?;
+        if result.success() {
+            Ok(())
+        } else {
+            Err(driver_error(
+                "drop test table",
+                result.error().unwrap_or_else(|| "unknown D1 error".into()),
+            ))
+        }
+    }
+}
+
+fn driver_error(context: &str, error: impl std::fmt::Display) -> toasty::Error {
+    toasty::Error::driver_operation_failed(std::io::Error::other(error.to_string())).context(
+        toasty::Error::from_args(format_args!("D1 test runner failed to {context}")),
+    )
+}
+
+#[derive(Serialize)]
+struct TestManifest {
+    compatibility_date: &'static str,
+    tests: &'static [&'static str],
+}
+
+#[derive(Serialize)]
+struct RunResult<'a> {
+    name: &'a str,
+    status: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+    operations: String,
+}
+
+#[worker::event(fetch)]
+async fn fetch(request: Request, env: Env, _context: Context) -> worker::Result<Response> {
+    let url = request.url()?;
+    match url.path() {
+        "/tests" => Response::from_json(&TestManifest {
+            compatibility_date: COMPATIBILITY_DATE,
+            tests: TESTS,
+        }),
+        "/run" => {
+            let name = url
+                .query_pairs()
+                .find_map(|(key, value)| (key == "name").then(|| value.into_owned()))
+                .ok_or_else(|| worker::Error::RustError("missing test name".into()))?;
+            let outcome = run(&name, env).await;
+            let response = match outcome.result {
+                Ok(()) => RunResult {
+                    name: &name,
+                    status: "passed",
+                    error: None,
+                    operations: outcome.operations,
+                },
+                Err(error) => RunResult {
+                    name: &name,
+                    status: "failed",
+                    error: Some(error),
+                    operations: outcome.operations,
+                },
+            };
+            Response::from_json(&response)
+        }
+        _ => Response::error("not found", 404),
+    }
+}
+
+struct TestOutcome {
+    result: Result<(), String>,
+    operations: String,
+}
+
+async fn run(name: &str, env: Env) -> TestOutcome {
+    use toasty_driver_integration_suite::tests;
+
+    let setup = Arc::new(D1Setup { env });
+    let mut test = Test::new_async(setup);
+    let result = match name {
+        "crud_basic::crud_one_string::id_uuid" => {
+            test.run_async(async move |test| {
+                tests::crud_basic::crud_one_string::id_uuid(test).await
+            })
+            .await
+        }
+        "type_primitives::ty_i64" => {
+            test.run_async(async move |test| tests::type_primitives::ty_i64(test).await)
+                .await
+        }
+        "type_primitives::ty_u64" => {
+            test.run_async(async move |test| tests::type_primitives::ty_u64(test).await)
+                .await
+        }
+        "type_primitives::ty_uuid" => {
+            test.run_async(async move |test| tests::type_primitives::ty_uuid(test).await)
+                .await
+        }
+        "raw_sql::statement_and_query_on_db" => {
+            test.run_async(async move |test| tests::raw_sql::statement_and_query_on_db(test).await)
+                .await
+        }
+        "select_projection::select_tuple" => {
+            test.run_async(async move |test| tests::select_projection::select_tuple(test).await)
+                .await
+        }
+        "filter_like::like_basic" => {
+            test.run_async(async move |test| tests::filter_like::like_basic(test).await)
+                .await
+        }
+        "starts_with::starts_with_case_sensitive" => {
+            test.run_async(async move |test| {
+                tests::starts_with::starts_with_case_sensitive(test).await
+            })
+            .await
+        }
+        "crud_upsert::upsert_by_primary_key_creates_then_updates::id_uuid" => {
+            test.run_async(async move |test| {
+                tests::crud_upsert::upsert_by_primary_key_creates_then_updates::id_uuid(test).await
+            })
+            .await
+        }
+        "type_document::vec_struct_create_get::id_uuid" => {
+            test.run_async(async move |test| {
+                tests::type_document::vec_struct_create_get::id_uuid(test).await
+            })
+            .await
+        }
+        "batch_query::batch_same_model::id_uuid" => {
+            test.run_async(async move |test| {
+                tests::batch_query::batch_same_model::id_uuid(test).await
+            })
+            .await
+        }
+        "batch_rollback::batch_two_creates_rolls_back_on_second_failure::id_uuid" => {
+            test.run_async(async move |test| {
+                tests::batch_rollback::batch_two_creates_rolls_back_on_second_failure::id_uuid(test)
+                    .await
+            })
+            .await
+        }
+        _ => Err(format!("unknown test: {name}")),
+    };
+    TestOutcome {
+        result,
+        operations: format!("{:?}", test.log()),
+    }
+}

--- a/tests/d1-worker/wrangler.toml
+++ b/tests/d1-worker/wrangler.toml
@@ -5,7 +5,3 @@ compatibility_date = "2026-07-25"
 [[d1_databases]]
 binding = "DB"
 database_name = "toasty-d1-local-tests"
-
-[build]
-command = "bash ./build.sh"
-watch_dir = ["src"]

--- a/tests/d1-worker/wrangler.toml
+++ b/tests/d1-worker/wrangler.toml
@@ -1,0 +1,11 @@
+name = "toasty-d1-worker-tests"
+main = "build/worker/shim.mjs"
+compatibility_date = "2026-07-25"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "toasty-d1-local-tests"
+
+[build]
+command = "bash ./build.sh"
+watch_dir = ["src"]

--- a/tests/tests/sqlite.rs
+++ b/tests/tests/sqlite.rs
@@ -60,7 +60,7 @@ async fn in_memory_caps_user_max_pool_size() {
         .await
         .unwrap();
 
-    assert_eq!(db.pool().status().max_size, 1);
+    assert_eq!(db.pool().unwrap().status().max_size, 1);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Warning this PR is ai written. It was for test purposes (that worked out fine!) same for the PR text here im not very good with words and this seems to explain it well. comments will be answered by a human tho no worries!

Im also aware this PR is way too big but at the end of this wall of text, there is an explanation of different parts.

## Summary

> [!IMPORTANT]
> This is a proof of concept for architecture discussion. It is not expected to
> merge in its current form.

This PR prototypes Cloudflare D1 support for Toasty applications running inside
Cloudflare Workers.

D1 is Cloudflare's managed SQLite-compatible database. Workers access it
through a [binding](https://developers.cloudflare.com/workers/runtime-apis/bindings/):
a runtime-provided handle that combines access permission with the database
API. There is no connection URL or socket.

Applications depend directly on `toasty-driver-d1`, retrieve the binding from
the Worker environment, and pass the driver to `Db::builder().build()`:

```rust
let binding = env.d1("DB")?;
let driver = toasty_driver_d1::D1::new("DB", binding);

let db = toasty::Db::builder()
    .models(toasty::models!(crate::*))
    .build(driver)
    .await?;
```

There is intentionally no D1 feature on the main `toasty` crate. Re-exporting
the driver would not remove the application's dependency on the Workers SDK or
its responsibility to retrieve the binding.

## Direct connections

Toasty normally treats a driver as a connection factory and places its
connections in a pool. A D1 binding is already a runtime-managed database
handle, so creating a pool around it adds background tasks and reconnection
behavior without providing additional connections.

This PR adds two connection strategies:

- `Pooled`, which remains the default for existing drivers.
- `Direct`, which creates one connection when the `Db` is built and serializes
  access to it.

The D1 driver uses `Direct`. Cloned `Db` handles share the same connection, and
pool-specific settings such as `max_pool_size` and `pool_pre_ping` are rejected.

## Transactions and atomic batches

The [D1 Worker API](https://developers.cloudflare.com/d1/worker-api/d1-database/)
does not expose interactive `BEGIN`, `COMMIT`, or `ROLLBACK` operations. It
does provide `D1Database::batch()`, which executes a prepared list of statements
in order and rolls back the batch when a statement fails.

The driver capability model now distinguishes:

```rust
interactive_transactions: false,
atomic_batch: true,
```

The planner uses an atomic batch only when it can prepare every statement
before execution. Plans are rejected before dispatch when a later statement
depends on an earlier database result.

This means that independent Toasty batches work, including rollback on
failure, while `db.transaction()`, savepoints, and interactive
read-modify-write flows remain unsupported.

`Connection::exec_atomic_batch()` has an unsupported default. Running the
statements sequentially would not preserve the requested atomicity.

## D1 driver behavior

The new `toasty-driver-d1` crate:

- Reuses Toasty's SQLite SQL serializer.
- Executes generated queries and raw SQL through the binding.
- Converts JavaScript result values into typed Toasty values.
- Supports inserts, updates, deletes, projections, upserts, documents, and
  independent atomic batches.
- Uses canonical text for UUIDs instead of SQLite's usual UUID BLOB format.
- Rejects interactive transactions, database reset, and runtime migration
  application.

D1 values cross a JavaScript boundary, so integers are limited to JavaScript's
safe integer range:

```text
-9,007,199,254,740,991 through 9,007,199,254,740,991
```

Larger Rust integers are rejected instead of being silently rounded.
Non-finite floating-point values are rejected for the same reason.

The driver also validates Cloudflare's documented
[D1 limits](https://developers.cloudflare.com/d1/platform/limits/):

| Limit | Maximum |
|---|---:|
| Bound parameters | 100 |
| Columns per table | 100 |
| SQL statement length | 100,000 bytes |
| String or BLOB value | 2,000,000 bytes |
| `LIKE` or `GLOB` pattern | 50 bytes |

D1 remains responsible for limits that depend on the final row or execution.

## Schema changes

`db.push_schema()` creates tables and indexes through one D1 atomic batch. It is
intended for local development and tests.

Production migrations remain owned by Wrangler. Toasty generates
SQLite-compatible migration SQL but does not maintain a separate runtime
migration ledger for D1.

Table rebuilds use `PRAGMA defer_foreign_keys = ON`, matching Cloudflare's
[D1 migration guidance](https://developers.cloudflare.com/d1/reference/migrations/).

## Wasm support

Rust Workers compile to `wasm32-unknown-unknown`. The D1 binding driver is
therefore available only on Wasm targets, while migration generation remains
available on native targets.

Supporting that target required:

- Narrowing native-only Tokio features.
- Using Workers-compatible UUID generation.
- Avoiding native `Instant` behavior in query logging.
- Avoiding pool timing code that does not compile or run on Wasm.
- Building the D1 crate's docs for the Wasm target.

Cloudflare's
[Rust Worker toolchain](https://developers.cloudflare.com/workers/languages/rust/)
uses `worker-build` to compile the Rust code, generate the JavaScript/Wasm
interop layer, and produce a bundle that Wrangler can run.

## Tests and Wrangler

A normal Rust test process cannot construct a `D1Database` binding. That object
only exists inside a Worker runtime.

The test project therefore compiles a Rust Worker and starts it with
`wrangler dev --local`. Wrangler runs Cloudflare's local `workerd` runtime and
provides a local D1 binding configured through `wrangler.toml`.

The Worker exposes two test-only HTTP endpoints:

- `/tests` returns the selected integration tests.
- `/run?name=...` executes one test using the request's D1 binding.

A small Node script starts Wrangler, calls those endpoints, reports failures,
and terminates the process. The JavaScript is process orchestration; the driver
and test implementations remain Rust.

The current Worker suite covers basic CRUD, primitive and UUID conversion, raw
SQL, projections, `LIKE`, case-sensitive prefix matching, upsert, documents,
batch queries, and rollback when a later batch statement fails.

Native tests separately cover direct connection ownership, serialization across
cloned `Db` handles, pool-setting rejection, limits, value validation, planner
atomicity, and migration SQL.

## Existing HTTP driver

There is already an experimental external driver,
[hirunefu/toasty-driver-d1](https://github.com/hirunefu/toasty-driver-d1),
which accesses D1 through Cloudflare's HTTP API using `reqwest`.

That implementation runs outside Workers and does not require Wasm, Wrangler,
or a binding. It also provides useful prior art for the same restrictions:
interactive transactions are unavailable, large integers cannot safely cross
the JSON boundary, and every statement requires an HTTPS request.

The two approaches cover different use cases:

- This PR tests the native Worker binding and its JavaScript/Wasm boundary.
- The external driver tests real D1 through the HTTP API and can run under
  native Rust.
- An HTTP transport is useful for broader native integration testing, but it
  does not replace binding tests because it bypasses `workers-rs`,
  `wasm-bindgen`, `worker-build`, and the Worker environment.

## Scope

This proof of concept changes several public driver abstractions:

- Connection ownership can be pooled or direct.
- Interactive transactions and atomic batches are separate capabilities.
- Drivers can expose argument and administration limits.
- Connections can execute an explicitly atomic SQL batch.

The branch intentionally includes all of these pieces to show the complete D1
path. Any mergeable version should split the driver-interface design, engine
atomicity changes, Wasm compatibility work, and D1 implementation into smaller
reviews.

## Type of change

- [x] Other: proof of concept combining design and implementation for discussion
