### PR TITLE
fix(engine): lower newtype foreign keys in via includes

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_via.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_via.rs
@@ -7,6 +7,155 @@
 
 use crate::prelude::*;
 
+/// A nullable one-field newtype foreign key uses its leaf column rather than
+/// its presence-guarded embed expression when preloading a via relation.
+#[driver_test(requires(and(sql, auto_increment)))]
+pub async fn include_with_newtype_foreign_key(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Embed)]
+    struct UserId(u64);
+
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        #[auto]
+        id: UserId,
+
+        #[has_many]
+        comments: toasty::Deferred<Vec<Comment>>,
+
+        #[has_many(via = comments.article)]
+        commented_articles: toasty::Deferred<Vec<Article>>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Comment {
+        #[key]
+        #[auto]
+        id: u64,
+
+        #[index]
+        user_id: Option<UserId>,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: toasty::Deferred<Option<User>>,
+
+        #[index]
+        article_id: u64,
+
+        #[belongs_to(key = article_id, references = id)]
+        article: toasty::Deferred<Article>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Article {
+        #[key]
+        #[auto]
+        id: u64,
+
+        #[has_many]
+        comments: toasty::Deferred<Vec<Comment>>,
+    }
+
+    let mut db = test.setup_db(models!(User, Comment, Article)).await;
+    let user = toasty::create!(User {}).exec(&mut db).await?;
+    let article = toasty::create!(Article {}).exec(&mut db).await?;
+    toasty::create!(Comment {
+        user: &user,
+        article: &article,
+    })
+    .exec(&mut db)
+    .await?;
+
+    let users: Vec<User> = User::all()
+        .include(User::fields().commented_articles())
+        .exec(&mut db)
+        .await?;
+
+    assert_struct!(users, [_ {
+        commented_articles.get().len(): 1,
+        ..
+    }]);
+
+    Ok(())
+}
+
+/// A unit enum key and foreign key link through the enum's discriminant column
+/// when preloading a via relation.
+#[driver_test(requires(sql))]
+pub async fn include_with_unit_enum_foreign_key(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Embed)]
+    enum UserId {
+        #[column(variant = 1)]
+        Alice,
+        #[column(variant = 2)]
+        Bob,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct User {
+        #[key]
+        id: UserId,
+
+        #[has_many]
+        comments: toasty::Deferred<Vec<Comment>>,
+
+        #[has_many(via = comments.article)]
+        commented_articles: toasty::Deferred<Vec<Article>>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Comment {
+        #[key]
+        id: u64,
+
+        #[index]
+        user_id: UserId,
+
+        #[belongs_to(key = user_id, references = id)]
+        user: toasty::Deferred<User>,
+
+        #[index]
+        article_id: u64,
+
+        #[belongs_to(key = article_id, references = id)]
+        article: toasty::Deferred<Article>,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Article {
+        #[key]
+        id: u64,
+
+        #[has_many]
+        comments: toasty::Deferred<Vec<Comment>>,
+    }
+
+    let mut db = test.setup_db(models!(User, Comment, Article)).await;
+    let user = toasty::create!(User { id: UserId::Alice })
+        .exec(&mut db)
+        .await?;
+    let article = toasty::create!(Article { id: 1 }).exec(&mut db).await?;
+    toasty::create!(Comment {
+        id: 1,
+        user: &user,
+        article: &article,
+    })
+    .exec(&mut db)
+    .await?;
+
+    let users: Vec<User> = User::all()
+        .include(User::fields().commented_articles())
+        .exec(&mut db)
+        .await?;
+
+    assert_struct!(users, [_ {
+        commented_articles.get().len(): 1,
+        ..
+    }]);
+
+    Ok(())
+}
+
 /// Querying a `via` relation returns the distinct targets reachable through
 /// the path — a target is listed once however many intermediates reach it.
 #[driver_test(

--- a/crates/toasty/src/engine/lower/via_join.rs
+++ b/crates/toasty/src/engine/lower/via_join.rs
@@ -253,11 +253,44 @@ impl Edge {
     }
 }
 
-/// The single-column mapping for a foreign-key field. Via include paths only
-/// resolve FK source/target fields, which the schema guarantees are primitive.
-fn fk_primitive(schema: &toasty_core::Schema, field_id: app::FieldId) -> &mapping::FieldPrimitive {
-    schema.mapping_for(field_id.model).fields[field_id.index]
-        .as_primitive()
+/// The single-column mapping for a foreign-key field.
+///
+/// Besides primitives, foreign keys may use embedded newtypes and unit enums.
+/// Newtypes map through one-field structs to a primitive leaf; unit enums map
+/// through their discriminant.
+struct SingleColumnFk<'a> {
+    primitive: &'a mapping::FieldPrimitive,
+    newtype_depth: usize,
+}
+
+fn single_column_fk(schema: &toasty_core::Schema, field_id: app::FieldId) -> SingleColumnFk<'_> {
+    fn resolve(field: &mapping::Field) -> Option<SingleColumnFk<'_>> {
+        match field {
+            mapping::Field::Primitive(primitive) => Some(SingleColumnFk {
+                primitive,
+                newtype_depth: 0,
+            }),
+            mapping::Field::Struct(field) if field.fields.len() == 1 => {
+                let mut fk = resolve(&field.fields[0])?;
+                fk.newtype_depth += 1;
+                Some(fk)
+            }
+            mapping::Field::Enum(field)
+                if field
+                    .variants
+                    .iter()
+                    .all(|variant| variant.fields.is_empty()) =>
+            {
+                Some(SingleColumnFk {
+                    primitive: &field.discriminant,
+                    newtype_depth: 0,
+                })
+            }
+            _ => None,
+        }
+    }
+
+    resolve(&schema.mapping_for(field_id.model).fields[field_id.index])
         .expect("FK field maps to a single column")
 }
 
@@ -267,22 +300,25 @@ fn fk_primitive(schema: &toasty_core::Schema, field_id: app::FieldId) -> &mappin
 fn raw_column(schema: &toasty_core::Schema, slot: usize, field_id: app::FieldId) -> stmt::Expr {
     stmt::Expr::column(stmt::ExprReference::column(
         slot,
-        fk_primitive(schema, field_id).column.index,
+        single_column_fk(schema, field_id).primitive.column.index,
     ))
 }
 
-/// The model-level expression for a FK field — its column reference wrapped in
-/// the storage→model cast when the storage type differs (e.g. `Uuid` stored as
-/// `Bytes`) — re-pointed at table `slot`.
+/// The single-column expression for a FK field, re-pointed at table `slot`.
 ///
-/// `FieldPrimitive::column_expr` is the schema's pre-built table→model
-/// expression at slot 0; we rewrite each column ref's slot.
+/// Primitive leaves and unit-enum discriminants use `column_expr` to preserve
+/// storage casts. This path does not use an embed's `default_returning`, which
+/// may contain nullable presence guards or deferred-field placeholders.
 fn model_level_column_expr(
     schema: &toasty_core::Schema,
     field_id: app::FieldId,
     slot: usize,
 ) -> stmt::Expr {
-    let mut expr = fk_primitive(schema, field_id).column_expr.clone();
+    let fk = single_column_fk(schema, field_id);
+    let mut expr = fk.primitive.column_expr.clone();
+    for _ in 0..fk.newtype_depth {
+        expr = stmt::Expr::record([expr]);
+    }
 
     stmt::visit_mut::for_each_expr_mut(&mut expr, |e| {
         if let stmt::Expr::Reference(stmt::ExprReference::Column(col)) = e {


### PR DESCRIPTION
## Summary

This pr adds support for new types and scalar enums as primary keys in combination with `via`.

Closes #1040

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test
- [ ] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`):
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers
N/A