### PR TITLE
refactor(core): centralize connection URL parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,8 @@ inventory = "0.3.24"
 # Must match the version used by `postgres-protocol` (the postgres driver
 # iterates over its `FallibleIterator` types); do not bump independently.
 fallible-iterator = "0.2"
+fluent-uri = "0.4.1"
+form_urlencoded = "1.2.2"
 jiff = "0.2.23"
 lru = "0.18.0"
 mysql_async = { version = "0.37.0", default-features = false, features = [

--- a/crates/toasty-cli/Cargo.toml
+++ b/crates/toasty-cli/Cargo.toml
@@ -15,6 +15,7 @@ documentation = "https://docs.rs/toasty-cli"
 
 [dependencies]
 toasty = { workspace = true, features = ["migration"] }
+toasty-core.workspace = true
 
 anyhow = "1.0.102"
 clap.workspace = true
@@ -25,7 +26,6 @@ jiff.workspace = true
 rand.workspace = true
 serde.workspace = true
 toml.workspace = true
-url.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/toasty-cli/src/utility.rs
+++ b/crates/toasty-cli/src/utility.rs
@@ -1,15 +1,9 @@
 /// Redact the password portion of a database URL for safe display.
 ///
 /// If the URL can be parsed and contains a password, replaces it with `***`.
-/// If parsing fails (e.g. `sqlite::memory:`), returns the original string unchanged.
+/// If parsing fails, returns the original string unchanged.
 pub(crate) fn redact_url_password(url: &str) -> String {
-    match url::Url::parse(url) {
-        Ok(mut parsed) => {
-            if parsed.password().is_some() {
-                let _ = parsed.set_password(Some("***"));
-            }
-            parsed.to_string()
-        }
-        Err(_) => url.to_string(),
-    }
+    toasty_core::driver::ConnectionUrl::parse(url)
+        .map(|url| url.redact_password().into_owned())
+        .unwrap_or_else(|_| url.to_string())
 }

--- a/crates/toasty-core/Cargo.toml
+++ b/crates/toasty-core/Cargo.toml
@@ -17,9 +17,12 @@ documentation = "https://docs.rs/toasty-core"
 assert-struct = { workspace = true, optional = true }
 async-trait.workspace = true
 bit-set.workspace = true
+fluent-uri.workspace = true
+form_urlencoded.workspace = true
 hashbrown.workspace = true
 indexmap.workspace = true
 jiff = { workspace = true, optional = true }
+percent-encoding.workspace = true
 rust_decimal = { workspace = true, optional = true }
 bigdecimal = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }

--- a/crates/toasty-core/src/driver.rs
+++ b/crates/toasty-core/src/driver.rs
@@ -58,6 +58,9 @@
 mod capability;
 pub use capability::{Capability, SchemaMutations, SqlPlaceholder, StorageTypes};
 
+mod connection_url;
+pub use connection_url::ConnectionUrl;
+
 pub mod log;
 pub use log::QueryLogConfig;
 

--- a/crates/toasty-core/src/driver/connection_url.rs
+++ b/crates/toasty-core/src/driver/connection_url.rs
@@ -1,0 +1,250 @@
+use crate::{Error, Result};
+use fluent_uri::IriRef;
+use percent_encoding::percent_decode_str;
+use std::{borrow::Cow, ops::Range, path::PathBuf};
+
+/// A parsed database connection URL.
+///
+/// Connection URLs use the common `<scheme>:<target>?<query>` form, but the
+/// target is interpreted by the selected database driver. Network drivers use
+/// the conventional `//user:password@host:port/path` target. File-backed
+/// drivers use [`file_path`](Self::file_path), which treats `//` as an optional
+/// marker and keeps the following text as the path.
+///
+/// This distinction allows connection strings such as `sqlite://todos.db` and
+/// `sqlite://:memory:` without interpreting `todos.db` or `:memory:` as a host.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ConnectionUrl<'a> {
+    value: &'a str,
+    scheme_end: usize,
+}
+
+impl<'a> ConnectionUrl<'a> {
+    /// Parses a database connection URL.
+    ///
+    /// This validates the scheme. Drivers validate the target and query
+    /// parameters they support.
+    pub fn parse(value: &'a str) -> Result<Self> {
+        let scheme_end = value.find(':').ok_or_else(|| {
+            Error::invalid_connection_url(format!("connection URL has no scheme; url={value}"))
+        })?;
+        let scheme = &value[..scheme_end];
+
+        if !is_valid_scheme(scheme) {
+            return Err(Error::invalid_connection_url(format!(
+                "connection URL has an invalid scheme; url={value}"
+            )));
+        }
+
+        Ok(Self { value, scheme_end })
+    }
+
+    /// Returns the connection URL exactly as supplied.
+    pub fn as_str(&self) -> &'a str {
+        self.value
+    }
+
+    /// Returns the URL scheme without the trailing colon.
+    pub fn scheme(&self) -> &'a str {
+        &self.value[..self.scheme_end]
+    }
+
+    /// Returns `true` when the URL uses `expected`.
+    ///
+    /// URL schemes are ASCII case-insensitive.
+    pub fn has_scheme(&self, expected: &str) -> bool {
+        self.scheme().eq_ignore_ascii_case(expected)
+    }
+
+    /// Returns the path component of an authority-based connection URL.
+    ///
+    /// For `postgresql://localhost/mydb`, this returns `/mydb`. Use
+    /// [`file_path`](Self::file_path) for SQLite and other file-backed drivers.
+    pub fn path(&self) -> &'a str {
+        let rest = self.rest();
+        let path = if let Some(authority) = self.authority_range() {
+            &rest[authority.end..]
+        } else {
+            rest
+        };
+
+        split_before(path, &['?', '#'])
+    }
+
+    /// Returns the percent-decoded path component.
+    pub fn decoded_path(&self) -> Result<Cow<'a, str>> {
+        percent_decode_str(self.path())
+            .decode_utf8()
+            .map_err(|_| Error::invalid_connection_url("URL path is not valid UTF-8"))
+    }
+
+    /// Returns the file path named by a file-backed connection URL.
+    ///
+    /// The optional `//` after the scheme is discarded, a query string is not
+    /// part of the path, and `#` remains a normal filename character. The path
+    /// is percent-decoded before it is returned.
+    pub fn file_path(&self) -> Result<PathBuf> {
+        let rest = self.rest();
+        let path = rest.strip_prefix("//").unwrap_or(rest);
+        let path = split_before(path, &['?']);
+
+        if path.is_empty() {
+            return Err(Error::invalid_connection_url(format!(
+                "connection URL does not name a database file; url={}",
+                self.value
+            )));
+        }
+
+        Ok(PathBuf::from(
+            percent_decode_str(path).decode_utf8_lossy().as_ref(),
+        ))
+    }
+
+    /// Returns the percent-decoded username from the authority component.
+    pub fn username(&self) -> Result<Option<Cow<'a, str>>> {
+        let Some(userinfo) = self.userinfo() else {
+            return Ok(None);
+        };
+        let username = userinfo.split_once(':').map_or(userinfo, |(name, _)| name);
+        percent_decode_str(username)
+            .decode_utf8()
+            .map(Some)
+            .map_err(|_| Error::invalid_connection_url("username is not valid UTF-8"))
+    }
+
+    /// Returns the percent-decoded password bytes from the authority component.
+    pub fn password(&self) -> Option<Cow<'a, [u8]>> {
+        let (_, password) = self.userinfo()?.split_once(':')?;
+
+        if password.as_bytes().contains(&b'%') {
+            Some(Cow::Owned(percent_decode_str(password).collect()))
+        } else {
+            Some(Cow::Borrowed(password.as_bytes()))
+        }
+    }
+
+    /// Returns the host from the authority component.
+    ///
+    /// Brackets around an IPv6 address are not included.
+    pub fn host(&self) -> Result<Option<&'a str>> {
+        let Some(authority) = self.parsed_authority()? else {
+            return Ok(None);
+        };
+        let host = authority.host();
+        let host = host
+            .strip_prefix('[')
+            .and_then(|host| host.strip_suffix(']'))
+            .unwrap_or(host);
+
+        Ok((!host.is_empty()).then_some(host))
+    }
+
+    /// Returns the port from the authority component.
+    pub fn port(&self) -> Result<Option<u16>> {
+        let Some(authority) = self.parsed_authority()? else {
+            return Ok(None);
+        };
+        authority
+            .port_to_u16()
+            .map_err(|_| self.invalid_authority())
+    }
+
+    /// Validates the host and port syntax of an authority component.
+    ///
+    /// URLs without an authority component are valid.
+    pub fn validate_authority(&self) -> Result<()> {
+        self.host()?;
+        self.port()?;
+        Ok(())
+    }
+
+    /// Iterates over the percent-decoded query parameters.
+    ///
+    /// Query components use form encoding, so `+` decodes to a space.
+    pub fn query_pairs(&self) -> impl Iterator<Item = (Cow<'a, str>, Cow<'a, str>)> + '_ {
+        self.query()
+            .into_iter()
+            .flat_map(|query| form_urlencoded::parse(query.as_bytes()))
+    }
+
+    /// Returns the URL with an authority password replaced by `***`.
+    pub fn redact_password(&self) -> Cow<'a, str> {
+        let Some(authority) = self.authority_range() else {
+            return Cow::Borrowed(self.value);
+        };
+        let authority_value = &self.rest()[authority.clone()];
+        let Some((userinfo, _)) = authority_value.rsplit_once('@') else {
+            return Cow::Borrowed(self.value);
+        };
+        let Some((username, _)) = userinfo.split_once(':') else {
+            return Cow::Borrowed(self.value);
+        };
+
+        let password_start = self.scheme_end + 1 + authority.start + username.len() + 1;
+        let password_end = self.scheme_end + 1 + authority.start + userinfo.len();
+        let mut redacted = String::with_capacity(self.value.len());
+        redacted.push_str(&self.value[..password_start]);
+        redacted.push_str("***");
+        redacted.push_str(&self.value[password_end..]);
+        Cow::Owned(redacted)
+    }
+
+    fn rest(&self) -> &'a str {
+        &self.value[self.scheme_end + 1..]
+    }
+
+    fn authority_range(&self) -> Option<Range<usize>> {
+        let rest = self.rest();
+        let authority = rest.strip_prefix("//")?;
+        let len = split_before(authority, &['/', '?', '#']).len();
+        Some(2..2 + len)
+    }
+
+    fn authority(&self) -> Option<&'a str> {
+        self.authority_range().map(|range| &self.rest()[range])
+    }
+
+    fn userinfo(&self) -> Option<&'a str> {
+        self.authority()?
+            .rsplit_once('@')
+            .map(|(userinfo, _)| userinfo)
+    }
+
+    fn parsed_authority(&self) -> Result<Option<fluent_uri::component::IAuthority<'a>>> {
+        let Some(range) = self.authority_range() else {
+            return Ok(None);
+        };
+        IriRef::parse(&self.rest()[..range.end])
+            .map_err(|_| self.invalid_authority())
+            .map(|url| url.authority())
+    }
+
+    fn query(&self) -> Option<&'a str> {
+        let rest = self.rest();
+        let query_start = rest.find('?')?;
+        if rest[..query_start].contains('#') {
+            return None;
+        }
+
+        Some(split_before(&rest[query_start + 1..], &['#']))
+    }
+
+    fn invalid_authority(&self) -> Error {
+        Error::invalid_connection_url(format!(
+            "connection URL has an invalid authority; url={}",
+            self.value
+        ))
+    }
+}
+
+fn is_valid_scheme(scheme: &str) -> bool {
+    let mut chars = scheme.chars();
+    matches!(chars.next(), Some(first) if first.is_ascii_alphabetic())
+        && chars.all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '+' | '-' | '.'))
+}
+
+fn split_before<'a>(value: &'a str, delimiters: &[char]) -> &'a str {
+    value
+        .find(delimiters)
+        .map_or(value, |index| &value[..index])
+}

--- a/crates/toasty-core/tests/connection_url.rs
+++ b/crates/toasty-core/tests/connection_url.rs
@@ -1,0 +1,124 @@
+use std::path::PathBuf;
+use toasty_core::driver::ConnectionUrl;
+
+#[test]
+fn parses_and_validates_scheme() {
+    let url = ConnectionUrl::parse("SQLITE::memory:").unwrap();
+    assert_eq!(url.scheme(), "SQLITE");
+    assert!(url.has_scheme("sqlite"));
+
+    assert!(ConnectionUrl::parse("sqlite").is_err());
+    assert!(ConnectionUrl::parse(":memory:").is_err());
+    assert!(ConnectionUrl::parse("sql@ite::memory:").is_err());
+}
+
+#[test]
+fn resolves_file_path_forms() {
+    for (url, expected) in [
+        ("sqlite:todos.db", "todos.db"),
+        ("sqlite://todos.db", "todos.db"),
+        ("sqlite://./todos.db", "./todos.db"),
+        ("sqlite://data/todos.db", "data/todos.db"),
+        ("sqlite:///tmp/todos.db", "/tmp/todos.db"),
+        ("sqlite://MyDatabase.db", "MyDatabase.db"),
+    ] {
+        assert_eq!(
+            ConnectionUrl::parse(url).unwrap().file_path().unwrap(),
+            PathBuf::from(expected)
+        );
+    }
+}
+
+#[test]
+fn decodes_file_path_without_form_or_fragment_rules() {
+    for (url, expected) in [
+        ("sqlite:/tmp/my db.sqlite", "/tmp/my db.sqlite"),
+        ("sqlite:/tmp/my%20db.sqlite", "/tmp/my db.sqlite"),
+        ("sqlite:/tmp/d%C3%A9j%C3%A0.db", "/tmp/déjà.db"),
+        ("sqlite:/tmp/a+b.db", "/tmp/a+b.db"),
+        ("sqlite:a%3Fb.db", "a?b.db"),
+        ("sqlite:notes#1.db", "notes#1.db"),
+    ] {
+        assert_eq!(
+            ConnectionUrl::parse(url).unwrap().file_path().unwrap(),
+            PathBuf::from(expected)
+        );
+    }
+}
+
+#[test]
+fn excludes_query_from_file_path() {
+    for (url, expected) in [
+        ("sqlite:app.db?cache=shared", "app.db"),
+        ("sqlite://app.db?mode=ro", "app.db"),
+        ("sqlite::memory:?cache=shared", ":memory:"),
+    ] {
+        assert_eq!(
+            ConnectionUrl::parse(url).unwrap().file_path().unwrap(),
+            PathBuf::from(expected)
+        );
+    }
+
+    assert!(
+        ConnectionUrl::parse("sqlite:")
+            .unwrap()
+            .file_path()
+            .is_err()
+    );
+    assert!(
+        ConnectionUrl::parse("sqlite://")
+            .unwrap()
+            .file_path()
+            .is_err()
+    );
+}
+
+#[test]
+fn parses_authority_url_components() {
+    let url = ConnectionUrl::parse("postgresql://alice:s3%3Acret@[::1]:5432/my%20db").unwrap();
+
+    assert_eq!(url.username().unwrap().as_deref(), Some("alice"));
+    assert_eq!(url.password().as_deref(), Some(&b"s3:cret"[..]));
+    assert_eq!(url.host().unwrap(), Some("::1"));
+    assert_eq!(url.port().unwrap(), Some(5432));
+    assert_eq!(url.path(), "/my%20db");
+    assert_eq!(url.decoded_path().unwrap(), "/my db");
+}
+
+#[test]
+fn rejects_invalid_authority() {
+    let url = ConnectionUrl::parse("dynamodb://:memory:").unwrap();
+    assert!(url.validate_authority().is_err());
+}
+
+#[test]
+fn decodes_query_pairs() {
+    let url =
+        ConnectionUrl::parse("postgresql:///mydb?host=%2Fvar%2Frun&application_name=my+app&flag")
+            .unwrap();
+    let pairs = url
+        .query_pairs()
+        .map(|(key, value)| (key.into_owned(), value.into_owned()))
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        pairs,
+        [
+            ("host".to_string(), "/var/run".to_string()),
+            ("application_name".to_string(), "my app".to_string()),
+            ("flag".to_string(), String::new()),
+        ]
+    );
+}
+
+#[test]
+fn redacts_authority_password() {
+    let url = ConnectionUrl::parse("postgresql://alice:secret@localhost/mydb").unwrap();
+    assert_eq!(
+        url.redact_password(),
+        "postgresql://alice:***@localhost/mydb"
+    );
+
+    let url = ConnectionUrl::parse("sqlite::memory:").unwrap();
+    assert_eq!(url.redact_password(), "sqlite::memory:");
+}

--- a/crates/toasty-driver-dynamodb/Cargo.toml
+++ b/crates/toasty-driver-dynamodb/Cargo.toml
@@ -22,7 +22,6 @@ hashbrown.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
-url.workspace = true
 uuid.workspace = true
 
 [lints]

--- a/crates/toasty-driver-dynamodb/src/lib.rs
+++ b/crates/toasty-driver-dynamodb/src/lib.rs
@@ -73,11 +73,10 @@ impl DynamoDb {
         // The URL does not name the endpoint — that comes from the ambient AWS
         // config — but validate it anyway, so a typo fails here instead of
         // silently connecting to whatever the environment points at.
-        let parsed = url::Url::parse(&url).map_err(|err| {
-            toasty_core::Error::invalid_connection_url(format!("{err}; url={url}"))
-        })?;
+        let parsed = toasty_core::driver::ConnectionUrl::parse(&url)?;
+        parsed.validate_authority()?;
 
-        if parsed.scheme() != "dynamodb" {
+        if !parsed.has_scheme("dynamodb") {
             return Err(toasty_core::Error::invalid_connection_url(format!(
                 "connection URL does not have a `dynamodb` scheme; url={url}"
             )));

--- a/crates/toasty-driver-mysql/Cargo.toml
+++ b/crates/toasty-driver-mysql/Cargo.toml
@@ -28,7 +28,6 @@ jiff = { workspace = true, optional = true }
 mysql_async.workspace = true
 tokio.workspace = true
 tracing.workspace = true
-url.workspace = true
 uuid.workspace = true
 
 [lints]

--- a/crates/toasty-driver-mysql/src/lib.rs
+++ b/crates/toasty-driver-mysql/src/lib.rs
@@ -21,7 +21,7 @@ use std::{borrow::Cow, cell::Cell, sync::Arc};
 use toasty_core::{
     Result, Schema,
     driver::{
-        Capability, ConnectContext, Driver, ExecResponse, Operation, QueryLogConfig,
+        Capability, ConnectContext, ConnectionUrl, Driver, ExecResponse, Operation, QueryLogConfig,
         log::QueryLog,
         operation::{RawSqlRet, Transaction, TransactionMode},
     },
@@ -32,7 +32,6 @@ use toasty_core::{
     stmt::{self, ValueRecord},
 };
 use toasty_sql::{self as sql};
-use url::Url;
 
 enum SqlReturn {
     Count {
@@ -98,30 +97,30 @@ impl MySQL {
     /// `mysql://user:pass@host:3306/dbname`.
     pub fn new(url: impl Into<String>) -> Result<Self> {
         let url_str = url.into();
-        let url = Url::parse(&url_str).map_err(toasty_core::Error::driver_operation_failed)?;
+        let url = ConnectionUrl::parse(&url_str)?;
 
-        if url.scheme() != "mysql" {
+        if !url.has_scheme("mysql") {
             return Err(toasty_core::Error::invalid_connection_url(format!(
                 "connection url does not have a `mysql` scheme; url={}",
-                url
+                url.as_str()
             )));
         }
 
-        url.host_str().ok_or_else(|| {
+        url.host()?.ok_or_else(|| {
             toasty_core::Error::invalid_connection_url(format!(
                 "missing host in connection URL; url={}",
-                url
+                url.as_str()
             ))
         })?;
 
         if url.path().is_empty() {
             return Err(toasty_core::Error::invalid_connection_url(format!(
                 "no database specified - missing path in connection URL; url={}",
-                url
+                url.as_str()
             )));
         }
 
-        let opts = mysql_async::Opts::from_url(url.as_ref())
+        let opts = mysql_async::Opts::from_url(url.as_str())
             .map_err(toasty_core::Error::driver_operation_failed)?;
         let opts = mysql_async::OptsBuilder::from_opts(opts).client_found_rows(true);
 

--- a/crates/toasty-driver-postgresql/Cargo.toml
+++ b/crates/toasty-driver-postgresql/Cargo.toml
@@ -36,14 +36,12 @@ bigdecimal = { workspace = true, optional = true }
 jiff = { workspace = true, optional = true }
 lru.workspace = true
 tracing.workspace = true
-percent-encoding.workspace = true
 postgres-protocol.workspace = true
 postgres-types.workspace = true
 fallible-iterator.workspace = true
 tokio.workspace = true
 tokio-postgres.workspace = true
 uuid.workspace = true
-url.workspace = true
 rustls = { workspace = true, optional = true }
 tokio-postgres-rustls = { workspace = true, optional = true }
 rustls-platform-verifier = { workspace = true, optional = true }

--- a/crates/toasty-driver-postgresql/src/lib.rs
+++ b/crates/toasty-driver-postgresql/src/lib.rs
@@ -21,12 +21,11 @@ mod value;
 pub(crate) use value::Value;
 
 use async_trait::async_trait;
-use percent_encoding::percent_decode_str;
 use std::{borrow::Cow, sync::Arc};
 use toasty_core::{
     Result, Schema,
     driver::{
-        Capability, ConnectContext, Driver, ExecResponse, Operation, QueryLogConfig,
+        Capability, ConnectContext, ConnectionUrl, Driver, ExecResponse, Operation, QueryLogConfig,
         log::QueryLog,
         operation::{RawSqlRet, Transaction, TransactionMode, TypedValue},
     },
@@ -39,7 +38,6 @@ use toasty_core::{
 };
 use toasty_sql::{self as sql};
 use tokio_postgres::{Client, Config, Socket, tls::MakeTlsConnect, types::ToSql};
-use url::Url;
 
 enum SqlReturn {
     Count,
@@ -108,42 +106,35 @@ impl PostgreSQL {
     /// Create a new PostgreSQL driver from a connection URL
     pub fn new(url: impl Into<String>) -> Result<Self> {
         let url_str = url.into();
-        let url = Url::parse(&url_str).map_err(toasty_core::Error::driver_operation_failed)?;
+        let url = ConnectionUrl::parse(&url_str)?;
 
-        if !matches!(url.scheme(), "postgresql" | "postgres") {
+        if !(url.has_scheme("postgresql") || url.has_scheme("postgres")) {
             return Err(toasty_core::Error::invalid_connection_url(format!(
                 "connection URL does not have a `postgresql` scheme; url={}",
-                url
+                url.as_str()
             )));
         }
 
         if url.path().is_empty() {
             return Err(toasty_core::Error::invalid_connection_url(format!(
                 "no database specified - missing path in connection URL; url={}",
-                url
+                url.as_str()
             )));
         }
 
         let mut config = Config::new();
 
-        let dbname = percent_decode_str(url.path().trim_start_matches('/'))
-            .decode_utf8()
-            .map_err(|_| {
-                toasty_core::Error::invalid_connection_url("database name is not valid UTF-8")
-            })?;
-        config.dbname(&*dbname);
+        let dbname = url.decoded_path().map_err(|_| {
+            toasty_core::Error::invalid_connection_url("database name is not valid UTF-8")
+        })?;
+        config.dbname(dbname.trim_start_matches('/'));
 
-        if !url.username().is_empty() {
-            let user = percent_decode_str(url.username())
-                .decode_utf8()
-                .map_err(|_| {
-                    toasty_core::Error::invalid_connection_url("username is not valid UTF-8")
-                })?;
+        if let Some(user) = url.username()?.filter(|user| !user.is_empty()) {
             config.user(&*user);
         }
 
         if let Some(password) = url.password() {
-            config.password(percent_decode_str(password).collect::<Vec<u8>>());
+            config.password(&*password);
         }
 
         // libpq lets standard connection parameters appear in the query
@@ -183,17 +174,15 @@ impl PostgreSQL {
             }
         }
 
-        let host = host
-            .or_else(|| url.host_str().filter(|h| !h.is_empty()).map(String::from))
-            .ok_or_else(|| {
-                toasty_core::Error::invalid_connection_url(format!(
-                    "missing host in connection URL; url={}",
-                    url
-                ))
-            })?;
+        let host = host.or(url.host()?.map(String::from)).ok_or_else(|| {
+            toasty_core::Error::invalid_connection_url(format!(
+                "missing host in connection URL; url={}",
+                url.as_str()
+            ))
+        })?;
         config.host(&host);
 
-        if let Some(port) = port.or_else(|| url.port()) {
+        if let Some(port) = port.or(url.port()?) {
             config.port(port);
         }
 

--- a/crates/toasty-driver-postgresql/src/tls/mod.rs
+++ b/crates/toasty-driver-postgresql/src/tls/mod.rs
@@ -2,12 +2,12 @@ mod config;
 
 use config::{SslVerifyMode, build_client_config};
 
+use toasty_core::driver::ConnectionUrl;
 use tokio_postgres::Config;
 use tokio_postgres_rustls::MakeRustlsConnect;
-use url::Url;
 
 pub(crate) fn configure_tls(
-    url: &Url,
+    url: &ConnectionUrl<'_>,
     config: &mut Config,
 ) -> Result<Option<MakeRustlsConnect>, toasty_core::Error> {
     let mut sslmode = SslVerifyMode::Prefer;

--- a/crates/toasty-driver-sqlite/Cargo.toml
+++ b/crates/toasty-driver-sqlite/Cargo.toml
@@ -26,7 +26,6 @@ rusqlite.workspace = true
 serde.workspace = true
 tracing.workspace = true
 uuid.workspace = true
-percent-encoding.workspace = true
 
 [lints]
 workspace = true

--- a/crates/toasty-driver-sqlite/src/lib.rs
+++ b/crates/toasty-driver-sqlite/src/lib.rs
@@ -30,7 +30,7 @@ use std::{
 use toasty_core::{
     Result, Schema,
     driver::{
-        Capability, ConnectContext, Driver, ExecResponse, QueryLogConfig,
+        Capability, ConnectContext, ConnectionUrl, Driver, ExecResponse, QueryLogConfig,
         log::QueryLog,
         operation::{IsolationLevel, Operation, RawSqlRet, Transaction, TypedValue},
     },
@@ -46,13 +46,6 @@ enum SqlReturn {
     Count,
     Infer,
     Types(Vec<stmt::Type>),
-}
-
-/// Strip a leading `<scheme>:` from a connection URL. Schemes are
-/// case-insensitive; returns `None` if the URL names a different scheme.
-fn strip_scheme<'a>(url: &'a str, scheme: &str) -> Option<&'a str> {
-    let (found, rest) = url.split_once(':')?;
-    found.eq_ignore_ascii_case(scheme).then_some(rest)
 }
 
 /// A SQLite [`Driver`] that opens connections to a file or in-memory database.
@@ -76,46 +69,20 @@ impl Sqlite {
     /// Create a new SQLite driver with an arbitrary connection URL
     pub fn new(url: impl Into<String>) -> Result<Self> {
         let url_str = url.into();
+        let url = ConnectionUrl::parse(&url_str)?;
 
-        // A `sqlite:` URL is a scheme followed by a path, where `//` is an
-        // optional authority marker. It is deliberately not parsed as a WHATWG
-        // URL: that grammar rejects `sqlite://:memory:` (`:memory:` reads as an
-        // invalid port) and reads `sqlite://todos.db` as host `todos.db` with an
-        // empty path, which SQLite opens as a private temporary database.
-        let Some(rest) = strip_scheme(&url_str, "sqlite") else {
+        if !url.has_scheme("sqlite") {
             return Err(toasty_core::Error::invalid_connection_url(format!(
                 "connection URL does not have a `sqlite` scheme; url={url_str}"
             )));
-        };
+        }
 
-        let path = rest.strip_prefix("//").unwrap_or(rest);
-
-        // A query string is not part of the file path. The driver does not
-        // support SQLite URI parameters (`?cache=shared`) — `Connection::open`
-        // treats its whole argument as a filename — so they are dropped.
-        //
-        // `#` is not special: a connection URL has no fragment, and `#` is a
-        // legal filename character, so it stays. Write `%3F` for a literal `?`.
-        let path = match path.find('?') {
-            Some(i) => &path[..i],
-            None => path,
-        };
-
-        if path == ":memory:" {
+        let path = url.file_path()?;
+        if path == Path::new(":memory:") {
             return Ok(Self::InMemory);
         }
 
-        if path.is_empty() {
-            return Err(toasty_core::Error::invalid_connection_url(format!(
-                "connection URL does not name a database file; url={url_str}"
-            )));
-        }
-
-        Ok(Self::File(PathBuf::from(
-            percent_encoding::percent_decode(path.as_bytes())
-                .decode_utf8_lossy()
-                .as_ref(),
-        )))
+        Ok(Self::File(path))
     }
 
     /// Create an in-memory SQLite database
@@ -485,123 +452,5 @@ impl Connection {
                 .map_err(toasty_core::Error::driver_operation_failed)?;
         }
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::Sqlite;
-    use std::path::PathBuf;
-
-    /// The file path `Sqlite::new` resolves out of a `sqlite:` URL.
-    fn file_path(url: &str) -> PathBuf {
-        match Sqlite::new(url).unwrap() {
-            Sqlite::File(path) => path,
-            Sqlite::InMemory => panic!("expected a file-backed database for {url}"),
-        }
-    }
-
-    #[test]
-    fn new_decodes_percent_encoded_path() {
-        // `url::Url` stores the path percent-encoded: a space becomes `%20` and
-        // non-ASCII bytes become `%XX` sequences. The driver must decode it back
-        // before opening the file, otherwise it opens one whose name literally
-        // contains `%20`.
-        assert_eq!(
-            file_path("sqlite:/tmp/my db.sqlite"),
-            PathBuf::from("/tmp/my db.sqlite")
-        );
-        assert_eq!(
-            file_path("sqlite:///tmp/my%20db.sqlite"),
-            PathBuf::from("/tmp/my db.sqlite")
-        );
-        assert_eq!(
-            file_path("sqlite:/tmp/d%C3%A9j%C3%A0.db"),
-            PathBuf::from("/tmp/déjà.db")
-        );
-        // Percent-decoding, not form-decoding: a literal `+` must stay a `+`.
-        assert_eq!(
-            file_path("sqlite:/tmp/a+b.db"),
-            PathBuf::from("/tmp/a+b.db")
-        );
-    }
-
-    #[test]
-    fn new_memory_url_stays_in_memory() {
-        assert!(matches!(
-            Sqlite::new("sqlite::memory:").unwrap(),
-            Sqlite::InMemory
-        ));
-        assert!(matches!(
-            Sqlite::new("sqlite://:memory:").unwrap(),
-            Sqlite::InMemory
-        ));
-        // Schemes are case-insensitive.
-        assert!(matches!(
-            Sqlite::new("SQLITE://:memory:").unwrap(),
-            Sqlite::InMemory
-        ));
-        assert!(matches!(
-            Sqlite::new("SQLITE::memory:").unwrap(),
-            Sqlite::InMemory
-        ));
-    }
-
-    #[test]
-    fn new_authority_form_names_a_relative_file() {
-        // Authority-form URLs: the host component is part of the file path.
-        assert_eq!(file_path("sqlite://todos.db"), PathBuf::from("todos.db"));
-        assert_eq!(
-            file_path("sqlite://./todos.db"),
-            PathBuf::from("./todos.db")
-        );
-        assert_eq!(
-            file_path("sqlite://data/todos.db"),
-            PathBuf::from("data/todos.db")
-        );
-        // Non-special schemes have opaque hosts: case is preserved,
-        // unlike `http`.
-        assert_eq!(
-            file_path("sqlite://MyDatabase.db"),
-            PathBuf::from("MyDatabase.db")
-        );
-    }
-
-    #[test]
-    fn new_url_without_a_path_is_rejected() {
-        assert!(Sqlite::new("sqlite:").is_err());
-        assert!(Sqlite::new("sqlite://").is_err());
-        assert!(Sqlite::new("sqlite:?cache=shared").is_err());
-    }
-
-    #[test]
-    fn new_drops_query_string() {
-        // The driver does not support SQLite URI parameters, so a query string
-        // must not end up in the filename.
-        assert_eq!(
-            file_path("sqlite:app.db?cache=shared"),
-            PathBuf::from("app.db")
-        );
-        assert_eq!(
-            file_path("sqlite://app.db?mode=ro"),
-            PathBuf::from("app.db")
-        );
-        assert!(matches!(
-            Sqlite::new("sqlite::memory:?cache=shared").unwrap(),
-            Sqlite::InMemory
-        ));
-    }
-
-    #[test]
-    fn new_keeps_hash_in_filename() {
-        // A connection URL has no fragment, and `#` is a legal filename
-        // character — truncating there would silently open the wrong file.
-        assert_eq!(file_path("sqlite:notes#1.db"), PathBuf::from("notes#1.db"));
-        assert_eq!(
-            file_path("sqlite://notes#1.db"),
-            PathBuf::from("notes#1.db")
-        );
-        // A literal `?` still has to be percent-encoded.
-        assert_eq!(file_path("sqlite:a%3Fb.db"), PathBuf::from("a?b.db"));
     }
 }

--- a/crates/toasty-driver-turso/Cargo.toml
+++ b/crates/toasty-driver-turso/Cargo.toml
@@ -29,7 +29,6 @@ tokio.workspace = true
 tracing.workspace = true
 turso.workspace = true
 uuid.workspace = true
-percent-encoding.workspace = true
 
 [dev-dependencies]
 reqwest = { version = "0.13.4", features = ["json"] }

--- a/crates/toasty-driver-turso/src/lib.rs
+++ b/crates/toasty-driver-turso/src/lib.rs
@@ -55,7 +55,7 @@ use std::{
 use toasty_core::{
     Result, Schema,
     driver::{
-        Capability, ConnectContext, Driver, ExecResponse, QueryLogConfig,
+        Capability, ConnectContext, ConnectionUrl, Driver, ExecResponse, QueryLogConfig,
         log::QueryLog,
         operation::{IsolationLevel, Operation, RawSqlRet, Transaction, TypedValue},
     },
@@ -77,13 +77,6 @@ enum SqlReturn {
     Count,
     Infer,
     Types(Vec<stmt::Type>),
-}
-
-/// Strip a leading `<scheme>:` from a connection URL. Schemes are
-/// case-insensitive; returns `None` if the URL names a different scheme.
-fn strip_scheme<'a>(url: &'a str, scheme: &str) -> Option<&'a str> {
-    let (found, rest) = url.split_once(':')?;
-    found.eq_ignore_ascii_case(scheme).then_some(rest)
 }
 
 const CREATE_MIGRATIONS_TABLE: &str = "\
@@ -344,45 +337,20 @@ impl Turso {
     /// `turso:/path/to/db`).
     pub fn new(url: impl Into<String>) -> Result<Self> {
         let url_str = url.into();
+        let url = ConnectionUrl::parse(&url_str)?;
 
-        // A `turso:` URL is a scheme followed by a path, where `//` is an
-        // optional authority marker. It is deliberately not parsed as a WHATWG
-        // URL: that grammar rejects `turso://:memory:` (`:memory:` reads as an
-        // invalid port) and reads `turso://todos.db` as host `todos.db` with an
-        // empty path.
-        let Some(rest) = strip_scheme(&url_str, "turso") else {
+        if !url.has_scheme("turso") {
             return Err(toasty_core::Error::invalid_connection_url(format!(
                 "connection URL does not have a `turso` scheme; url={url_str}"
             )));
-        };
+        }
 
-        let path = rest.strip_prefix("//").unwrap_or(rest);
-
-        // A query string is not part of the file path. The driver does not
-        // support URI parameters, so they are dropped.
-        //
-        // `#` is not special: a connection URL has no fragment, and `#` is a
-        // legal filename character, so it stays. Write `%3F` for a literal `?`.
-        let path = match path.find('?') {
-            Some(i) => &path[..i],
-            None => path,
-        };
-
-        if path == ":memory:" {
+        let path = url.file_path()?;
+        if path == Path::new(":memory:") {
             return Ok(Self::with_path(TursoPath::InMemory));
         }
 
-        if path.is_empty() {
-            return Err(toasty_core::Error::invalid_connection_url(format!(
-                "connection URL does not name a database file; url={url_str}"
-            )));
-        }
-
-        Ok(Self::with_path(TursoPath::File(PathBuf::from(
-            percent_encoding::percent_decode(path.as_bytes())
-                .decode_utf8_lossy()
-                .as_ref(),
-        ))))
+        Ok(Self::with_path(TursoPath::File(path)))
     }
 
     /// Create an in-memory Turso database.
@@ -1030,112 +998,6 @@ impl toasty_core::driver::Connection for Connection {
             .map_err(classify_turso_error)?;
 
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{Turso, TursoPath};
-    use std::path::PathBuf;
-
-    /// The file path `Turso::new` resolves out of a `turso:` URL.
-    fn file_path(url: &str) -> PathBuf {
-        match Turso::new(url).unwrap().path {
-            TursoPath::File(path) => path,
-            TursoPath::InMemory => panic!("expected a file-backed database for {url}"),
-        }
-    }
-
-    #[test]
-    fn new_decodes_percent_encoded_path() {
-        // `url::Url` stores the path percent-encoded: a space becomes `%20` and
-        // non-ASCII bytes become `%XX` sequences. The driver must decode it back
-        // before opening the file, otherwise it opens one whose name literally
-        // contains `%20`.
-        assert_eq!(
-            file_path("turso:/tmp/my db.sqlite"),
-            PathBuf::from("/tmp/my db.sqlite")
-        );
-        assert_eq!(
-            file_path("turso:///tmp/my%20db.sqlite"),
-            PathBuf::from("/tmp/my db.sqlite")
-        );
-        assert_eq!(
-            file_path("turso:/tmp/d%C3%A9j%C3%A0.db"),
-            PathBuf::from("/tmp/déjà.db")
-        );
-        // Percent-decoding, not form-decoding: a literal `+` must stay a `+`.
-        assert_eq!(file_path("turso:/tmp/a+b.db"), PathBuf::from("/tmp/a+b.db"));
-    }
-
-    #[test]
-    fn new_memory_url_stays_in_memory() {
-        assert!(matches!(
-            Turso::new("turso::memory:").unwrap().path,
-            TursoPath::InMemory
-        ));
-        assert!(matches!(
-            Turso::new("turso://:memory:").unwrap().path,
-            TursoPath::InMemory
-        ));
-        // Schemes are case-insensitive.
-        assert!(matches!(
-            Turso::new("TURSO://:memory:").unwrap().path,
-            TursoPath::InMemory
-        ));
-        assert!(matches!(
-            Turso::new("TURSO::memory:").unwrap().path,
-            TursoPath::InMemory
-        ));
-    }
-
-    #[test]
-    fn new_authority_form_names_a_relative_file() {
-        // Authority-form URLs: the host component is part of the file path.
-        assert_eq!(file_path("turso://todos.db"), PathBuf::from("todos.db"));
-        assert_eq!(file_path("turso://./todos.db"), PathBuf::from("./todos.db"));
-        assert_eq!(
-            file_path("turso://data/todos.db"),
-            PathBuf::from("data/todos.db")
-        );
-        // Non-special schemes have opaque hosts: case is preserved,
-        // unlike `http`.
-        assert_eq!(
-            file_path("turso://MyDatabase.db"),
-            PathBuf::from("MyDatabase.db")
-        );
-    }
-
-    #[test]
-    fn new_drops_query_string() {
-        // The driver does not support URI parameters, so a query string must
-        // not end up in the filename.
-        assert_eq!(
-            file_path("turso:app.db?cache=shared"),
-            PathBuf::from("app.db")
-        );
-        assert_eq!(file_path("turso://app.db?mode=ro"), PathBuf::from("app.db"));
-        assert!(matches!(
-            Turso::new("turso::memory:?cache=shared").unwrap().path,
-            TursoPath::InMemory
-        ));
-    }
-
-    #[test]
-    fn new_keeps_hash_in_filename() {
-        // A connection URL has no fragment, and `#` is a legal filename
-        // character — truncating there would silently open the wrong file.
-        assert_eq!(file_path("turso:notes#1.db"), PathBuf::from("notes#1.db"));
-        assert_eq!(file_path("turso://notes#1.db"), PathBuf::from("notes#1.db"));
-        // A literal `?` still has to be percent-encoded.
-        assert_eq!(file_path("turso:a%3Fb.db"), PathBuf::from("a?b.db"));
-    }
-
-    #[test]
-    fn new_url_without_a_path_is_rejected() {
-        assert!(Turso::new("turso:").is_err());
-        assert!(Turso::new("turso://").is_err());
-        assert!(Turso::new("turso:?cache=shared").is_err());
     }
 }
 

--- a/crates/toasty/src/db/connect.rs
+++ b/crates/toasty/src/db/connect.rs
@@ -2,7 +2,7 @@ use crate::Result;
 
 use async_trait::async_trait;
 use std::borrow::Cow;
-use toasty_core::driver::{Capability, ConnectContext, Driver};
+use toasty_core::driver::{Capability, ConnectContext, ConnectionUrl, Driver};
 use toasty_core::{
     driver::Connection,
     schema::{db::Migration, diff},
@@ -51,25 +51,15 @@ impl Connect {
             allow(unused_variables, unreachable_code)
         )]
 
-        // Dispatch on the scheme alone — each driver parses and validates the
-        // full URL itself. Schemes are case-insensitive, and some accepted
-        // forms (`sqlite://:memory:`) are not valid WHATWG URLs, so the string
-        // must not be parsed as one here.
-        let scheme = url
-            .split_once(':')
-            .map(|(scheme, _)| scheme.to_ascii_lowercase())
-            .ok_or_else(|| {
-                toasty_core::Error::invalid_connection_url(format!(
-                    "connection URL has no scheme; url={url}"
-                ))
-            })?;
+        let url = ConnectionUrl::parse(url)?;
+        let scheme = url.scheme().to_ascii_lowercase();
 
         let driver: Box<dyn Driver> = match scheme.as_str() {
             #[cfg(feature = "dynamodb")]
             "dynamodb" => {
                 // DynamoDB driver requires async initialization to load AWS config from environment
                 // Spawn a new thread to avoid runtime context issues
-                let url = url.to_string();
+                let url = url.as_str().to_string();
                 let driver = toasty_driver_dynamodb::DynamoDb::from_env(url).await?;
                 Box::new(driver)
             }
@@ -81,7 +71,7 @@ impl Connect {
             }
 
             #[cfg(feature = "mysql")]
-            "mysql" => Box::new(toasty_driver_mysql::MySQL::new(url.to_string())?),
+            "mysql" => Box::new(toasty_driver_mysql::MySQL::new(url.as_str())?),
             #[cfg(not(feature = "mysql"))]
             "mysql" => {
                 return Err(toasty_core::Error::unsupported_feature(
@@ -90,7 +80,9 @@ impl Connect {
             }
 
             #[cfg(feature = "postgresql")]
-            "postgresql" | "postgres" => Box::new(toasty_driver_postgresql::PostgreSQL::new(url)?),
+            "postgresql" | "postgres" => {
+                Box::new(toasty_driver_postgresql::PostgreSQL::new(url.as_str())?)
+            }
             #[cfg(not(feature = "postgresql"))]
             "postgresql" | "postgres" => {
                 return Err(toasty_core::Error::unsupported_feature(
@@ -99,7 +91,7 @@ impl Connect {
             }
 
             #[cfg(feature = "sqlite")]
-            "sqlite" => Box::new(toasty_driver_sqlite::Sqlite::new(url)?),
+            "sqlite" => Box::new(toasty_driver_sqlite::Sqlite::new(url.as_str())?),
             #[cfg(not(feature = "sqlite"))]
             "sqlite" => {
                 return Err(toasty_core::Error::unsupported_feature(
@@ -108,7 +100,7 @@ impl Connect {
             }
 
             #[cfg(feature = "turso")]
-            "turso" => Box::new(toasty_driver_turso::Turso::new(url)?),
+            "turso" => Box::new(toasty_driver_turso::Turso::new(url.as_str())?),
             #[cfg(not(feature = "turso"))]
             "turso" => {
                 return Err(toasty_core::Error::unsupported_feature(

--- a/tests/tests/turso.rs
+++ b/tests/tests/turso.rs
@@ -308,14 +308,14 @@ async fn experimental_encryption_smoke() {
     let _ = std::fs::remove_file(&tmp);
 }
 
-/// `Turso::new` must accept both `turso::memory:` and `turso:/path/...`
-/// and reject anything else. Mirrors the PostgreSQL driver's `url_encoding`
-/// test in spirit: exercises the URL-parsing path that doesn't run through
-/// the shared integration suite.
+/// `Turso::new` accepts in-memory and file targets after the shared connection
+/// URL parser validates the scheme.
 #[test]
 fn url_scheme_parsing() {
-    let mem = Turso::new("turso::memory:").expect("in-memory URL must parse");
-    assert_eq!(mem.url(), "turso::memory:");
+    for url in ["turso::memory:", "turso://:memory:"] {
+        let mem = Turso::new(url).expect("in-memory URL must parse");
+        assert_eq!(mem.url(), "turso::memory:");
+    }
 
     let file = Turso::new("turso:/var/tmp/toasty.db").expect("file URL must parse");
     assert_eq!(file.url(), "turso:/var/tmp/toasty.db");


### PR DESCRIPTION
## Summary

- Centralize database connection-string parsing in `toasty_core::driver::ConnectionUrl` and migrate all drivers and the CLI without changing accepted SQLite and Turso file-target forms.
- Use `fluent-uri` only for network authority and port parsing and `form_urlencoded` for query decoding. Toasty retains custom file-target parsing and password redaction.
- `connection_url.rs` shrinks from 307 to 250 lines; four added manifest lines make the net non-test reduction 53 lines.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

`ConnectionUrl` retains custom file-target parsing because SQLite and Turso accept double-slash forms that RFC parsers interpret as authorities, including `sqlite://todos.db`, `sqlite://:memory:`, and `turso://:memory:`. Password redaction operates on the original input so it does not normalize the connection string.

Focused parser tests cover file targets, userinfo, password redaction, bracketed IPv6 addresses and ports, and form-decoded query pairs. The Turso URL test covers `turso://:memory:`.