### PR TITLE
fix(engine): exclude null foreign keys from relation subqueries

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_filter.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_filter.rs
@@ -143,3 +143,25 @@ pub async fn filter_parent_all_children_match(test: &mut Test) -> Result<()> {
 
     Ok(())
 }
+
+#[driver_test(requires(scan), scenario(crate::scenarios::has_many_nullable_fk))]
+pub async fn filter_parent_all_ignores_unlinked_children(test: &mut Test) -> Result<()> {
+    let mut db = setup(test).await;
+
+    toasty::create!(User {}).exec(&mut db).await?;
+    toasty::create!(Todo { title: "later" })
+        .exec(&mut db)
+        .await?;
+
+    let users: Vec<User> = User::filter(
+        User::fields()
+            .todos()
+            .all(Todo::fields().title().eq("urgent")),
+    )
+    .exec(&mut db)
+    .await?;
+
+    assert_eq!(users.len(), 1);
+
+    Ok(())
+}

--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -101,7 +101,8 @@ impl LoweringState<'_> {
         // BelongsTo→FK) fires inside the lowering walk itself via
         // `LowerStatement::visit_expr_binary_op_mut`.
         association::RewriteVia::new(expr_cx).rewrite(&mut stmt);
-        lift_in_subquery::LiftInSubquery::new(expr_cx).rewrite(&mut stmt);
+        lift_in_subquery::LiftInSubquery::new(expr_cx, self.engine.capability.sql)
+            .rewrite(&mut stmt);
         lift_update_query::LiftUpdateQuery::new().rewrite(&mut stmt);
 
         Simplify::with_context(expr_cx, self.engine.capability).visit_mut(&mut stmt);
@@ -1743,7 +1744,8 @@ impl<'a, 'b> LowerStatement<'a, 'b> {
             // (model→PK, BelongsTo→FK) fires inside the lowering walk via
             // `LowerStatement::visit_expr_binary_op_mut`.
             association::RewriteVia::new(child.expr_cx).rewrite(&mut stmt);
-            lift_in_subquery::LiftInSubquery::new(child.expr_cx).rewrite(&mut stmt);
+            lift_in_subquery::LiftInSubquery::new(child.expr_cx, child.state.engine.capability.sql)
+                .rewrite(&mut stmt);
             // Pre-lower simplify: remaining heavyweight rules the lowering
             // visitor expects to have already fired.
             Simplify::with_context(child.expr_cx, child.state.engine.capability)

--- a/crates/toasty/src/engine/lower/lift_in_subquery.rs
+++ b/crates/toasty/src/engine/lower/lift_in_subquery.rs
@@ -67,6 +67,31 @@ impl<'a> LiftInSubquery<'a> {
             exclude_nulls: self.exclude_nulls,
         }
     }
+
+    fn exclude_nulls(&self, expr: &mut stmt::Expr) {
+        if !self.exclude_nulls {
+            return;
+        }
+
+        let stmt::Expr::InSubquery(expr) = expr else {
+            return;
+        };
+        let select = expr.query.body.as_select_mut_unwrap();
+        let target = select.source.model_id_unwrap();
+        let returning = select.returning.as_project_unwrap().clone();
+
+        for field in returning
+            .as_record()
+            .map_or(std::slice::from_ref(&returning), |record| &record.fields)
+        {
+            let stmt::Expr::Reference(stmt::ExprReference::Field { index, .. }) = field else {
+                unreachable!();
+            };
+            if self.cx.schema().app.field(target.field(*index)).nullable {
+                select.add_filter(stmt::Expr::is_not_null(field.clone()));
+            }
+        }
+    }
 }
 
 impl VisitMut for LiftInSubquery<'_> {
@@ -76,35 +101,28 @@ impl VisitMut for LiftInSubquery<'_> {
         // would not introduce relation references that were not there.
         match expr {
             stmt::Expr::InSubquery(e) => {
-                if let Some(lifted) =
-                    lift_in_subquery_inner(&self.cx, &e.expr, &e.query, self.exclude_nulls)
-                {
+                if let Some(mut lifted) = lift_in_subquery(&self.cx, &e.expr, &e.query) {
+                    self.exclude_nulls(&mut lifted);
                     *expr = lifted;
                 }
             }
             stmt::Expr::BinaryOp(e) => {
-                if let Some(lifted) = try_lift_relation_path_comparison(
-                    &self.cx,
-                    e.op,
-                    &e.lhs,
-                    &e.rhs,
-                    self.exclude_nulls,
-                ) {
+                if let Some(mut lifted) =
+                    try_lift_relation_path_comparison(&self.cx, e.op, &e.lhs, &e.rhs)
+                {
+                    self.exclude_nulls(&mut lifted);
                     *expr = lifted;
                 } else if let Some(commuted) = e.op.commute()
-                    && let Some(lifted) = try_lift_relation_path_comparison(
-                        &self.cx,
-                        commuted,
-                        &e.rhs,
-                        &e.lhs,
-                        self.exclude_nulls,
-                    )
+                    && let Some(mut lifted) =
+                        try_lift_relation_path_comparison(&self.cx, commuted, &e.rhs, &e.lhs)
                 {
+                    self.exclude_nulls(&mut lifted);
                     *expr = lifted;
                 }
             }
             stmt::Expr::Like(e) => {
-                if let Some(lifted) = try_lift_relation_path_like(&self.cx, e, self.exclude_nulls) {
+                if let Some(mut lifted) = try_lift_relation_path_like(&self.cx, e) {
+                    self.exclude_nulls(&mut lifted);
                     *expr = lifted;
                 }
             }
@@ -184,20 +202,10 @@ struct LiftBelongsTo<'a> {
 /// the lift cannot apply.  When the lift succeeds, the returned
 /// expression may itself contain unlowered references and the caller is
 /// expected to re-visit it through the lowering walk.
-#[cfg(test)]
 pub(super) fn lift_in_subquery(
     cx: &ExprContext,
     expr: &stmt::Expr,
     query: &stmt::Query,
-) -> Option<stmt::Expr> {
-    lift_in_subquery_inner(cx, expr, query, true)
-}
-
-fn lift_in_subquery_inner(
-    cx: &ExprContext,
-    expr: &stmt::Expr,
-    query: &stmt::Query,
-    exclude_nulls: bool,
 ) -> Option<stmt::Expr> {
     // The expression is a path expression referencing a relation.
     let field = match expr {
@@ -207,7 +215,7 @@ fn lift_in_subquery_inner(
         // nested IN-subquery on that model, then recurse to lift the outer
         // `rel` hop.
         stmt::Expr::Project(project_expr) => {
-            return lift_projection_in_subquery(cx, project_expr, query, exclude_nulls);
+            return lift_projection_in_subquery(cx, project_expr, query);
         }
         stmt::Expr::Reference(expr_reference @ stmt::ExprReference::Field { .. }) => {
             cx.resolve_expr_reference(expr_reference).as_field_unwrap()
@@ -221,17 +229,9 @@ fn lift_in_subquery_inner(
     // their paired foreign keys. A `via` has no single pair, so normalize its
     // relation chain into a projected path and use the projection lift.
     match &field.ty {
-        FieldTy::BelongsTo(belongs_to) => {
-            lift_belongs_to_in_subquery(cx, belongs_to, query, exclude_nulls)
-        }
-        FieldTy::Has(has) => lift_has_n_in_subquery(
-            cx,
-            has.target,
-            has.pair(&cx.schema().app),
-            query,
-            exclude_nulls,
-        ),
-        FieldTy::Via(via) => lift_via_in_subquery(cx, via, query, exclude_nulls),
+        FieldTy::BelongsTo(belongs_to) => lift_belongs_to_in_subquery(cx, belongs_to, query),
+        FieldTy::Has(has) => lift_has_n_in_subquery(has.target, has.pair(&cx.schema().app), query),
+        FieldTy::Via(via) => lift_via_in_subquery(cx, via, query),
         _ => None,
     }
 }
@@ -257,7 +257,6 @@ fn lift_via_in_subquery(
     cx: &ExprContext,
     via: &app::Via,
     query: &stmt::Query,
-    exclude_nulls: bool,
 ) -> Option<stmt::Expr> {
     if via.is_scalar() {
         return None;
@@ -284,7 +283,7 @@ fn lift_via_in_subquery(
         stmt::Expr::project(base, projection.as_slice())
     };
 
-    lift_in_subquery_inner(cx, &path, query, exclude_nulls)
+    lift_in_subquery(cx, &path, query)
 }
 
 /// Lifts an `IN`-subquery whose left side is a path through a relation field.
@@ -330,7 +329,6 @@ fn lift_projection_in_subquery(
     cx: &ExprContext,
     project_expr: &stmt::ExprProject,
     query: &stmt::Query,
-    exclude_nulls: bool,
 ) -> Option<stmt::Expr> {
     let Expr::Reference(expr_ref) = &*project_expr.base else {
         return None;
@@ -345,7 +343,7 @@ fn lift_projection_in_subquery(
 
     if tail.is_empty()
         && let Some(direct) =
-            try_fuse_paired_relations(cx, field, target_model_id, *head_idx, query, exclude_nulls)
+            try_fuse_paired_relations(cx, field, target_model_id, *head_idx, query)
     {
         return Some(direct);
     }
@@ -365,7 +363,7 @@ fn lift_projection_in_subquery(
         Expr::in_subquery(inner_lhs, query.clone()),
     );
 
-    lift_in_subquery_inner(cx, &project_expr.base, &new_subquery, exclude_nulls)
+    lift_in_subquery(cx, &project_expr.base, &new_subquery)
 }
 
 /// Fuses a `BelongsTo → Has` chain into a single FK-on-FK `IN` when both
@@ -426,7 +424,6 @@ fn try_fuse_paired_relations(
     target_model_id: ModelId,
     head_idx: usize,
     query: &stmt::Query,
-    exclude_nulls: bool,
 ) -> Option<stmt::Expr> {
     let outer_belongs_to = match &outer_field.ty {
         FieldTy::BelongsTo(rel) => rel,
@@ -457,7 +454,6 @@ fn try_fuse_paired_relations(
     }
 
     lift_fk_in_subquery(
-        cx,
         inner_has.target,
         super::key_field_refs(
             0,
@@ -469,7 +465,6 @@ fn try_fuse_paired_relations(
         ),
         super::key_field_refs(0, inner_pair.foreign_key.fields.iter().map(|fk| fk.source)),
         query,
-        exclude_nulls,
     )
 }
 
@@ -491,14 +486,10 @@ pub(super) fn try_lift_relation_path_comparison(
     op: stmt::BinaryOp,
     project_side: &stmt::Expr,
     other_side: &stmt::Expr,
-    exclude_nulls: bool,
 ) -> Option<stmt::Expr> {
-    lift_relation_path_predicate(
-        cx,
-        project_side,
-        |target_lhs| Expr::binary_op(target_lhs, op, other_side.clone()),
-        exclude_nulls,
-    )
+    lift_relation_path_predicate(cx, project_side, |target_lhs| {
+        Expr::binary_op(target_lhs, op, other_side.clone())
+    })
 }
 
 /// Rewrites a `LIKE`/`ILIKE` that walks a relation field into a foreign-key
@@ -519,22 +510,16 @@ pub(super) fn try_lift_relation_path_comparison(
 pub(super) fn try_lift_relation_path_like(
     cx: &ExprContext,
     like: &stmt::ExprLike,
-    exclude_nulls: bool,
 ) -> Option<stmt::Expr> {
-    lift_relation_path_predicate(
-        cx,
-        &like.expr,
-        |target_lhs| {
-            stmt::ExprLike {
-                expr: Box::new(target_lhs),
-                pattern: like.pattern.clone(),
-                escape: like.escape,
-                case_insensitive: like.case_insensitive,
-            }
-            .into()
-        },
-        exclude_nulls,
-    )
+    lift_relation_path_predicate(cx, &like.expr, |target_lhs| {
+        stmt::ExprLike {
+            expr: Box::new(target_lhs),
+            pattern: like.pattern.clone(),
+            escape: like.escape,
+            case_insensitive: like.case_insensitive,
+        }
+        .into()
+    })
 }
 
 /// Shared core of the relation-path lifts.
@@ -556,7 +541,6 @@ fn lift_relation_path_predicate(
     cx: &ExprContext,
     project_side: &stmt::Expr,
     make_filter: impl FnOnce(stmt::Expr) -> stmt::Expr,
-    exclude_nulls: bool,
 ) -> Option<stmt::Expr> {
     let Expr::Project(project_expr) = project_side else {
         return None;
@@ -587,7 +571,7 @@ fn lift_relation_path_predicate(
     let subquery =
         stmt::Query::new_select(stmt::Source::from(target_model_id), make_filter(target_lhs));
 
-    lift_in_subquery_inner(cx, &project_expr.base, &subquery, exclude_nulls)
+    lift_in_subquery(cx, &project_expr.base, &subquery)
 }
 
 /// Build a foreign-key `IN` subquery for one direct relation edge.
@@ -595,31 +579,16 @@ fn lift_relation_path_predicate(
 /// `lhs` references key fields on the current model. `returning` references
 /// the matching key fields on `target`, which is also the subquery source.
 fn lift_fk_in_subquery(
-    cx: &ExprContext,
     target: ModelId,
     lhs: stmt::Expr,
     returning: stmt::Expr,
     query: &stmt::Query,
-    exclude_nulls: bool,
 ) -> Option<stmt::Expr> {
     if target != query.body.as_select_unwrap().source.model_id_unwrap() {
         return None;
     }
 
     let mut subquery = query.clone();
-    if exclude_nulls {
-        for field in returning
-            .as_record()
-            .map_or(std::slice::from_ref(&returning), |record| &record.fields)
-        {
-            let stmt::Expr::Reference(stmt::ExprReference::Field { index, .. }) = field else {
-                unreachable!();
-            };
-            if cx.schema().app.field(target.field(*index)).nullable {
-                subquery.add_filter(stmt::Expr::is_not_null(field.clone()));
-            }
-        }
-    }
     subquery.body.as_select_mut_unwrap().returning = stmt::Returning::Project(returning);
 
     Some(stmt::Expr::in_subquery(lhs, subquery))
@@ -636,7 +605,6 @@ fn lift_belongs_to_in_subquery(
     cx: &ExprContext,
     belongs_to: &BelongsTo,
     query: &stmt::Query,
-    exclude_nulls: bool,
 ) -> Option<stmt::Expr> {
     if belongs_to.target != query.body.as_select_unwrap().source.model_id_unwrap() {
         return None;
@@ -664,12 +632,10 @@ fn lift_belongs_to_in_subquery(
 
     if lift.fail || !all_fks_matched {
         lift_fk_in_subquery(
-            cx,
             belongs_to.target,
             super::key_field_refs(0, belongs_to.foreign_key.fields.iter().map(|fk| fk.source)),
             super::key_field_refs(0, belongs_to.foreign_key.fields.iter().map(|fk| fk.target)),
             query,
-            exclude_nulls,
         )
     } else {
         Some(if lift.operands.len() == 1 {
@@ -688,19 +654,15 @@ fn lift_belongs_to_in_subquery(
 /// FKs produce a tuple-form IN that the SQL serializer renders as
 /// `(a, b) IN (SELECT a, b FROM ...)`.
 fn lift_has_n_in_subquery(
-    cx: &ExprContext,
     target: ModelId,
     pair: &BelongsTo,
     query: &stmt::Query,
-    exclude_nulls: bool,
 ) -> Option<stmt::Expr> {
     lift_fk_in_subquery(
-        cx,
         target,
         super::key_field_refs(0, pair.foreign_key.fields.iter().map(|fk| fk.target)),
         super::key_field_refs(0, pair.foreign_key.fields.iter().map(|fk| fk.source)),
         query,
-        exclude_nulls,
     )
 }
 

--- a/crates/toasty/src/engine/lower/lift_in_subquery.rs
+++ b/crates/toasty/src/engine/lower/lift_in_subquery.rs
@@ -199,7 +199,9 @@ pub(super) fn lift_in_subquery(
     // relation chain into a projected path and use the projection lift.
     match &field.ty {
         FieldTy::BelongsTo(belongs_to) => lift_belongs_to_in_subquery(cx, belongs_to, query),
-        FieldTy::Has(has) => lift_has_n_in_subquery(has.target, has.pair(&cx.schema().app), query),
+        FieldTy::Has(has) => {
+            lift_has_n_in_subquery(cx, has.target, has.pair(&cx.schema().app), query)
+        }
         FieldTy::Via(via) => lift_via_in_subquery(cx, via, query),
         _ => None,
     }
@@ -423,6 +425,7 @@ fn try_fuse_paired_relations(
     }
 
     lift_fk_in_subquery(
+        cx,
         inner_has.target,
         super::key_field_refs(
             0,
@@ -548,6 +551,7 @@ fn lift_relation_path_predicate(
 /// `lhs` references key fields on the current model. `returning` references
 /// the matching key fields on `target`, which is also the subquery source.
 fn lift_fk_in_subquery(
+    cx: &ExprContext,
     target: ModelId,
     lhs: stmt::Expr,
     returning: stmt::Expr,
@@ -558,6 +562,17 @@ fn lift_fk_in_subquery(
     }
 
     let mut subquery = query.clone();
+    for field in returning
+        .as_record()
+        .map_or(std::slice::from_ref(&returning), |record| &record.fields)
+    {
+        let stmt::Expr::Reference(stmt::ExprReference::Field { index, .. }) = field else {
+            unreachable!();
+        };
+        if cx.schema().app.field(target.field(*index)).nullable {
+            subquery.add_filter(stmt::Expr::is_not_null(field.clone()));
+        }
+    }
     subquery.body.as_select_mut_unwrap().returning = stmt::Returning::Project(returning);
 
     Some(stmt::Expr::in_subquery(lhs, subquery))
@@ -601,6 +616,7 @@ fn lift_belongs_to_in_subquery(
 
     if lift.fail || !all_fks_matched {
         lift_fk_in_subquery(
+            cx,
             belongs_to.target,
             super::key_field_refs(0, belongs_to.foreign_key.fields.iter().map(|fk| fk.source)),
             super::key_field_refs(0, belongs_to.foreign_key.fields.iter().map(|fk| fk.target)),
@@ -623,11 +639,13 @@ fn lift_belongs_to_in_subquery(
 /// FKs produce a tuple-form IN that the SQL serializer renders as
 /// `(a, b) IN (SELECT a, b FROM ...)`.
 fn lift_has_n_in_subquery(
+    cx: &ExprContext,
     target: ModelId,
     pair: &BelongsTo,
     query: &stmt::Query,
 ) -> Option<stmt::Expr> {
     lift_fk_in_subquery(
+        cx,
         target,
         super::key_field_refs(0, pair.foreign_key.fields.iter().map(|fk| fk.target)),
         super::key_field_refs(0, pair.foreign_key.fields.iter().map(|fk| fk.source)),

--- a/crates/toasty/src/engine/lower/lift_in_subquery.rs
+++ b/crates/toasty/src/engine/lower/lift_in_subquery.rs
@@ -49,11 +49,12 @@ use toasty_core::{
 /// `ApplyInsertScope::apply_expr`) see the already-lifted form.
 pub(super) struct LiftInSubquery<'a> {
     cx: ExprContext<'a>,
+    exclude_nulls: bool,
 }
 
 impl<'a> LiftInSubquery<'a> {
-    pub(super) fn new(cx: ExprContext<'a>) -> Self {
-        Self { cx }
+    pub(super) fn new(cx: ExprContext<'a>, exclude_nulls: bool) -> Self {
+        Self { cx, exclude_nulls }
     }
 
     pub(super) fn rewrite(&mut self, stmt: &mut stmt::Statement) {
@@ -63,6 +64,7 @@ impl<'a> LiftInSubquery<'a> {
     fn scope<'scope>(&'scope self, target: impl IntoExprTarget<'scope>) -> LiftInSubquery<'scope> {
         LiftInSubquery {
             cx: self.cx.scope(target),
+            exclude_nulls: self.exclude_nulls,
         }
     }
 }
@@ -74,24 +76,35 @@ impl VisitMut for LiftInSubquery<'_> {
         // would not introduce relation references that were not there.
         match expr {
             stmt::Expr::InSubquery(e) => {
-                if let Some(lifted) = lift_in_subquery(&self.cx, &e.expr, &e.query) {
+                if let Some(lifted) =
+                    lift_in_subquery_inner(&self.cx, &e.expr, &e.query, self.exclude_nulls)
+                {
                     *expr = lifted;
                 }
             }
             stmt::Expr::BinaryOp(e) => {
-                if let Some(lifted) =
-                    try_lift_relation_path_comparison(&self.cx, e.op, &e.lhs, &e.rhs)
-                {
+                if let Some(lifted) = try_lift_relation_path_comparison(
+                    &self.cx,
+                    e.op,
+                    &e.lhs,
+                    &e.rhs,
+                    self.exclude_nulls,
+                ) {
                     *expr = lifted;
                 } else if let Some(commuted) = e.op.commute()
-                    && let Some(lifted) =
-                        try_lift_relation_path_comparison(&self.cx, commuted, &e.rhs, &e.lhs)
+                    && let Some(lifted) = try_lift_relation_path_comparison(
+                        &self.cx,
+                        commuted,
+                        &e.rhs,
+                        &e.lhs,
+                        self.exclude_nulls,
+                    )
                 {
                     *expr = lifted;
                 }
             }
             stmt::Expr::Like(e) => {
-                if let Some(lifted) = try_lift_relation_path_like(&self.cx, e) {
+                if let Some(lifted) = try_lift_relation_path_like(&self.cx, e, self.exclude_nulls) {
                     *expr = lifted;
                 }
             }
@@ -171,10 +184,20 @@ struct LiftBelongsTo<'a> {
 /// the lift cannot apply.  When the lift succeeds, the returned
 /// expression may itself contain unlowered references and the caller is
 /// expected to re-visit it through the lowering walk.
+#[cfg(test)]
 pub(super) fn lift_in_subquery(
     cx: &ExprContext,
     expr: &stmt::Expr,
     query: &stmt::Query,
+) -> Option<stmt::Expr> {
+    lift_in_subquery_inner(cx, expr, query, true)
+}
+
+fn lift_in_subquery_inner(
+    cx: &ExprContext,
+    expr: &stmt::Expr,
+    query: &stmt::Query,
+    exclude_nulls: bool,
 ) -> Option<stmt::Expr> {
     // The expression is a path expression referencing a relation.
     let field = match expr {
@@ -184,7 +207,7 @@ pub(super) fn lift_in_subquery(
         // nested IN-subquery on that model, then recurse to lift the outer
         // `rel` hop.
         stmt::Expr::Project(project_expr) => {
-            return lift_projection_in_subquery(cx, project_expr, query);
+            return lift_projection_in_subquery(cx, project_expr, query, exclude_nulls);
         }
         stmt::Expr::Reference(expr_reference @ stmt::ExprReference::Field { .. }) => {
             cx.resolve_expr_reference(expr_reference).as_field_unwrap()
@@ -198,11 +221,17 @@ pub(super) fn lift_in_subquery(
     // their paired foreign keys. A `via` has no single pair, so normalize its
     // relation chain into a projected path and use the projection lift.
     match &field.ty {
-        FieldTy::BelongsTo(belongs_to) => lift_belongs_to_in_subquery(cx, belongs_to, query),
-        FieldTy::Has(has) => {
-            lift_has_n_in_subquery(cx, has.target, has.pair(&cx.schema().app), query)
+        FieldTy::BelongsTo(belongs_to) => {
+            lift_belongs_to_in_subquery(cx, belongs_to, query, exclude_nulls)
         }
-        FieldTy::Via(via) => lift_via_in_subquery(cx, via, query),
+        FieldTy::Has(has) => lift_has_n_in_subquery(
+            cx,
+            has.target,
+            has.pair(&cx.schema().app),
+            query,
+            exclude_nulls,
+        ),
+        FieldTy::Via(via) => lift_via_in_subquery(cx, via, query, exclude_nulls),
         _ => None,
     }
 }
@@ -228,6 +257,7 @@ fn lift_via_in_subquery(
     cx: &ExprContext,
     via: &app::Via,
     query: &stmt::Query,
+    exclude_nulls: bool,
 ) -> Option<stmt::Expr> {
     if via.is_scalar() {
         return None;
@@ -254,7 +284,7 @@ fn lift_via_in_subquery(
         stmt::Expr::project(base, projection.as_slice())
     };
 
-    lift_in_subquery(cx, &path, query)
+    lift_in_subquery_inner(cx, &path, query, exclude_nulls)
 }
 
 /// Lifts an `IN`-subquery whose left side is a path through a relation field.
@@ -300,6 +330,7 @@ fn lift_projection_in_subquery(
     cx: &ExprContext,
     project_expr: &stmt::ExprProject,
     query: &stmt::Query,
+    exclude_nulls: bool,
 ) -> Option<stmt::Expr> {
     let Expr::Reference(expr_ref) = &*project_expr.base else {
         return None;
@@ -314,7 +345,7 @@ fn lift_projection_in_subquery(
 
     if tail.is_empty()
         && let Some(direct) =
-            try_fuse_paired_relations(cx, field, target_model_id, *head_idx, query)
+            try_fuse_paired_relations(cx, field, target_model_id, *head_idx, query, exclude_nulls)
     {
         return Some(direct);
     }
@@ -334,7 +365,7 @@ fn lift_projection_in_subquery(
         Expr::in_subquery(inner_lhs, query.clone()),
     );
 
-    lift_in_subquery(cx, &project_expr.base, &new_subquery)
+    lift_in_subquery_inner(cx, &project_expr.base, &new_subquery, exclude_nulls)
 }
 
 /// Fuses a `BelongsTo → Has` chain into a single FK-on-FK `IN` when both
@@ -395,6 +426,7 @@ fn try_fuse_paired_relations(
     target_model_id: ModelId,
     head_idx: usize,
     query: &stmt::Query,
+    exclude_nulls: bool,
 ) -> Option<stmt::Expr> {
     let outer_belongs_to = match &outer_field.ty {
         FieldTy::BelongsTo(rel) => rel,
@@ -437,6 +469,7 @@ fn try_fuse_paired_relations(
         ),
         super::key_field_refs(0, inner_pair.foreign_key.fields.iter().map(|fk| fk.source)),
         query,
+        exclude_nulls,
     )
 }
 
@@ -458,10 +491,14 @@ pub(super) fn try_lift_relation_path_comparison(
     op: stmt::BinaryOp,
     project_side: &stmt::Expr,
     other_side: &stmt::Expr,
+    exclude_nulls: bool,
 ) -> Option<stmt::Expr> {
-    lift_relation_path_predicate(cx, project_side, |target_lhs| {
-        Expr::binary_op(target_lhs, op, other_side.clone())
-    })
+    lift_relation_path_predicate(
+        cx,
+        project_side,
+        |target_lhs| Expr::binary_op(target_lhs, op, other_side.clone()),
+        exclude_nulls,
+    )
 }
 
 /// Rewrites a `LIKE`/`ILIKE` that walks a relation field into a foreign-key
@@ -482,16 +519,22 @@ pub(super) fn try_lift_relation_path_comparison(
 pub(super) fn try_lift_relation_path_like(
     cx: &ExprContext,
     like: &stmt::ExprLike,
+    exclude_nulls: bool,
 ) -> Option<stmt::Expr> {
-    lift_relation_path_predicate(cx, &like.expr, |target_lhs| {
-        stmt::ExprLike {
-            expr: Box::new(target_lhs),
-            pattern: like.pattern.clone(),
-            escape: like.escape,
-            case_insensitive: like.case_insensitive,
-        }
-        .into()
-    })
+    lift_relation_path_predicate(
+        cx,
+        &like.expr,
+        |target_lhs| {
+            stmt::ExprLike {
+                expr: Box::new(target_lhs),
+                pattern: like.pattern.clone(),
+                escape: like.escape,
+                case_insensitive: like.case_insensitive,
+            }
+            .into()
+        },
+        exclude_nulls,
+    )
 }
 
 /// Shared core of the relation-path lifts.
@@ -513,6 +556,7 @@ fn lift_relation_path_predicate(
     cx: &ExprContext,
     project_side: &stmt::Expr,
     make_filter: impl FnOnce(stmt::Expr) -> stmt::Expr,
+    exclude_nulls: bool,
 ) -> Option<stmt::Expr> {
     let Expr::Project(project_expr) = project_side else {
         return None;
@@ -543,7 +587,7 @@ fn lift_relation_path_predicate(
     let subquery =
         stmt::Query::new_select(stmt::Source::from(target_model_id), make_filter(target_lhs));
 
-    lift_in_subquery(cx, &project_expr.base, &subquery)
+    lift_in_subquery_inner(cx, &project_expr.base, &subquery, exclude_nulls)
 }
 
 /// Build a foreign-key `IN` subquery for one direct relation edge.
@@ -556,21 +600,24 @@ fn lift_fk_in_subquery(
     lhs: stmt::Expr,
     returning: stmt::Expr,
     query: &stmt::Query,
+    exclude_nulls: bool,
 ) -> Option<stmt::Expr> {
     if target != query.body.as_select_unwrap().source.model_id_unwrap() {
         return None;
     }
 
     let mut subquery = query.clone();
-    for field in returning
-        .as_record()
-        .map_or(std::slice::from_ref(&returning), |record| &record.fields)
-    {
-        let stmt::Expr::Reference(stmt::ExprReference::Field { index, .. }) = field else {
-            unreachable!();
-        };
-        if cx.schema().app.field(target.field(*index)).nullable {
-            subquery.add_filter(stmt::Expr::is_not_null(field.clone()));
+    if exclude_nulls {
+        for field in returning
+            .as_record()
+            .map_or(std::slice::from_ref(&returning), |record| &record.fields)
+        {
+            let stmt::Expr::Reference(stmt::ExprReference::Field { index, .. }) = field else {
+                unreachable!();
+            };
+            if cx.schema().app.field(target.field(*index)).nullable {
+                subquery.add_filter(stmt::Expr::is_not_null(field.clone()));
+            }
         }
     }
     subquery.body.as_select_mut_unwrap().returning = stmt::Returning::Project(returning);
@@ -589,6 +636,7 @@ fn lift_belongs_to_in_subquery(
     cx: &ExprContext,
     belongs_to: &BelongsTo,
     query: &stmt::Query,
+    exclude_nulls: bool,
 ) -> Option<stmt::Expr> {
     if belongs_to.target != query.body.as_select_unwrap().source.model_id_unwrap() {
         return None;
@@ -621,6 +669,7 @@ fn lift_belongs_to_in_subquery(
             super::key_field_refs(0, belongs_to.foreign_key.fields.iter().map(|fk| fk.source)),
             super::key_field_refs(0, belongs_to.foreign_key.fields.iter().map(|fk| fk.target)),
             query,
+            exclude_nulls,
         )
     } else {
         Some(if lift.operands.len() == 1 {
@@ -643,6 +692,7 @@ fn lift_has_n_in_subquery(
     target: ModelId,
     pair: &BelongsTo,
     query: &stmt::Query,
+    exclude_nulls: bool,
 ) -> Option<stmt::Expr> {
     lift_fk_in_subquery(
         cx,
@@ -650,6 +700,7 @@ fn lift_has_n_in_subquery(
         super::key_field_refs(0, pair.foreign_key.fields.iter().map(|fk| fk.target)),
         super::key_field_refs(0, pair.foreign_key.fields.iter().map(|fk| fk.source)),
         query,
+        exclude_nulls,
     )
 }
 


### PR DESCRIPTION
## Summary

Exclude nullable foreign-key values from generated relation-membership subqueries. An unlinked child could otherwise put NULL in the NOT IN expression generated for all(), causing SQL to evaluate the predicate as unknown and exclude an unrelated parent.

Add a regression covering all() with an orphaned child and a parent with no related rows.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] cargo fmt and cargo clippy are clean
- [x] cargo test passes

## Notes for reviewers

The filter is added while lifting generated foreign-key subqueries, where schema nullability and relation semantics are both available.