### PR TITLE
refactor!: remove unused schema and statement APIs

### DIFF
--- a/crates/toasty-core/src/schema.rs
+++ b/crates/toasty-core/src/schema.rs
@@ -77,19 +77,6 @@ pub struct Schema {
 }
 
 impl Schema {
-    /// Returns a new [`Builder`] for constructing a `Schema`.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// use toasty_core::Schema;
-    ///
-    /// let builder = Schema::builder();
-    /// ```
-    pub fn builder() -> Builder {
-        Builder::default()
-    }
-
     /// Returns the mapping for the given model.
     ///
     /// # Panics

--- a/crates/toasty-core/src/schema/app/embedded.rs
+++ b/crates/toasty-core/src/schema/app/embedded.rs
@@ -1,8 +1,5 @@
 use crate::{
-    schema::{
-        app::{Model, ModelId, Schema},
-        db,
-    },
+    schema::{app::ModelId, db},
     stmt,
 };
 
@@ -18,8 +15,8 @@ use crate::{
 /// use toasty_core::schema::app::Embedded;
 ///
 /// // Embedded is typically constructed by the schema builder.
-/// let embedded: &Embedded = field.ty.as_embedded_unwrap();
-/// let target_model = embedded.target(&schema);
+/// let embedded: &Embedded = embedded_field;
+/// let target_model = schema.model(embedded.target);
 /// ```
 #[derive(Debug, Clone)]
 pub struct Embedded {
@@ -34,11 +31,4 @@ pub struct Embedded {
     /// column. Embedded structs do not accept a type override because they may
     /// map to more than one column.
     pub storage_ty: Option<db::Type>,
-}
-
-impl Embedded {
-    /// Resolves the target [`Model`] from the given schema.
-    pub fn target<'a>(&self, schema: &'a Schema) -> &'a Model {
-        schema.model(self.target)
-    }
 }

--- a/crates/toasty-core/src/schema/app/field.rs
+++ b/crates/toasty-core/src/schema/app/field.rs
@@ -1,9 +1,7 @@
 mod primitive;
 pub use primitive::{FieldPrimitive, SerializeFormat};
 
-use super::{
-    AutoStrategy, BelongsTo, Constraint, Embedded, Has, Model, ModelId, Schema, VariantId, Via,
-};
+use super::{AutoStrategy, BelongsTo, Constraint, Embedded, Has, ModelId, VariantId, Via};
 use crate::{Result, driver, schema::Name, stmt};
 use std::fmt;
 
@@ -158,19 +156,6 @@ impl FieldName {
     pub fn storage_name(&self) -> Option<&str> {
         self.storage.as_deref().or(self.app.as_deref())
     }
-
-    /// Returns the storage (database column) name for this field.
-    ///
-    /// This is a convenience wrapper around [`storage_name`](FieldName::storage_name)
-    /// for callers that expect a name to always be present.
-    ///
-    /// # Panics
-    ///
-    /// Panics if both `storage` and `app` are `None`.
-    pub fn storage_name_unwrap(&self) -> &str {
-        self.storage_name()
-            .expect("must specify app name or storage name")
-    }
 }
 
 impl fmt::Display for FieldName {
@@ -193,7 +178,7 @@ impl fmt::Display for FieldName {
 ///     storage_ty: None,
 ///     serialize: None,
 /// });
-/// assert!(ty.is_primitive());
+/// assert!(ty.as_primitive().is_some());
 /// assert!(!ty.is_relation());
 /// ```
 #[derive(Clone)]
@@ -221,19 +206,9 @@ impl Field {
         &self.name
     }
 
-    /// Returns a reference to this field's [`FieldTy`].
-    pub fn ty(&self) -> &FieldTy {
-        &self.ty
-    }
-
     /// Returns `true` if this field is nullable.
     pub fn nullable(&self) -> bool {
         self.nullable
-    }
-
-    /// Returns `true` if this field is part of the primary key.
-    pub fn primary_key(&self) -> bool {
-        self.primary_key
     }
 
     /// Returns the auto-population strategy, if one is configured.
@@ -257,14 +232,6 @@ impl Field {
         self.ty.is_relation()
     }
 
-    /// Returns a fully qualified name for the field.
-    pub fn full_name(&self, schema: &Schema) -> Option<String> {
-        self.name.app.as_ref().map(|app_name| {
-            let model = schema.model(self.id.model);
-            format!("{}::{}", model.name().upper_camel_case(), app_name)
-        })
-    }
-
     /// If the field is a relation, return the relation's target ModelId.
     pub fn relation_target_id(&self) -> Option<ModelId> {
         match &self.ty {
@@ -273,11 +240,6 @@ impl Field {
             FieldTy::Via(via) => Some(via.target),
             _ => None,
         }
-    }
-
-    /// If the field is a relation, return the target of the relation.
-    pub fn relation_target<'a>(&self, schema: &'a Schema) -> Option<&'a Model> {
-        self.relation_target_id().map(|id| schema.model(id))
     }
 
     /// Returns the expression type this field evaluates to.
@@ -322,11 +284,6 @@ impl Field {
 }
 
 impl FieldTy {
-    /// Returns `true` if this is a [`FieldTy::Primitive`].
-    pub fn is_primitive(&self) -> bool {
-        matches!(self, Self::Primitive(..))
-    }
-
     /// Returns the inner [`FieldPrimitive`] if this is a primitive field.
     pub fn as_primitive(&self) -> Option<&FieldPrimitive> {
         match self {
@@ -349,70 +306,10 @@ impl FieldTy {
         }
     }
 
-    /// Returns a mutable reference to the inner [`FieldPrimitive`], panicking
-    /// if this is not a primitive field.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `self` is not [`FieldTy::Primitive`].
-    #[track_caller]
-    pub fn as_primitive_mut_unwrap(&mut self) -> &mut FieldPrimitive {
-        match self {
-            Self::Primitive(simple) => simple,
-            _ => panic!("expected simple field, but was {self:?}"),
-        }
-    }
-
-    /// Returns `true` if this is a [`FieldTy::Embedded`].
-    pub fn is_embedded(&self) -> bool {
-        matches!(self, Self::Embedded(..))
-    }
-
-    /// Returns the inner [`Embedded`] if this is an embedded field.
-    pub fn as_embedded(&self) -> Option<&Embedded> {
-        match self {
-            Self::Embedded(embedded) => Some(embedded),
-            _ => None,
-        }
-    }
-
-    /// Returns the inner [`Embedded`], panicking if this is not an embedded
-    /// field.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `self` is not [`FieldTy::Embedded`].
-    #[track_caller]
-    pub fn as_embedded_unwrap(&self) -> &Embedded {
-        match self {
-            Self::Embedded(embedded) => embedded,
-            _ => panic!("expected embedded field, but was {self:?}"),
-        }
-    }
-
-    /// Returns a mutable reference to the inner [`Embedded`], panicking if
-    /// this is not an embedded field.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `self` is not [`FieldTy::Embedded`].
-    #[track_caller]
-    pub fn as_embedded_mut_unwrap(&mut self) -> &mut Embedded {
-        match self {
-            Self::Embedded(embedded) => embedded,
-            _ => panic!("expected embedded field, but was {self:?}"),
-        }
-    }
-
     /// Returns `true` if this is a relation type (`BelongsTo`, `Has`, or
     /// `Via`).
     pub fn is_relation(&self) -> bool {
         matches!(self, Self::BelongsTo(..) | Self::Has(..) | Self::Via(..))
-    }
-
-    /// Returns `true` if this is a [`FieldTy::Has`] relation.
-    pub fn is_has_n(&self) -> bool {
-        matches!(self, Self::Has(..))
     }
 
     /// Returns the inner [`Has`] if this is a has field.
@@ -420,19 +317,6 @@ impl FieldTy {
         match self {
             Self::Has(has) => Some(has),
             _ => None,
-        }
-    }
-
-    /// Returns the inner [`Has`], panicking if this is not a has field.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `self` is not [`FieldTy::Has`].
-    #[track_caller]
-    pub fn as_has_unwrap(&self) -> &Has {
-        match self {
-            Self::Has(has) => has,
-            _ => panic!("expected field to be `Has`, but was {self:?}"),
         }
     }
 
@@ -475,23 +359,6 @@ impl FieldTy {
             .unwrap_or_else(|| panic!("expected field to be `HasMany`, but was {self:?}"))
     }
 
-    /// Returns a mutable reference to the inner [`Has`], panicking if this is
-    /// not a many-valued has field.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `self` is not a many-valued [`FieldTy::Has`].
-    #[track_caller]
-    pub fn as_has_many_mut_unwrap(&mut self) -> &mut Has {
-        if !self.is_has_many() {
-            panic!("expected field to be `HasMany`, but was {self:?}");
-        }
-        match self {
-            Self::Has(has) => has,
-            _ => unreachable!(),
-        }
-    }
-
     /// Returns the inner [`Has`] if this is a one-valued has field.
     pub fn as_has_one(&self) -> Option<&Has> {
         match self {
@@ -515,23 +382,6 @@ impl FieldTy {
     pub fn as_has_one_unwrap(&self) -> &Has {
         self.as_has_one()
             .unwrap_or_else(|| panic!("expected field to be `HasOne`, but it was {self:?}"))
-    }
-
-    /// Returns a mutable reference to the inner [`Has`], panicking if this is
-    /// not a one-valued has field.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `self` is not a one-valued [`FieldTy::Has`].
-    #[track_caller]
-    pub fn as_has_one_mut_unwrap(&mut self) -> &mut Has {
-        if !self.is_has_one() {
-            panic!("expected field to be `HasOne`, but it was {self:?}");
-        }
-        match self {
-            Self::Has(has) => has,
-            _ => unreachable!(),
-        }
     }
 
     /// Returns `true` if this is a [`FieldTy::BelongsTo`].

--- a/crates/toasty-core/src/schema/app/fk.rs
+++ b/crates/toasty-core/src/schema/app/fk.rs
@@ -1,4 +1,4 @@
-use super::{Field, FieldId, Schema};
+use super::FieldId;
 
 /// A foreign key linking one model's fields to another model's primary key.
 ///
@@ -53,17 +53,5 @@ pub struct ForeignKeyField {
 impl ForeignKey {
     pub(crate) fn is_placeholder(&self) -> bool {
         self.fields.is_empty()
-    }
-}
-
-impl ForeignKeyField {
-    /// Resolves the source [`Field`] from the given schema.
-    pub fn source<'a>(&self, schema: &'a Schema) -> &'a Field {
-        schema.field(self.source)
-    }
-
-    /// Resolves the target [`Field`] from the given schema.
-    pub fn target<'a>(&self, schema: &'a Schema) -> &'a Field {
-        schema.field(self.target)
     }
 }

--- a/crates/toasty-core/src/schema/app/index.rs
+++ b/crates/toasty-core/src/schema/app/index.rs
@@ -99,30 +99,3 @@ pub struct IndexField {
     /// Whether this field is a partition key or a local (sort) key.
     pub scope: IndexScope,
 }
-
-impl Index {
-    /// Returns the partition-scoped fields of this index.
-    ///
-    /// Partition fields come before local fields and determine data
-    /// distribution in NoSQL backends.
-    pub fn partition_fields(&self) -> &[IndexField] {
-        let i = self.index_of_first_local_field();
-        &self.fields[0..i]
-    }
-
-    /// Returns the local (sort-key) fields of this index.
-    ///
-    /// Local fields follow partition fields and determine ordering within a
-    /// partition.
-    pub fn local_fields(&self) -> &[IndexField] {
-        let i = self.index_of_first_local_field();
-        &self.fields[i..]
-    }
-
-    fn index_of_first_local_field(&self) -> usize {
-        self.fields
-            .iter()
-            .position(|field| field.scope.is_local())
-            .unwrap_or(self.fields.len())
-    }
-}

--- a/crates/toasty-core/src/schema/app/model.rs
+++ b/crates/toasty-core/src/schema/app/model.rs
@@ -49,8 +49,8 @@ pub enum Model {
 /// ```
 /// use toasty_core::schema::app::{Model, ModelSet};
 ///
-/// let mut set = ModelSet::new();
-/// assert_eq!(set.iter().len(), 0);
+/// let set = ModelSet::new();
+/// assert_eq!((&set).into_iter().len(), 0);
 /// ```
 #[derive(Debug, Clone, Default)]
 pub struct ModelSet {
@@ -83,11 +83,6 @@ impl ModelSet {
     /// If a model with the same ID already exists, it is replaced.
     pub fn add(&mut self, model: Model) {
         self.models.insert(model.id(), model);
-    }
-
-    /// Returns an iterator over the models in insertion order.
-    pub fn iter(&self) -> impl ExactSizeIterator<Item = &Model> {
-        self.models.values()
     }
 }
 
@@ -416,11 +411,6 @@ impl Model {
         matches!(self, Model::EmbeddedStruct(_) | Model::EmbeddedEnum(_))
     }
 
-    /// Returns true if this model can be the target of a relation
-    pub fn can_be_relation_target(&self) -> bool {
-        self.is_root()
-    }
-
     /// Returns the inner [`ModelRoot`] if this is a root model.
     pub fn as_root(&self) -> Option<&ModelRoot> {
         match self {
@@ -505,9 +495,9 @@ impl Model {
 /// # Examples
 ///
 /// ```
-/// use toasty_core::schema::app::ModelId;
+/// use toasty_core::schema::app::{ModelId, VariantId};
 ///
-/// let variant_id = ModelId(1).variant(0);
+/// let variant_id = VariantId { model: ModelId(1), index: 0 };
 /// assert_eq!(variant_id.model, ModelId(1));
 /// assert_eq!(variant_id.index, 0);
 /// ```
@@ -530,12 +520,6 @@ impl ModelId {
     /// `index`.
     pub const fn field(self, index: usize) -> FieldId {
         FieldId { model: self, index }
-    }
-
-    /// Create a `VariantId` representing the current model's variant at
-    /// `index`.
-    pub const fn variant(self, index: usize) -> VariantId {
-        VariantId { model: self, index }
     }
 
     pub(crate) const fn placeholder() -> Self {

--- a/crates/toasty-core/src/schema/app/relation/has.rs
+++ b/crates/toasty-core/src/schema/app/relation/has.rs
@@ -49,11 +49,6 @@ impl Has {
         self.cardinality.is_one()
     }
 
-    /// Returns the singular item name for a one-to-many relation.
-    pub fn singular(&self) -> Option<&Name> {
-        self.cardinality.singular()
-    }
-
     /// Resolves the target [`Model`] from the given schema.
     pub fn target<'a>(&self, schema: &'a Schema) -> &'a Model {
         schema.model(self.target)
@@ -78,13 +73,5 @@ impl Cardinality {
     /// Returns `true` when this relation yields at most one item.
     pub fn is_one(&self) -> bool {
         matches!(self, Cardinality::One)
-    }
-
-    /// Returns the singular item name for a one-to-many relation.
-    pub fn singular(&self) -> Option<&Name> {
-        match self {
-            Cardinality::Many { singular } => Some(singular),
-            Cardinality::One => None,
-        }
     }
 }

--- a/crates/toasty-core/src/schema/app/relation/via.rs
+++ b/crates/toasty-core/src/schema/app/relation/via.rs
@@ -1,5 +1,5 @@
 use crate::{
-    schema::app::{Cardinality, Model, ModelId, Name, Schema},
+    schema::app::{Cardinality, Model, ModelId, Schema},
     stmt,
 };
 
@@ -88,13 +88,8 @@ impl Via {
         self.cardinality.is_one()
     }
 
-    /// Returns the singular item name for a one-to-many relation.
-    pub fn singular(&self) -> Option<&Name> {
-        self.cardinality.singular()
-    }
-
     /// Resolves the target [`Model`] from the given schema.
-    pub fn target<'a>(&self, schema: &'a Schema) -> &'a Model {
+    pub(crate) fn target<'a>(&self, schema: &'a Schema) -> &'a Model {
         schema.model(self.target)
     }
 }

--- a/crates/toasty-core/src/schema/app/schema.rs
+++ b/crates/toasty-core/src/schema/app/schema.rs
@@ -1,4 +1,4 @@
-use super::{EnumVariant, Field, FieldId, FieldPrimitive, FieldTy, Model, ModelId, VariantId};
+use super::{EnumVariant, Field, FieldId, FieldPrimitive, FieldTy, Model, ModelId};
 
 use crate::{Result, stmt};
 use indexmap::IndexMap;
@@ -76,19 +76,6 @@ impl Schema {
             .fields()
             .get(id.index)
             .expect("invalid field ID")
-    }
-
-    /// Returns a reference to the [`EnumVariant`] identified by `id`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the model is not an [`EmbeddedEnum`](super::EmbeddedEnum) or
-    /// the variant index is out of bounds.
-    pub fn variant(&self, id: VariantId) -> &EnumVariant {
-        let Model::EmbeddedEnum(e) = self.model(id.model) else {
-            panic!("VariantId references a non-enum model");
-        };
-        e.variants.get(id.index).expect("invalid variant index")
     }
 
     /// Returns an iterator over all models in the schema.

--- a/crates/toasty-core/src/schema/db/schema.rs
+++ b/crates/toasty-core/src/schema/db/schema.rs
@@ -33,19 +33,6 @@ impl Schema {
             .expect("invalid column ID")
     }
 
-    /// Returns a mutable reference to the column identified by `id`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the table or column index is out of bounds.
-    pub fn column_mut(&mut self, id: impl Into<ColumnId>) -> &mut Column {
-        let id = id.into();
-        self.table_mut(id.table)
-            .columns
-            .get_mut(id.index)
-            .expect("invalid column ID")
-    }
-
     /// Returns the index identified by `id`.
     ///
     /// # Panics
@@ -57,20 +44,6 @@ impl Schema {
         self.table(id.table)
             .indices
             .get(id.index)
-            .expect("invalid index ID")
-    }
-
-    /// Returns a mutable reference to the index identified by `id`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the table or index offset is out of bounds.
-    // NOTE: this is unlikely to confuse users given the context.
-    #[allow(clippy::should_implement_trait)]
-    pub fn index_mut(&mut self, id: IndexId) -> &mut Index {
-        self.table_mut(id.table)
-            .indices
-            .get_mut(id.index)
             .expect("invalid index ID")
     }
 

--- a/crates/toasty-core/src/schema/db/table.rs
+++ b/crates/toasty-core/src/schema/db/table.rs
@@ -50,15 +50,6 @@ pub struct Table {
 pub struct TableId(pub usize);
 
 impl Table {
-    /// Returns the `i`-th column of this table's primary key.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `i` is out of bounds for the primary key column list.
-    pub fn primary_key_column(&self, i: usize) -> &Column {
-        &self.columns[self.primary_key.columns[i].index]
-    }
-
     /// Returns an iterator over the columns that make up this table's primary key.
     pub fn primary_key_columns(&self) -> impl ExactSizeIterator<Item = &Column> + '_ {
         self.primary_key

--- a/crates/toasty-core/src/schema/diff.rs
+++ b/crates/toasty-core/src/schema/diff.rs
@@ -44,8 +44,6 @@ use crate::schema::db::{ColumnId, IndexId, Schema as DbSchema, TableId};
 ///
 /// let mut hints = diff::RenameHints::new();
 /// hints.add_table_hint(TableId(0), TableId(1));
-/// assert_eq!(hints.get_table(TableId(0)), Some(TableId(1)));
-/// assert_eq!(hints.get_table(TableId(2)), None);
 /// ```
 #[derive(Default)]
 pub struct RenameHints {
@@ -76,17 +74,17 @@ impl RenameHints {
     }
 
     /// Returns the new [`TableId`] if a rename hint exists for `from`.
-    pub fn get_table(&self, from: TableId) -> Option<TableId> {
+    pub(super) fn get_table(&self, from: TableId) -> Option<TableId> {
         self.tables.get(&from).copied()
     }
 
     /// Returns the new [`ColumnId`] if a rename hint exists for `from`.
-    pub fn get_column(&self, from: ColumnId) -> Option<ColumnId> {
+    pub(super) fn get_column(&self, from: ColumnId) -> Option<ColumnId> {
         self.columns.get(&from).copied()
     }
 
     /// Returns the new [`IndexId`] if a rename hint exists for `from`.
-    pub fn get_index(&self, from: IndexId) -> Option<IndexId> {
+    pub(super) fn get_index(&self, from: IndexId) -> Option<IndexId> {
         self.indices.get(&from).copied()
     }
 }
@@ -105,7 +103,7 @@ impl RenameHints {
 /// let next = db::Schema::default();
 /// let hints = diff::RenameHints::new();
 /// let cx = diff::Context::new(&previous, &next, &hints);
-/// assert!(cx.previous().tables.is_empty());
+/// assert!(cx.next().tables.is_empty());
 /// ```
 pub struct Context<'a> {
     previous: &'a DbSchema,
@@ -115,6 +113,16 @@ pub struct Context<'a> {
 }
 
 impl<'a> Context<'a> {
+    /// Returns the rename hints for this diff.
+    pub(super) fn rename_hints(&self) -> &'a RenameHints {
+        self.rename_hints
+    }
+
+    /// Returns the schema before the change.
+    pub(super) fn previous(&self) -> &'a DbSchema {
+        self.previous
+    }
+
     /// Creates a new diff context from the previous schema, the next schema,
     /// and the rename hints that map old IDs to new IDs.
     pub fn new(previous: &'a DbSchema, next: &'a DbSchema, rename_hints: &'a RenameHints) -> Self {
@@ -123,16 +131,6 @@ impl<'a> Context<'a> {
             next,
             rename_hints,
         }
-    }
-
-    /// Returns the rename hints for this diff.
-    pub fn rename_hints(&self) -> &'a RenameHints {
-        self.rename_hints
-    }
-
-    /// Returns the schema before the change.
-    pub fn previous(&self) -> &'a DbSchema {
-        self.previous
     }
 
     /// Returns the schema after the change.

--- a/crates/toasty-core/src/schema/diff/column.rs
+++ b/crates/toasty-core/src/schema/diff/column.rs
@@ -50,7 +50,6 @@ impl<'a> Column<'a> {
 
         let mut changes = vec![];
         let mut add_ids: HashSet<_> = next.iter().map(|next| next.id).collect();
-
         let next_map = HashMap::<&str, &'a db::Column>::from_iter(
             next.iter().map(|to| (to.name.as_str(), to)),
         );

--- a/crates/toasty-core/src/schema/diff/index.rs
+++ b/crates/toasty-core/src/schema/diff/index.rs
@@ -49,7 +49,7 @@ impl<'a> Index<'a> {
                 return true;
             }
 
-            for (previous_col, next_col) in previous.columns.iter().zip(next.columns.iter()) {
+            for (previous_col, next_col) in previous.columns.iter().zip(&next.columns) {
                 if previous_col.op != next_col.op || previous_col.scope != next_col.scope {
                     return true;
                 }
@@ -73,7 +73,6 @@ impl<'a> Index<'a> {
 
         let mut changes = vec![];
         let mut create_ids: HashSet<_> = next.iter().map(|to| to.id).collect();
-
         let next_map =
             HashMap::<&str, &'a db::Index>::from_iter(next.iter().map(|to| (to.name.as_str(), to)));
 

--- a/crates/toasty-core/src/schema/diff/ty.rs
+++ b/crates/toasty-core/src/schema/diff/ty.rs
@@ -5,8 +5,8 @@ use hashbrown::HashMap;
 /// A single change to a named enum type between two schema versions.
 ///
 /// Enum types are not top-level schema objects — they are embedded in column
-/// definitions. [`Type::diff`] collects all named `TypeEnum` types from both
-/// schemas (by scanning columns) and computes the changes.
+/// definitions. Diffing schemas collects named `TypeEnum` types by scanning
+/// columns in both schemas.
 pub enum Type<'a> {
     /// A new named enum type must be created.
     Create(&'a db::TypeEnum),
@@ -30,7 +30,7 @@ impl<'a> Type<'a> {
     ///
     /// Panics if existing variants were removed or reordered. Callers should
     /// validate schema transitions before computing the diff.
-    pub fn diff(previous: &'a db::Schema, next: &'a db::Schema) -> Vec<Self> {
+    pub(super) fn diff(previous: &'a db::Schema, next: &'a db::Schema) -> Vec<Self> {
         let prev_types = collect_named_enums(previous);
         let next_types = collect_named_enums(next);
 

--- a/crates/toasty-core/src/schema/mapping/field.rs
+++ b/crates/toasty-core/src/schema/mapping/field.rs
@@ -91,15 +91,6 @@ impl Field {
         }
     }
 
-    /// Returns a mutable reference to the inner [`FieldPrimitive`] if this is
-    /// a `Primitive` variant, or `None` otherwise.
-    pub fn as_primitive_mut(&mut self) -> Option<&mut FieldPrimitive> {
-        match self {
-            Field::Primitive(p) => Some(p),
-            _ => None,
-        }
-    }
-
     /// Returns the inner [`FieldStruct`] if this is a `Struct` variant, or
     /// `None` otherwise.
     pub fn as_struct(&self) -> Option<&FieldStruct> {

--- a/crates/toasty-core/src/schema/name.rs
+++ b/crates/toasty-core/src/schema/name.rs
@@ -1,10 +1,6 @@
-use heck::{ToLowerCamelCase, ToShoutySnakeCase, ToSnakeCase, ToUpperCamelCase};
+use heck::{ToSnakeCase, ToUpperCamelCase};
 
-/// A multi-part identifier that can be rendered in various casing conventions.
-///
-/// `Name` stores the identifier as individual lowercase words (parts). It is
-/// created from a string in any common casing style (snake_case, camelCase,
-/// PascalCase) and can be converted back to any of those forms.
+/// A multi-part identifier that can be rendered in snake case or upper camel case.
 ///
 /// # Examples
 ///
@@ -14,8 +10,6 @@ use heck::{ToLowerCamelCase, ToShoutySnakeCase, ToSnakeCase, ToUpperCamelCase};
 /// let name = Name::new("UserProfile");
 /// assert_eq!(name.snake_case(), "user_profile");
 /// assert_eq!(name.upper_camel_case(), "UserProfile");
-/// assert_eq!(name.camel_case(), "userProfile");
-/// assert_eq!(name.upper_snake_case(), "USER_PROFILE");
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Name {
@@ -39,21 +33,8 @@ impl Name {
     pub fn new(src: &str) -> Self {
         // TODO: make better
         let snake = src.to_snake_case();
-        let parts = snake.split("_").map(String::from).collect();
+        let parts = snake.split('_').map(String::from).collect();
         Self { parts }
-    }
-
-    /// Returns this name in `camelCase`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use toasty_core::schema::Name;
-    ///
-    /// assert_eq!(Name::new("user_id").camel_case(), "userId");
-    /// ```
-    pub fn camel_case(&self) -> String {
-        self.snake_case().to_lower_camel_case()
     }
 
     /// Returns this name in `UpperCamelCase` (PascalCase).
@@ -80,19 +61,6 @@ impl Name {
     /// ```
     pub fn snake_case(&self) -> String {
         self.parts.join("_")
-    }
-
-    /// Returns this name in `UPPER_SNAKE_CASE`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use toasty_core::schema::Name;
-    ///
-    /// assert_eq!(Name::new("user_id").upper_snake_case(), "USER_ID");
-    /// ```
-    pub fn upper_snake_case(&self) -> String {
-        self.snake_case().to_shouty_snake_case()
     }
 }
 

--- a/crates/toasty-core/src/stmt/cx.rs
+++ b/crates/toasty-core/src/stmt/cx.rs
@@ -2,12 +2,12 @@ use crate::{
     Schema,
     schema::{
         app::{Field, Model, ModelId, ModelRoot},
-        db::{self, Column, ColumnId, Table, TableId},
+        db::{self, Column, Table, TableId},
     },
     stmt::{
-        Delete, Expr, ExprArg, ExprColumn, ExprFunc, ExprReference, ExprSet, Insert, InsertTarget,
-        Query, Returning, Select, Source, SourceTable, Statement, TableDerived, TableFactor,
-        TableRef, Type, TypeUnion, Update, UpdateTarget,
+        Delete, Expr, ExprArg, ExprFunc, ExprReference, ExprSet, Insert, InsertTarget, Query,
+        Returning, Select, Source, SourceTable, Statement, TableDerived, TableFactor, TableRef,
+        Type, TypeUnion, Update, UpdateTarget,
     },
 };
 
@@ -615,49 +615,6 @@ impl<'a> ExprContext<'a, Schema> {
     pub fn target_as_model(&self) -> Option<&'a ModelRoot> {
         self.target.as_model()
     }
-
-    /// Creates an `ExprReference::Column` for the given column ID.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the context has no table target (`ExprTarget::Free`), if the column does not
-    /// belong to the table associated with the current target, or if the target's model has no
-    /// mapped database table.
-    pub fn expr_ref_column(&self, column_id: impl Into<ColumnId>) -> ExprReference {
-        let column_id = column_id.into();
-
-        match self.target {
-            ExprTarget::Free => {
-                panic!("Cannot create ExprColumn in free context - no table target available")
-            }
-            ExprTarget::Model(model) => {
-                let Some(table) = self.schema.table_for_model(model) else {
-                    panic!(
-                        "Failed to find database table for model '{:?}' - model may not be mapped to a table",
-                        model.name
-                    )
-                };
-
-                assert_eq!(table.id, column_id.table);
-            }
-            ExprTarget::Table(table) => assert_eq!(table.id, column_id.table),
-            ExprTarget::Source(source_table) => {
-                let [TableRef::Table(table_id)] = source_table.tables[..] else {
-                    panic!(
-                        "Expected exactly one table reference, found {} tables",
-                        source_table.tables.len()
-                    );
-                };
-                assert_eq!(table_id, column_id.table);
-            }
-        }
-
-        ExprReference::Column(ExprColumn {
-            nesting: 0,
-            table: 0,
-            column: column_id.index,
-        })
-    }
 }
 
 impl<'a, T> Clone for ExprContext<'a, T> {
@@ -760,30 +717,11 @@ impl<'a> ExprTarget<'a> {
     }
 
     /// Returns the model ID if this target is [`ExprTarget::Model`], or `None`.
-    pub fn model_id(self) -> Option<ModelId> {
+    fn model_id(self) -> Option<ModelId> {
         Some(match self {
             ExprTarget::Model(model) => model.id,
             _ => return None,
         })
-    }
-
-    /// Returns the table if this target is [`ExprTarget::Table`], or `None`.
-    pub fn as_table(self) -> Option<&'a Table> {
-        match self {
-            ExprTarget::Table(table) => Some(table),
-            _ => None,
-        }
-    }
-
-    /// Returns the table, panicking if not [`ExprTarget::Table`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if the target is not `Table`.
-    #[track_caller]
-    pub fn as_table_unwrap(self) -> &'a Table {
-        self.as_table()
-            .unwrap_or_else(|| panic!("expected ExprTarget::Table; was {self:#?}"))
     }
 }
 

--- a/crates/toasty-core/src/stmt/entry.rs
+++ b/crates/toasty-core/src/stmt/entry.rs
@@ -1,6 +1,6 @@
 use crate::Result;
 
-use super::{Expr, Input, Value};
+use super::{Expr, Value};
 
 /// A borrowed reference to either an [`Expr`] or a [`Value`] within a
 /// composite structure.
@@ -17,7 +17,7 @@ use super::{Expr, Input, Value};
 /// let value = Value::from(42_i64);
 /// let entry = Entry::from(&value);
 /// assert!(entry.is_value());
-/// assert!(!entry.is_expr());
+/// assert!(matches!(entry, Entry::Value(_)));
 /// ```
 #[derive(Debug)]
 pub enum Entry<'a> {
@@ -28,28 +28,6 @@ pub enum Entry<'a> {
 }
 
 impl Entry<'_> {
-    /// Evaluates the entry to a value using the provided input.
-    ///
-    /// For `Entry::Expr`, evaluates the expression with the given input context.
-    /// For `Entry::Value`, returns a clone of the value directly.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use toasty_core::stmt::{Entry, Value, ConstInput};
-    /// let value = Value::from(42);
-    /// let entry = Entry::from(&value);
-    ///
-    /// let result = entry.eval(ConstInput::new()).unwrap();
-    /// assert_eq!(result, Value::from(42));
-    /// ```
-    pub fn eval(&self, input: impl Input) -> Result<Value> {
-        match self {
-            Entry::Expr(expr) => expr.eval(input),
-            Entry::Value(value) => Ok((*value).clone()),
-        }
-    }
-
     /// Evaluates the entry as a constant expression.
     ///
     /// For `Entry::Expr`, attempts to evaluate the expression without any input context.
@@ -108,11 +86,6 @@ impl Entry<'_> {
         }
     }
 
-    /// Returns `true` if this entry contains an expression.
-    pub fn is_expr(&self) -> bool {
-        matches!(self, Entry::Expr(_))
-    }
-
     /// Converts this entry to an owned [`Expr`] by cloning the contained
     /// expression or wrapping the value.
     pub fn to_expr(&self) -> Expr {
@@ -139,18 +112,6 @@ impl Entry<'_> {
             self,
             Entry::Value(Value::Null) | Entry::Expr(Expr::Value(Value::Null))
         )
-    }
-
-    /// Returns `true` if this entry holds a record, either as an
-    /// `Expr::Record`, an `Expr::Value(Value::Record)`, or a bare
-    /// `Value::Record`.
-    pub fn is_record(&self) -> bool {
-        match self {
-            Entry::Expr(Expr::Record(_)) => true,
-            Entry::Expr(Expr::Value(value)) => value.is_record(),
-            Entry::Value(value) => value.is_record(),
-            Entry::Expr(_) => false,
-        }
     }
 
     /// Returns a reference to the contained value, or `None` if this entry

--- a/crates/toasty-core/src/stmt/entry_mut.rs
+++ b/crates/toasty-core/src/stmt/entry_mut.rs
@@ -13,7 +13,7 @@ use super::{Expr, Value};
 ///
 /// let mut expr = Expr::from(Value::from(42_i64));
 /// let mut entry = EntryMut::from(&mut expr);
-/// assert!(entry.is_expr());
+/// assert!(matches!(entry, EntryMut::Expr(_)));
 /// ```
 #[derive(Debug)]
 pub enum EntryMut<'a> {
@@ -24,56 +24,6 @@ pub enum EntryMut<'a> {
 }
 
 impl EntryMut<'_> {
-    /// Returns a reference to the contained expression, or `None`.
-    pub fn as_expr(&self) -> Option<&Expr> {
-        match self {
-            EntryMut::Expr(e) => Some(e),
-            _ => None,
-        }
-    }
-
-    /// Returns a reference to the contained expression, panicking if not an expression.
-    ///
-    /// # Panics
-    ///
-    /// Panics if this entry is not `EntryMut::Expr`.
-    #[track_caller]
-    pub fn as_expr_unwrap(&self) -> &Expr {
-        self.as_expr()
-            .unwrap_or_else(|| panic!("expected EntryMut::Expr; actual={self:#?}"))
-    }
-
-    /// Returns a mutable reference to the contained expression, or `None`.
-    pub fn as_expr_mut(&mut self) -> Option<&mut Expr> {
-        match self {
-            EntryMut::Expr(e) => Some(e),
-            _ => None,
-        }
-    }
-
-    /// Returns a mutable reference to the contained expression, panicking if not an expression.
-    ///
-    /// # Panics
-    ///
-    /// Panics if this entry is not `EntryMut::Expr`.
-    #[track_caller]
-    pub fn as_expr_mut_unwrap(&mut self) -> &mut Expr {
-        match self {
-            EntryMut::Expr(e) => e,
-            _ => panic!("expected EntryMut::Expr"),
-        }
-    }
-
-    /// Returns `true` if this entry holds an expression.
-    pub fn is_expr(&self) -> bool {
-        matches!(self, EntryMut::Expr(_))
-    }
-
-    /// Returns `true` if this entry holds a statement expression.
-    pub fn is_statement(&self) -> bool {
-        matches!(self, EntryMut::Expr(e) if e.is_stmt())
-    }
-
     /// Returns `true` if this entry holds a concrete value.
     pub fn is_value(&self) -> bool {
         matches!(self, EntryMut::Value(_) | EntryMut::Expr(Expr::Value(_)))

--- a/crates/toasty-core/src/stmt/path.rs
+++ b/crates/toasty-core/src/stmt/path.rs
@@ -55,7 +55,7 @@ impl PathRoot {
 ///
 /// // Path pointing to the root of model 0
 /// let p = Path::model(ModelId::from_index(0));
-/// assert!(p.is_empty()); // no field steps
+/// assert!(p.projection.is_empty()); // no field steps
 /// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct Path {
@@ -104,16 +104,6 @@ impl Path {
             },
             projection: Projection::identity(),
         }
-    }
-
-    /// Returns `true` if the path has no field steps (identity projection).
-    pub fn is_empty(&self) -> bool {
-        self.projection.is_empty()
-    }
-
-    /// Returns the number of field steps in the path.
-    pub fn len(&self) -> usize {
-        self.projection.len()
     }
 
     /// Appends all field steps from `other` onto this path's projection.

--- a/crates/toasty-core/src/stmt/path_field_set.rs
+++ b/crates/toasty-core/src/stmt/path_field_set.rs
@@ -17,7 +17,7 @@ use std::ops::{BitAnd, BitOr, BitOrAssign};
 /// set.insert(2);
 /// assert!(set.contains(0_usize));
 /// assert!(!set.contains(1_usize));
-/// assert_eq!(set.len(), 2);
+/// assert_eq!(set.iter().len(), 2);
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -59,16 +59,6 @@ impl PathFieldSet {
         Self::default()
     }
 
-    /// Creates a field set from a slice of values convertible to `usize`.
-    pub fn from_slice<T>(fields: &[T]) -> Self
-    where
-        for<'a> &'a T: Into<usize>,
-    {
-        Self {
-            container: fields.iter().map(Into::into).collect(),
-        }
-    }
-
     /// Returns `true` if the set contains the given field index.
     pub fn contains(&self, val: impl Into<usize>) -> bool {
         self.container.contains(val.into())
@@ -85,11 +75,6 @@ impl PathFieldSet {
     /// Returns `true` if the set contains no field indices.
     pub fn is_empty(&self) -> bool {
         self.container.is_empty()
-    }
-
-    /// Returns the number of field indices in the set.
-    pub fn len(&self) -> usize {
-        self.container.count()
     }
 
     /// Inserts a field index into the set.

--- a/crates/toasty/src/schema.rs
+++ b/crates/toasty/src/schema.rs
@@ -43,15 +43,4 @@ pub use scope::Scope;
 mod via;
 pub use via::{ViaMany, ViaManyField, ViaPath, ViaTarget};
 
-use crate::Result;
-
 pub use toasty_core::schema::{app, app::ModelSet, db, diff, mapping};
-
-/// Build an [`app::Schema`] from a slice of model definitions produced by
-/// `#[derive(Model)]`.
-///
-/// This is a thin wrapper around [`app::Schema::from_macro`] exposed for
-/// use by generated code.
-pub fn from_macro(models: impl IntoIterator<Item = app::Model>) -> Result<app::Schema> {
-    app::Schema::from_macro(models)
-}

--- a/crates/toasty/src/stmt/association.rs
+++ b/crates/toasty/src/stmt/association.rs
@@ -14,8 +14,8 @@ use toasty_core::stmt;
 /// - `Association<List<M>>` — a has-many relation, returns `Vec<M>`.
 /// - `Association<M>` — a has-one or belongs-to relation, returns `M`.
 ///
-/// Associations are constructed by generated code (see [`many`](Association::many),
-/// [`many_via_one`](Association::many_via_one), and [`one`](Association::one)).
+/// Associations are constructed by generated code (see [`many`](Association::many)
+/// and [`one`](Association::one)).
 /// They implement [`IntoStatement`] so they can be passed directly to
 /// [`Db::exec`](crate::Db::exec).
 pub struct Association<T> {
@@ -24,11 +24,6 @@ pub struct Association<T> {
 }
 
 impl<T> Association<T> {
-    /// Borrow the underlying untyped association.
-    pub fn untyped(&self) -> &stmt::Association {
-        &self.untyped
-    }
-
     /// Construct a typed association from a raw untyped one. Used by
     /// generated code that re-types an association after carrying it through
     /// an untyped storage slot.
@@ -116,30 +111,7 @@ impl<M: Model> Association<List<M>> {
     ///
     /// Panics if the root of `path` does not match the model id of `T`.
     ///
-    /// # Examples
-    ///
-    /// ```
-    /// # #[derive(Debug, toasty::Model)]
-    /// # struct User {
-    /// #     #[key]
-    /// #     id: i64,
-    /// #     name: String,
-    /// # }
-    /// # #[derive(Debug, toasty::Model)]
-    /// # struct Todo {
-    /// #     #[key]
-    /// #     id: i64,
-    /// #     user_id: i64,
-    /// #     title: String,
-    /// # }
-    /// use toasty::stmt::{Association, List, Query};
-    /// use toasty::schema::Model;
-    ///
-    /// let source = Query::<List<Todo>>::all();
-    /// let path = Todo::path_field::<User>(1);
-    /// let _assoc: Association<List<User>> = Association::many_via_one(source, path);
-    /// ```
-    pub fn many_via_one<T: Model>(source: super::Query<List<T>>, path: Path<T, M>) -> Self {
+    pub(crate) fn many_via_one<T: Model>(source: super::Query<List<T>>, path: Path<T, M>) -> Self {
         assert_eq!(path.untyped.root.as_model_unwrap(), T::id());
 
         Self {

--- a/crates/toasty/src/stmt/create_many.rs
+++ b/crates/toasty/src/stmt/create_many.rs
@@ -10,9 +10,8 @@ use toasty_core::stmt as core_stmt;
 ///
 /// Records are accumulated with [`item`](CreateMany::item) or
 /// [`with_item`](CreateMany::with_item), then executed with
-/// [`exec`](CreateMany::exec). Alternatively, call
-/// [`into_expr`](CreateMany::into_expr) to embed the batch insert as an
-/// expression inside another statement (e.g., a has-many association insert).
+/// [`exec`](CreateMany::exec). `CreateMany` also implements [`IntoExpr`] so a
+/// batch insert can be embedded inside another statement.
 ///
 /// # Examples
 ///
@@ -28,11 +27,9 @@ use toasty_core::stmt as core_stmt;
 /// # let driver = toasty_driver_sqlite::Sqlite::in_memory();
 /// # let mut db = toasty::Db::builder().models(toasty::models!(User)).build(driver).await.unwrap();
 /// # db.push_schema().await.unwrap();
-/// use toasty::stmt::CreateMany;
-///
-/// let users = CreateMany::<User>::new()
-///     .with_item(|u| u.name("Alice"))
-///     .with_item(|u| u.name("Bob"))
+/// let users = User::create_many()
+///     .item(User::create().name("Alice"))
+///     .item(User::create().name("Bob"))
 ///     .exec(&mut db)
 ///     .await
 ///     .unwrap();
@@ -44,11 +41,6 @@ pub struct CreateMany<M: Model> {
 }
 
 impl<M: Model> CreateMany<M> {
-    /// Create an empty `CreateMany` builder with no records queued.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     /// Append a record from any value that implements [`IntoInsert`]
     /// for model `M`.
     ///
@@ -66,8 +58,8 @@ impl<M: Model> CreateMany<M> {
     /// Append a record using a closure that configures the model's generated
     /// create builder.
     ///
-    /// `f` receives a default create builder and must return it after setting
-    /// the desired fields.
+    /// `f` receives a default create builder and returns it after setting the
+    /// desired fields.
     ///
     /// Returns `self` for method chaining.
     pub fn with_item(
@@ -88,7 +80,7 @@ impl<M: Model> CreateMany<M> {
     /// embedding in a parent insert statement (e.g., as a nested HasMany value).
     ///
     /// Unlike `exec`, this does not run any database query.
-    pub fn into_expr(self) -> Expr<List<M>> {
+    fn into_expr(self) -> Expr<List<M>> {
         if self.stmts.is_empty() {
             return Expr::from_untyped(
                 core_stmt::Expr::list(std::iter::empty::<core_stmt::Expr>()),

--- a/crates/toasty/src/stmt/insert.rs
+++ b/crates/toasty/src/stmt/insert.rs
@@ -14,7 +14,7 @@ use toasty_core::stmt;
 /// matches the model being inserted.
 ///
 /// Field values are set with [`set`](Insert::set). Collection fields can be
-/// extended with [`insert`](Insert::insert) and [`insert_all`](Insert::insert_all).
+/// extended with [`insert_all`](Insert::insert_all).
 pub struct Insert<M> {
     pub(crate) untyped: stmt::Insert,
     _p: PhantomData<M>,
@@ -70,38 +70,6 @@ impl<M: Model> Insert<M> {
         }
     }
 
-    /// Wrap a raw untyped [`stmt::Insert`](toasty_core::stmt::Insert).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # #[derive(Debug, toasty::Model)]
-    /// # struct User {
-    /// #     #[key]
-    /// #     id: i64,
-    /// #     name: String,
-    /// # }
-    /// use toasty::stmt::Insert;
-    /// use toasty::schema::Model;
-    ///
-    /// // Construct from a raw untyped insert
-    /// let raw = toasty_core::stmt::Insert {
-    ///     target: toasty_core::stmt::InsertTarget::Model(
-    ///         <User as Model>::id(),
-    ///     ),
-    ///     source: toasty_core::stmt::Query::unit(),
-    ///     upsert: None,
-    ///     returning: None,
-    /// };
-    /// let _typed = Insert::<User>::from_untyped(raw);
-    /// ```
-    pub const fn from_untyped(untyped: stmt::Insert) -> Self {
-        Self {
-            untyped,
-            _p: PhantomData,
-        }
-    }
-
     /// Set the scope of the insert.
     ///
     /// # Examples
@@ -146,42 +114,6 @@ impl<M: Model> Insert<M> {
     /// ```
     pub fn set(&mut self, field: usize, expr: impl Into<stmt::Expr>) {
         *self.expr_mut(field) = expr.into();
-    }
-
-    /// Append a single value to the list field at `field` index.
-    ///
-    /// If the field is currently `NULL`, it is replaced with a new single-element
-    /// list. If it is already a list, `expr` is appended.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # #[derive(Debug, toasty::Model)]
-    /// # struct User {
-    /// #     #[key]
-    /// #     id: i64,
-    /// #     name: String,
-    /// # }
-    /// use toasty::stmt::Insert;
-    ///
-    /// let mut insert = Insert::<User>::blank_single();
-    /// // Append a value to a list field (field index 1 for illustration)
-    /// insert.insert(1, toasty_core::stmt::Value::from("tag1"));
-    /// insert.insert(1, toasty_core::stmt::Value::from("tag2"));
-    /// ```
-    pub fn insert(&mut self, field: usize, expr: impl Into<stmt::Expr>) {
-        // self.expr_mut(field).push(expr);
-        let target = self.expr_mut(field);
-
-        match target {
-            stmt::Expr::Value(stmt::Value::Null) => {
-                *target = stmt::Expr::list_from_vec(vec![expr.into()]);
-            }
-            stmt::Expr::List(expr_list) => {
-                expr_list.items.push(expr.into());
-            }
-            _ => todo!("existing={target:#?}; expr={:#?}", expr.into()),
-        }
     }
 
     /// Merge a list expression into the list field at `field` index,
@@ -247,21 +179,7 @@ impl<M: Model> Insert<M> {
     /// which can be used as the right-hand side of an association
     /// [`insert`](Association::insert) call or embedded in other expressions.
     ///
-    /// # Examples
-    ///
-    /// ```
-    /// # #[derive(Debug, toasty::Model)]
-    /// # struct User {
-    /// #     #[key]
-    /// #     id: i64,
-    /// #     name: String,
-    /// # }
-    /// use toasty::stmt::{Insert, Expr, List};
-    ///
-    /// let insert = Insert::<User>::blank_single();
-    /// let _expr: Expr<List<User>> = insert.into_list_expr();
-    /// ```
-    pub fn into_list_expr(self) -> Expr<List<M>> {
+    pub(crate) fn into_list_expr(self) -> Expr<List<M>> {
         Expr::from_untyped(stmt::Expr::Stmt(self.untyped.into()))
     }
 }

--- a/crates/toasty/src/stmt/update.rs
+++ b/crates/toasty/src/stmt/update.rs
@@ -8,20 +8,17 @@ use toasty_core::stmt;
 
 /// A typed update statement.
 ///
-/// `Update` modifies records matching a selection (typically derived from a
-/// [`Query`]). Field assignments are added with [`set`](Update::set),
-/// [`insert`](Update::insert), and [`remove`](Update::remove).
+/// `Update` modifies records matching a selection, typically derived from a
+/// [`Query`]. Field assignments can be added with [`set`](Update::set) or
+/// populated by generated update builders.
 ///
-/// The type parameter `T` is the **returning type** — it determines what
-/// `exec()` produces, not which model is being updated. For example,
-/// `Update<User>` returns the updated `User` (single-row update), while
-/// `Update<List<User>>` returns the updated records as `Vec<User>`.
+/// The type parameter `T` is the returning type—it determines what `exec()`
+/// produces, not which model is being updated. For example, `Update<User>`
+/// returns one updated `User`, while `Update<List<User>>` returns the updated
+/// records as `Vec<User>`.
 ///
 /// Generated update-builders wrap this type and expose typed setter methods.
 /// You rarely construct `Update` by hand.
-///
-/// By default, an update returns the changed records. Call
-/// [`set_returning_none`](Update::set_returning_none) to suppress this.
 pub struct Update<T> {
     pub(crate) untyped: stmt::Update,
     _p: PhantomData<T>,
@@ -53,30 +50,6 @@ impl<T> Update<T> {
 
         Self {
             untyped: stmt,
-            _p: PhantomData,
-        }
-    }
-
-    /// Wrap a raw untyped [`stmt::Update`](toasty_core::stmt::Update).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # #[derive(Debug, toasty::Model)]
-    /// # struct User {
-    /// #     #[key]
-    /// #     id: i64,
-    /// #     name: String,
-    /// # }
-    /// use toasty::stmt::{List, Query, Update};
-    ///
-    /// // Round-trip through an untyped update
-    /// let update = Update::<List<User>>::new(Query::<List<User>>::all());
-    /// let raw = update.into_untyped();
-    /// ```
-    pub const fn from_untyped(untyped: stmt::Update) -> Self {
-        Self {
-            untyped,
             _p: PhantomData,
         }
     }
@@ -139,71 +112,10 @@ impl<T> Update<T> {
     /// use toasty::stmt::{List, Query, Update};
     ///
     /// let mut update = Update::<List<User>>::new(Query::<List<User>>::all());
-    /// // Set field at index 1 (name) to "Bob"
     /// update.set(1, toasty_core::stmt::Value::from("Bob"));
     /// ```
     pub fn set(&mut self, field: impl Into<stmt::Projection>, expr: impl Into<stmt::Expr>) {
         self.untyped.assignments.set(field, expr);
-    }
-
-    /// Append a value to a collection field (e.g., a has-many relation).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # #[derive(Debug, toasty::Model)]
-    /// # struct User {
-    /// #     #[key]
-    /// #     id: i64,
-    /// #     name: String,
-    /// # }
-    /// use toasty::stmt::{List, Query, Update};
-    ///
-    /// let mut update = Update::<List<User>>::new(Query::<List<User>>::all());
-    /// update.insert(1, toasty_core::stmt::Value::from("new_tag"));
-    /// ```
-    pub fn insert(&mut self, field: impl Into<stmt::Projection>, expr: impl Into<stmt::Expr>) {
-        self.untyped.assignments.insert(field, expr);
-    }
-
-    /// Remove a value from a collection field.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # #[derive(Debug, toasty::Model)]
-    /// # struct User {
-    /// #     #[key]
-    /// #     id: i64,
-    /// #     name: String,
-    /// # }
-    /// use toasty::stmt::{List, Query, Update};
-    ///
-    /// let mut update = Update::<List<User>>::new(Query::<List<User>>::all());
-    /// update.remove(1, toasty_core::stmt::Value::from("old_tag"));
-    /// ```
-    pub fn remove(&mut self, field: impl Into<stmt::Projection>, expr: impl Into<stmt::Expr>) {
-        self.untyped.assignments.remove(field, expr);
-    }
-
-    /// Don't return anything.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # #[derive(Debug, toasty::Model)]
-    /// # struct User {
-    /// #     #[key]
-    /// #     id: i64,
-    /// #     name: String,
-    /// # }
-    /// use toasty::stmt::{List, Query, Update};
-    ///
-    /// let mut update = Update::<List<User>>::new(Query::<List<User>>::all());
-    /// update.set_returning_none();
-    /// ```
-    pub fn set_returning_none(&mut self) {
-        self.untyped.returning = None;
     }
 
     /// Consume this typed update and return the untyped core statement.
@@ -229,9 +141,6 @@ impl<T> Update<T> {
 
 impl<T: Load> Update<T> {
     /// Execute this update statement against the given executor.
-    ///
-    /// Returns the updated records unless
-    /// [`set_returning_none`](Update::set_returning_none) was called.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
## Summary

Remove exported schema and statement helpers that have no workspace callers. Keep generated-code helpers at crate visibility and update rustdoc examples to use retained APIs.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [ ] Touches a public API → a design doc under `docs/dev/design/` describes the behavior

## Notes for reviewers

The removed methods are exported but have no workspace callers, so the commit and PR title mark the change as breaking. This cleanup does not include a design doc; please review whether any helper should remain exported.