### PR TITLE
fix: preserve query offset when selecting one row

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/crud_sort_limit.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/crud_sort_limit.rs
@@ -247,6 +247,31 @@ pub async fn first_narrows_to_single_row(t: &mut Test) -> Result<()> {
 }
 
 #[driver_test(scenario(crate::scenarios::user_with_age), requires(sql))]
+pub async fn first_respects_offset(t: &mut Test) -> Result<()> {
+    let mut db = setup(t).await;
+
+    toasty::create!(User::[
+        { name: "Alice", age: 30 },
+        { name: "Bob", age: 20 },
+        { name: "Carol", age: 40 },
+    ])
+    .exec(&mut db)
+    .await?;
+
+    let user = User::all()
+        .order_by(User::fields().age().asc())
+        .limit(3)
+        .offset(1)
+        .first()
+        .exec(&mut db)
+        .await?;
+
+    assert_struct!(user, Some(_ { name: "Alice", .. }));
+
+    Ok(())
+}
+
+#[driver_test(scenario(crate::scenarios::user_with_age), requires(sql))]
 pub async fn order_by_multiple_columns_composes(t: &mut Test) -> Result<()> {
     let mut db = setup(t).await;
 

--- a/crates/toasty/src/stmt/query.rs
+++ b/crates/toasty/src/stmt/query.rs
@@ -466,9 +466,13 @@ impl<T: Model> Query<List<T>> {
 fn set_first(query: &mut stmt::Query) {
     assert!(!query.single, "query is single");
     query.single = true;
+    let offset = match &query.limit {
+        Some(stmt::Limit::Offset(limit_offset)) => limit_offset.offset.clone(),
+        _ => None,
+    };
     query.limit = Some(stmt::Limit::Offset(stmt::LimitOffset {
         limit: stmt::Expr::Static(stmt::Value::I64(1)),
-        offset: None,
+        offset,
     }));
 }
 


### PR DESCRIPTION
## Summary

Preserve an existing offset when `.first()` or `.one()` changes a query's limit to one. Previously, narrowing an offset query silently selected from the start of the result set.

Add a SQL integration regression test for an ordered query using `.limit().offset().first()`.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

The shared `set_first` helper covers both `.first()` and `.one()`.
