### PR TITLE
fix(engine): omit previous cursor on first page

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/paginate_multi_column.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/paginate_multi_column.rs
@@ -16,6 +16,31 @@ fn cursor_len(cursor: Option<&Value>) -> usize {
     cursor.fields.len()
 }
 
+#[driver_test(requires(and(sql, backward_pagination)))]
+pub async fn paginate_first_page_has_no_previous_page(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        id: i64,
+    }
+
+    let mut db = test.setup_db(models!(Item)).await;
+    toasty::create!(Item::[{ id: 1 }, { id: 2 }])
+        .exec(&mut db)
+        .await?;
+
+    let first: Page<Item> = Item::all()
+        .order_by(Item::fields().id().asc())
+        .paginate(1)
+        .exec(&mut db)
+        .await?;
+
+    assert!(!first.has_prev());
+    assert!(first.prev(&mut db).await?.is_none());
+
+    Ok(())
+}
+
 #[driver_test(requires(sql))]
 pub async fn paginate_single_non_unique_column(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]

--- a/crates/toasty-driver-integration-suite/src/tests/paginate_multi_column.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/paginate_multi_column.rs
@@ -6,8 +6,11 @@
 //! into a WHERE filter; NoSQL drivers use a driver-level cursor instead.
 
 use crate::prelude::*;
-use toasty::stmt::Page;
-use toasty_core::stmt::Value;
+use toasty::{
+    Executor,
+    stmt::{IntoStatement, Page},
+};
+use toasty_core::stmt::{self, Value};
 
 fn cursor_len(cursor: Option<&Value>) -> usize {
     let Some(Value::Record(cursor)) = cursor else {
@@ -37,6 +40,50 @@ pub async fn paginate_first_page_has_no_previous_page(test: &mut Test) -> Result
 
     assert!(!first.has_prev());
     assert!(first.prev(&mut db).await?.is_none());
+
+    Ok(())
+}
+
+#[driver_test(requires(and(sql, backward_pagination)))]
+pub async fn paginate_first_page_ignores_subquery_cursor(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        id: i64,
+    }
+
+    let mut db = test.setup_db(models!(Item)).await;
+    toasty::create!(Item::[{ id: 1 }, { id: 2 }])
+        .exec(&mut db)
+        .await?;
+
+    let mut statement = Item::filter(
+        Item::fields().id().in_query(
+            Item::all()
+                .order_by(Item::fields().id().asc())
+                .select(Item::fields().id()),
+        ),
+    )
+    .order_by(Item::fields().id().asc())
+    .into_statement()
+    .into_untyped();
+
+    let outer = statement.as_query_mut().unwrap();
+    outer.limit = Some(stmt::Limit::Cursor(stmt::LimitCursor {
+        page_size: stmt::Value::from(1_i64).into(),
+        after: None,
+    }));
+
+    let stmt::Expr::InSubquery(inner) = outer.filter_mut_unwrap().expr.as_mut().unwrap() else {
+        panic!("expected an IN subquery filter");
+    };
+    inner.query.limit = Some(stmt::Limit::Cursor(stmt::LimitCursor {
+        page_size: stmt::Value::from(2_i64).into(),
+        after: Some(stmt::Value::from(0_i64).into()),
+    }));
+
+    let response = db.exec_untyped(statement).await?;
+    assert!(response.prev_cursor.is_none());
 
     Ok(())
 }

--- a/crates/toasty-driver-integration-suite/src/tests/paginate_multi_column.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/paginate_multi_column.rs
@@ -57,30 +57,30 @@ pub async fn paginate_first_page_ignores_subquery_cursor(test: &mut Test) -> Res
         .exec(&mut db)
         .await?;
 
-    let mut statement = Item::filter(
-        Item::fields().id().in_query(
-            Item::all()
-                .order_by(Item::fields().id().asc())
-                .select(Item::fields().id()),
-        ),
-    )
-    .order_by(Item::fields().id().asc())
-    .into_statement()
-    .into_untyped();
+    let mut inner = Item::all()
+        .order_by(Item::fields().id().asc())
+        .select((Item::fields().id(), Item::fields().id()))
+        .into_statement()
+        .into_untyped()
+        .into_query_unwrap();
+    inner.limit = Some(stmt::Limit::Cursor(stmt::LimitCursor {
+        page_size: stmt::Value::from(2_i64).into(),
+        after: Some(stmt::Value::from(0_i64).into()),
+    }));
+
+    let mut statement = Item::all()
+        .order_by(Item::fields().id().asc())
+        .into_statement()
+        .into_untyped();
 
     let outer = statement.as_query_mut().unwrap();
     outer.limit = Some(stmt::Limit::Cursor(stmt::LimitCursor {
         page_size: stmt::Value::from(1_i64).into(),
         after: None,
     }));
-
-    let stmt::Expr::InSubquery(inner) = outer.filter_mut_unwrap().expr.as_mut().unwrap() else {
-        panic!("expected an IN subquery filter");
-    };
-    inner.query.limit = Some(stmt::Limit::Cursor(stmt::LimitCursor {
-        page_size: stmt::Value::from(2_i64).into(),
-        after: Some(stmt::Value::from(0_i64).into()),
-    }));
+    outer.with = Some(stmt::With {
+        ctes: vec![stmt::Cte { query: inner }],
+    });
 
     let response = db.exec_untyped(statement).await?;
     assert!(response.prev_cursor.is_none());

--- a/crates/toasty-driver-integration-suite/src/tests/paginate_multi_column.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/paginate_multi_column.rs
@@ -88,6 +88,50 @@ pub async fn paginate_first_page_ignores_subquery_cursor(test: &mut Test) -> Res
     Ok(())
 }
 
+#[driver_test(requires(and(sql, backward_pagination)))]
+pub async fn paginate_first_page_ignores_nested_statement_cursor(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Item {
+        #[key]
+        id: i64,
+    }
+
+    let mut db = test.setup_db(models!(Item)).await;
+    toasty::create!(Item::[{ id: 1 }, { id: 2 }])
+        .exec(&mut db)
+        .await?;
+
+    let mut nested = Item::all()
+        .order_by(Item::fields().id().asc())
+        .into_statement()
+        .into_untyped();
+    nested.as_query_mut().unwrap().limit = Some(stmt::Limit::Cursor(stmt::LimitCursor {
+        page_size: stmt::Value::from(1_i64).into(),
+        after: Some(stmt::Value::from(0_i64).into()),
+    }));
+
+    let mut statement = Item::all()
+        .order_by(Item::fields().id().asc())
+        .select((Item::fields().id(), Item::fields().id()))
+        .into_statement()
+        .into_untyped();
+    let outer = statement.as_query_mut().unwrap();
+    outer.limit = Some(stmt::Limit::Cursor(stmt::LimitCursor {
+        page_size: stmt::Value::from(1_i64).into(),
+        after: None,
+    }));
+
+    let stmt::Expr::Record(returning) = outer.returning_mut_unwrap().as_project_mut_unwrap() else {
+        panic!("expected a record projection");
+    };
+    returning.fields[1] = stmt::Expr::stmt(nested);
+
+    let response = db.exec_untyped(statement).await?;
+    assert!(response.prev_cursor.is_none());
+
+    Ok(())
+}
+
 #[driver_test(requires(sql))]
 pub async fn paginate_single_non_unique_column(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]

--- a/crates/toasty/src/engine/exec/exec_statement.rs
+++ b/crates/toasty/src/engine/exec/exec_statement.rs
@@ -37,6 +37,8 @@ pub(crate) enum ConditionalOutput {
 pub(crate) struct PaginationConfig {
     /// Number of items per page
     pub page_size: i64,
+    /// Whether the query starts after a cursor and can have a previous page.
+    pub has_previous_page: bool,
     /// Function to extract cursor from a row (SQL only).
     /// For NoSQL drivers, this is None (driver provides cursor).
     pub extract_cursor: Option<eval::Func>,
@@ -296,8 +298,11 @@ impl Exec<'_> {
             None
         };
 
-        // Extract prev cursor from first row only when the driver supports backward pagination
-        res.prev_cursor = if !row_vec.is_empty() && self.engine.capability().backward_pagination {
+        // Extract a previous cursor only when this query started after another page.
+        res.prev_cursor = if pagination.has_previous_page
+            && !row_vec.is_empty()
+            && self.engine.capability().backward_pagination
+        {
             let cursor_row = &row_vec[0];
             Some(extract_cursor.eval(&self.engine.schema, std::slice::from_ref(cursor_row))?)
         } else {

--- a/crates/toasty/src/engine/hir.rs
+++ b/crates/toasty/src/engine/hir.rs
@@ -47,6 +47,9 @@ pub(super) struct StatementInfo {
     /// are complete. Contains the table-level statement ready for planning.
     pub(super) stmt: Option<Box<stmt::Statement>>,
 
+    /// Whether cursor pagination resumed this query after an earlier page.
+    pub(super) has_pagination_cursor: bool,
+
     /// Statement IDs that must execute before this statement.
     ///
     /// Dependencies ensure execution order for consistency, even when this
@@ -106,6 +109,7 @@ impl StatementInfo {
     pub(super) fn new(deps: HashSet<StmtId>) -> StatementInfo {
         StatementInfo {
             stmt: None,
+            has_pagination_cursor: false,
             deps,
             args: vec![],
             back_refs: HashMap::new(),

--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -1169,6 +1169,13 @@ impl visit_mut::VisitMut for LowerStatement<'_, '_> {
     }
 
     fn visit_stmt_query_mut(&mut self, stmt: &mut stmt::Query) {
+        if matches!(
+            &stmt.limit,
+            Some(stmt::Limit::Cursor(cursor)) if cursor.after.is_some()
+        ) {
+            self.curr_stmt_info().has_pagination_cursor = true;
+        }
+
         let mut lower = self.scope_expr(&stmt.body);
 
         if let Some(with) = &mut stmt.with {

--- a/crates/toasty/src/engine/lower.rs
+++ b/crates/toasty/src/engine/lower.rs
@@ -611,6 +611,19 @@ impl LowerStatement<'_, '_> {
 }
 
 impl visit_mut::VisitMut for LowerStatement<'_, '_> {
+    fn visit_stmt_mut(&mut self, stmt: &mut stmt::Statement) {
+        if let stmt::Statement::Query(query) = stmt
+            && matches!(
+                &query.limit,
+                Some(stmt::Limit::Cursor(cursor)) if cursor.after.is_some()
+            )
+        {
+            self.curr_stmt_info().has_pagination_cursor = true;
+        }
+
+        visit_mut::visit_stmt_mut(self, stmt);
+    }
+
     fn visit_order_by_expr_mut(&mut self, node: &mut stmt::OrderByExpr) {
         // First, run the default visitor to lower sub-expressions
         self.visit_expr_mut(&mut node.expr);
@@ -1169,13 +1182,6 @@ impl visit_mut::VisitMut for LowerStatement<'_, '_> {
     }
 
     fn visit_stmt_query_mut(&mut self, stmt: &mut stmt::Query) {
-        if matches!(
-            &stmt.limit,
-            Some(stmt::Limit::Cursor(cursor)) if cursor.after.is_some()
-        ) {
-            self.curr_stmt_info().has_pagination_cursor = true;
-        }
-
         let mut lower = self.scope_expr(&stmt.body);
 
         if let Some(with) = &mut stmt.with {

--- a/crates/toasty/src/engine/plan/statement.rs
+++ b/crates/toasty/src/engine/plan/statement.rs
@@ -131,6 +131,7 @@ struct ReturningInfo {
 
 struct PaginationInfo {
     page_size: i64,
+    has_previous_page: bool,
     cursor_column_indices: Vec<usize>,
 }
 
@@ -1107,6 +1108,7 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
 
         Ok(Some(PaginationInfo {
             page_size,
+            has_previous_page: self.stmt_info.has_pagination_cursor,
             cursor_column_indices,
         }))
     }
@@ -1137,6 +1139,7 @@ impl<'a, 'b> PlanStatement<'a, 'b> {
 
         exec::PaginationConfig {
             page_size: info.page_size,
+            has_previous_page: info.has_previous_page,
             extract_cursor: Some(extract_cursor_func),
         }
     }


### PR DESCRIPTION
## Summary

Prevent the first SQL cursor-paginated page from reporting a previous page. Preserve whether a query resumed from a cursor through lowering, and expose `prev_cursor` only for resumed queries.

Add shared integration coverage for `has_prev()` and `prev()` on the first page.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

The cursor expression is consumed while lowering it into a SQL filter, so the resumed-query flag is stored in HIR before that rewrite.