### PR TITLE
feat(cli): ship a standalone toasty binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,12 @@ heck = "0.5.0"
 indexmap = "2.13.0"
 index_vec = "0.1.4"
 inventory = "0.3.24"
+libloading = "0.8.9"
+linktime = { version = "0.18.0", default-features = false, features = [
+	"std",
+	"ctor",
+	"proc_macro",
+] }
 # Must match the version used by `postgres-protocol` (the postgres driver
 # iterates over its `FallibleIterator` types); do not bump independently.
 fallible-iterator = "0.2"

--- a/crates/toasty-cli/Cargo.toml
+++ b/crates/toasty-cli/Cargo.toml
@@ -13,6 +13,27 @@ categories.workspace = true
 readme.workspace = true
 documentation = "https://docs.rs/toasty-cli"
 
+[features]
+default = ["cli"]
+
+# The standalone `toasty` binary. Pulls in the SQL drivers it connects with and
+# the machinery for building a user's package and reading the schema back out.
+# Depend on this crate with `default-features = false` to use it purely as a
+# library for a CLI of your own.
+cli = [
+	"dep:libloading",
+	"dep:serde_json",
+	"dep:tokio",
+	"toasty/mysql",
+	"toasty/postgresql",
+	"toasty/sqlite",
+]
+
+[[bin]]
+name = "toasty"
+path = "src/bin/toasty.rs"
+required-features = ["cli"]
+
 [dependencies]
 toasty = { workspace = true, features = ["migration"] }
 toasty-core.workspace = true
@@ -23,8 +44,11 @@ console.workspace = true
 dialoguer.workspace = true
 hashbrown.workspace = true
 jiff.workspace = true
+libloading = { workspace = true, optional = true }
 rand.workspace = true
 serde.workspace = true
+serde_json = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true, features = ["rt", "macros"] }
 toml.workspace = true
 
 [dev-dependencies]

--- a/crates/toasty-cli/src/bin/toasty.rs
+++ b/crates/toasty-cli/src/bin/toasty.rs
@@ -1,0 +1,8 @@
+//! The standalone `toasty` binary. See [`toasty_cli::standalone`].
+
+fn main() {
+    if let Err(err) = toasty_cli::standalone::run() {
+        eprintln!("{} {err:#}", console::style("error:").red().bold());
+        std::process::exit(1);
+    }
+}

--- a/crates/toasty-cli/src/lib.rs
+++ b/crates/toasty-cli/src/lib.rs
@@ -1,10 +1,25 @@
 #![warn(missing_docs)]
-//! A library for building Toasty command-line tools.
+//! The Toasty command-line tool, and a library for building your own.
 //!
-//! `toasty-cli` provides [`ToastyCli`], a ready-made CLI runner that wraps a
-//! [`toasty::Db`] handle and exposes database migration subcommands (generate,
-//! apply, drop, reset, snapshot). It uses [clap] for argument parsing and
-//! [dialoguer] for interactive prompts.
+//! Installing this crate gives you the standalone `toasty` binary:
+//!
+//! ```text
+//! cargo install toasty-cli
+//! ```
+//!
+//! Run it from any Cargo package that uses Toasty — it reads your schema out
+//! of the artifact your project already builds, so there is nothing to add to
+//! your `Cargo.toml` and no code to write. See [`standalone`] for the details.
+//!
+//! ```text
+//! toasty migrate generate --flavor postgresql --name init
+//! toasty migrate apply --url postgres://localhost/app
+//! ```
+//!
+//! As a library, `toasty-cli` provides [`ToastyCli`], a CLI runner that wraps
+//! a [`toasty::Db`] handle and exposes the same migration subcommands from a
+//! binary of your own. It uses [clap] for argument parsing and [dialoguer] for
+//! interactive prompts.
 //!
 //! The crate also exposes the underlying configuration used by the command
 //! runner. Reusable migration history, snapshot, and generation types live in
@@ -34,6 +49,8 @@
 
 mod config;
 mod migration;
+#[cfg(feature = "cli")]
+pub mod standalone;
 mod theme;
 mod utility;
 

--- a/crates/toasty-cli/src/migration.rs
+++ b/crates/toasty-cli/src/migration.rs
@@ -12,6 +12,13 @@ pub use generate::GenerateCommand;
 pub use reset::ResetCommand;
 pub use snapshot::SnapshotCommand;
 
+// The `Db`-free entry points. Each command's `run` calls into these too, but
+// only the standalone CLI reaches them from outside this module.
+#[cfg(feature = "cli")]
+pub(crate) use {
+    apply::run_apply, generate::run_generate, reset::run_reset, snapshot::run_snapshot,
+};
+
 use crate::Config;
 use anyhow::Result;
 use clap::Parser;

--- a/crates/toasty-cli/src/migration/apply.rs
+++ b/crates/toasty-cli/src/migration/apply.rs
@@ -5,6 +5,7 @@ use console::style;
 use hashbrown::HashSet;
 use std::fs;
 use toasty::Db;
+use toasty::db::Driver;
 use toasty::migration::History;
 use toasty::schema::db::Migration;
 
@@ -21,24 +22,33 @@ pub struct ApplyCommand {}
 
 impl ApplyCommand {
     pub(crate) async fn run(self, db: &Db, config: &Config) -> Result<()> {
-        println!();
-        println!("  {}", style("Apply Migrations").cyan().bold().underlined());
-        println!();
-        println!(
-            "  {}",
-            style(format!(
-                "Connected to {}",
-                crate::utility::redact_url_password(&db.driver().url())
-            ))
-            .dim()
-        );
-        println!();
-
-        apply_migrations(db, config).await
+        run_apply(db.driver(), config).await
     }
 }
 
-pub(crate) async fn apply_migrations(db: &Db, config: &Config) -> Result<()> {
+/// Applies pending migrations against `driver`.
+///
+/// Takes a driver rather than a [`Db`] because applying a migration needs a
+/// connection and nothing else — in particular, not the models. That is what
+/// lets the standalone CLI apply migrations with only a `--url`.
+pub(crate) async fn run_apply(driver: &dyn Driver, config: &Config) -> Result<()> {
+    println!();
+    println!("  {}", style("Apply Migrations").cyan().bold().underlined());
+    println!();
+    println!(
+        "  {}",
+        style(format!(
+            "Connected to {}",
+            crate::utility::redact_url_password(&driver.url())
+        ))
+        .dim()
+    );
+    println!();
+
+    apply_migrations(driver, config).await
+}
+
+pub(crate) async fn apply_migrations(driver: &dyn Driver, config: &Config) -> Result<()> {
     let history_path = config.migration.get_history_file_path();
 
     // Load migration history
@@ -56,8 +66,7 @@ pub(crate) async fn apply_migrations(db: &Db, config: &Config) -> Result<()> {
     }
 
     // Get a connection to check which migrations have been applied
-    let mut conn = db
-        .driver()
+    let mut conn = driver
         .connect(&toasty::db::ConnectContext::default())
         .await?;
 

--- a/crates/toasty-cli/src/migration/drop.rs
+++ b/crates/toasty-cli/src/migration/drop.rs
@@ -26,6 +26,12 @@ pub struct DropCommand {
 
 impl DropCommand {
     pub(crate) fn run(self, _db: &Db, config: &Config) -> Result<()> {
+        self.run_drop(config)
+    }
+
+    /// Drops a migration from the history and deletes its files. Touches no
+    /// database, so the standalone CLI runs it without a `--url`.
+    pub(crate) fn run_drop(self, config: &Config) -> Result<()> {
         let history_path = config.migration.get_history_file_path();
         let mut history = History::load_or_default(&history_path)?;
 

--- a/crates/toasty-cli/src/migration/generate.rs
+++ b/crates/toasty-cli/src/migration/generate.rs
@@ -6,7 +6,7 @@ use dialoguer::Select;
 use hashbrown::{HashMap, HashSet};
 use rand::RngExt;
 use std::fs;
-use toasty::migration::{self, History, HistoryEntry, Snapshot};
+use toasty::migration::{self, Flavor, History, HistoryEntry, Snapshot};
 use toasty::{
     Db,
     schema::{
@@ -229,6 +229,32 @@ fn collect_rename_hints(previous_schema: &Schema, schema: &Schema) -> Result<dif
 
 impl GenerateCommand {
     pub(crate) fn run(self, db: &Db, config: &Config) -> Result<()> {
+        let capability = db.driver().capability();
+        let Some(flavor) = capability.sql_flavor else {
+            anyhow::bail!(
+                "{} cannot generate migrations; its schema changes are made outside Toasty",
+                capability.driver_name
+            );
+        };
+
+        let schema = toasty::schema::db::Schema::clone(&db.schema().db);
+        run_generate(&schema, flavor, config, self.name.as_deref())
+    }
+}
+
+/// Generates a migration advancing the latest snapshot to `schema`.
+///
+/// Takes the schema and flavor directly rather than a [`Db`]: the migration is
+/// a function of the two, and the standalone CLI has neither a connection nor
+/// a reason to open one. `--flavor` names the dialect, and the schema comes
+/// from the project's own build artifact.
+pub(crate) fn run_generate(
+    schema: &Schema,
+    flavor: Flavor,
+    config: &Config,
+    name: Option<&str>,
+) -> Result<()> {
+    {
         println!();
         println!(
             "  {}",
@@ -253,11 +279,8 @@ impl GenerateCommand {
             .map(|snapshot| snapshot.schema)
             .unwrap_or_else(Schema::default);
 
-        let schema = toasty::schema::db::Schema::clone(&db.schema().db);
-
-        let rename_hints = collect_rename_hints(&previous_schema, &schema)?;
-        let Some(generated) =
-            migration::generate(db.driver(), &previous_schema, &schema, &rename_hints)
+        let rename_hints = collect_rename_hints(&previous_schema, schema)?;
+        let Some(generated) = migration::generate(flavor, &previous_schema, schema, &rename_hints)
         else {
             println!(
                 "  {}",
@@ -283,7 +306,7 @@ impl GenerateCommand {
         let migration_name = format!(
             "{:04}_{}.sql",
             migration_prefix,
-            self.name.as_deref().unwrap_or("migration")
+            name.unwrap_or("migration")
         );
         let migration_path = config.migration.get_migrations_dir().join(&migration_name);
 

--- a/crates/toasty-cli/src/migration/reset.rs
+++ b/crates/toasty-cli/src/migration/reset.rs
@@ -6,6 +6,7 @@ use clap::Parser;
 use console::style;
 use dialoguer::Confirm;
 use toasty::Db;
+use toasty::db::Driver;
 
 /// Drops all tables in the database, then optionally re-applies migrations.
 ///
@@ -21,6 +22,20 @@ pub struct ResetCommand {
 
 impl ResetCommand {
     pub(crate) async fn run(self, db: &Db, config: &Config) -> Result<()> {
+        run_reset(db.driver(), config, self.skip_migrations).await
+    }
+}
+
+/// Drops every table on `driver` and optionally re-applies the migrations.
+///
+/// Driver-based for the same reason as [`run_apply`](super::apply::run_apply):
+/// the models play no part.
+pub(crate) async fn run_reset(
+    driver: &dyn Driver,
+    config: &Config,
+    skip_migrations: bool,
+) -> Result<()> {
+    {
         println!();
         println!("  {}", style("Reset Database").cyan().bold().underlined());
         println!();
@@ -28,7 +43,7 @@ impl ResetCommand {
             "  {}",
             style(format!(
                 "Connected to {}",
-                crate::utility::redact_url_password(&db.driver().url())
+                crate::utility::redact_url_password(&driver.url())
             ))
             .dim()
         );
@@ -57,7 +72,7 @@ impl ResetCommand {
         println!();
         println!("  {} Resetting database...", style("→").cyan());
 
-        db.reset_db().await?;
+        driver.reset_db().await?;
 
         println!(
             "  {} {}",
@@ -66,8 +81,8 @@ impl ResetCommand {
         );
         println!();
 
-        if !self.skip_migrations {
-            apply_migrations(db, config).await?;
+        if !skip_migrations {
+            apply_migrations(driver, config).await?;
         }
 
         Ok(())

--- a/crates/toasty-cli/src/migration/snapshot.rs
+++ b/crates/toasty-cli/src/migration/snapshot.rs
@@ -17,6 +17,13 @@ pub struct SnapshotCommand {
 
 impl SnapshotCommand {
     pub(crate) fn run(self, db: &Db, _config: &Config) -> Result<()> {
+        run_snapshot(&toasty::schema::db::Schema::clone(&db.schema().db))
+    }
+}
+
+/// Prints `schema` as a TOML snapshot.
+pub(crate) fn run_snapshot(schema: &toasty::schema::db::Schema) -> Result<()> {
+    {
         println!();
         println!(
             "  {}",
@@ -24,7 +31,7 @@ impl SnapshotCommand {
         );
         println!();
 
-        let snapshot = Snapshot::new(toasty::schema::db::Schema::clone(&db.schema().db));
+        let snapshot = Snapshot::new(schema.clone());
 
         // Print the snapshot with nice formatting
         let snapshot_str = snapshot.to_toml_string()?;

--- a/crates/toasty-cli/src/standalone.rs
+++ b/crates/toasty-cli/src/standalone.rs
@@ -1,0 +1,224 @@
+//! The standalone `toasty` binary.
+//!
+//! Installed once with `cargo install toasty-cli` and run from any Cargo
+//! package that uses Toasty. Unlike [`ToastyCli`](crate::ToastyCli), which a
+//! project embeds in a binary of its own, this CLI links none of the user's
+//! models: it reads the schema out of the artifact the project already builds.
+//! See [`extract`] for how.
+
+mod cargo;
+mod extract;
+
+use crate::{Config, migration};
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+use toasty::migration::Flavor;
+
+use std::path::{Path, PathBuf};
+
+/// Runs the standalone `toasty` CLI, parsing arguments from the environment.
+///
+/// This is the entry point of the `toasty` binary.
+///
+/// # Errors
+///
+/// Returns an error if the command fails. Argument parsing failures exit the
+/// process directly, as clap does for every CLI.
+pub fn run() -> Result<()> {
+    Cli::parse().run()
+}
+
+#[derive(Parser, Debug)]
+#[command(name = "toasty")]
+#[command(about = "Manage a Toasty project's database schema")]
+// A flattened `Args` struct otherwise donates its doc comment to the command.
+#[command(long_about = None)]
+#[command(version)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+
+    #[command(flatten)]
+    target: cargo::TargetFlags,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Generate, apply, and manage schema migrations
+    #[command(subcommand)]
+    Migrate(MigrateCommand),
+
+    /// Load a cdylib so its constructors run.
+    ///
+    /// Internal: the CLI re-execs itself with this to dump a lib-only
+    /// project's schema in a process it can afford to have exit.
+    #[command(name = extract::LOAD_CDYLIB_SUBCOMMAND, hide = true)]
+    LoadCdylib {
+        /// The shared library to load.
+        path: PathBuf,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum MigrateCommand {
+    /// Generate a migration from the changes since the last snapshot
+    Generate {
+        /// SQL dialect to generate for
+        #[arg(long, value_name = "FLAVOR")]
+        flavor: FlavorArg,
+
+        /// Name for the migration
+        #[arg(short, long)]
+        name: Option<String>,
+    },
+
+    /// Apply pending migrations to a database
+    Apply {
+        /// Database connection URL
+        #[arg(long, value_name = "URL")]
+        url: String,
+    },
+
+    /// Drop every table in a database, then re-apply the migrations
+    Reset {
+        /// Database connection URL
+        #[arg(long, value_name = "URL")]
+        url: String,
+
+        /// Skip applying migrations after the reset
+        #[arg(long)]
+        skip_migrations: bool,
+    },
+
+    /// Remove a migration from the history and delete its files
+    Drop(migration::DropCommand),
+
+    /// Print the current schema as a snapshot
+    Snapshot {
+        /// SQL dialect to resolve the schema against
+        #[arg(long, value_name = "FLAVOR")]
+        flavor: FlavorArg,
+    },
+}
+
+/// `--flavor`, as clap sees it.
+///
+/// A local enum rather than [`Flavor`] itself, which belongs to `toasty-core`
+/// and so cannot implement clap's traits here. Mirroring it lets clap list the
+/// choices in `--help` and reject anything else with its usual message.
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+enum FlavorArg {
+    Sqlite,
+    #[value(alias = "postgres", alias = "pg")]
+    Postgresql,
+    #[value(alias = "mariadb")]
+    Mysql,
+}
+
+impl From<FlavorArg> for Flavor {
+    fn from(arg: FlavorArg) -> Self {
+        match arg {
+            FlavorArg::Sqlite => Self::Sqlite,
+            FlavorArg::Postgresql => Self::Postgresql,
+            FlavorArg::Mysql => Self::Mysql,
+        }
+    }
+}
+
+impl Cli {
+    fn run(self) -> Result<()> {
+        match self.command {
+            Command::LoadCdylib { path } => extract::load_cdylib(&path),
+            Command::Migrate(command) => command.run(&self.target),
+        }
+    }
+}
+
+impl MigrateCommand {
+    fn run(self, target: &cargo::TargetFlags) -> Result<()> {
+        match self {
+            Self::Generate { flavor, name } => {
+                let flavor = flavor.into();
+                let (schema, config) = resolve_schema(target, flavor)?;
+                migration::run_generate(&schema, flavor, &config, name.as_deref())
+            }
+            Self::Snapshot { flavor } => {
+                let (schema, _) = resolve_schema(target, flavor.into())?;
+                migration::run_snapshot(&schema)
+            }
+            Self::Drop(command) => command.run_drop(&project_config(target)?),
+            // Applying and resetting only need a connection, so they skip the
+            // build entirely and go straight to the URL.
+            Self::Apply { url } => {
+                let config = project_config(target)?;
+                block_on(async {
+                    let driver = toasty::db::Connect::new(&url).await?;
+                    migration::run_apply(&driver, &config).await
+                })
+            }
+            Self::Reset {
+                url,
+                skip_migrations,
+            } => {
+                let config = project_config(target)?;
+                block_on(async {
+                    let driver = toasty::db::Connect::new(&url).await?;
+                    migration::run_reset(&driver, &config, skip_migrations).await
+                })
+            }
+        }
+    }
+}
+
+/// Extracts the project's schema and lowers it for `flavor`.
+///
+/// The dump is the application schema — models, fields, relations — which is
+/// independent of any database. Turning it into tables and columns is where
+/// the flavor comes in, because storage types and identifier limits differ.
+fn resolve_schema(
+    target: &cargo::TargetFlags,
+    flavor: Flavor,
+) -> Result<(toasty::schema::db::Schema, Config)> {
+    let config = project_config(target)?;
+    let app_schema = extract::schema(target)?;
+
+    let schema = toasty_core::schema::Builder::default()
+        .build(app_schema, flavor.capability())
+        .context("the extracted schema is not valid for this flavor")?;
+
+    Ok((schema.db, config))
+}
+
+/// Loads `Toasty.toml` from the target package and roots its migration paths
+/// there, so the CLI reads and writes the same files from anywhere in the
+/// workspace.
+fn project_config(target: &cargo::TargetFlags) -> Result<Config> {
+    let metadata = cargo::Metadata::load(target)?;
+    let root = metadata.target_package(target)?.root_dir().to_path_buf();
+
+    let mut config = Config::load_or_default(&root)?;
+    config.migration.path = absolutize(&root, &config.migration.path);
+
+    Ok(config)
+}
+
+fn absolutize(root: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        root.join(path)
+    }
+}
+
+/// Runs `future` on a current-thread runtime.
+///
+/// Only the database-facing commands are async, and they issue one statement
+/// at a time; a full multi-threaded runtime would buy nothing.
+fn block_on<T>(future: impl Future<Output = Result<T>>) -> Result<T> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("failed to start the async runtime")?
+        .block_on(future)
+}

--- a/crates/toasty-cli/src/standalone/cargo.rs
+++ b/crates/toasty-cli/src/standalone/cargo.rs
@@ -1,0 +1,623 @@
+//! The parts of `cargo` the CLI drives: reading a workspace's layout and
+//! building one target out of it.
+
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+};
+
+/// Where to find the workspace and which member to work on.
+///
+/// These mirror `cargo`'s own flags and are passed straight through, so their
+/// meaning matches `cargo` exactly.
+#[derive(Debug, Default, Clone, clap::Args)]
+#[command(next_help_heading = "Target selection")]
+pub struct TargetFlags {
+    /// Package to extract the schema from
+    #[arg(short, long, value_name = "SPEC", global = true)]
+    pub package: Option<String>,
+
+    /// Binary target to extract the schema from
+    #[arg(long, value_name = "NAME", global = true)]
+    pub bin: Option<String>,
+
+    /// Path to Cargo.toml
+    #[arg(long, value_name = "PATH", global = true)]
+    pub manifest_path: Option<PathBuf>,
+}
+
+/// A workspace as `cargo metadata` describes it.
+#[derive(Deserialize)]
+pub struct Metadata {
+    packages: Vec<Package>,
+    workspace_members: Vec<String>,
+    workspace_root: PathBuf,
+    /// The resolved dependency graph. Absent only if cargo omits it.
+    #[serde(default)]
+    resolve: Option<Resolve>,
+}
+
+/// One package in the workspace.
+#[derive(Deserialize)]
+pub struct Package {
+    /// The package name, as `-p` accepts it.
+    pub name: String,
+    /// Opaque package identifier, used to match against `workspace_members`
+    /// and the resolve graph.
+    pub id: String,
+    /// Absolute path to the package's `Cargo.toml`.
+    pub manifest_path: PathBuf,
+    /// The package's build targets.
+    pub targets: Vec<Target>,
+}
+
+/// One build target of a [`Package`].
+#[derive(Deserialize)]
+pub struct Target {
+    /// The target name — for a bin, what `--bin` takes.
+    pub name: String,
+    /// Target kinds, e.g. `["bin"]`, `["lib"]`, `["proc-macro"]`.
+    pub kind: Vec<String>,
+}
+
+/// The resolved dependency graph, one node per package.
+#[derive(Deserialize)]
+struct Resolve {
+    nodes: Vec<ResolveNode>,
+}
+
+#[derive(Deserialize)]
+struct ResolveNode {
+    id: String,
+    dependencies: Vec<String>,
+}
+
+impl Package {
+    /// The directory holding this package's `Cargo.toml`. Migration files and
+    /// `Toasty.toml` are resolved relative to it, so the CLI behaves the same
+    /// from anywhere in the workspace.
+    pub fn root_dir(&self) -> &Path {
+        self.manifest_path
+            .parent()
+            .expect("a manifest path always has a parent")
+    }
+
+    /// The names of this package's `[[bin]]` targets.
+    pub fn bin_names(&self) -> Vec<&str> {
+        self.targets
+            .iter()
+            .filter(|t| t.kind.iter().any(|k| k == "bin"))
+            .map(|t| t.name.as_str())
+            .collect()
+    }
+
+    /// Whether this package has a `[lib]` target that can be rebuilt as a
+    /// `cdylib`. A proc-macro crate has a `lib` section but cannot.
+    pub fn has_linkable_lib(&self) -> bool {
+        self.targets.iter().any(|t| {
+            t.kind
+                .iter()
+                .any(|k| matches!(k.as_str(), "lib" | "rlib" | "cdylib" | "dylib"))
+        })
+    }
+}
+
+impl Metadata {
+    /// Reads the workspace layout and resolved dependency graph with
+    /// `cargo metadata`.
+    pub fn load(flags: &TargetFlags) -> Result<Self> {
+        let mut cmd = Command::new(cargo_bin());
+        cmd.args(["metadata", "--format-version", "1"]);
+
+        if let Some(manifest_path) = &flags.manifest_path {
+            cmd.arg("--manifest-path").arg(manifest_path);
+        }
+
+        let output = cmd
+            .stderr(Stdio::inherit())
+            .output()
+            .context("failed to run `cargo metadata`; is cargo on PATH?")?;
+
+        if !output.status.success() {
+            bail!("`cargo metadata` failed; see the error above");
+        }
+
+        serde_json::from_slice(&output.stdout).context("could not parse `cargo metadata`")
+    }
+
+    /// Whether `package` links `toasty`, directly or through another crate.
+    ///
+    /// The dump constructor comes from `toasty`; a package that does not reach
+    /// it would build fine and produce nothing. The whole graph is searched
+    /// rather than the direct dependencies alone, because a binary whose models
+    /// live in a sibling library reaches `toasty` only through that library.
+    pub fn links_toasty(&self, package: &Package) -> bool {
+        let Some(resolve) = &self.resolve else {
+            // Without a resolve graph there is nothing to check; let the build
+            // proceed and report a missing dump afterwards.
+            return true;
+        };
+
+        let toasty_ids: Vec<&str> = self
+            .packages
+            .iter()
+            .filter(|p| p.name == "toasty")
+            .map(|p| p.id.as_str())
+            .collect();
+
+        if toasty_ids.is_empty() {
+            return false;
+        }
+
+        let mut seen = vec![package.id.as_str()];
+        let mut queue = vec![package.id.as_str()];
+
+        while let Some(id) = queue.pop() {
+            if toasty_ids.contains(&id) {
+                return true;
+            }
+
+            let Some(node) = resolve.nodes.iter().find(|n| n.id == id) else {
+                continue;
+            };
+
+            for dep in &node.dependencies {
+                if !seen.contains(&dep.as_str()) {
+                    seen.push(dep);
+                    queue.push(dep);
+                }
+            }
+        }
+
+        false
+    }
+
+    /// The package to extract a schema from: the one `-p` names, or the
+    /// workspace root package.
+    ///
+    /// A virtual manifest has no root package, so `-p` is required there. The
+    /// error lists the members rather than making the user go read the
+    /// manifest.
+    pub fn target_package(&self, flags: &TargetFlags) -> Result<&Package> {
+        if let Some(name) = &flags.package {
+            return self.members().find(|p| p.name == *name).with_context(|| {
+                format!("no package named `{name}` in this workspace{}", {
+                    let members = self.member_list();
+                    format!("\n\nworkspace members:\n{members}")
+                })
+            });
+        }
+
+        let root_manifest = self.workspace_root.join("Cargo.toml");
+        self.members()
+            .find(|p| p.manifest_path == root_manifest)
+            .with_context(|| {
+                format!(
+                    "this workspace has no root package, so there is nothing to \
+                     extract a schema from by default; pass `-p <package>`\n\n\
+                     workspace members:\n{}",
+                    self.member_list()
+                )
+            })
+    }
+
+    fn members(&self) -> impl Iterator<Item = &Package> {
+        self.packages
+            .iter()
+            .filter(|p| self.workspace_members.contains(&p.id))
+    }
+
+    fn member_list(&self) -> String {
+        let mut names: Vec<_> = self.members().map(|p| p.name.as_str()).collect();
+        names.sort_unstable();
+        names
+            .iter()
+            .map(|name| format!("  {name}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}
+
+/// What to build in order to get a schema out of a package.
+#[derive(Debug, PartialEq, Eq)]
+pub enum BuildTarget {
+    /// Build this `[[bin]]`. The dump constructor runs before its `main`.
+    Bin(String),
+
+    /// Rebuild the `[lib]` as a `cdylib`, which `dlopen` can load and whose
+    /// constructors run at load time.
+    Cdylib,
+}
+
+impl BuildTarget {
+    /// Chooses what to build for `package`.
+    ///
+    /// A bin is preferred: it is a plain process to spawn. A lib-only package
+    /// gets rebuilt as a `cdylib`, which is what makes the extraction work
+    /// without a `main` to run. `--bin` disambiguates a package with several.
+    pub fn select(package: &Package, requested_bin: Option<&str>) -> Result<Self> {
+        let bins = package.bin_names();
+
+        if let Some(name) = requested_bin {
+            if !bins.contains(&name) {
+                bail!(
+                    "package `{}` has no bin target named `{name}`{}",
+                    package.name,
+                    format_alternatives("available bins", &bins),
+                );
+            }
+            return Ok(Self::Bin(name.to_string()));
+        }
+
+        match bins.as_slice() {
+            [only] => Ok(Self::Bin((*only).to_string())),
+            [] if package.has_linkable_lib() => Ok(Self::Cdylib),
+            [] => bail!(
+                "package `{}` has neither a bin nor a lib target, so there is \
+                 nothing to extract a schema from",
+                package.name
+            ),
+            _ => bail!(
+                "package `{}` has several bin targets; pick one with `--bin <name>`{}",
+                package.name,
+                format_alternatives("bins", &bins),
+            ),
+        }
+    }
+}
+
+fn format_alternatives(label: &str, names: &[&str]) -> String {
+    if names.is_empty() {
+        return String::new();
+    }
+    let list = names
+        .iter()
+        .map(|n| format!("  {n}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!("\n\n{label}:\n{list}")
+}
+
+/// Builds `target` in `package` and returns the path of the artifact.
+///
+/// Always the `dev` profile: the dump constructor is `cfg(debug_assertions)`,
+/// and a release build's dead-stripping and cross-crate LTO have no reason to
+/// preserve it.
+pub fn build(flags: &TargetFlags, package: &Package, target: &BuildTarget) -> Result<PathBuf> {
+    let mut cmd = Command::new(cargo_bin());
+
+    match target {
+        BuildTarget::Bin(name) => {
+            cmd.args(["build", "--bin", name]);
+        }
+        // `cargo rustc --crate-type cdylib` overrides the crate type for this
+        // one invocation, so the user's `Cargo.toml` stays untouched.
+        BuildTarget::Cdylib => {
+            cmd.args(["rustc", "--lib", "--crate-type", "cdylib"]);
+        }
+    }
+
+    cmd.args(["--package", &package.name]);
+    cmd.arg("--message-format=json-render-diagnostics");
+
+    if let Some(manifest_path) = &flags.manifest_path {
+        cmd.arg("--manifest-path").arg(manifest_path);
+    }
+
+    // The environment is passed through untouched, so this build sees the same
+    // `CARGO_TARGET_DIR`, `RUSTFLAGS`, and toolchain settings as a `cargo
+    // build` the user would run from here — and reuses the artifacts.
+
+    // `json-render-diagnostics` sends rendered diagnostics to stderr, leaving
+    // stdout to the artifact messages alone.
+    let output = cmd
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .output()
+        .context("failed to run cargo; is cargo on PATH?")?;
+
+    if !output.status.success() {
+        bail!("building `{}` failed; see the errors above", package.name);
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    artifact_path(&stdout, target).with_context(|| {
+        format!(
+            "cargo reported no {} artifact for `{}`",
+            match target {
+                BuildTarget::Bin(_) => "executable",
+                BuildTarget::Cdylib => "cdylib",
+            },
+            package.name
+        )
+    })
+}
+
+/// Picks the built artifact out of cargo's JSON message stream.
+///
+/// Cargo reports an artifact for every crate it compiles, so the requested one
+/// has to be identified rather than assumed: it sets `executable` only on the
+/// bin targets that were asked for, and it uplifts only the requested
+/// package's library out of `deps/`. A proc-macro dependency also produces a
+/// shared object, which is why the crate type is checked too.
+fn artifact_path(stdout: &str, target: &BuildTarget) -> Option<PathBuf> {
+    stdout
+        .lines()
+        .filter_map(|line| serde_json::from_str::<ArtifactMessage>(line).ok())
+        .filter(|message| message.reason == "compiler-artifact")
+        .find_map(|message| match target {
+            BuildTarget::Bin(_) => message.executable,
+            BuildTarget::Cdylib => {
+                if !message.target.crate_types.iter().any(|ty| ty == "cdylib") {
+                    return None;
+                }
+                message
+                    .filenames
+                    .into_iter()
+                    .find(|path| is_final_shared_library(path))
+            }
+        })
+}
+
+#[derive(Deserialize)]
+struct ArtifactMessage {
+    reason: String,
+    #[serde(default)]
+    target: ArtifactTarget,
+    #[serde(default)]
+    executable: Option<PathBuf>,
+    #[serde(default)]
+    filenames: Vec<PathBuf>,
+}
+
+#[derive(Deserialize, Default)]
+struct ArtifactTarget {
+    #[serde(default)]
+    crate_types: Vec<String>,
+}
+
+/// Whether `path` is the build's own loadable library: a shared object by
+/// extension — as opposed to the rlib, import library, or dep-info file cargo
+/// lists beside it — that cargo uplifted out of `deps/`, which it does only
+/// for the requested package.
+fn is_final_shared_library(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(OsStr::to_str),
+        Some("so" | "dylib" | "dll")
+    ) && path
+        .parent()
+        .and_then(Path::file_name)
+        .is_none_or(|dir| dir != "deps")
+}
+
+/// The cargo to invoke: the one running us when there is one, so a `+toolchain`
+/// or a rustup override is honored, and plain `cargo` otherwise.
+fn cargo_bin() -> PathBuf {
+    std::env::var_os("CARGO")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("cargo"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn package(name: &str, targets: serde_json::Value) -> Package {
+        serde_json::from_value(json!({
+            "name": name,
+            "id": format!("{name} 0.1.0"),
+            "manifest_path": format!("/ws/{name}/Cargo.toml"),
+            "targets": targets,
+        }))
+        .unwrap()
+    }
+
+    /// A workspace of `app -> models -> toasty`, so the search has to go two
+    /// hops.
+    fn workspace() -> Metadata {
+        serde_json::from_value(json!({
+            "packages": [
+                { "name": "app", "id": "app", "manifest_path": "/ws/app/Cargo.toml", "targets": [] },
+                { "name": "models", "id": "models", "manifest_path": "/ws/models/Cargo.toml", "targets": [] },
+                { "name": "toasty", "id": "toasty", "manifest_path": "/reg/toasty/Cargo.toml", "targets": [] },
+                { "name": "lonely", "id": "lonely", "manifest_path": "/ws/lonely/Cargo.toml", "targets": [] },
+            ],
+            "workspace_members": ["app", "models", "lonely"],
+            "workspace_root": "/ws",
+            "resolve": {
+                "nodes": [
+                    { "id": "app", "dependencies": ["models"] },
+                    { "id": "models", "dependencies": ["toasty"] },
+                    { "id": "toasty", "dependencies": [] },
+                    { "id": "lonely", "dependencies": [] },
+                ],
+            },
+        }))
+        .unwrap()
+    }
+
+    fn find<'a>(metadata: &'a Metadata, name: &str) -> &'a Package {
+        metadata.packages.iter().find(|p| p.name == name).unwrap()
+    }
+
+    #[test]
+    fn toasty_is_found_through_an_intermediate_crate() {
+        // A binary whose models live in a sibling library never names `toasty`
+        // in its own manifest, but still links the dump constructor.
+        let metadata = workspace();
+        assert!(metadata.links_toasty(find(&metadata, "app")));
+    }
+
+    #[test]
+    fn a_package_outside_the_toasty_graph_is_rejected() {
+        let metadata = workspace();
+        assert!(!metadata.links_toasty(find(&metadata, "lonely")));
+    }
+
+    #[test]
+    fn a_lone_bin_is_selected_without_asking() {
+        let package = package("app", json!([{ "name": "app", "kind": ["bin"] }]));
+        assert_eq!(
+            BuildTarget::select(&package, None).unwrap(),
+            BuildTarget::Bin("app".into())
+        );
+    }
+
+    #[test]
+    fn a_bin_is_preferred_over_the_lib_beside_it() {
+        // Spawning a process is simpler than dlopening a library, so a package
+        // that has both takes the bin path.
+        let package = package(
+            "app",
+            json!([
+                { "name": "app", "kind": ["lib"] },
+                { "name": "app", "kind": ["bin"] },
+            ]),
+        );
+        assert_eq!(
+            BuildTarget::select(&package, None).unwrap(),
+            BuildTarget::Bin("app".into())
+        );
+    }
+
+    #[test]
+    fn a_lib_only_package_is_rebuilt_as_a_cdylib() {
+        let package = package("lib", json!([{ "name": "lib", "kind": ["lib"] }]));
+        assert_eq!(
+            BuildTarget::select(&package, None).unwrap(),
+            BuildTarget::Cdylib
+        );
+    }
+
+    #[test]
+    fn several_bins_require_an_explicit_choice() {
+        let package = package(
+            "app",
+            json!([
+                { "name": "server", "kind": ["bin"] },
+                { "name": "worker", "kind": ["bin"] },
+            ]),
+        );
+
+        let err = BuildTarget::select(&package, None).unwrap_err().to_string();
+        assert!(err.contains("--bin"), "{err}");
+        assert!(err.contains("server") && err.contains("worker"), "{err}");
+
+        assert_eq!(
+            BuildTarget::select(&package, Some("worker")).unwrap(),
+            BuildTarget::Bin("worker".into())
+        );
+    }
+
+    #[test]
+    fn an_unknown_bin_name_lists_the_real_ones() {
+        let package = package("app", json!([{ "name": "server", "kind": ["bin"] }]));
+        let err = BuildTarget::select(&package, Some("nope"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("no bin target named `nope`"), "{err}");
+        assert!(err.contains("server"), "{err}");
+    }
+
+    #[test]
+    fn a_proc_macro_package_has_nothing_to_extract_from() {
+        // A proc-macro crate is a compiler plugin: it has a lib section, but
+        // it cannot be rebuilt as a cdylib and links no models.
+        let package = package(
+            "macros",
+            json!([{ "name": "macros", "kind": ["proc-macro"] }]),
+        );
+        let err = BuildTarget::select(&package, None).unwrap_err().to_string();
+        assert!(err.contains("neither a bin nor a lib"), "{err}");
+    }
+
+    #[test]
+    fn the_executable_is_read_from_the_artifact_stream() {
+        let stdout = [
+            json!({ "reason": "compiler-artifact", "executable": null, "filenames": ["/t/debug/deps/libdep.rlib"] }),
+            json!({ "reason": "compiler-artifact", "executable": "/t/debug/app", "filenames": ["/t/debug/app"] }),
+            json!({ "reason": "build-finished", "success": true }),
+        ]
+        .map(|v| v.to_string())
+        .join("\n");
+
+        assert_eq!(
+            artifact_path(&stdout, &BuildTarget::Bin("app".into())),
+            Some(PathBuf::from("/t/debug/app"))
+        );
+    }
+
+    #[test]
+    fn the_cdylib_is_picked_over_its_rlib_and_dep_info_companions() {
+        let stdout = json!({
+            "reason": "compiler-artifact",
+            "target": { "crate_types": ["cdylib"] },
+            "executable": null,
+            "filenames": ["/t/debug/libapp.rlib", "/t/debug/libapp.so", "/t/debug/libapp.d"],
+        })
+        .to_string();
+
+        assert_eq!(
+            artifact_path(&stdout, &BuildTarget::Cdylib),
+            Some(PathBuf::from("/t/debug/libapp.so"))
+        );
+    }
+
+    #[test]
+    fn a_proc_macro_dependency_is_not_mistaken_for_the_cdylib() {
+        // Every proc-macro in the dependency graph compiles to a shared
+        // object, and cargo reports it before the crate being built.
+        let stdout = [
+            json!({
+                "reason": "compiler-artifact",
+                "target": { "crate_types": ["proc-macro"] },
+                "executable": null,
+                "filenames": ["/t/debug/deps/libserde_derive.so"],
+            }),
+            json!({
+                "reason": "compiler-artifact",
+                "target": { "crate_types": ["cdylib"] },
+                "executable": null,
+                "filenames": ["/t/debug/libapp.so"],
+            }),
+        ]
+        .map(|v| v.to_string())
+        .join("\n");
+
+        assert_eq!(
+            artifact_path(&stdout, &BuildTarget::Cdylib),
+            Some(PathBuf::from("/t/debug/libapp.so"))
+        );
+    }
+
+    #[test]
+    fn a_dependency_that_is_itself_a_cdylib_is_left_in_deps() {
+        // Cargo uplifts only the requested package's library; anything still
+        // in `deps/` belongs to a dependency.
+        let stdout = json!({
+            "reason": "compiler-artifact",
+            "target": { "crate_types": ["cdylib"] },
+            "executable": null,
+            "filenames": ["/t/debug/deps/libdep.so"],
+        })
+        .to_string();
+
+        assert_eq!(artifact_path(&stdout, &BuildTarget::Cdylib), None);
+    }
+
+    #[test]
+    fn non_json_lines_do_not_derail_artifact_parsing() {
+        let stdout = format!(
+            "not json\n{}\n",
+            json!({ "reason": "compiler-artifact", "executable": "/t/debug/app", "filenames": [] })
+        );
+        assert_eq!(
+            artifact_path(&stdout, &BuildTarget::Bin("app".into())),
+            Some(PathBuf::from("/t/debug/app"))
+        );
+    }
+}

--- a/crates/toasty-cli/src/standalone/cargo.rs
+++ b/crates/toasty-cli/src/standalone/cargo.rs
@@ -568,6 +568,24 @@ mod tests {
     }
 
     #[test]
+    fn the_windows_dll_is_picked_over_its_import_library() {
+        // A Windows cdylib reports the loadable `.dll` alongside the `.dll.lib`
+        // import library and a `.pdb`; only the first can be loaded.
+        let stdout = json!({
+            "reason": "compiler-artifact",
+            "target": { "crate_types": ["cdylib"] },
+            "executable": null,
+            "filenames": [r"C:\t\debug\app.dll", r"C:\t\debug\app.dll.lib", r"C:\t\debug\app.pdb"],
+        })
+        .to_string();
+
+        assert_eq!(
+            artifact_path(&stdout, &BuildTarget::Cdylib),
+            Some(PathBuf::from(r"C:\t\debug\app.dll"))
+        );
+    }
+
+    #[test]
     fn a_proc_macro_dependency_is_not_mistaken_for_the_cdylib() {
         // Every proc-macro in the dependency graph compiles to a shared
         // object, and cargo reports it before the crate being built.

--- a/crates/toasty-cli/src/standalone/extract.rs
+++ b/crates/toasty-cli/src/standalone/extract.rs
@@ -1,0 +1,210 @@
+//! Reading a project's schema out of the artifact it already builds.
+//!
+//! `toasty` contributes a constructor that dumps the schema and exits when
+//! `TOASTY_DUMP_SCHEMA` is set (see `toasty::schema::dump`). This module builds
+//! the user's own target and runs it with that variable set.
+//!
+//! A bin is a process to spawn. A `cdylib` has no entry point, so it has to be
+//! `dlopen`ed — and the constructor calls `exit`, which would take the CLI down
+//! with it. The load therefore happens in a child: the CLI re-execs itself with
+//! the hidden `__load-cdylib` subcommand, which exists only for that.
+
+use super::cargo::{self, BuildTarget, Package, TargetFlags};
+
+use anyhow::{Context, Result, bail};
+use toasty::schema::{
+    app,
+    dump::{DUMP_ENV, DUMP_MARKER, Dump},
+};
+
+use std::{path::Path, process::Command};
+
+/// Builds `flags`' target package and returns the schema linked into it.
+pub fn schema(flags: &TargetFlags) -> Result<app::Schema> {
+    let metadata = cargo::Metadata::load(flags)?;
+    let package = metadata.target_package(flags)?;
+
+    // The constructor lives in `toasty`. Without it in the graph the build
+    // would succeed and produce nothing, which is a confusing way to find out.
+    if !metadata.links_toasty(package) {
+        bail!(
+            "package `{}` does not depend on `toasty`, so it has no schema to \
+             extract; add toasty as a dependency, or select another package \
+             with `-p <package>`",
+            package.name
+        );
+    }
+
+    let target = BuildTarget::select(package, flags.bin.as_deref())?;
+    let artifact = cargo::build(flags, package, &target)?;
+
+    let stdout = run_dumper(&target, &artifact)?;
+    parse_dump(&stdout, package)
+}
+
+/// Runs the built artifact so its constructor dumps the schema, and returns
+/// what it wrote to stdout.
+fn run_dumper(target: &BuildTarget, artifact: &Path) -> Result<String> {
+    let mut cmd = match target {
+        BuildTarget::Bin(_) => {
+            let mut cmd = Command::new(artifact);
+            // Set only on this child; the variable is never exported into the
+            // user's shell.
+            cmd.env(DUMP_ENV, "1");
+            cmd
+        }
+        BuildTarget::Cdylib => {
+            let toasty = std::env::current_exe()
+                .context("could not locate the running `toasty` binary to re-exec")?;
+            let mut cmd = Command::new(toasty);
+            cmd.arg(LOAD_CDYLIB_SUBCOMMAND).arg(artifact);
+            // Deliberately *not* set here. This CLI links `toasty` too, so it
+            // carries the dump constructor itself; a child that started with
+            // the variable set would dump the CLI's own (empty) schema before
+            // reaching the `dlopen`. `load_cdylib` sets it once that risk has
+            // passed.
+            cmd.env_remove(DUMP_ENV);
+            cmd
+        }
+    };
+
+    let output = cmd
+        .output()
+        .with_context(|| format!("failed to run `{}`", artifact.display()))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stderr = stderr.trim();
+        bail!(
+            "the schema dumper exited with {}{}",
+            output.status,
+            if stderr.is_empty() {
+                String::new()
+            } else {
+                format!(":\n\n{stderr}")
+            }
+        );
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Finds the dump payload in the dumper's stdout and decodes it.
+///
+/// The payload is located by its marker rather than by assuming it is all of
+/// stdout: other constructors run before this one, and a project is free to
+/// print during static initialization.
+fn parse_dump(stdout: &str, package: &Package) -> Result<app::Schema> {
+    let Some((_, rest)) = stdout.split_once(DUMP_MARKER) else {
+        bail!(
+            "`{}` produced no schema dump.\n\n\
+             This usually means the `toasty` it links was built without the \
+             `schema-dump` feature (it is on by default), so nothing \
+             contributed the dump constructor.",
+            package.name
+        );
+    };
+
+    let json = rest.trim_start();
+    let dump: Dump =
+        serde_json::from_str(json.lines().next().unwrap_or_default()).with_context(|| {
+            format!(
+                "could not read the schema `{}` dumped. The `toasty` it links \
+                 and this CLI may be different versions; reinstall with \
+                 `cargo install toasty-cli`.",
+                package.name
+            )
+        })?;
+
+    Ok(dump.schema)
+}
+
+/// The hidden subcommand the CLI re-execs to `dlopen` a cdylib.
+pub const LOAD_CDYLIB_SUBCOMMAND: &str = "__load-cdylib";
+
+/// Loads `path`, letting the constructors in its initialization image run.
+///
+/// The library's constructors include the one `toasty` contributes, which —
+/// with `TOASTY_DUMP_SCHEMA` set — writes the schema and exits the process
+/// from inside the load, so this never returns normally.
+///
+/// The variable is set here rather than inherited: this process runs its own
+/// constructors before `main`, and this CLI links `toasty` too. Setting it now
+/// means the only constructor that sees it belongs to the library being
+/// loaded.
+pub fn load_cdylib(path: &Path) -> Result<()> {
+    // SAFETY: `set_var` requires that no other thread is touching the
+    // environment. This process was spawned to perform one load and has not
+    // started a thread; the dump constructor reads the variable synchronously
+    // inside the `Library::new` call below.
+    #[allow(unsafe_code)]
+    unsafe {
+        std::env::set_var(DUMP_ENV, "1");
+    }
+
+    // SAFETY: loading a library runs its initializers, which is precisely the
+    // point here. The path comes from the build this CLI just ran, and this
+    // process exists only to perform the load.
+    #[allow(unsafe_code)]
+    let library = unsafe { libloading::Library::new(path) }
+        .with_context(|| format!("failed to load `{}`", path.display()))?;
+
+    // Reaching here means the library loaded without the constructor firing.
+    drop(library);
+    bail!(
+        "`{}` loaded without dumping a schema; the `toasty` it links was \
+         probably built without the `schema-dump` feature",
+        path.display()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn package() -> Package {
+        serde_json::from_value(json!({
+            "name": "app",
+            "id": "app 0.1.0",
+            "manifest_path": "/ws/app/Cargo.toml",
+            "targets": [],
+        }))
+        .unwrap()
+    }
+
+    fn dump_line() -> String {
+        json!({ "toasty_version": "0.9.0", "schema": { "models": {} } }).to_string()
+    }
+
+    #[test]
+    fn the_payload_is_found_after_the_marker() {
+        let stdout = format!("\n{DUMP_MARKER}\n{}\n", dump_line());
+        assert_eq!(parse_dump(&stdout, &package()).unwrap().models.len(), 0);
+    }
+
+    #[test]
+    fn output_printed_before_the_dump_is_ignored() {
+        // Another crate's constructor, or the project's own static
+        // initialization, can reach stdout first.
+        let stdout = format!(
+            "some other ctor said hello\n{DUMP_MARKER}\n{}\n",
+            dump_line()
+        );
+        assert!(parse_dump(&stdout, &package()).is_ok());
+    }
+
+    #[test]
+    fn a_missing_marker_points_at_the_feature_that_produces_it() {
+        let err = parse_dump("hello\n", &package()).unwrap_err().to_string();
+        assert!(err.contains("no schema dump"), "{err}");
+        assert!(err.contains("schema-dump"), "{err}");
+    }
+
+    #[test]
+    fn an_undecodable_payload_suggests_a_version_mismatch() {
+        let stdout = format!("{DUMP_MARKER}\n{}\n", json!({ "unexpected": true }));
+        let err = format!("{:#}", parse_dump(&stdout, &package()).unwrap_err());
+        assert!(err.contains("different versions"), "{err}");
+    }
+}

--- a/crates/toasty-cli/tests/standalone_cli.rs
+++ b/crates/toasty-cli/tests/standalone_cli.rs
@@ -1,0 +1,171 @@
+//! End-to-end tests for the standalone `toasty` binary.
+//!
+//! These build a throwaway package against this checkout's `toasty` and run
+//! the real CLI over it. That is the only way to cover what the design turns
+//! on: that a constructor contributed by `toasty` survives into the user's own
+//! build artifact, and that running that artifact yields the schema.
+//!
+//! Both extraction paths are covered, because they differ in how the
+//! constructor is reached — before `main` for a bin, during `dlopen` for a
+//! lib-only package rebuilt as a `cdylib`.
+
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+/// A generated package that depends on this checkout's `toasty`.
+struct Project {
+    dir: tempfile::TempDir,
+}
+
+impl Project {
+    /// Writes a package whose `src/<name>` holds `source`.
+    fn new(entry: &str, source: &str) -> Self {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let toasty = workspace_root().join("crates/toasty");
+
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            format!(
+                r#"
+                [package]
+                name = "extract-fixture"
+                version = "0.0.0"
+                edition = "2024"
+
+                [dependencies]
+                toasty = {{ path = "{}" }}
+
+                [workspace]
+                "#,
+                toasty.display()
+            ),
+        )
+        .expect("write manifest");
+
+        std::fs::create_dir(dir.path().join("src")).expect("create src");
+        std::fs::write(dir.path().join("src").join(entry), source).expect("write source");
+
+        Self { dir }
+    }
+
+    /// Runs the CLI in this project and returns its combined output, requiring
+    /// success.
+    fn toasty(&self, args: &[&str]) -> String {
+        let output = Command::new(env!("CARGO_BIN_EXE_toasty"))
+            .args(args)
+            .current_dir(self.dir.path())
+            // Share the workspace target directory so the fixture reuses the
+            // already-compiled `toasty` rather than rebuilding its dep tree.
+            .env("CARGO_TARGET_DIR", workspace_root().join("target"))
+            .output()
+            .expect("run toasty");
+
+        assert!(
+            output.status.success(),
+            "toasty {args:?} failed with {}\n--- stdout ---\n{}\n--- stderr ---\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+
+        String::from_utf8_lossy(&output.stdout).into_owned()
+    }
+
+    fn read(&self, path: &str) -> String {
+        std::fs::read_to_string(self.dir.path().join(path))
+            .unwrap_or_else(|err| panic!("reading {path}: {err}"))
+    }
+}
+
+fn workspace_root() -> PathBuf {
+    // `crates/toasty-cli` -> repository root
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("workspace root")
+        .to_path_buf()
+}
+
+const MODELS: &str = r#"
+    #[derive(Debug, toasty::Model)]
+    pub struct Account {
+        #[key]
+        pub id: i64,
+        #[unique]
+        pub email: String,
+    }
+"#;
+
+/// A bin target reaches the constructor before `main`, so the project's own
+/// entry point never runs.
+#[test]
+fn a_bin_project_yields_its_schema_without_running_main() {
+    let project = Project::new(
+        "main.rs",
+        &format!("{MODELS}\nfn main() {{ panic!(\"main must not run\"); }}"),
+    );
+
+    project.toasty(&[
+        "migrate",
+        "generate",
+        "--flavor",
+        "postgresql",
+        "--name",
+        "init",
+    ]);
+
+    let sql = project.read("toasty/migrations/0000_init.sql");
+    assert!(sql.contains(r#"CREATE TABLE "accounts""#), "{sql}");
+    assert!(sql.contains(r#""email" TEXT NOT NULL"#), "{sql}");
+}
+
+/// A lib-only project has no entry point at all. This is the path that
+/// rebuilds it as a `cdylib` and reaches the constructor through `dlopen`.
+#[test]
+fn a_lib_only_project_yields_its_schema_through_the_cdylib_path() {
+    let project = Project::new("lib.rs", MODELS);
+
+    project.toasty(&[
+        "migrate", "generate", "--flavor", "sqlite", "--name", "init",
+    ]);
+
+    let sql = project.read("toasty/migrations/0000_init.sql");
+    assert!(sql.contains(r#"CREATE TABLE "accounts""#), "{sql}");
+}
+
+/// The flavor decides the DDL, and it is chosen without a database to connect
+/// to — the whole reason generation is keyed by dialect rather than driver.
+#[test]
+fn the_flavor_selects_the_dialect() {
+    let project = Project::new("lib.rs", MODELS);
+
+    let postgres = project.toasty(&["migrate", "snapshot", "--flavor", "postgresql"]);
+    let mysql = project.toasty(&["migrate", "snapshot", "--flavor", "mysql"]);
+
+    // MySQL needs a length on an indexed string column; PostgreSQL does not.
+    assert!(postgres.contains("Text"), "{postgres}");
+    assert!(mysql.contains("VarChar"), "{mysql}");
+}
+
+/// Generating twice with no source change must not invent an empty migration.
+#[test]
+fn an_unchanged_schema_generates_nothing_the_second_time() {
+    let project = Project::new("lib.rs", MODELS);
+
+    project.toasty(&[
+        "migrate", "generate", "--flavor", "sqlite", "--name", "init",
+    ]);
+    let second = project.toasty(&["migrate", "generate", "--flavor", "sqlite"]);
+
+    assert!(second.contains("matches the previous snapshot"), "{second}");
+    assert!(
+        !project
+            .dir
+            .path()
+            .join("toasty/migrations/0001_migration.sql")
+            .exists(),
+        "a second migration file should not have been written"
+    );
+}

--- a/crates/toasty-cli/tests/standalone_cli.rs
+++ b/crates/toasty-cli/tests/standalone_cli.rs
@@ -35,7 +35,9 @@ impl Project {
                 edition = "2024"
 
                 [dependencies]
-                toasty = {{ path = "{}" }}
+                # A TOML literal string: a Windows path is full of backslashes,
+                # which a basic string would read as escape sequences.
+                toasty = {{ path = '{}' }}
 
                 [workspace]
                 "#,

--- a/crates/toasty-core/Cargo.toml
+++ b/crates/toasty-core/Cargo.toml
@@ -39,12 +39,13 @@ rust_decimal = ["dep:rust_decimal"]
 bigdecimal = ["dep:bigdecimal"]
 jiff = ["dep:jiff"]
 migration = ["serde", "dep:toml"]
-serde = ["dep:serde", "bit-set/serde"]
+serde = ["dep:serde", "bit-set/serde", "indexmap/serde"]
 
 [dev-dependencies]
 jiff.workspace = true
 pretty_assertions.workspace = true
 serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
 toml.workspace = true
 
 [lints]

--- a/crates/toasty-core/src/driver.rs
+++ b/crates/toasty-core/src/driver.rs
@@ -56,7 +56,7 @@
 //! [`crate::Error::driver_operation_failed`].
 
 mod capability;
-pub use capability::{Capability, SchemaMutations, SqlPlaceholder, StorageTypes};
+pub use capability::{Capability, SchemaMutations, SqlFlavor, SqlPlaceholder, StorageTypes};
 
 mod connection_url;
 pub use connection_url::ConnectionUrl;
@@ -73,7 +73,6 @@ pub use operation::{IsolationLevel, Operation};
 use crate::schema::{
     Schema,
     db::{AppliedMigration, Migration},
-    diff,
 };
 
 use async_trait::async_trait;
@@ -139,9 +138,6 @@ pub trait Driver: Debug + Send + Sync + 'static {
     fn max_connections(&self) -> Option<usize> {
         None
     }
-
-    /// Generates a migration from a [`diff::Schema`].
-    fn generate_migration(&self, schema_diff: &diff::Schema<'_>) -> Migration;
 
     /// Drops the entire database and recreates an empty one without applying migrations.
     ///

--- a/crates/toasty-core/src/driver/capability.rs
+++ b/crates/toasty-core/src/driver/capability.rs
@@ -35,6 +35,14 @@ pub struct Capability {
     /// SQL drivers set this to `Some`. Non-SQL drivers set this to `None`.
     pub sql_placeholder: Option<SqlPlaceholder>,
 
+    /// The SQL dialect this driver speaks, selecting how statements and
+    /// migration DDL are rendered.
+    ///
+    /// SQL drivers set this to `Some`. Non-SQL drivers set this to `None`.
+    /// Must agree with [`sql`](Self::sql); [`validate`](Self::validate)
+    /// checks the invariant.
+    pub sql_flavor: Option<SqlFlavor>,
+
     /// Column storage types supported by the database.
     pub storage_types: StorageTypes,
 
@@ -478,6 +486,91 @@ pub enum SqlPlaceholder {
     DollarNumber,
 }
 
+/// The SQL dialect a driver speaks.
+///
+/// Everything Toasty renders as SQL — statements and migration DDL alike —
+/// is a function of the dialect, not of the live connection. Naming the
+/// dialect separately is what lets `toasty migrate generate --flavor
+/// postgresql` produce PostgreSQL DDL without a PostgreSQL to connect to.
+///
+/// Dialect-compatible engines share a variant: Turso reports
+/// [`Sqlite`](Self::Sqlite) because it accepts SQLite's SQL.
+///
+/// # Examples
+///
+/// ```
+/// use toasty_core::driver::{Capability, SqlFlavor};
+///
+/// assert_eq!(Capability::SQLITE.sql_flavor, Some(SqlFlavor::Sqlite));
+/// assert_eq!(Capability::TURSO.sql_flavor, Some(SqlFlavor::Sqlite));
+/// assert_eq!(Capability::DYNAMODB.sql_flavor, None);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SqlFlavor {
+    /// SQLite, and engines that accept SQLite's SQL.
+    Sqlite,
+
+    /// PostgreSQL.
+    Postgresql,
+
+    /// MySQL.
+    Mysql,
+}
+
+impl SqlFlavor {
+    /// Every flavor, in the order the CLI lists them.
+    pub const ALL: [Self; 3] = [Self::Sqlite, Self::Postgresql, Self::Mysql];
+
+    /// The lowercase name this flavor is written as on the command line.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use toasty_core::driver::SqlFlavor;
+    ///
+    /// assert_eq!(SqlFlavor::Postgresql.as_str(), "postgresql");
+    /// ```
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Sqlite => "sqlite",
+            Self::Postgresql => "postgresql",
+            Self::Mysql => "mysql",
+        }
+    }
+
+    /// The capabilities of a database speaking this flavor.
+    pub const fn capability(self) -> &'static Capability {
+        match self {
+            Self::Sqlite => &Capability::SQLITE,
+            Self::Postgresql => &Capability::POSTGRESQL,
+            Self::Mysql => &Capability::MYSQL,
+        }
+    }
+}
+
+impl std::fmt::Display for SqlFlavor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for SqlFlavor {
+    type Err = crate::Error;
+
+    /// Parses a flavor name, accepting the aliases users reach for:
+    /// `postgres` and `pg` for PostgreSQL, `mariadb` for MySQL.
+    fn from_str(src: &str) -> crate::Result<Self> {
+        match src.to_ascii_lowercase().as_str() {
+            "sqlite" | "sqlite3" => Ok(Self::Sqlite),
+            "postgresql" | "postgres" | "pg" => Ok(Self::Postgresql),
+            "mysql" | "mariadb" => Ok(Self::Mysql),
+            other => Err(crate::Error::unsupported_feature(format!(
+                "unknown SQL flavor `{other}`; expected one of: sqlite, postgresql, mysql"
+            ))),
+        }
+    }
+}
+
 impl Capability {
     /// Validates the consistency of the capability configuration.
     ///
@@ -538,6 +631,18 @@ impl Capability {
             ));
         }
 
+        if self.sql && self.sql_flavor.is_none() {
+            return Err(crate::Error::invalid_driver_configuration(
+                "sql is true but sql_flavor is None",
+            ));
+        }
+
+        if !self.sql && self.sql_flavor.is_some() {
+            return Err(crate::Error::invalid_driver_configuration(
+                "sql is false but sql_flavor is Some",
+            ));
+        }
+
         Ok(())
     }
 
@@ -582,6 +687,7 @@ impl Capability {
         driver_name: "SQLite",
         sql: true,
         sql_placeholder: Some(SqlPlaceholder::NumberedQuestionMark),
+        sql_flavor: Some(SqlFlavor::Sqlite),
         storage_types: StorageTypes::SQLITE,
         schema_mutations: SchemaMutations::SQLITE,
         cte_with_update: false,
@@ -676,6 +782,7 @@ impl Capability {
         driver_name: "PostgreSQL",
         cte_with_update: true,
         sql_placeholder: Some(SqlPlaceholder::DollarNumber),
+        sql_flavor: Some(SqlFlavor::Postgresql),
         storage_types: StorageTypes::POSTGRESQL,
         schema_mutations: SchemaMutations::POSTGRESQL,
         select_for_update: true,
@@ -739,6 +846,7 @@ impl Capability {
         driver_name: "MySQL",
         cte_with_update: false,
         sql_placeholder: Some(SqlPlaceholder::QuestionMark),
+        sql_flavor: Some(SqlFlavor::Mysql),
         storage_types: StorageTypes::MYSQL,
         schema_mutations: SchemaMutations::MYSQL,
         select_for_update: true,
@@ -815,6 +923,7 @@ impl Capability {
         driver_name: "DynamoDB",
         sql: false,
         sql_placeholder: None,
+        sql_flavor: None,
         storage_types: StorageTypes::DYNAMODB,
         schema_mutations: SchemaMutations::DYNAMODB,
         cte_with_update: false,

--- a/crates/toasty-core/src/schema/app/auto.rs
+++ b/crates/toasty-core/src/schema/app/auto.rs
@@ -16,6 +16,7 @@
 /// assert!(inc.is_increment());
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum AutoStrategy {
     /// Generate a UUID of the specified version.
     Uuid(UuidVersion),
@@ -34,6 +35,7 @@ pub enum AutoStrategy {
 /// let v7 = UuidVersion::V7;
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum UuidVersion {
     /// Random UUID (version 4).
     V4,

--- a/crates/toasty-core/src/schema/app/constraint.rs
+++ b/crates/toasty-core/src/schema/app/constraint.rs
@@ -18,6 +18,7 @@ use crate::{Result, stmt};
 /// // The constraint can be checked against field values at runtime.
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Constraint {
     /// A length constraint on a string field.
     Length(ConstraintLength),

--- a/crates/toasty-core/src/schema/app/constraint/length.rs
+++ b/crates/toasty-core/src/schema/app/constraint/length.rs
@@ -17,6 +17,7 @@ use crate::{Result, stmt};
 /// assert_eq!(c.max, Some(255));
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConstraintLength {
     /// The minimum length of the field. `None` means no lower bound.
     pub min: Option<u64>,

--- a/crates/toasty-core/src/schema/app/embedded.rs
+++ b/crates/toasty-core/src/schema/app/embedded.rs
@@ -22,6 +22,7 @@ use crate::{
 /// let target_model = embedded.target(&schema);
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Embedded {
     /// The [`ModelId`] of the embedded model being referenced.
     pub target: ModelId,

--- a/crates/toasty-core/src/schema/app/field.rs
+++ b/crates/toasty-core/src/schema/app/field.rs
@@ -26,6 +26,7 @@ use std::fmt;
 /// }
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Field {
     /// Uniquely identifies this field within its containing model.
     pub id: FieldId,
@@ -113,6 +114,7 @@ pub struct FieldId {
 /// assert_eq!(default_name.storage_name(), Some("email"));
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FieldName {
     /// The application-level (Rust) name of the field. `None` for unnamed
     /// (tuple) fields.
@@ -197,6 +199,7 @@ impl fmt::Display for FieldName {
 /// assert!(!ty.is_relation());
 /// ```
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FieldTy {
     /// A primitive (scalar) field backed by a single column.
     Primitive(FieldPrimitive),

--- a/crates/toasty-core/src/schema/app/field/primitive.rs
+++ b/crates/toasty-core/src/schema/app/field/primitive.rs
@@ -14,6 +14,7 @@ use crate::{schema::db, stmt};
 /// let fmt = SerializeFormat::Json;
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum SerializeFormat {
     /// Serialize the value as JSON using `serde_json`.
     Json,
@@ -38,6 +39,7 @@ pub enum SerializeFormat {
 /// };
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FieldPrimitive {
     /// The application-level primitive type of this field.
     pub ty: stmt::Type,

--- a/crates/toasty-core/src/schema/app/fk.rs
+++ b/crates/toasty-core/src/schema/app/fk.rs
@@ -21,6 +21,7 @@ use super::{Field, FieldId, Schema};
 /// assert_eq!(fk.fields.len(), 1);
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ForeignKey {
     /// The field pairs that make up this foreign key.
     pub fields: Vec<ForeignKeyField>,
@@ -42,6 +43,7 @@ pub struct ForeignKey {
 /// };
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ForeignKeyField {
     /// The field on the source model that stores the foreign key value.
     pub source: FieldId,

--- a/crates/toasty-core/src/schema/app/index.rs
+++ b/crates/toasty-core/src/schema/app/index.rs
@@ -31,6 +31,7 @@ use crate::schema::db::{IndexOp, IndexScope};
 /// assert!(index.primary_key);
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Index {
     /// Uniquely identifies this index within the schema.
     pub id: IndexId,
@@ -64,6 +65,7 @@ pub struct Index {
 /// assert_eq!(id.model, ModelId(0));
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IndexId {
     /// The model this index belongs to.
     pub model: ModelId,
@@ -89,6 +91,7 @@ pub struct IndexId {
 /// };
 /// ```
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IndexField {
     /// The field being indexed.
     pub field: FieldId,

--- a/crates/toasty-core/src/schema/app/model.rs
+++ b/crates/toasty-core/src/schema/app/model.rs
@@ -26,6 +26,7 @@ use std::fmt;
 /// }
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Model {
     /// A root model that maps to its own database table and can be queried
     /// directly.
@@ -143,6 +144,7 @@ impl ExactSizeIterator for ModelSetIntoIter {}
 /// let pk_fields: Vec<_> = root.primary_key_fields().collect();
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ModelRoot {
     /// Uniquely identifies this model within the schema.
     pub id: ModelId,
@@ -260,6 +262,7 @@ impl ModelRoot {
 /// }
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EmbeddedStruct {
     /// Uniquely identifies this model within the schema.
     pub id: ModelId,
@@ -303,6 +306,7 @@ impl EmbeddedStruct {
 /// }
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EmbeddedEnum {
     /// Uniquely identifies this model within the schema.
     pub id: ModelId,
@@ -333,6 +337,7 @@ pub struct EmbeddedEnum {
 /// Each variant has a name and a discriminant value (integer or string) that is
 /// stored in the database to identify which variant is active.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EnumVariant {
     /// The Rust variant name.
     pub name: Name,
@@ -340,7 +345,81 @@ pub struct EnumVariant {
     /// The discriminant value stored in the database column.
     /// Typically `Value::I64` for integer discriminants or `Value::String` for
     /// string discriminants.
+    #[cfg_attr(feature = "serde", serde(with = "discriminant_serde"))]
     pub discriminant: stmt::Value,
+}
+
+/// Serializes an [`EnumVariant`] discriminant.
+///
+/// [`stmt::Value`] is the engine's general-purpose runtime value and is
+/// deliberately not `Serialize`. A discriminant is only ever the integer or
+/// string the `#[derive(Model)]` expansion emits, so this codec covers exactly
+/// those two shapes and rejects anything else rather than committing the whole
+/// value type to a wire format.
+#[cfg(feature = "serde")]
+mod discriminant_serde {
+    use crate::stmt;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    #[derive(Serialize, Deserialize)]
+    #[serde(rename_all = "snake_case")]
+    enum Discriminant {
+        Int(i64),
+        String(String),
+    }
+
+    pub(super) fn serialize<S: Serializer>(
+        value: &stmt::Value,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        let discriminant = match value {
+            stmt::Value::I64(v) => Discriminant::Int(*v),
+            stmt::Value::String(v) => Discriminant::String(v.clone()),
+            other => {
+                return Err(serde::ser::Error::custom(format!(
+                    "enum discriminant must be an integer or a string, found {other:?}"
+                )));
+            }
+        };
+        discriminant.serialize(serializer)
+    }
+
+    pub(super) fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<stmt::Value, D::Error> {
+        Ok(match Discriminant::deserialize(deserializer)? {
+            Discriminant::Int(v) => stmt::Value::I64(v),
+            Discriminant::String(v) => stmt::Value::String(v),
+        })
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[derive(Serialize, Deserialize, Debug, PartialEq)]
+        struct Wrapper(#[serde(with = "super")] stmt::Value);
+
+        #[test]
+        fn integer_and_string_discriminants_round_trip() {
+            for value in [stmt::Value::I64(7), stmt::Value::String("open".into())] {
+                let json = serde_json::to_string(&Wrapper(value.clone())).unwrap();
+                assert_eq!(
+                    serde_json::from_str::<Wrapper>(&json).unwrap(),
+                    Wrapper(value)
+                );
+            }
+        }
+
+        #[test]
+        fn other_value_kinds_are_rejected() {
+            let err = serde_json::to_string(&Wrapper(stmt::Value::Bool(true))).unwrap_err();
+            assert!(
+                err.to_string().contains("must be an integer or a string"),
+                "unexpected error: {err}"
+            );
+        }
+    }
 }
 
 impl EmbeddedEnum {
@@ -512,6 +591,7 @@ impl Model {
 /// assert_eq!(variant_id.index, 0);
 /// ```
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VariantId {
     /// The enum model this variant belongs to.
     pub model: ModelId,

--- a/crates/toasty-core/src/schema/app/pk.rs
+++ b/crates/toasty-core/src/schema/app/pk.rs
@@ -17,6 +17,7 @@ use super::{FieldId, IndexId};
 /// assert_eq!(pk.fields.len(), 1);
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrimaryKey {
     /// The fields that compose this primary key, in order.
     pub fields: Vec<FieldId>,

--- a/crates/toasty-core/src/schema/app/relation/belongs_to.rs
+++ b/crates/toasty-core/src/schema/app/relation/belongs_to.rs
@@ -18,6 +18,7 @@ use crate::{
 /// let post_model = belongs_to.target(&schema);
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BelongsTo {
     /// The [`ModelId`] of the referenced (target) model.
     pub target: ModelId,

--- a/crates/toasty-core/src/schema/app/relation/has.rs
+++ b/crates/toasty-core/src/schema/app/relation/has.rs
@@ -9,6 +9,7 @@ use crate::{
 /// [`BelongsTo`] field on B that holds the foreign key. Its cardinality records
 /// whether the field represents "A has many Bs" or "A has one B".
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Has {
     /// The [`ModelId`] of the associated (target) model.
     pub target: ModelId,
@@ -26,6 +27,7 @@ pub struct Has {
 
 /// Cardinality for a relation field that reaches another model.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Cardinality {
     /// The relation yields zero or more associated items.
     Many {

--- a/crates/toasty-core/src/schema/app/relation/via.rs
+++ b/crates/toasty-core/src/schema/app/relation/via.rs
@@ -29,6 +29,7 @@ use crate::{
 /// reachable from a user. The join model owns the foreign keys and any fields
 /// that describe the connection.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Via {
     /// The [`ModelId`] of the model the relation chain reaches. For a relation
     /// terminal this is the associated (target) model; for a scalar terminal

--- a/crates/toasty-core/src/schema/app/schema.rs
+++ b/crates/toasty-core/src/schema/app/schema.rs
@@ -47,6 +47,7 @@ pub enum Resolved<'a> {
 /// assert_eq!(schema.models().count(), 0);
 /// ```
 #[derive(Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Schema {
     /// All models in the schema, keyed by [`ModelId`].
     pub models: IndexMap<ModelId, Model>,

--- a/crates/toasty-core/src/schema/name.rs
+++ b/crates/toasty-core/src/schema/name.rs
@@ -18,6 +18,7 @@ use heck::{ToLowerCamelCase, ToShoutySnakeCase, ToSnakeCase, ToUpperCamelCase};
 /// assert_eq!(name.upper_snake_case(), "USER_PROFILE");
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Name {
     /// The individual lowercase word parts of this name.
     pub parts: Vec<String>,

--- a/crates/toasty-core/src/stmt/path.rs
+++ b/crates/toasty-core/src/stmt/path.rs
@@ -6,6 +6,7 @@ use crate::schema::app::{FieldId, ModelId, VariantId};
 /// A path can originate from a top-level model or from a specific variant of
 /// an embedded enum field.
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PathRoot {
     /// The path originates from a top-level model.
     Model(ModelId),
@@ -58,6 +59,7 @@ impl PathRoot {
 /// assert!(p.is_empty()); // no field steps
 /// ```
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Path {
     /// Where the path originates from.
     pub root: PathRoot,

--- a/crates/toasty-core/src/stmt/projection.rs
+++ b/crates/toasty-core/src/stmt/projection.rs
@@ -239,6 +239,24 @@ impl<const N: usize> From<[usize; N]> for Projection {
     }
 }
 
+/// A projection is its steps; [`Steps`] only exists to keep the common
+/// identity and single-step cases off the heap. Serializing the slice keeps
+/// that representation choice private and makes the encoding independent of it.
+#[cfg(feature = "serde")]
+impl serde::Serialize for Projection {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.as_slice().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Projection {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let steps = Vec::<usize>::deserialize(deserializer)?;
+        Ok(Self::from(&steps[..]))
+    }
+}
+
 impl fmt::Debug for Projection {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut f = f.debug_tuple("Projection");

--- a/crates/toasty-driver-dynamodb/src/lib.rs
+++ b/crates/toasty-driver-dynamodb/src/lib.rs
@@ -28,10 +28,7 @@ use toasty_core::{
         Capability, ConnectContext, Driver, ExecResponse, QueryLogConfig, log::QueryLog,
         operation::Operation,
     },
-    schema::{
-        db::{self, Column, ColumnId, Migration, Table},
-        diff,
-    },
+    schema::db::{self, Column, ColumnId, Table},
     stmt::{self, ExprContext},
 };
 
@@ -112,12 +109,6 @@ impl Driver for DynamoDb {
         let mut connection = Connection::new(self.client.clone());
         connection.query_log = cx.query_log;
         Ok(Box::new(connection))
-    }
-
-    fn generate_migration(&self, _schema_diff: &diff::Schema<'_>) -> Migration {
-        unimplemented!(
-            "DynamoDB migrations are not yet supported. DynamoDB schema changes require manual table updates through the AWS console or SDK."
-        )
     }
 
     async fn reset_db(&self) -> toasty_core::Result<()> {

--- a/crates/toasty-driver-integration-suite/src/instrumented_driver.rs
+++ b/crates/toasty-driver-integration-suite/src/instrumented_driver.rs
@@ -11,10 +11,7 @@ use std::{
 use toasty_core::{
     Result, Schema,
     driver::{Capability, ConnectContext, Connection, Driver, ExecResponse, Operation, Rows},
-    schema::{
-        db::{AppliedMigration, Migration},
-        diff,
-    },
+    schema::db::{AppliedMigration, Migration},
 };
 
 /// A fault that can be injected into the next operation routed through
@@ -163,10 +160,6 @@ impl Driver for InstrumentedDriver {
             handle: self.handle.clone(),
             valid: AtomicBool::new(true),
         }))
-    }
-
-    fn generate_migration(&self, schema_diff: &diff::Schema<'_>) -> Migration {
-        self.inner.generate_migration(schema_diff)
     }
 
     async fn reset_db(&self) -> Result<()> {

--- a/crates/toasty-driver-mysql/src/lib.rs
+++ b/crates/toasty-driver-mysql/src/lib.rs
@@ -25,10 +25,7 @@ use toasty_core::{
         log::QueryLog,
         operation::{RawSqlRet, Transaction, TransactionMode},
     },
-    schema::{
-        db::{self, Migration, Table},
-        diff,
-    },
+    schema::db::{self, Table},
     stmt::{self, ValueRecord},
 };
 use toasty_sql::{self as sql};
@@ -148,17 +145,6 @@ impl Driver for MySQL {
         let mut connection = Connection::new(conn);
         connection.query_log = cx.query_log;
         Ok(Box::new(connection))
-    }
-
-    fn generate_migration(&self, schema_diff: &diff::Schema<'_>) -> Migration {
-        let statements = sql::MigrationStatement::from_diff(schema_diff, &Capability::MYSQL);
-
-        let sql_strings: Vec<String> = statements
-            .iter()
-            .map(|stmt| sql::Serializer::mysql(stmt.schema()).serialize(stmt.statement()))
-            .collect();
-
-        Migration::new_sql_with_breakpoints(&sql_strings)
     }
 
     async fn reset_db(&self) -> toasty_core::Result<()> {

--- a/crates/toasty-driver-postgresql/src/lib.rs
+++ b/crates/toasty-driver-postgresql/src/lib.rs
@@ -29,10 +29,7 @@ use toasty_core::{
         log::QueryLog,
         operation::{RawSqlRet, Transaction, TransactionMode, TypedValue},
     },
-    schema::{
-        db::{self, Migration, Table},
-        diff,
-    },
+    schema::db::{self, Table},
     stmt,
     stmt::ValueRecord,
 };
@@ -232,17 +229,6 @@ impl Driver for PostgreSQL {
         let mut connection = self.connect_with_config(self.config.clone()).await?;
         connection.query_log = cx.query_log;
         Ok(Box::new(connection))
-    }
-
-    fn generate_migration(&self, schema_diff: &diff::Schema<'_>) -> Migration {
-        let statements = sql::MigrationStatement::from_diff(schema_diff, &Capability::POSTGRESQL);
-
-        let sql_strings: Vec<String> = statements
-            .iter()
-            .map(|stmt| sql::Serializer::postgresql(stmt.schema()).serialize(stmt.statement()))
-            .collect();
-
-        Migration::new_sql(sql_strings.join("\n"))
     }
 
     async fn reset_db(&self) -> toasty_core::Result<()> {

--- a/crates/toasty-driver-sqlite/src/lib.rs
+++ b/crates/toasty-driver-sqlite/src/lib.rs
@@ -34,10 +34,7 @@ use toasty_core::{
         log::QueryLog,
         operation::{IsolationLevel, Operation, RawSqlRet, Transaction, TypedValue},
     },
-    schema::{
-        db::{self, Migration, Table},
-        diff,
-    },
+    schema::db::{self, Table},
     stmt,
 };
 use toasty_sql::{self as sql};
@@ -123,17 +120,6 @@ impl Driver for Sqlite {
 
     fn max_connections(&self) -> Option<usize> {
         matches!(self, Self::InMemory).then_some(1)
-    }
-
-    fn generate_migration(&self, schema_diff: &diff::Schema<'_>) -> Migration {
-        let statements = sql::MigrationStatement::from_diff(schema_diff, &Capability::SQLITE);
-
-        let sql_strings: Vec<String> = statements
-            .iter()
-            .map(|stmt| sql::Serializer::sqlite(stmt.schema()).serialize(stmt.statement()))
-            .collect();
-
-        Migration::new_sql_with_breakpoints(&sql_strings)
     }
 
     async fn reset_db(&self) -> toasty_core::Result<()> {

--- a/crates/toasty-driver-turso/src/lib.rs
+++ b/crates/toasty-driver-turso/src/lib.rs
@@ -59,10 +59,7 @@ use toasty_core::{
         log::QueryLog,
         operation::{IsolationLevel, Operation, RawSqlRet, Transaction, TypedValue},
     },
-    schema::{
-        db::{self, Migration, Table},
-        diff,
-    },
+    schema::db::{self, Table},
     stmt,
 };
 use toasty_sql::{self as sql};
@@ -711,17 +708,6 @@ impl Driver for Turso {
             },
             query_log: cx.query_log,
         }))
-    }
-
-    fn generate_migration(&self, schema_diff: &diff::Schema<'_>) -> Migration {
-        let statements = sql::MigrationStatement::from_diff(schema_diff, &Capability::SQLITE);
-
-        let sql_strings: Vec<String> = statements
-            .iter()
-            .map(|stmt| sql::Serializer::sqlite(stmt.schema()).serialize(stmt.statement()))
-            .collect();
-
-        Migration::new_sql_with_breakpoints(&sql_strings)
     }
 
     async fn reset_db(&self) -> Result<()> {

--- a/crates/toasty-sql/src/lib.rs
+++ b/crates/toasty-sql/src/lib.rs
@@ -10,6 +10,13 @@
 pub mod migration;
 pub use migration::*;
 
+/// The SQL dialect being targeted.
+///
+/// Re-exported from `toasty-core` so callers that only need to name a dialect
+/// — `toasty migrate generate --flavor postgresql` — can do so without
+/// depending on the driver interface.
+pub use toasty_core::driver::SqlFlavor as Flavor;
+
 /// SQL serialization and parameter handling.
 pub mod serializer;
 pub use serializer::Serializer;

--- a/crates/toasty-sql/src/migration.rs
+++ b/crates/toasty-sql/src/migration.rs
@@ -1,14 +1,54 @@
 use std::borrow::Cow;
 
 use toasty_core::{
-    driver::Capability,
+    driver::{Capability, SqlFlavor},
     schema::{
-        db::{Column, Schema, Table, TableId, Type, TypeEnum},
+        db::{Column, Migration, Schema, Table, TableId, Type, TypeEnum},
         diff,
     },
 };
 
-use crate::stmt::{AlterColumnChanges, AlterTable, AlterTableAction, DropTable, Name, Statement};
+use crate::{
+    Serializer,
+    stmt::{AlterColumnChanges, AlterTable, AlterTableAction, DropTable, Name, Statement},
+};
+
+/// Renders the DDL that migrates `schema_diff`'s previous schema into its next
+/// one, in `flavor`'s dialect.
+///
+/// Migration DDL is a function of the dialect alone, never of a live
+/// connection. That is what lets `toasty migrate generate --flavor postgresql`
+/// emit PostgreSQL DDL with no PostgreSQL to connect to, and it is the same
+/// call each SQL driver makes at runtime.
+///
+/// # Examples
+///
+/// ```
+/// use toasty_core::schema::{db, diff};
+/// use toasty_sql::Flavor;
+///
+/// let empty = db::Schema::default();
+/// let hints = diff::RenameHints::default();
+/// let schema_diff = diff::Schema::from(&empty, &empty, &hints);
+/// let db::Migration::Sql(sql) = toasty_sql::generate_migration(Flavor::Postgresql, &schema_diff);
+/// assert!(sql.is_empty());
+/// ```
+pub fn generate_migration(flavor: SqlFlavor, schema_diff: &diff::Schema<'_>) -> Migration {
+    let statements = MigrationStatement::from_diff(schema_diff, flavor.capability());
+
+    let sql: Vec<String> = statements
+        .iter()
+        .map(|stmt| Serializer::new(flavor, stmt.schema()).serialize(stmt.statement()))
+        .collect();
+
+    match flavor {
+        // PostgreSQL runs a whole multi-statement migration in one implicit
+        // transaction, so it wants a single script. SQLite and MySQL execute
+        // statement by statement and need the breakpoints to split on.
+        SqlFlavor::Postgresql => Migration::new_sql(sql.join("\n")),
+        SqlFlavor::Sqlite | SqlFlavor::Mysql => Migration::new_sql_with_breakpoints(&sql),
+    }
+}
 
 /// Returns `true` if the only difference between two columns is the variant
 /// list of a named enum type. These changes are handled by `diff::Type`

--- a/crates/toasty-sql/src/serializer.rs
+++ b/crates/toasty-sql/src/serializer.rs
@@ -11,7 +11,9 @@ mod delim;
 use delim::{Comma, Delimited, Period};
 
 mod flavor;
-use flavor::Flavor;
+// The dialect enum lives in `toasty-core` (drivers report it through
+// `Capability`); the serializer has always called it `Flavor`.
+use toasty_core::driver::SqlFlavor as Flavor;
 
 mod ident;
 use ident::Ident;

--- a/crates/toasty-sql/src/serializer/flavor.rs
+++ b/crates/toasty-sql/src/serializer/flavor.rs
@@ -1,15 +1,20 @@
 use super::Serializer;
 
-use toasty_core::{driver::SqlPlaceholder, schema::db};
-
-#[derive(Debug)]
-pub(super) enum Flavor {
-    Postgresql,
-    Sqlite,
-    Mysql,
-}
+use toasty_core::{
+    driver::{SqlFlavor, SqlPlaceholder},
+    schema::db,
+};
 
 impl<'a> Serializer<'a> {
+    /// Creates a serializer that emits SQL in `flavor`'s dialect.
+    pub fn new(flavor: SqlFlavor, schema: &'a db::Schema) -> Self {
+        match flavor {
+            SqlFlavor::Sqlite => Self::sqlite(schema),
+            SqlFlavor::Postgresql => Self::postgresql(schema),
+            SqlFlavor::Mysql => Self::mysql(schema),
+        }
+    }
+
     /// Creates a serializer that emits SQLite SQL.
     pub fn sqlite(schema: &'a db::Schema) -> Self {
         Self::sqlite_with_default_begin(schema, "BEGIN")
@@ -26,21 +31,21 @@ impl<'a> Serializer<'a> {
     pub fn sqlite_with_default_begin(schema: &'a db::Schema, default_begin: &'static str) -> Self {
         Serializer {
             schema,
-            flavor: Flavor::Sqlite,
+            flavor: SqlFlavor::Sqlite,
             sqlite_default_begin: default_begin,
         }
     }
 
     /// Returns `true` if this serializer targets SQLite.
     pub fn is_sqlite(&self) -> bool {
-        matches!(self.flavor, Flavor::Sqlite)
+        matches!(self.flavor, SqlFlavor::Sqlite)
     }
 
     /// Creates a serializer that emits PostgreSQL SQL.
     pub fn postgresql(schema: &'a db::Schema) -> Self {
         Serializer {
             schema,
-            flavor: Flavor::Postgresql,
+            flavor: SqlFlavor::Postgresql,
             sqlite_default_begin: "BEGIN",
         }
     }
@@ -49,22 +54,21 @@ impl<'a> Serializer<'a> {
     pub fn mysql(schema: &'a db::Schema) -> Self {
         Serializer {
             schema,
-            flavor: Flavor::Mysql,
+            flavor: SqlFlavor::Mysql,
             sqlite_default_begin: "BEGIN",
         }
     }
 
     pub(super) fn is_mysql(&self) -> bool {
-        matches!(self.flavor, Flavor::Mysql)
+        matches!(self.flavor, SqlFlavor::Mysql)
     }
 }
 
-impl Flavor {
-    pub(super) fn sql_placeholder(&self) -> SqlPlaceholder {
-        match self {
-            Flavor::Postgresql => SqlPlaceholder::DollarNumber,
-            Flavor::Sqlite => SqlPlaceholder::NumberedQuestionMark,
-            Flavor::Mysql => SqlPlaceholder::QuestionMark,
-        }
+/// The bind-parameter syntax `flavor` accepts.
+pub(super) fn sql_placeholder(flavor: SqlFlavor) -> SqlPlaceholder {
+    match flavor {
+        SqlFlavor::Postgresql => SqlPlaceholder::DollarNumber,
+        SqlFlavor::Sqlite => SqlPlaceholder::NumberedQuestionMark,
+        SqlFlavor::Mysql => SqlPlaceholder::QuestionMark,
     }
 }

--- a/crates/toasty-sql/src/serializer/params.rs
+++ b/crates/toasty-sql/src/serializer/params.rs
@@ -1,4 +1,4 @@
-use super::{Formatter, ToSql};
+use super::{Formatter, ToSql, flavor};
 
 use std::fmt;
 use toasty_core::driver::SqlPlaceholder;
@@ -20,7 +20,8 @@ pub struct Placeholder(pub usize);
 
 impl ToSql for Placeholder {
     fn to_sql(self, f: &mut Formatter<'_>) {
-        write_sql_placeholder(&mut f.dst, f.serializer.flavor.sql_placeholder(), self.0).unwrap();
+        let placeholder = flavor::sql_placeholder(f.serializer.flavor);
+        write_sql_placeholder(&mut f.dst, placeholder, self.0).unwrap();
     }
 }
 

--- a/crates/toasty/Cargo.toml
+++ b/crates/toasty/Cargo.toml
@@ -14,9 +14,23 @@ readme.workspace = true
 documentation = "https://docs.rs/toasty"
 
 [features]
-default = []
+default = ["schema-dump"]
 dynamodb = ["dep:toasty-driver-dynamodb"]
-migration = ["dep:serde", "dep:toml", "dep:toml_edit", "toasty-core/migration"]
+
+# Contributes a constructor that dumps the linked schema when
+# `TOASTY_DUMP_SCHEMA` is set, so the standalone `toasty` CLI can read a
+# project's schema out of the binary it already builds. Compiled only under
+# `cfg(debug_assertions)`; release builds carry none of it. On by default so
+# the CLI works with no `Cargo.toml` changes — turn it off to drop the
+# `linktime` and `serde_json` dependencies.
+schema-dump = ["dep:linktime", "dep:serde", "dep:serde_json", "toasty-core/serde"]
+migration = [
+	"dep:serde",
+	"dep:toml",
+	"dep:toml_edit",
+	"dep:toasty-sql",
+	"toasty-core/migration",
+]
 mysql = ["dep:toasty-driver-mysql"]
 postgresql = ["dep:toasty-driver-postgresql"]
 sqlite = ["dep:toasty-driver-sqlite"]
@@ -51,6 +65,7 @@ serde = ["dep:serde_core", "dep:serde_json"]
 async-trait.workspace = true
 toasty-macros.workspace = true
 toasty-core.workspace = true
+toasty-sql = { workspace = true, optional = true }
 
 # Built-in database drivers
 toasty-driver-dynamodb = { workspace = true, optional = true }
@@ -73,6 +88,7 @@ uuid.workspace = true
 indexmap.workspace = true
 index_vec.workspace = true
 inventory.workspace = true
+linktime = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 tokio.workspace = true
 toml = { workspace = true, optional = true }

--- a/crates/toasty/src/db/connect.rs
+++ b/crates/toasty/src/db/connect.rs
@@ -2,11 +2,8 @@ use crate::Result;
 
 use async_trait::async_trait;
 use std::borrow::Cow;
+use toasty_core::driver::Connection;
 use toasty_core::driver::{Capability, ConnectContext, ConnectionUrl, Driver};
-use toasty_core::{
-    driver::Connection,
-    schema::{db::Migration, diff},
-};
 
 /// A connection to a database, wrapping the specific driver implementation.
 pub struct Connect {
@@ -131,10 +128,6 @@ impl Driver for Connect {
 
     async fn connect(&self, cx: &ConnectContext) -> Result<Box<dyn Connection>> {
         self.driver.connect(cx).await
-    }
-
-    fn generate_migration(&self, schema_diff: &diff::Schema<'_>) -> Migration {
-        self.driver.generate_migration(schema_diff)
     }
 
     async fn reset_db(&self) -> Result<()> {

--- a/crates/toasty/src/migration.rs
+++ b/crates/toasty/src/migration.rs
@@ -11,6 +11,6 @@ mod generate;
 mod snapshot;
 
 pub use embed::{MigrationFile, MigrationReport, MigrationSet};
-pub use generate::{Generated, generate};
+pub use generate::{Flavor, Generated, generate};
 pub use snapshot::Snapshot;
 pub use toasty_core::migration::{History, HistoryEntry};

--- a/crates/toasty/src/migration/generate.rs
+++ b/crates/toasty/src/migration/generate.rs
@@ -1,9 +1,8 @@
-use crate::{
-    db::Driver,
-    schema::{db, diff},
-};
+use crate::schema::{db, diff};
 
 use super::Snapshot;
+
+pub use toasty_sql::Flavor;
 
 /// A generated database migration and the schema snapshot it advances to.
 ///
@@ -12,19 +11,24 @@ use super::Snapshot;
 /// policies.
 #[derive(Debug)]
 pub struct Generated {
-    /// The driver-specific migration statements.
+    /// The migration statements, in the target flavor's dialect.
     pub migration: db::Migration,
 
     /// Snapshot of the schema after the migration is applied.
     pub snapshot: Snapshot,
 }
 
-/// Generate a database migration from `previous` to `next`.
+/// Generate a database migration from `previous` to `next`, targeting
+/// `flavor`.
 ///
 /// Returns `None` when the schemas are equivalent after applying
 /// `rename_hints`.
+///
+/// The migration depends on the SQL dialect, not on a connection, so this can
+/// generate for a database that is not running — which is how
+/// `toasty migrate generate --flavor <flavor>` works.
 pub fn generate(
-    driver: &dyn Driver,
+    flavor: Flavor,
     previous: &db::Schema,
     next: &db::Schema,
     rename_hints: &diff::RenameHints,
@@ -36,7 +40,7 @@ pub fn generate(
     }
 
     Some(Generated {
-        migration: driver.generate_migration(&schema_diff),
+        migration: toasty_sql::generate_migration(flavor, &schema_diff),
         snapshot: Snapshot::new(next.clone()),
     })
 }

--- a/crates/toasty/src/schema.rs
+++ b/crates/toasty/src/schema.rs
@@ -4,6 +4,9 @@ pub use auto::Auto;
 mod deferred;
 pub use deferred::Deferred;
 
+#[cfg(feature = "schema-dump")]
+pub mod dump;
+
 mod embed;
 pub use embed::Embed;
 

--- a/crates/toasty/src/schema/dump.rs
+++ b/crates/toasty/src/schema/dump.rs
@@ -1,0 +1,136 @@
+//! Schema extraction for the standalone `toasty` CLI.
+//!
+//! `toasty migrate generate` needs the user's resolved schema, and the only
+//! thing that can resolve it is a compiled artifact that links the user's
+//! models: `#[derive(Model)]` registers each model through `inventory`, and
+//! relations, embedded types, and `via` paths are linked across those
+//! registrations at runtime. Rather than ask users to write a dumper binary,
+//! `toasty` contributes one to whatever they already build.
+//!
+//! The [constructor](ctor) below runs before `main` in an executable, and
+//! during `dlopen` in a `cdylib`. When [`DUMP_ENV`] is set it writes the
+//! schema to stdout and exits; when it is not, it returns immediately and the
+//! program runs normally. The CLI builds the user's own bin (or their lib as a
+//! `cdylib`) and runs it with that variable set.
+//!
+//! The constructor is compiled only under `cfg(debug_assertions)`, so release
+//! builds carry no schema-dump machinery, and only with the `schema-dump`
+//! feature, which is enabled by default.
+
+use crate::{Result, schema::DiscoverItem};
+
+use toasty_core::schema::app::{self, ModelSet};
+
+use std::io::{self, Write};
+
+/// Setting this environment variable makes a Toasty-linked program dump its
+/// schema and exit instead of running.
+///
+/// The CLI sets it only on the child process it spawns; it is never exported
+/// into the user's shell. Setting it by hand is the supported way to check
+/// what the CLI will see:
+///
+/// ```text
+/// TOASTY_DUMP_SCHEMA=1 cargo run
+/// ```
+pub const DUMP_ENV: &str = "TOASTY_DUMP_SCHEMA";
+
+/// Written on its own line immediately before the JSON payload.
+///
+/// Constructors from other crates may run — and print — before this one, and
+/// nothing stops the user's own build from writing to stdout during static
+/// initialization. The marker lets the CLI find the payload rather than
+/// assuming it owns the stream.
+pub const DUMP_MARKER: &str = "--- toasty schema dump v1 ---";
+
+/// The envelope written to stdout, so a CLI built against a different `toasty`
+/// can say so instead of failing to parse.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct Dump {
+    /// The version of `toasty` that produced this dump.
+    pub toasty_version: String,
+
+    /// The resolved application schema.
+    pub schema: app::Schema,
+}
+
+/// Builds the application schema from every model linked into this program.
+///
+/// [`models!`](crate::models!) filters registrations by crate because an
+/// application chooses which models a given `Db` serves. Extraction has no
+/// such choice to make: every model reachable from the built artifact is part
+/// of the schema the migration is generated against.
+///
+/// # Errors
+///
+/// Returns an error if the registered models do not form a valid schema — an
+/// unregistered relation target, an eager-load cycle, an unresolvable `via`
+/// path.
+pub fn schema_from_linked_models() -> Result<app::Schema> {
+    let mut models = ModelSet::new();
+
+    for item in crate::schema::inventory::iter::<DiscoverItem> {
+        item.add_to(&mut models);
+    }
+
+    app::Schema::from_macro(models)
+}
+
+/// Writes this program's schema to `out` as a marker line followed by one line
+/// of JSON.
+///
+/// # Errors
+///
+/// Returns an error if the schema cannot be built or `out` cannot be written.
+pub fn write_dump(out: &mut impl Write) -> Result<()> {
+    let dump = Dump {
+        toasty_version: env!("CARGO_PKG_VERSION").to_string(),
+        schema: schema_from_linked_models()?,
+    };
+
+    let json = serde_json::to_string(&dump)
+        .map_err(|err| toasty_core::Error::serialization_failure(err.to_string()))?;
+
+    writeln!(out, "\n{DUMP_MARKER}\n{json}")
+        .map_err(toasty_core::Error::driver_operation_failed)?;
+    out.flush()
+        .map_err(toasty_core::Error::driver_operation_failed)?;
+
+    Ok(())
+}
+
+/// Dumps the schema to stdout and terminates the process.
+///
+/// Exits `0` on success and `1` after reporting a failure on stderr. Called
+/// from the constructor; exposed so the path can be exercised directly.
+pub fn dump_schema_to_stdout_and_exit() -> ! {
+    let stdout = io::stdout();
+    match write_dump(&mut stdout.lock()) {
+        Ok(()) => std::process::exit(0),
+        Err(err) => {
+            eprintln!("toasty: failed to dump schema: {err}");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Dumps the schema and exits when [`DUMP_ENV`] is set; otherwise returns and
+/// lets the program run.
+///
+/// Runs before `main` for an executable and during `dlopen` for a `cdylib`.
+/// Doing the work in a constructor is what makes the user's existing build
+/// artifact serve as the dumper: no call site to add, and it works for a
+/// library that has no `main` at all.
+#[cfg(debug_assertions)]
+// `linktime::ctor` places the function pointer in a platform-specific
+// initializer section, which requires `unsafe`. The workspace denies
+// `unsafe_code`, so the acknowledgment is scoped to this one item.
+#[allow(unsafe_code)]
+#[linktime::ctor(unsafe)]
+fn maybe_dump_schema() {
+    if std::env::var_os(DUMP_ENV).is_none() {
+        return;
+    }
+
+    dump_schema_to_stdout_and_exit();
+}

--- a/crates/toasty/tests/embedded_migrations.rs
+++ b/crates/toasty/tests/embedded_migrations.rs
@@ -9,10 +9,7 @@ use async_trait::async_trait;
 use toasty::codegen_support::core::{
     Result, Schema,
     driver::{Capability, ConnectContext, Connection, Driver, ExecResponse, Operation},
-    schema::{
-        db::{AppliedMigration, Migration},
-        diff,
-    },
+    schema::db::{AppliedMigration, Migration},
 };
 
 #[derive(Debug, toasty::Model)]
@@ -66,10 +63,6 @@ impl Driver for MigrationDriver {
 
     fn max_connections(&self) -> Option<usize> {
         Some(1)
-    }
-
-    fn generate_migration(&self, _schema_diff: &diff::Schema<'_>) -> Migration {
-        Migration::new_sql(String::new())
     }
 
     async fn reset_db(&self) -> Result<()> {

--- a/crates/toasty/tests/migration_generate.rs
+++ b/crates/toasty/tests/migration_generate.rs
@@ -1,9 +1,8 @@
 #![cfg(feature = "migration")]
 
-use toasty::migration;
+use toasty::migration::{self, Flavor};
 use toasty::schema::{db, diff};
 use toasty_core::stmt;
-use toasty_driver_sqlite::Sqlite;
 
 fn round_trip_snapshot(schema: db::Schema) -> (String, migration::Snapshot) {
     let dir = tempfile::tempdir().unwrap();
@@ -53,9 +52,8 @@ fn users_schema() -> db::Schema {
 fn generate_returns_none_for_empty_diff() {
     let schema = users_schema();
     let hints = diff::RenameHints::new();
-    let driver = Sqlite::in_memory();
 
-    let generated = migration::generate(&driver, &schema, &schema, &hints);
+    let generated = migration::generate(Flavor::Sqlite, &schema, &schema, &hints);
 
     assert!(generated.is_none());
 }
@@ -65,9 +63,8 @@ fn generate_returns_migration_and_next_snapshot() {
     let previous = db::Schema::default();
     let next = users_schema();
     let hints = diff::RenameHints::new();
-    let driver = Sqlite::in_memory();
 
-    let generated = migration::generate(&driver, &previous, &next, &hints).unwrap();
+    let generated = migration::generate(Flavor::Sqlite, &previous, &next, &hints).unwrap();
 
     assert_eq!(generated.snapshot.schema.tables[0].name, "users");
     let db::Migration::Sql(sql) = generated.migration;

--- a/crates/toasty/tests/pool_sweep.rs
+++ b/crates/toasty/tests/pool_sweep.rs
@@ -21,10 +21,7 @@ use tempfile::TempDir;
 use toasty_core::{
     Result, Schema,
     driver::{Capability, ConnectContext, Connection, Driver, ExecResponse, Operation},
-    schema::{
-        db::{AppliedMigration, Migration},
-        diff,
-    },
+    schema::db::{AppliedMigration, Migration},
 };
 
 #[derive(Debug, toasty::Model)]
@@ -87,10 +84,6 @@ impl Driver for MockDriver {
             state: self.state.clone(),
             valid: true,
         }))
-    }
-
-    fn generate_migration(&self, diff: &diff::Schema<'_>) -> Migration {
-        self.inner.generate_migration(diff)
     }
 
     async fn reset_db(&self) -> Result<()> {

--- a/docs/guide/src/schema-management.md
+++ b/docs/guide/src/schema-management.md
@@ -29,52 +29,58 @@ snapshot of the previous schema. It computes the diff and generates a SQL
 migration file containing only the changes (new tables, altered columns, dropped
 indexes, etc.).
 
-Migrations are managed through a small CLI binary that you create in your
-project using the `toasty-cli` library crate. Toasty cannot ship a ready-made
-CLI tool because the tool needs access to your model types to compute the
-schema. The `toasty-cli` crate provides `ToastyCli`, which handles argument
-parsing and all migration subcommands:
+Migrations are managed with the `toasty` command-line tool:
 
 | Command | What it does |
 |---|---|
-| `migration generate` | Diffs the current schema against the last snapshot and writes a SQL migration file |
-| `migration apply` | Runs pending migrations against the database |
-| `migration snapshot` | Prints the current schema as TOML |
-| `migration drop` | Removes a migration from history and deletes its files |
-| `migration reset` | Drops all tables and optionally re-applies all migrations |
+| `migrate generate` | Diffs the current schema against the last snapshot and writes a SQL migration file |
+| `migrate apply` | Runs pending migrations against the database |
+| `migrate snapshot` | Prints the current schema as TOML |
+| `migrate drop` | Removes a migration from history and deletes its files |
+| `migrate reset` | Drops all tables and optionally re-applies all migrations |
 
-## Setting up the CLI
+## Installing the CLI
 
-Add `toasty-cli` to your project:
+Install it once:
 
-```toml
-[dependencies]
-toasty = { version = "{{toasty_version}}", features = ["sqlite"] }
-toasty-cli = "{{toasty_version}}"
-tokio = { version = "1", features = ["full"] }
-anyhow = "1"
+```bash
+cargo install toasty-cli
 ```
 
-Create a CLI binary in `src/bin/cli.rs`:
+Then run it from any Cargo package that depends on `toasty`. There is nothing
+to add to your `Cargo.toml` and no code to write.
 
-```rust,ignore
-use toasty_cli::{Config, ToastyCli};
+Computing a schema diff needs your model types, which only exist in a compiled
+artifact. `toasty migrate generate` builds one — your package's binary, or its
+library as a `cdylib` when the package has no binary — and reads the schema
+back out of it. `toasty` contributes a constructor to that build which writes
+the schema and exits when the CLI sets `TOASTY_DUMP_SCHEMA`. Your `main` never
+runs. The constructor is compiled only under `cfg(debug_assertions)`, so
+release builds do not carry it.
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    let config = Config::load()?;
+To see what the CLI sees, set the variable yourself:
 
-    let db = toasty::Db::builder()
-        .models(toasty::models!(crate::*))
-        .connect("sqlite:./my_app.db")
-        .await?;
-
-    let cli = ToastyCli::with_config(db, config);
-    cli.parse_and_run().await?;
-
-    Ok(())
-}
+```bash
+TOASTY_DUMP_SCHEMA=1 cargo run
 ```
+
+### Selecting a package
+
+In a workspace, the CLI uses the root package. Use `-p` to pick a different
+member, as with `cargo`:
+
+```bash
+toasty -p api migrate generate --flavor postgresql
+```
+
+A workspace with no root package (a virtual manifest) requires `-p`. A package
+with more than one binary requires `--bin <name>`.
+
+Migration files and `Toasty.toml` are resolved relative to the selected
+package's directory, so the commands behave the same from anywhere in the
+workspace.
+
+## Configuration
 
 Add a `Toasty.toml` configuration file in your project root:
 
@@ -99,11 +105,15 @@ The `[migration]` section in `Toasty.toml` controls migration behavior:
 
 ## Generating a migration
 
-Run the generate command to create your first migration:
+Run the generate command to create your first migration. `--flavor` names the
+SQL dialect to generate for — `sqlite`, `postgresql`, or `mysql`:
 
 ```bash
-cargo run --bin my-cli -- migration generate
+toasty migrate generate --flavor sqlite
 ```
+
+The dialect is named rather than discovered from a connection, so migrations
+can be generated for a database that is not running.
 
 If there are schema changes since the last snapshot (or no snapshot exists yet),
 the CLI creates three things inside the configured `path` directory:
@@ -127,7 +137,7 @@ toasty/
 You can give a migration a descriptive name with `--name`:
 
 ```bash
-cargo run --bin my-cli -- migration generate --name add_posts_table
+toasty migrate generate --flavor sqlite --name add_posts_table
 ```
 
 This produces `0001_add_posts_table.sql` instead of `0001_migration.sql`.
@@ -152,8 +162,11 @@ instead of a `DROP TABLE` followed by a `CREATE TABLE`.
 Run pending migrations against the database:
 
 ```bash
-cargo run --bin my-cli -- migration apply
+toasty migrate apply --url sqlite://my_app.db
 ```
+
+Applying a migration runs saved SQL files, so it needs no models and does not
+build your package.
 
 The CLI reads `history.toml` to find all defined migrations, then queries the
 database's `__toasty_migrations` tracking table to see which ones have already
@@ -211,7 +224,7 @@ application decides which set applies to each `Db` and when to run it.
 Print the schema snapshot derived from your current model definitions:
 
 ```bash
-cargo run --bin my-cli -- migration snapshot
+toasty migrate snapshot --flavor sqlite
 ```
 
 This outputs the full schema as TOML, showing all tables, columns, and indexes.
@@ -223,38 +236,38 @@ Remove a migration from history and delete its files:
 
 ```bash
 # Drop by name
-cargo run --bin my-cli -- migration drop --name 0001_add_posts_table.sql
+toasty migrate drop --name 0001_add_posts_table.sql
 
 # Drop the latest migration
-cargo run --bin my-cli -- migration drop --latest
+toasty migrate drop --latest
 
 # Interactive picker
-cargo run --bin my-cli -- migration drop
+toasty migrate drop
 ```
 
 Dropping a migration removes its SQL file, its snapshot file, and its entry in
 `history.toml`. It does not undo changes already applied to the database. To
-undo applied changes, use `migration reset` and re-apply.
+undo applied changes, use `migrate reset` and re-apply.
 
 ## Resetting the database
 
 Drop all tables and optionally re-apply migrations from scratch:
 
 ```bash
-cargo run --bin my-cli -- migration reset
+toasty migrate reset --url sqlite://my_app.db
 ```
 
 The CLI prompts for confirmation before proceeding. After dropping all tables,
 it re-applies every migration in the history. To skip the re-apply step:
 
 ```bash
-cargo run --bin my-cli -- migration reset --skip-migrations
+toasty migrate reset --url sqlite://my_app.db --skip-migrations
 ```
 
 ## Generated SQL
 
 A generated migration file contains standard SQL DDL. Toasty generates
-database-specific SQL based on the driver you connect with. Here is an example
+database-specific SQL for the flavor you pass to `--flavor`. Here is an example
 for SQLite:
 
 ```sql
@@ -280,14 +293,40 @@ creates automatically. Each row stores the migration's ID (a random 64-bit
 integer from `history.toml`), its name, and a timestamp. The `migration apply`
 command checks this table to determine which migrations are pending.
 
+## Running the commands from your own binary
+
+The `toasty-cli` crate is also a library. `ToastyCli` exposes the same
+migration subcommands over a `Db` you build yourself, which is useful when a
+deployment runs migrations from a binary it already ships rather than from an
+installed tool:
+
+```rust,ignore
+use toasty_cli::{Config, ToastyCli};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let config = Config::load()?;
+    let db = toasty::Db::builder()
+        .models(toasty::models!(crate::*))
+        .connect("sqlite:./my_app.db")
+        .await?;
+
+    ToastyCli::with_config(db, config).parse_and_run().await?;
+    Ok(())
+}
+```
+
+Because this binary links your models and connects to a database, it takes
+neither `--flavor` nor `--url`: both come from the `Db` you pass it.
+
 ## Typical workflow
 
 A common development cycle looks like this:
 
 1. Edit your model structs (add a field, change a type, add an index)
-2. Run `migration generate --name describe_change`
+2. Run `toasty migrate generate --flavor <flavor> --name describe_change`
 3. Review the generated SQL file
-4. Run `migration apply` to update the database
+4. Run `toasty migrate apply --url <url>` to update the database
 5. Commit the migration files, snapshot, and updated history alongside your code
 
 For early development when the schema changes frequently, `push_schema` is

--- a/examples/README.md
+++ b/examples/README.md
@@ -43,8 +43,9 @@ TOASTY_CONNECTION_URL=postgresql://user:pass@localhost/mydb \
 ### service-ops
 
 `service-ops` has two binaries. `cargo run -p example-service-ops` runs the
-`server` binary (the default). The migration CLI is a separate binary; run it
-from the example's directory so it finds `Toasty.toml`:
+`server` binary (the default). The `migrate` binary embeds the migration
+commands with `toasty-cli` as a library; run it from the example's directory so
+it finds `Toasty.toml`:
 
 ```sh
 cd examples/service-ops
@@ -54,6 +55,17 @@ cargo run --bin migrate -- migration generate --name <name>
 
 # Apply pending migrations to a persistent database:
 TOASTY_CONNECTION_URL=sqlite:./service.db cargo run --bin migrate -- migration apply
+```
+
+The installed `toasty` command (`cargo install toasty-cli`) does the same
+without a project binary — it builds the package and reads the schema out of
+the artifact:
+
+```sh
+cd examples/service-ops
+
+toasty migrate generate --flavor sqlite --name <name>
+toasty migrate apply --url sqlite:./service.db
 ```
 
 Each example's `src/main.rs` (or `src/lib.rs`) opens with a comment describing

--- a/examples/service-ops/src/bin/migrate.rs
+++ b/examples/service-ops/src/bin/migrate.rs
@@ -1,12 +1,18 @@
-//! service-ops (migrate binary): a project-local migration CLI built from `toasty-cli`. The
-//! tool is YOUR binary — not a global command — because diffing the schema needs your compiled
-//! model types. Run it from this crate's directory (so it finds `Toasty.toml`):
+//! service-ops (migrate binary): the migration commands embedded in a binary of this project's
+//! own, built from `toasty-cli` as a library. Run it from this crate's directory (so it finds
+//! `Toasty.toml`):
 //!
 //!   cargo run -p example-service-ops --bin migrate -- migration generate --name initial
 //!   cargo run -p example-service-ops --bin migrate -- migration apply
 //!
 //! `generate` diffs the models against the stored snapshot and writes incremental SQL under
 //! `toasty/`; `apply` runs the pending files and records them in a `__toasty_migrations` table.
+//!
+//! Embedding is optional. `cargo install toasty-cli` gives you a `toasty` command that does the
+//! same thing for any project without a binary like this one — it builds the package and reads
+//! the schema out of the artifact. Ship a binary like this when a deployment should carry its
+//! own migration command rather than depend on an installed tool. Because it links the models
+//! and connects to a database, it needs neither `--flavor` nor `--url`.
 
 use toasty_cli::{Config, ToastyCli};
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -61,6 +61,7 @@ tests-fixture-user = { path = "tests/fixtures/user" }
 
 # Third-party types
 uuid.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
 

--- a/tests/tests/migration_generate.rs
+++ b/tests/tests/migration_generate.rs
@@ -4,10 +4,7 @@ use toasty::db::{Capability, ConnectContext, Driver, ExecResponse};
 use toasty_core::{
     Schema,
     driver::{Connection, Operation},
-    schema::{
-        db::{AppliedMigration, Migration, Type},
-        diff,
-    },
+    schema::db::{AppliedMigration, Migration, Type},
     stmt,
 };
 
@@ -26,10 +23,6 @@ impl Driver for PostgresSchemaDriver {
 
     async fn connect(&self, _cx: &ConnectContext) -> toasty::Result<Box<dyn Connection>> {
         Ok(Box::new(SchemaConnection))
-    }
-
-    fn generate_migration(&self, _schema_diff: &diff::Schema<'_>) -> Migration {
-        Migration::Sql("-- generated migration".to_string())
     }
 
     async fn reset_db(&self) -> toasty::Result<()> {

--- a/tests/tests/schema_dump.rs
+++ b/tests/tests/schema_dump.rs
@@ -1,0 +1,148 @@
+//! The schema the standalone CLI reads out of a build artifact must be the
+//! same schema the program itself would run against. These tests exercise the
+//! dump payload directly; `standalone_cli.rs` covers the CLI end to end.
+
+use toasty::schema::dump::{self, Dump};
+use toasty_core::stmt::Value;
+
+#[derive(Debug, toasty::Model)]
+struct SchemaDumpUser {
+    #[key]
+    id: u64,
+
+    #[unique]
+    email: String,
+
+    #[has_many(pair = user)]
+    orders: toasty::Deferred<Vec<SchemaDumpOrder>>,
+
+    status: SchemaDumpStatus,
+
+    priority: SchemaDumpPriority,
+}
+
+#[derive(Debug, toasty::Model)]
+struct SchemaDumpOrder {
+    #[key]
+    id: u64,
+
+    #[index]
+    user_id: u64,
+
+    #[belongs_to(key = user_id, references = id)]
+    user: toasty::Deferred<SchemaDumpUser>,
+}
+
+#[derive(Debug, toasty::Embed)]
+enum SchemaDumpStatus {
+    Draft,
+    Placed { note: String },
+}
+
+/// Explicit integer discriminants take the codec's other arm.
+#[derive(Debug, toasty::Embed)]
+enum SchemaDumpPriority {
+    #[column(variant = 1)]
+    Low,
+    #[column(variant = 2)]
+    High,
+}
+
+/// The dump payload, decoded the way the CLI decodes it.
+fn round_trip() -> Dump {
+    let mut out = Vec::new();
+    dump::write_dump(&mut out).unwrap();
+
+    let text = String::from_utf8(out).unwrap();
+    let json = text
+        .split_once(dump::DUMP_MARKER)
+        .expect("payload is preceded by the marker")
+        .1;
+
+    serde_json::from_str(json.trim()).unwrap()
+}
+
+/// The whole point of running the user's own artifact is that relations,
+/// embeds, and enum variants come back linked, not as isolated declarations.
+#[test]
+fn dump_round_trips_a_linked_schema() {
+    let dumped = round_trip().schema;
+    let built = toasty::Db::builder()
+        .models(toasty::models!(SchemaDumpUser, SchemaDumpOrder))
+        .build_app_schema()
+        .unwrap();
+
+    for model in built.models() {
+        let name = model.name().upper_camel_case();
+        let found = dumped
+            .models()
+            .find(|m| m.name().upper_camel_case() == name)
+            .unwrap_or_else(|| panic!("`{name}` missing from the dump"));
+
+        assert_eq!(
+            format!("{:?}", found.fields()),
+            format!("{:?}", model.fields()),
+            "`{name}` differs after a round trip"
+        );
+    }
+}
+
+/// A relation is only useful once it points somewhere; a dump that lost the
+/// resolved target would still deserialize.
+#[test]
+fn relations_survive_the_round_trip() {
+    let schema = round_trip().schema;
+
+    let order = schema
+        .models()
+        .find(|m| m.name().upper_camel_case() == "SchemaDumpOrder")
+        .unwrap();
+    let belongs_to = order
+        .fields()
+        .iter()
+        .find_map(|f| f.ty.as_belongs_to())
+        .expect("SchemaDumpOrder belongs to SchemaDumpUser");
+
+    assert_eq!(
+        schema.model(belongs_to.target).name().upper_camel_case(),
+        "SchemaDumpUser"
+    );
+}
+
+/// Embedded enums carry a discriminant, which serializes through a codec
+/// narrower than `stmt::Value` — one arm per discriminant kind.
+#[test]
+fn enum_discriminants_survive_the_round_trip() {
+    let schema = round_trip().schema;
+
+    let discriminants = |name: &str| -> Vec<Value> {
+        schema
+            .models()
+            .find(|m| m.name().upper_camel_case() == name)
+            .expect("embedded enums are discovered through the models that hold them")
+            .as_embedded_enum_unwrap()
+            .variants
+            .iter()
+            .map(|v| v.discriminant.clone())
+            .collect()
+    };
+
+    assert_eq!(
+        discriminants("SchemaDumpStatus"),
+        vec![
+            Value::String("draft".into()),
+            Value::String("placed".into())
+        ]
+    );
+    assert_eq!(
+        discriminants("SchemaDumpPriority"),
+        vec![Value::I64(1), Value::I64(2)]
+    );
+}
+
+/// The CLI reports a version mismatch rather than a parse failure, which only
+/// works if the version rides along with the schema.
+#[test]
+fn dump_reports_the_toasty_version_that_produced_it() {
+    assert!(!round_trip().toasty_version.is_empty());
+}


### PR DESCRIPTION
## Summary

Implements [`docs/dev/design/standalone-cli.md`](https://github.com/tokio-rs/toasty/blob/worktree-bright-moseying-penguin/docs/dev/design/standalone-cli.md). The design doc is not merged yet — it lives on `worktree-bright-moseying-penguin`.

`cargo install toasty-cli` now provides a `toasty` command that runs from any Cargo package, replacing the per-project migration binary users had to write. No `Cargo.toml` changes, no call site.

```
toasty migrate generate --flavor postgresql --name init
toasty migrate apply --url postgres://localhost/app
toasty -p api migrate generate --flavor postgresql
```

Three pieces:

- **Schema extraction** (`toasty::schema::dump`). A `linktime` constructor, gated on `cfg(debug_assertions)` and a default-on `schema-dump` feature, walks the `inventory` registrations and writes the resolved `app::Schema` as JSON when `TOASTY_DUMP_SCHEMA` is set. The CLI builds the package's bin — or its lib as a `cdylib` via `cargo rustc --crate-type cdylib` — and runs it. The user's `main` never executes. Serializing the payload required serde on the `app::Schema` graph in `toasty-core`.
- **Flavor-keyed DDL.** `SqlFlavor` moves into `toasty-core` and is reported through `Capability::sql_flavor`, so `--flavor postgresql` renders PostgreSQL DDL with no PostgreSQL to connect to.
- **The binary** (`toasty-cli/src/standalone/`). `cargo metadata` for package selection, artifact discovery from `--message-format=json-render-diagnostics`, and the hidden `__load-cdylib` re-exec. The existing commands were refactored to take a driver or a schema instead of a `Db`, so this and `ToastyCli` share one implementation.

## Type of change

- [x] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`): [standalone-cli.md](https://github.com/tokio-rs/toasty/blob/worktree-bright-moseying-penguin/docs/dev/design/standalone-cli.md) — **not yet merged**

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes (3335 tests)
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers

**Breaking:** `Driver::generate_migration` is removed — drivers no longer render DDL. Callers use `toasty_sql::generate_migration(flavor, diff)` or `toasty::migration::generate`, which now takes a `Flavor`. `Capability` gains a `sql_flavor` field, validated against `sql`.

**Two deviations from the design, both worth a look:**

1. *The env var is set inside the `__load-cdylib` child, not inherited.* The design has the parent set `TOASTY_DUMP_SCHEMA` on the child's environment. That doesn't work: the CLI links `toasty` too, so its own constructor fired at startup and dumped an empty schema before ever reaching the `dlopen`. Setting it immediately before `Library::new` means the only constructor that sees it belongs to the library being loaded. This is the one real bug the design as written would have shipped.

2. *The payload has a marker line and a version envelope.* Other constructors run before ours and can print, so the CLI locates the payload by marker rather than assuming it owns stdout. The envelope carries the producing `toasty` version, so a CLI installed at a different version reports a mismatch instead of a serde error.

Smaller notes: `Flavor::generate_migration` is a free function, since an inherent impl isn't allowed on a type from another crate and the enum has to live in `toasty-core` for `Capability` to report it. The `toasty`-dependency precheck walks the resolve graph rather than direct dependencies — a binary whose models live in a sibling library never names `toasty` in its own manifest.

Both design open questions landed where the design leaned: the `cfg(debug_assertions)` gate stayed, and `--bin <name>` is a target-selection flag alongside `-p`.

**Coverage:** `crates/toasty-cli/tests/standalone_cli.rs` builds throwaway packages and runs the real binary over both extraction paths on every CI run (~29s), which is what keeps the constructor-survives-the-cdylib-link property honest across platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)