### PR TITLE
test(tests): gate unreferenced-CTE pagination test off MySQL

### DIFF
--- a/crates/toasty-driver-integration-suite-macros/src/driver_test.rs
+++ b/crates/toasty-driver-integration-suite-macros/src/driver_test.rs
@@ -279,6 +279,12 @@ fn extract_db_capabilities(expr: &BoolExpr, expansion: &Expansion) -> Vec<(Strin
                     return; // Skip ID variant identifiers
                 }
 
+                // Test flags have no `Capability` field to assert against; the
+                // per-driver list gates them at expansion time instead.
+                if crate::parse::is_test_flag(name) {
+                    return;
+                }
+
                 // This must be a database capability
                 result.push((name.clone(), negated));
             }

--- a/crates/toasty-driver-integration-suite-macros/src/parse.rs
+++ b/crates/toasty-driver-integration-suite-macros/src/parse.rs
@@ -35,6 +35,34 @@ pub struct DriverTest {
     pub attr: DriverTestAttr,
 }
 
+/// Gate names in `requires(...)` that are properties of the test suite rather
+/// than of the database.
+///
+/// A `Capability` states what a backend can do, and the engine reads it to
+/// decide what to emit. A test flag states only that some driver cannot run a
+/// particular test — usually a limitation of the client library rather than of
+/// the database — so it has no business being consulted by the engine.
+///
+/// Flags are named in `requires(...)` exactly like capabilities, and drivers
+/// set them in the `generate_driver_tests!` list alongside capability
+/// overrides. Unlike capabilities, they generate no `Capability` field read,
+/// so they are skipped by both the per-test runtime assertion and the
+/// `validate_driver_capabilities` cross-check.
+pub const TEST_FLAGS: &[&str] = &[
+    // MySQL eliminates a CTE that nothing references before it resolves
+    // placeholder types, then reports every placeholder inside it as
+    // `MYSQL_TYPE_INVALID` (0xf3). SQLx has no mapping for that type and fails
+    // the prepare with an unknown-column-type protocol error, dropping the
+    // connection.
+    "cte_unreferenced",
+];
+
+/// Returns `true` if `name` is a [test flag](TEST_FLAGS) rather than a driver
+/// capability.
+pub fn is_test_flag(name: &str) -> bool {
+    TEST_FLAGS.contains(&name)
+}
+
 /// Builds the expression that reads capability `cap` off `capability`, a
 /// `&Capability` expression.
 ///

--- a/crates/toasty-driver-integration-suite-macros/src/test_registry.rs
+++ b/crates/toasty-driver-integration-suite-macros/src/test_registry.rs
@@ -103,8 +103,14 @@ fn scan_test_directory(dir: &Path) -> TestStructure {
 fn extract_capability_names(expr: &BoolExpr, result: &mut hashbrown::HashSet<String>) {
     match expr {
         BoolExpr::Ident(name) => {
-            // Skip common matrix identifiers
-            if name != "single" && name != "composite" && name != "id_u64" && name != "id_uuid" {
+            // Skip common matrix identifiers, and test flags, which have no
+            // `Capability` field to validate against.
+            if name != "single"
+                && name != "composite"
+                && name != "id_u64"
+                && name != "id_uuid"
+                && !crate::parse::is_test_flag(name)
+            {
                 result.insert(name.clone());
             }
         }

--- a/crates/toasty-driver-integration-suite/src/tests/paginate_multi_column.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/paginate_multi_column.rs
@@ -44,7 +44,10 @@ pub async fn paginate_first_page_has_no_previous_page(test: &mut Test) -> Result
     Ok(())
 }
 
-#[driver_test(requires(and(sql, backward_pagination)))]
+// The outer query never references the CTE, so `cte_unreferenced` gates out
+// drivers that cannot prepare a statement whose eliminated CTE holds
+// placeholders.
+#[driver_test(requires(and(sql, backward_pagination, cte_unreferenced)))]
 pub async fn paginate_first_page_ignores_subquery_cursor(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
     struct Item {

--- a/tests/tests/mysql.rs
+++ b/tests/tests/mysql.rs
@@ -52,6 +52,7 @@ impl toasty_driver_integration_suite::Setup for MySqlSetup {
 
 // Generate all driver tests
 toasty_driver_integration_suite::generate_driver_tests!(MySqlSetup::new(),
+    cte_unreferenced: false,
     decimal_arbitrary_precision: false,
     native_ilike: false,
     native_jsonb: false,


### PR DESCRIPTION
## Summary

Fixes the red MySQL job on `main`.

`paginate_first_page_ignores_subquery_cursor` attaches a CTE the outer query never references. MySQL eliminates the dead CTE before resolving placeholder types, then reports every placeholder inside it as `MYSQL_TYPE_INVALID` (`0xf3`). SQLx has no mapping for that type, so the prepare fails with an unknown-column-type protocol error that drops the connection. #1147 moving the driver to SQLx is what exposed this.

Reproduces identically on MySQL 8.0.46 and 26.7.0, so it is not a server-version issue. A placeholder in a *referenced* CTE is fine; only the eliminated one breaks. `sqlx-mysql` 0.9.0 is the newest release, so there is no upstream fix to bump to.

The test is gated off MySQL rather than rewritten — it exists to check that a cursor on a nested query does not mark the outer first page as resumed, and any rewrite that avoids the dead CTE stops testing that.

Gating it needed a mechanism. `requires(...)` resolved every name against a `Capability` field, and `Capability` is the wrong home for this: it states what a backend can do and the engine reads it to decide what to emit, whereas this is a client-library limitation the engine should never consult. (`test_connection_pool` is the existing precedent, and it carries a `TODO: come up with a better way`.)

So this adds test flags. They are named in `requires(...)` and set per driver in `generate_driver_tests!` exactly like capabilities, but read no `Capability` field, so they are skipped by the per-test runtime assertion and by `validate_driver_capabilities`. The change is small because the compile-time filter in `generate_driver_test_variants!` already worked purely off the per-driver list and never consulted `Capability`. `toasty-core` is untouched.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

Verified locally against real databases: MySQL 26.7 765 passed, SQLite 775, Turso 780, PostgreSQL 802, DynamoDB 608 — all 0 failed. Also confirmed by name that the test still appears in SQLite's generated list and passes, and is absent from MySQL's (compiled out, not ignored). `cargo test -p toasty-driver-mysql` and the quickstart example against MySQL both pass.

The underlying SQLx gap is still live: any query with a placeholder inside an unreferenced CTE will kill a MySQL connection. The engine only emits such a CTE deliberately for PostgreSQL data-modifying CTEs, so normal usage is unaffected, but a hand-built statement via `exec_untyped` can still hit it. Worth an upstream issue if you want it closed properly.