### PR TITLE
feat: accept #[belongs_to] fields in embedded types

### DIFF
--- a/crates/toasty-core/src/schema/builder/table.rs
+++ b/crates/toasty-core/src/schema/builder/table.rs
@@ -951,7 +951,9 @@ impl<'a, 'b> MapField<'a, 'b> {
                 }
             }
             app::FieldTy::BelongsTo(_) | app::FieldTy::Has(_) | app::FieldTy::Via(_) => {
-                assert!(!self.force_nullable);
+                // A relation field maps to no column, so the nullability
+                // context (`force_nullable`, set inside enum variants and
+                // nullable struct embeds) has nothing to apply to.
                 let bit = self.build.next_bit();
                 Ok(mapping::Field::Relation(mapping::FieldRelation {
                     field_mask: stmt::PathFieldSet::from_iter([bit]),

--- a/crates/toasty-driver-integration-suite/src/tests.rs
+++ b/crates/toasty-driver-integration-suite/src/tests.rs
@@ -40,6 +40,7 @@ pub mod embed_enum_shared_type;
 pub mod embed_enum_string_discriminant;
 pub mod embed_enum_unit;
 pub mod embed_newtype;
+pub mod embed_relation;
 pub mod embed_struct;
 pub mod embed_struct_index;
 pub mod embed_struct_optional;

--- a/crates/toasty-driver-integration-suite/src/tests/embed_enum_filter_variant_field.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embed_enum_filter_variant_field.rs
@@ -172,3 +172,59 @@ pub async fn filter_variant_field_with_cast_storage(t: &mut Test) -> Result<()> 
 
     Ok(())
 }
+
+/// Same as above, but the variant field overrides its storage type away from
+/// the backend default (`#[column(type = text)]` UUID; SQLite's default UUID
+/// storage is a blob). The comparison constant must be converted to the
+/// referenced column's stored type, not the backend default for the model
+/// type — the latter silently matches zero rows.
+#[driver_test(requires(sql))]
+pub async fn filter_variant_field_with_storage_override(t: &mut Test) -> Result<()> {
+    #[derive(Debug, PartialEq, toasty::Embed)]
+    enum Owner {
+        #[column(variant = 1)]
+        Human {
+            #[column(type = text)]
+            id: uuid::Uuid,
+        },
+        #[column(variant = 2)]
+        Animal { tag: uuid::Uuid },
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Object {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+        owner: Owner,
+    }
+
+    let mut db = t.setup_db(models!(Object)).await;
+
+    let target = uuid::Uuid::new_v4();
+    let expected = toasty::create!(Object {
+        owner: Owner::Human { id: target }
+    })
+    .exec(&mut db)
+    .await?;
+    toasty::create!(Object {
+        owner: Owner::Human {
+            id: uuid::Uuid::new_v4()
+        }
+    })
+    .exec(&mut db)
+    .await?;
+
+    let found = Object::filter(
+        Object::fields()
+            .owner()
+            .human()
+            .matches(|h| h.id().eq(target)),
+    )
+    .exec(&mut db)
+    .await?;
+    assert_eq!(found.len(), 1);
+    assert_eq!(found[0].id, expected.id);
+
+    Ok(())
+}

--- a/crates/toasty-driver-integration-suite/src/tests/embed_enum_filter_variant_field.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embed_enum_filter_variant_field.rs
@@ -120,3 +120,55 @@ pub async fn cross_variant_or(t: &mut Test) -> Result<()> {
     assert_eq!(rows.len(), 2);
     Ok(())
 }
+
+/// A variant field whose model type differs from its stored column type
+/// (`uuid::Uuid`, stored as a string) is filterable. The decode cast the
+/// enum's `Match` arm wraps around the column used to reach the SQL
+/// serializer unchanged and panic; simplify now moves the conversion onto
+/// the constant side.
+#[driver_test]
+pub async fn filter_variant_field_with_cast_storage(t: &mut Test) -> Result<()> {
+    #[derive(Debug, PartialEq, toasty::Embed)]
+    enum Owner {
+        #[column(variant = 1)]
+        Human { id: uuid::Uuid },
+        #[column(variant = 2)]
+        Animal { tag: uuid::Uuid },
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Object {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+        owner: Owner,
+    }
+
+    let mut db = t.setup_db(models!(Object)).await;
+
+    let target = uuid::Uuid::new_v4();
+    let expected = toasty::create!(Object {
+        owner: Owner::Human { id: target }
+    })
+    .exec(&mut db)
+    .await?;
+    // Same UUID in the other variant's column: must not match.
+    toasty::create!(Object {
+        owner: Owner::Animal { tag: target }
+    })
+    .exec(&mut db)
+    .await?;
+
+    let found = Object::filter(
+        Object::fields()
+            .owner()
+            .human()
+            .matches(|h| h.id().eq(target)),
+    )
+    .exec(&mut db)
+    .await?;
+    assert_eq!(found.len(), 1);
+    assert_eq!(found[0].id, expected.id);
+
+    Ok(())
+}

--- a/crates/toasty-driver-integration-suite/src/tests/embed_relation.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embed_relation.rs
@@ -1,0 +1,445 @@
+use crate::prelude::*;
+
+/// The polymorphic-owner shape: `#[belongs_to]` fields inside embedded enum
+/// variants. The relation fields map to no columns — the discriminant and the
+/// key fields own the storage. Creating supplies the variant value with
+/// explicit keys, `match` reads the stored keys back, and the owner loads
+/// with an ordinary `get_by_*`.
+#[driver_test]
+pub async fn belongs_to_in_enum_variants(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Human {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+        name: String,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Bot {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+        #[unique]
+        serial: String,
+        name: String,
+    }
+
+    #[derive(Debug, toasty::Embed)]
+    enum Owner {
+        Human {
+            #[index]
+            id: uuid::Uuid,
+            #[belongs_to(key = id)]
+            human: toasty::Deferred<Human>,
+        },
+        Bot {
+            #[index]
+            serial: String,
+            #[belongs_to(key = serial, references = serial)]
+            bot: toasty::Deferred<Bot>,
+        },
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Object {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+        owner: Owner,
+    }
+
+    let mut db = test.setup_db(models!(Object, Human, Bot)).await;
+
+    // The relation fields contribute no columns: discriminant + one column
+    // per key field.
+    let table = &db.schema().db.tables[0];
+    let names: Vec<_> = table.columns.iter().map(|c| c.name.as_str()).collect();
+    assert_eq!(names, ["id", "owner", "owner_id", "owner_serial"]);
+
+    let alice = toasty::create!(Human { name: "Alice" })
+        .exec(&mut db)
+        .await?;
+    let bot = toasty::create!(Bot {
+        serial: "B-1000",
+        name: "Marvin"
+    })
+    .exec(&mut db)
+    .await?;
+
+    // Create with explicit keys; the relation stays unloaded.
+    let obj_a = toasty::create!(Object {
+        owner: Owner::Human {
+            id: alice.id,
+            human: toasty::Deferred::default(),
+        }
+    })
+    .exec(&mut db)
+    .await?;
+    let obj_b = toasty::create!(Object {
+        owner: Owner::Bot {
+            serial: bot.serial.clone(),
+            bot: toasty::Deferred::default(),
+        }
+    })
+    .exec(&mut db)
+    .await?;
+
+    // `match` gives direct access to the stored keys; the owner loads with an
+    // ordinary lookup.
+    let obj_a = Object::get_by_id(&mut db, obj_a.id).await?;
+    match &obj_a.owner {
+        Owner::Human { id, human } => {
+            assert!(human.is_unloaded());
+            let human = Human::get_by_id(&mut db, id).await?;
+            assert_eq!(human.name, "Alice");
+        }
+        other => panic!("expected Owner::Human, got {other:?}"),
+    }
+
+    let obj_b = Object::get_by_id(&mut db, obj_b.id).await?;
+    match &obj_b.owner {
+        Owner::Bot { serial, bot } => {
+            assert!(bot.is_unloaded());
+            let bot = Bot::get_by_serial(&mut db, serial).await?;
+            assert_eq!(bot.name, "Marvin");
+        }
+        other => panic!("expected Owner::Bot, got {other:?}"),
+    }
+
+    Ok(())
+}
+
+/// Key fields of relation-carrying variants stay queryable through the
+/// existing variant filter paths: the variant closure gates on the
+/// discriminant and compares the key column.
+#[driver_test]
+pub async fn filter_by_relation_key_through_variant_path(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Human {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+        name: String,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Animal {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+        name: String,
+    }
+
+    // `Human` and `Animal` share one key column; `#[index(id)]` indexes it
+    // once for both.
+    #[derive(Debug, toasty::Embed)]
+    #[index(id)]
+    enum Owner {
+        Human {
+            #[shared(id)]
+            id: uuid::Uuid,
+            #[belongs_to(key = id)]
+            human: toasty::Deferred<Human>,
+        },
+        Animal {
+            #[shared(id)]
+            id: uuid::Uuid,
+            #[belongs_to(key = id)]
+            animal: toasty::Deferred<Animal>,
+        },
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Object {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+        owner: Owner,
+    }
+
+    let mut db = test.setup_db(models!(Object, Human, Animal)).await;
+
+    // One shared key column, indexed by the enum-level attribute.
+    let table = &db.schema().db.tables[0];
+    let names: Vec<_> = table.columns.iter().map(|c| c.name.as_str()).collect();
+    assert_eq!(names, ["id", "owner", "owner_id"]);
+    let key_col = columns(&db, "objects", &["owner_id"])[0];
+    assert_struct!(table.indices, [
+        { primary_key: true },
+        { unique: false, primary_key: false, columns: [{ column: == key_col }] },
+    ]);
+
+    let alice = toasty::create!(Human { name: "Alice" })
+        .exec(&mut db)
+        .await?;
+    // An animal holding the same UUID as Alice, to prove the variant gate.
+    let rex = toasty::create!(Animal { name: "Rex" })
+        .exec(&mut db)
+        .await?;
+
+    let human_obj = toasty::create!(Object {
+        owner: Owner::Human {
+            id: alice.id,
+            human: toasty::Deferred::default(),
+        }
+    })
+    .exec(&mut db)
+    .await?;
+    toasty::create!(Object {
+        owner: Owner::Animal {
+            id: rex.id,
+            animal: toasty::Deferred::default(),
+        }
+    })
+    .exec(&mut db)
+    .await?;
+
+    // Variant-gated key filter: only the Human row matches, even though the
+    // Animal row stores its key in the same column.
+    let found: Vec<Object> = Object::filter(
+        Object::fields()
+            .owner()
+            .human()
+            .matches(|h| h.id().eq(alice.id)),
+    )
+    .exec(&mut db)
+    .await?;
+    assert_eq!(found.len(), 1);
+    assert_eq!(found[0].id, human_obj.id);
+
+    // The discriminant filter alone works as before.
+    let humans: Vec<Object> = Object::filter(Object::fields().owner().is_human())
+        .exec(&mut db)
+        .await?;
+    assert_eq!(humans.len(), 1);
+    assert_eq!(humans[0].id, human_obj.id);
+
+    Ok(())
+}
+
+/// Changing the owner — including its kind — is a whole-value replacement of
+/// the embed, per existing embedded-enum update semantics.
+#[driver_test]
+pub async fn update_replaces_owner_variant(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Human {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+        name: String,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Bot {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+        #[unique]
+        serial: String,
+    }
+
+    #[derive(Debug, toasty::Embed)]
+    enum Owner {
+        Human {
+            #[index]
+            id: uuid::Uuid,
+            #[belongs_to(key = id)]
+            human: toasty::Deferred<Human>,
+        },
+        Bot {
+            #[index]
+            serial: String,
+            #[belongs_to(key = serial, references = serial)]
+            bot: toasty::Deferred<Bot>,
+        },
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Object {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+        owner: Owner,
+    }
+
+    let mut db = test.setup_db(models!(Object, Human, Bot)).await;
+
+    let alice = toasty::create!(Human { name: "Alice" })
+        .exec(&mut db)
+        .await?;
+    let bot = toasty::create!(Bot { serial: "B-1000" })
+        .exec(&mut db)
+        .await?;
+
+    let mut obj = toasty::create!(Object {
+        owner: Owner::Human {
+            id: alice.id,
+            human: toasty::Deferred::default(),
+        }
+    })
+    .exec(&mut db)
+    .await?;
+
+    obj.update()
+        .owner(Owner::Bot {
+            serial: bot.serial.clone(),
+            bot: toasty::Deferred::default(),
+        })
+        .exec(&mut db)
+        .await?;
+
+    let reloaded = Object::get_by_id(&mut db, obj.id).await?;
+    assert_struct!(
+        reloaded.owner,
+        Owner::Bot {
+            serial: "B-1000",
+            ..
+        }
+    );
+
+    Ok(())
+}
+
+/// `#[belongs_to]` inside an embedded struct: same storage rule — the key
+/// field owns the column, the relation maps to nothing.
+#[driver_test]
+pub async fn belongs_to_in_embedded_struct(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Author {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+        name: String,
+    }
+
+    #[derive(Debug, toasty::Embed)]
+    struct Attribution {
+        #[index]
+        author_id: uuid::Uuid,
+        #[belongs_to(key = author_id)]
+        author: toasty::Deferred<Author>,
+        note: String,
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Post {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+        attribution: Attribution,
+    }
+
+    let mut db = test.setup_db(models!(Post, Author)).await;
+
+    let table = &db.schema().db.tables[0];
+    let names: Vec<_> = table.columns.iter().map(|c| c.name.as_str()).collect();
+    assert_eq!(names, ["id", "attribution_author_id", "attribution_note"]);
+
+    let author = toasty::create!(Author { name: "Ann" })
+        .exec(&mut db)
+        .await?;
+
+    let post = toasty::create!(Post {
+        attribution: Attribution {
+            author_id: author.id,
+            author: toasty::Deferred::default(),
+            note: "first draft".to_string(),
+        }
+    })
+    .exec(&mut db)
+    .await?;
+
+    let post = Post::get_by_id(&mut db, post.id).await?;
+    assert!(post.attribution.author.is_unloaded());
+    assert_eq!(post.attribution.note, "first draft");
+    let author = Author::get_by_id(&mut db, &post.attribution.author_id).await?;
+    assert_eq!(author.name, "Ann");
+
+    // The key field stays queryable through the embed path.
+    let found: Vec<Post> = Post::filter(
+        Post::fields()
+            .attribution()
+            .author_id()
+            .eq(post.attribution.author_id),
+    )
+    .exec(&mut db)
+    .await?;
+    assert_eq!(found.len(), 1);
+
+    // And assignable through the embed update builder.
+    let other = toasty::create!(Author { name: "Bea" })
+        .exec(&mut db)
+        .await?;
+    let mut post = post;
+    post.update()
+        .attribution(toasty::stmt::patch(
+            Attribution::fields().author_id(),
+            other.id,
+        ))
+        .exec(&mut db)
+        .await?;
+    assert_eq!(post.attribution.author_id, other.id);
+
+    Ok(())
+}
+
+/// An `Option<Owner>` field: an ownerless row stores NULL in the discriminant
+/// column, per existing optional-embed support.
+#[driver_test]
+pub async fn optional_relation_carrying_embed(test: &mut Test) -> Result<()> {
+    #[derive(Debug, toasty::Model)]
+    struct Human {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+    }
+
+    #[derive(Debug, toasty::Embed)]
+    enum Owner {
+        Human {
+            #[index]
+            id: uuid::Uuid,
+            #[belongs_to(key = id)]
+            human: toasty::Deferred<Human>,
+        },
+    }
+
+    #[derive(Debug, toasty::Model)]
+    struct Object {
+        #[key]
+        #[auto]
+        id: uuid::Uuid,
+        owner: Option<Owner>,
+    }
+
+    let mut db = test.setup_db(models!(Object, Human)).await;
+
+    let orphan = toasty::create!(Object { owner: None })
+        .exec(&mut db)
+        .await?;
+
+    let human = toasty::create!(Human {}).exec(&mut db).await?;
+    let owned = toasty::create!(Object {
+        owner: Some(Owner::Human {
+            id: human.id,
+            human: toasty::Deferred::default(),
+        })
+    })
+    .exec(&mut db)
+    .await?;
+
+    let orphan = Object::get_by_id(&mut db, orphan.id).await?;
+    assert!(orphan.owner.is_none());
+
+    let owned = Object::get_by_id(&mut db, owned.id).await?;
+    match owned.owner {
+        Some(Owner::Human { id, human: rel }) => {
+            assert_eq!(id, human.id);
+            assert!(rel.is_unloaded());
+        }
+        other => panic!("expected Some(Owner::Human), got {other:?}"),
+    }
+
+    Ok(())
+}

--- a/crates/toasty-driver-integration-suite/src/tests/embed_relation.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embed_relation.rs
@@ -1,10 +1,12 @@
 use crate::prelude::*;
 
 /// The polymorphic-owner shape: `#[belongs_to]` fields inside embedded enum
-/// variants. The relation fields map to no columns — the discriminant and the
-/// key fields own the storage. Creating supplies the variant value with
-/// explicit keys, `match` reads the stored keys back, and the owner loads
-/// with an ordinary `get_by_*`.
+/// variants, exercised through the full CRUD cycle. The relation fields map
+/// to no columns — the discriminant and the key fields own the storage.
+/// Creating supplies the variant value with explicit keys, `match` reads the
+/// stored keys back, the owner loads with an ordinary `get_by_*`, and
+/// changing the owner — including its kind — is a whole-value replacement of
+/// the embed.
 #[driver_test]
 pub async fn belongs_to_in_enum_variants(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
@@ -87,7 +89,7 @@ pub async fn belongs_to_in_enum_variants(test: &mut Test) -> Result<()> {
 
     // `match` gives direct access to the stored keys; the owner loads with an
     // ordinary lookup.
-    let obj_a = Object::get_by_id(&mut db, obj_a.id).await?;
+    let mut obj_a = Object::get_by_id(&mut db, obj_a.id).await?;
     match &obj_a.owner {
         Owner::Human { id, human } => {
             assert!(human.is_unloaded());
@@ -107,12 +109,40 @@ pub async fn belongs_to_in_enum_variants(test: &mut Test) -> Result<()> {
         other => panic!("expected Owner::Bot, got {other:?}"),
     }
 
+    // Changing the owner — including its kind — is a whole-value replacement
+    // of the embed.
+    obj_a
+        .update()
+        .owner(Owner::Bot {
+            serial: bot.serial.clone(),
+            bot: toasty::Deferred::default(),
+        })
+        .exec(&mut db)
+        .await?;
+    let reloaded = Object::get_by_id(&mut db, obj_a.id).await?;
+    assert_struct!(
+        reloaded.owner,
+        Owner::Bot {
+            serial: "B-1000",
+            ..
+        }
+    );
+
+    let obj_a_id = obj_a.id;
+    obj_a.delete().exec(&mut db).await?;
+    assert_err!(Object::get_by_id(&mut db, obj_a_id).await);
+    assert!(matches!(
+        Object::get_by_id(&mut db, obj_b.id).await?.owner,
+        Owner::Bot { .. }
+    ));
+
     Ok(())
 }
 
 /// Key fields of relation-carrying variants stay queryable through the
-/// existing variant filter paths: the variant closure gates on the
-/// discriminant and compares the key column.
+/// existing variant filter paths — the variant closure gates on the
+/// discriminant and compares the shared key column — and stay consistent
+/// as rows are re-pointed and deleted.
 #[driver_test]
 pub async fn filter_by_relation_key_through_variant_path(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
@@ -178,7 +208,7 @@ pub async fn filter_by_relation_key_through_variant_path(test: &mut Test) -> Res
         .exec(&mut db)
         .await?;
 
-    let human_obj = toasty::create!(Object {
+    let mut human_obj = toasty::create!(Object {
         owner: Owner::Human {
             id: alice.id,
             human: toasty::Deferred::default(),
@@ -197,14 +227,13 @@ pub async fn filter_by_relation_key_through_variant_path(test: &mut Test) -> Res
 
     // Variant-gated key filter: only the Human row matches, even though the
     // Animal row stores its key in the same column.
-    let found: Vec<Object> = Object::filter(
+    let by_key = |id: uuid::Uuid| {
         Object::fields()
             .owner()
             .human()
-            .matches(|h| h.id().eq(alice.id)),
-    )
-    .exec(&mut db)
-    .await?;
+            .matches(move |h| h.id().eq(id))
+    };
+    let found: Vec<Object> = Object::filter(by_key(alice.id)).exec(&mut db).await?;
     assert_eq!(found.len(), 1);
     assert_eq!(found[0].id, human_obj.id);
 
@@ -215,94 +244,46 @@ pub async fn filter_by_relation_key_through_variant_path(test: &mut Test) -> Res
     assert_eq!(humans.len(), 1);
     assert_eq!(humans[0].id, human_obj.id);
 
-    Ok(())
-}
-
-/// Changing the owner — including its kind — is a whole-value replacement of
-/// the embed, per existing embedded-enum update semantics.
-#[driver_test]
-pub async fn update_replaces_owner_variant(test: &mut Test) -> Result<()> {
-    #[derive(Debug, toasty::Model)]
-    struct Human {
-        #[key]
-        #[auto]
-        id: uuid::Uuid,
-        name: String,
-    }
-
-    #[derive(Debug, toasty::Model)]
-    struct Bot {
-        #[key]
-        #[auto]
-        id: uuid::Uuid,
-        #[unique]
-        serial: String,
-    }
-
-    #[derive(Debug, toasty::Embed)]
-    enum Owner {
-        Human {
-            #[index]
-            id: uuid::Uuid,
-            #[belongs_to(key = id)]
-            human: toasty::Deferred<Human>,
-        },
-        Bot {
-            #[index]
-            serial: String,
-            #[belongs_to(key = serial, references = serial)]
-            bot: toasty::Deferred<Bot>,
-        },
-    }
-
-    #[derive(Debug, toasty::Model)]
-    struct Object {
-        #[key]
-        #[auto]
-        id: uuid::Uuid,
-        owner: Owner,
-    }
-
-    let mut db = test.setup_db(models!(Object, Human, Bot)).await;
-
-    let alice = toasty::create!(Human { name: "Alice" })
-        .exec(&mut db)
-        .await?;
-    let bot = toasty::create!(Bot { serial: "B-1000" })
-        .exec(&mut db)
-        .await?;
-
-    let mut obj = toasty::create!(Object {
-        owner: Owner::Human {
-            id: alice.id,
+    // Re-point the relation within the same variant by replacing the embed
+    // value; the key filter follows.
+    let bea = toasty::create!(Human { name: "Bea" }).exec(&mut db).await?;
+    human_obj
+        .update()
+        .owner(Owner::Human {
+            id: bea.id,
             human: toasty::Deferred::default(),
-        }
-    })
-    .exec(&mut db)
-    .await?;
-
-    obj.update()
-        .owner(Owner::Bot {
-            serial: bot.serial.clone(),
-            bot: toasty::Deferred::default(),
         })
         .exec(&mut db)
         .await?;
-
-    let reloaded = Object::get_by_id(&mut db, obj.id).await?;
-    assert_struct!(
-        reloaded.owner,
-        Owner::Bot {
-            serial: "B-1000",
-            ..
-        }
+    assert!(
+        Object::filter(by_key(alice.id))
+            .exec(&mut db)
+            .await?
+            .is_empty()
     );
+    let found: Vec<Object> = Object::filter(by_key(bea.id)).exec(&mut db).await?;
+    assert_eq!(found.len(), 1);
+    assert_eq!(found[0].id, human_obj.id);
+
+    // Deleting the row empties the key filter; the Animal row is untouched.
+    human_obj.delete().exec(&mut db).await?;
+    assert!(
+        Object::filter(by_key(bea.id))
+            .exec(&mut db)
+            .await?
+            .is_empty()
+    );
+    let animals: Vec<Object> = Object::filter(Object::fields().owner().is_animal())
+        .exec(&mut db)
+        .await?;
+    assert_eq!(animals.len(), 1);
 
     Ok(())
 }
 
 /// `#[belongs_to]` inside an embedded struct: same storage rule — the key
-/// field owns the column, the relation maps to nothing.
+/// field owns the column, the relation maps to nothing — through the full
+/// CRUD cycle.
 #[driver_test]
 pub async fn belongs_to_in_embedded_struct(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
@@ -350,7 +331,7 @@ pub async fn belongs_to_in_embedded_struct(test: &mut Test) -> Result<()> {
     .exec(&mut db)
     .await?;
 
-    let post = Post::get_by_id(&mut db, post.id).await?;
+    let mut post = Post::get_by_id(&mut db, post.id).await?;
     assert!(post.attribution.author.is_unloaded());
     assert_eq!(post.attribution.note, "first draft");
     let author = Author::get_by_id(&mut db, &post.attribution.author_id).await?;
@@ -371,7 +352,6 @@ pub async fn belongs_to_in_embedded_struct(test: &mut Test) -> Result<()> {
     let other = toasty::create!(Author { name: "Bea" })
         .exec(&mut db)
         .await?;
-    let mut post = post;
     post.update()
         .attribution(toasty::stmt::patch(
             Attribution::fields().author_id(),
@@ -380,12 +360,24 @@ pub async fn belongs_to_in_embedded_struct(test: &mut Test) -> Result<()> {
         .exec(&mut db)
         .await?;
     assert_eq!(post.attribution.author_id, other.id);
+    assert_eq!(
+        Post::get_by_id(&mut db, post.id)
+            .await?
+            .attribution
+            .author_id,
+        other.id
+    );
+
+    let post_id = post.id;
+    post.delete().exec(&mut db).await?;
+    assert_err!(Post::get_by_id(&mut db, post_id).await);
 
     Ok(())
 }
 
 /// An `Option<Owner>` field: an ownerless row stores NULL in the discriminant
-/// column, per existing optional-embed support.
+/// column, per existing optional-embed support, and updates move rows in and
+/// out of ownership.
 #[driver_test]
 pub async fn optional_relation_carrying_embed(test: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
@@ -429,17 +421,34 @@ pub async fn optional_relation_carrying_embed(test: &mut Test) -> Result<()> {
     .exec(&mut db)
     .await?;
 
-    let orphan = Object::get_by_id(&mut db, orphan.id).await?;
+    let mut orphan = Object::get_by_id(&mut db, orphan.id).await?;
     assert!(orphan.owner.is_none());
 
-    let owned = Object::get_by_id(&mut db, owned.id).await?;
-    match owned.owner {
+    let mut owned = Object::get_by_id(&mut db, owned.id).await?;
+    match &owned.owner {
         Some(Owner::Human { id, human: rel }) => {
-            assert_eq!(id, human.id);
+            assert_eq!(*id, human.id);
             assert!(rel.is_unloaded());
         }
         other => panic!("expected Some(Owner::Human), got {other:?}"),
     }
+
+    // Assign an owner to the ownerless row and clear the owned row.
+    orphan
+        .update()
+        .owner(Some(Owner::Human {
+            id: human.id,
+            human: toasty::Deferred::default(),
+        }))
+        .exec(&mut db)
+        .await?;
+    assert!(matches!(
+        Object::get_by_id(&mut db, orphan.id).await?.owner,
+        Some(Owner::Human { .. })
+    ));
+
+    owned.update().owner(None).exec(&mut db).await?;
+    assert!(Object::get_by_id(&mut db, owned.id).await?.owner.is_none());
 
     Ok(())
 }

--- a/crates/toasty-macros/src/lib.rs
+++ b/crates/toasty-macros/src/lib.rs
@@ -1172,11 +1172,18 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
 /// ## `#[belongs_to(...)]` — relations stored in embedded types
 ///
 /// A field of an embedded struct or enum variant may declare
-/// `#[belongs_to]`, referencing a sibling key field of the same struct or
-/// variant. The relation itself maps to no column — the key field owns the
-/// storage — and the field type must be `toasty::Deferred<..>`: reads
-/// return it unloaded, and the referenced model loads with an ordinary
-/// `get_by_*` / `find_by_*` on the stored key.
+/// `#[belongs_to]`, with the same parameters as the model-level attribute
+/// (see [`Model`][`derive@Model`]). The differences:
+///
+/// - `key` references a sibling field of the same struct or variant.
+/// - The field type must be `toasty::Deferred<..>`; the always-loaded
+///   form is not supported.
+/// - There is no `.include()`: load the referenced model with an
+///   ordinary `get_by_*` / `find_by_*` on the stored key.
+/// - Writes set the key field explicitly and leave the relation unloaded
+///   (`Deferred::default()`); setting it from a model value is not
+///   supported.
+/// - A `has_many` on the target cannot pair with it.
 ///
 /// ```no_run
 /// # #[derive(Debug, toasty::Model)]
@@ -1196,11 +1203,6 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
 ///     // ... other owner kinds
 /// }
 /// ```
-///
-/// Creating and updating supply the embed value with explicit keys and the
-/// relation left unloaded (`Deferred::default()`). Setting the relation
-/// from a model value, preloading it with `.include()`, and pairing it
-/// with a `has_many` on the target are not supported yet.
 ///
 /// # Using embedded types in a model
 ///

--- a/crates/toasty-macros/src/lib.rs
+++ b/crates/toasty-macros/src/lib.rs
@@ -1169,6 +1169,39 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
 /// `#[index]` / `#[unique]` on a `#[shared]` field is a compile error
 /// pointing at the enum-level form.
 ///
+/// ## `#[belongs_to(...)]` — relations stored in embedded types
+///
+/// A field of an embedded struct or enum variant may declare
+/// `#[belongs_to]`, referencing a sibling key field of the same struct or
+/// variant. The relation itself maps to no column — the key field owns the
+/// storage — and the field type must be `toasty::Deferred<..>`: reads
+/// return it unloaded, and the referenced model loads with an ordinary
+/// `get_by_*` / `find_by_*` on the stored key.
+///
+/// ```no_run
+/// # #[derive(Debug, toasty::Model)]
+/// # struct Human {
+/// #     #[key]
+/// #     #[auto]
+/// #     id: uuid::Uuid,
+/// # }
+/// #[derive(Debug, toasty::Embed)]
+/// enum Owner {
+///     Human {
+///         #[index]
+///         id: uuid::Uuid,
+///         #[belongs_to(key = id)]
+///         human: toasty::Deferred<Human>,
+///     },
+///     // ... other owner kinds
+/// }
+/// ```
+///
+/// Creating and updating supply the embed value with explicit keys and the
+/// relation left unloaded (`Deferred::default()`). Setting the relation
+/// from a model value, preloading it with `.include()`, and pairing it
+/// with a `has_many` on the target are not supported yet.
+///
 /// # Using embedded types in a model
 ///
 /// Reference an embedded type as a field on a [`Model`][`derive@Model`]
@@ -1234,8 +1267,10 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
 /// - `#[column(rename_all = "...")]` applies only to string labels.
 /// - Enum variants may be unit variants or have named fields. Tuple
 ///   variants are not supported.
-/// - Embedded types cannot have primary keys, relations, `#[auto]`,
-///   `#[default]`, or `#[update]` attributes.
+/// - Embedded types cannot have primary keys, `has_many` / `has_one`
+///   relations, `#[auto]`, `#[default]`, or `#[update]` attributes.
+///   `#[belongs_to]` is supported; the field must be
+///   `toasty::Deferred<..>`.
 ///
 /// # Full example
 ///
@@ -1299,7 +1334,7 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
 /// ```
 ///
 /// [`Embed`]: toasty::Embed
-#[proc_macro_derive(Embed, attributes(column, document, index, unique, shared))]
+#[proc_macro_derive(Embed, attributes(belongs_to, column, document, index, unique, shared))]
 pub fn derive_embed(input: TokenStream) -> TokenStream {
     match model::generate_embed(input.into()) {
         Ok(output) => output.into(),

--- a/crates/toasty-macros/src/model/expand.rs
+++ b/crates/toasty-macros/src/model/expand.rs
@@ -105,6 +105,7 @@ pub(super) fn embedded_model(model: &Model) -> TokenStream {
     let storage_compat_checks = expand.expand_storage_compat_checks();
     let column_type_requirement_checks = expand.expand_column_type_requirement_checks();
     let indexable_checks = expand.expand_indexable_checks();
+    let embedded_relation_checks = expand.expand_embedded_relation_checks();
     let newtype_marker = expand.expand_embedded_newtype_marker();
     let newtype_indexable_impl = expand.expand_embedded_indexable_impl();
     let field_list_struct_ident = &embedded.field_list_struct_ident;
@@ -123,6 +124,7 @@ pub(super) fn embedded_model(model: &Model) -> TokenStream {
         #storage_compat_checks
         #column_type_requirement_checks
         #indexable_checks
+        #embedded_relation_checks
 
         impl #toasty::Embed for #model_ident {
             fn id() -> #toasty::core::schema::app::ModelId {
@@ -264,6 +266,7 @@ pub(super) fn embedded_enum(model: &Model) -> TokenStream {
     let discriminant_storage_compat_impls = e.expand_enum_discriminant_compat_impls();
     let shared_column_checks = e.expand_shared_column_checks();
     let indexable_checks = e.expand_indexable_checks();
+    let embedded_relation_checks = e.expand_embedded_relation_checks();
 
     // A unit (data-less) enum is a single scalar discriminant: indexable, and a
     // valid `Vec<Enum>` element (`Scalar` unlocks the container operators).
@@ -286,6 +289,7 @@ pub(super) fn embedded_enum(model: &Model) -> TokenStream {
         #discriminant_storage_compat_impls
         #shared_column_checks
         #indexable_checks
+        #embedded_relation_checks
         #unit_enum_impls
 
         impl #toasty::Embed for #model_ident {
@@ -387,6 +391,34 @@ pub(super) fn embedded_enum(model: &Model) -> TokenStream {
 // === Shared token-generation helpers ===
 
 impl Expand<'_> {
+    /// For relation fields in embedded types, require the declared type to be
+    /// deferred (`toasty::Deferred<..>`). A non-deferred relation could never
+    /// load: the relation carries no storage, so its record slot always
+    /// decodes from `Null`, which only a deferred type represents (as the
+    /// unloaded state).
+    fn expand_embedded_relation_checks(&self) -> TokenStream {
+        let toasty = &self.toasty;
+
+        let checks = self.model.fields.iter().filter_map(|field| {
+            let FieldTy::BelongsTo(rel) = &field.ty else {
+                return None;
+            };
+            let ty = &rel.ty;
+
+            Some(quote_spanned! { syn::spanned::Spanned::span(ty)=>
+                const _: () = {
+                    assert!(
+                        <#ty as #toasty::RelationOneField>::DEFERRED,
+                        "a relation stored in an embedded type must be wrapped \
+                         in `toasty::Deferred`",
+                    );
+                };
+            })
+        });
+
+        quote! { #( #checks )* }
+    }
+
     /// For tuple-newtype `#[derive(Embed)]` types (one unnamed field), emit
     /// the `NewtypeOf` marker carrying the inner field's type. The blanket
     /// `impl<T: NewtypeOf, T::Inner: Auto> Auto for T` in `codegen_support`

--- a/crates/toasty-macros/src/model/expand/embedded_enum.rs
+++ b/crates/toasty-macros/src/model/expand/embedded_enum.rs
@@ -215,11 +215,21 @@ impl Expand<'_> {
                     .variant_fields(variant_index)
                     .iter()
                     .enumerate()
-                    .map(|(field_index, field)| {
+                    .filter_map(|(field_index, field)| {
+                        // A relation field has no filter path yet; only its
+                        // key fields are queryable. The offset comes from the
+                        // enumeration before this filter, so skipping does not
+                        // shift later fields.
+                        let FieldTy::Primitive(field_ty) = &field.ty else {
+                            return None;
+                        };
                         let field_ident = &field.name.ident;
-                        let field_ty = primitive_ty_unwrap(field);
                         let field_offset = util::int(field_index);
-                        self.expand_primitive_field_method(field_ident, field_ty, &field_offset)
+                        Some(self.expand_primitive_field_method(
+                            field_ident,
+                            field_ty,
+                            &field_offset,
+                        ))
                     })
                     .collect();
 
@@ -388,6 +398,63 @@ impl Expand<'_> {
             .map(|field| {
                 let index = util::int(field.id);
                 let app_name = field.name.as_str();
+                let variant_index = field.variant.expect("enum field must have variant");
+                let variant_idx = util::int(variant_index);
+
+                // A relation field owns no storage: the sibling key fields map
+                // to columns, the relation itself registers only its schema
+                // entry (target + foreign key).
+                if let FieldTy::BelongsTo(rel) = &field.ty {
+                    let ty = &rel.ty;
+                    let fk_fields = rel.foreign_key.iter().map(|fk_field| {
+                        let source = util::int(fk_field.source);
+                        let target = fk_field.target.to_string();
+
+                        quote! {
+                            #toasty::core::schema::app::ForeignKeyField {
+                                source: #toasty::core::schema::app::FieldId {
+                                    model: id,
+                                    index: #source,
+                                },
+                                target: {
+                                    type __RelationTarget =
+                                        <#ty as #toasty::RelationOneField>::Target;
+                                    <__RelationTarget as #toasty::Model>::field_name_to_id(#target)
+                                },
+                            }
+                        }
+                    });
+
+                    return quote! {
+                        #toasty::core::schema::app::Field {
+                            id: #toasty::core::schema::app::FieldId {
+                                model: id,
+                                index: #index,
+                            },
+                            name: #toasty::core::schema::app::FieldName {
+                                app: Some(#app_name.to_string()),
+                                storage: None,
+                            },
+                            ty: <#ty as #toasty::RelationOneField>::belongs_to_relation_field_ty(
+                                #toasty::core::schema::app::ForeignKey {
+                                    fields: vec![ #( #fk_fields ),* ],
+                                },
+                            ),
+                            nullable: <#ty as #toasty::RelationOneField>::NULLABLE,
+                            primary_key: false,
+                            auto: None,
+                            versionable: false,
+                            deferred: <#ty as #toasty::RelationOneField>::DEFERRED,
+                            constraints: vec![],
+                            variant: Some(#toasty::core::schema::app::VariantId {
+                                model: id,
+                                index: #variant_idx,
+                            }),
+                            shared: None,
+                        }
+                    };
+                }
+
                 // A `#[column("name")]` on a variant field overrides its
                 // database column name. For a `#[shared]` field, the override
                 // declared by any member of the group applies to all of them.
@@ -429,8 +496,6 @@ impl Expand<'_> {
                     }
                     None => quote! { None },
                 };
-                let variant_index = field.variant.expect("enum field must have variant");
-                let variant_idx = util::int(variant_index);
                 quote! {
                     #toasty::core::schema::app::Field {
                         id: #toasty::core::schema::app::FieldId {
@@ -676,7 +741,7 @@ impl Expand<'_> {
                         .enumerate()
                         .map(|(i, field)| {
                             let field_ident = &field.name.ident;
-                            let ty = primitive_ty_unwrap(field);
+                            let ty = loadable_ty(field);
                             let record_pos = util::int(i + 1);
                             let load = quote! {
                                 <#ty as #toasty::Load>::load(record[#record_pos].take())?
@@ -751,8 +816,17 @@ impl Expand<'_> {
 
                     let field_exprs = fields.iter().map(|field| {
                         let field_ident = &field.name.ident;
-                        let ty = primitive_ty_unwrap(field);
-                        quote!(#toasty::into_untyped_expr::<FieldExprTarget<#ty>, _>(#field_ident))
+                        match &field.ty {
+                            // The relation slot encodes as `Null`; the sibling
+                            // key fields carry the storage.
+                            FieldTy::BelongsTo(_) => {
+                                quote!(#toasty::embedded_relation_expr(&#field_ident))
+                            }
+                            _ => {
+                                let ty = primitive_ty_unwrap(field);
+                                quote!(#toasty::into_untyped_expr::<FieldExprTarget<#ty>, _>(#field_ident))
+                            }
+                        }
                     });
 
                     quote! {
@@ -848,6 +922,17 @@ fn primitive_ty_unwrap(field: &crate::model::schema::Field) -> &syn::Type {
     match &field.ty {
         FieldTy::Primitive(ty) => ty,
         _ => panic!("expected primitive field type for enum variant field"),
+    }
+}
+
+/// The Rust type a variant field loads through. A relation field loads
+/// through its declared type (`Deferred<..>`); the engine supplies `Null`
+/// for its record slot, which decodes to the unloaded state.
+fn loadable_ty(field: &crate::model::schema::Field) -> &syn::Type {
+    match &field.ty {
+        FieldTy::Primitive(ty) => ty,
+        FieldTy::BelongsTo(rel) => &rel.ty,
+        _ => panic!("unsupported field type in embedded enum"),
     }
 }
 

--- a/crates/toasty-macros/src/model/expand/embedded_enum.rs
+++ b/crates/toasty-macros/src/model/expand/embedded_enum.rs
@@ -1,5 +1,5 @@
 use super::{Expand, schema, util};
-use crate::model::schema::{EnumStorageStrategy, FieldTy, Name, VariantValue};
+use crate::model::schema::{BelongsTo, EnumStorageStrategy, FieldTy, Name, VariantValue};
 
 use hashbrown::HashMap;
 use proc_macro2::TokenStream;
@@ -375,13 +375,27 @@ impl Expand<'_> {
     /// Generates the flat list of `Field` schema tokens for all variant fields,
     /// with each field tagged with its `VariantId`.
     pub(super) fn expand_enum_schema_fields(&self) -> Vec<TokenStream> {
-        let toasty = &self.toasty;
+        let shared_overrides = self.shared_column_overrides();
 
-        // Effective `#[column("name")]` override per shared group: declaring
-        // the override on one sharing field suffices, so propagate it to every
-        // member. Disagreeing overrides are rejected by
-        // `expand_shared_column_checks`; here the first one wins.
-        let mut shared_overrides: HashMap<String, &syn::LitStr> = HashMap::new();
+        self.model
+            .fields
+            .iter()
+            .map(|field| {
+                let parts = match &field.ty {
+                    FieldTy::BelongsTo(rel) => self.belongs_to_schema_parts(rel),
+                    _ => self.primitive_schema_parts(field, &shared_overrides),
+                };
+                self.expand_schema_field(field, parts)
+            })
+            .collect()
+    }
+
+    /// Effective `#[column("name")]` override per shared group: declaring the
+    /// override on one sharing field suffices, so propagate it to every
+    /// member. Disagreeing overrides are rejected by
+    /// `expand_shared_column_checks`; here the first one wins.
+    fn shared_column_overrides(&self) -> HashMap<String, &syn::LitStr> {
+        let mut overrides = HashMap::new();
         for field in &self.model.fields {
             let Some(ident) = &field.attrs.shared else {
                 continue;
@@ -389,139 +403,164 @@ impl Expand<'_> {
             let Some(lit) = field.attrs.column.as_ref().and_then(|c| c.name.as_ref()) else {
                 continue;
             };
-            shared_overrides.entry(ident.to_string()).or_insert(lit);
+            overrides.entry(ident.to_string()).or_insert(lit);
         }
+        overrides
+    }
 
-        self.model
-            .fields
-            .iter()
-            .map(|field| {
-                let index = util::int(field.id);
-                let app_name = field.name.as_str();
-                let variant_index = field.variant.expect("enum field must have variant");
-                let variant_idx = util::int(variant_index);
+    /// A relation field owns no storage: the sibling key fields map to
+    /// columns, the relation itself registers only its schema entry
+    /// (target + foreign key).
+    fn belongs_to_schema_parts(&self, rel: &BelongsTo) -> SchemaFieldParts {
+        let toasty = &self.toasty;
+        let ty = &rel.ty;
+        let foreign_key = self.expand_belongs_to_foreign_key(rel);
 
-                // A relation field owns no storage: the sibling key fields map
-                // to columns, the relation itself registers only its schema
-                // entry (target + foreign key).
-                if let FieldTy::BelongsTo(rel) = &field.ty {
-                    let ty = &rel.ty;
-                    let fk_fields = rel.foreign_key.iter().map(|fk_field| {
-                        let source = util::int(fk_field.source);
-                        let target = fk_field.target.to_string();
+        SchemaFieldParts {
+            storage_name: quote! { None },
+            ty: quote! {
+                <#ty as #toasty::RelationOneField>::belongs_to_relation_field_ty(#foreign_key)
+            },
+            nullable: quote! { <#ty as #toasty::RelationOneField>::NULLABLE },
+            deferred: quote! { <#ty as #toasty::RelationOneField>::DEFERRED },
+            shared: quote! { None },
+        }
+    }
 
-                        quote! {
-                            #toasty::core::schema::app::ForeignKeyField {
-                                source: #toasty::core::schema::app::FieldId {
-                                    model: id,
-                                    index: #source,
-                                },
-                                target: {
-                                    type __RelationTarget =
-                                        <#ty as #toasty::RelationOneField>::Target;
-                                    <__RelationTarget as #toasty::Model>::field_name_to_id(#target)
-                                },
-                            }
-                        }
-                    });
+    fn expand_belongs_to_foreign_key(&self, rel: &BelongsTo) -> TokenStream {
+        let toasty = &self.toasty;
+        let ty = &rel.ty;
 
-                    return quote! {
-                        #toasty::core::schema::app::Field {
-                            id: #toasty::core::schema::app::FieldId {
-                                model: id,
-                                index: #index,
-                            },
-                            name: #toasty::core::schema::app::FieldName {
-                                app: Some(#app_name.to_string()),
-                                storage: None,
-                            },
-                            ty: <#ty as #toasty::RelationOneField>::belongs_to_relation_field_ty(
-                                #toasty::core::schema::app::ForeignKey {
-                                    fields: vec![ #( #fk_fields ),* ],
-                                },
-                            ),
-                            nullable: <#ty as #toasty::RelationOneField>::NULLABLE,
-                            primary_key: false,
-                            auto: None,
-                            versionable: false,
-                            deferred: <#ty as #toasty::RelationOneField>::DEFERRED,
-                            constraints: vec![],
-                            variant: Some(#toasty::core::schema::app::VariantId {
-                                model: id,
-                                index: #variant_idx,
-                            }),
-                            shared: None,
-                        }
-                    };
+        let fk_fields = rel.foreign_key.iter().map(|fk_field| {
+            let source = util::int(fk_field.source);
+            let target = fk_field.target.to_string();
+
+            quote! {
+                #toasty::core::schema::app::ForeignKeyField {
+                    source: #toasty::core::schema::app::FieldId {
+                        model: id,
+                        index: #source,
+                    },
+                    target: {
+                        type __RelationTarget =
+                            <#ty as #toasty::RelationOneField>::Target;
+                        <__RelationTarget as #toasty::Model>::field_name_to_id(#target)
+                    },
                 }
+            }
+        });
 
-                // A `#[column("name")]` on a variant field overrides its
-                // database column name. For a `#[shared]` field, the override
-                // declared by any member of the group applies to all of them.
-                let storage_override = field
-                    .attrs
-                    .column
-                    .as_ref()
-                    .and_then(|column| column.name.as_ref())
-                    .or_else(|| {
-                        let ident = field.attrs.shared.as_ref()?.to_string();
-                        shared_overrides.get(&ident).copied()
-                    });
-                let storage_name = match storage_override {
-                    Some(name) => quote! { Some(#name.to_string()) },
-                    None => quote! { None },
-                };
-                // `#[shared(<ident>)]` names the logical field this variant
-                // field participates in. Fields declaring the same identifier
-                // are coalesced into one shared column by the schema builder
-                // (see `BuildMapping::map_field_primitive`).
-                let shared = match &field.attrs.shared {
-                    Some(ident) => {
-                        let name = Name::from_ident(ident);
-                        let name = schema::expand_name(toasty, &name);
-                        quote! { Some(#name) }
-                    }
-                    None => quote! { None },
-                };
-                let ty = primitive_ty_unwrap(field);
-                let storage_ty = match field
-                    .attrs
-                    .column
-                    .as_ref()
-                    .and_then(|column| column.ty.as_ref())
-                {
-                    Some(column_ty) => {
-                        let expanded = column_ty.expand_with(toasty);
-                        quote! { Some(#expanded) }
-                    }
-                    None => quote! { None },
-                };
-                quote! {
-                    #toasty::core::schema::app::Field {
-                        id: #toasty::core::schema::app::FieldId {
-                            model: id,
-                            index: #index,
-                        },
-                        name: #toasty::core::schema::app::FieldName {
-                            app: Some(#app_name.to_string()),
-                            storage: #storage_name,
-                        },
-                        ty: <#ty as #toasty::Field>::field_ty(#storage_ty),
-                        nullable: <#ty as #toasty::Field>::NULLABLE,
-                        primary_key: false,
-                        auto: None,
-                        versionable: false,
-                        deferred: <#ty as #toasty::Field>::DEFERRED,
-                        constraints: vec![],
-                        variant: Some(#toasty::core::schema::app::VariantId {
-                            model: id,
-                            index: #variant_idx,
-                        }),
-                        shared: #shared,
-                    }
-                }
-            })
-            .collect()
+        quote! {
+            #toasty::core::schema::app::ForeignKey {
+                fields: vec![ #( #fk_fields ),* ],
+            }
+        }
+    }
+
+    fn primitive_schema_parts(
+        &self,
+        field: &crate::model::schema::Field,
+        shared_overrides: &HashMap<String, &syn::LitStr>,
+    ) -> SchemaFieldParts {
+        let toasty = &self.toasty;
+        let ty = primitive_ty_unwrap(field);
+
+        // `#[shared(<ident>)]` names the logical field this variant field
+        // participates in. Fields declaring the same identifier are coalesced
+        // into one shared column by the schema builder
+        // (see `BuildMapping::map_field_primitive`).
+        let shared = match &field.attrs.shared {
+            Some(ident) => {
+                let name = Name::from_ident(ident);
+                let name = schema::expand_name(toasty, &name);
+                quote! { Some(#name) }
+            }
+            None => quote! { None },
+        };
+
+        // `#[column(type = ...)]` overrides the storage type.
+        let column_ty = field.attrs.column.as_ref().and_then(|c| c.ty.as_ref());
+        let storage_ty = match column_ty {
+            Some(column_ty) => {
+                let expanded = column_ty.expand_with(toasty);
+                quote! { Some(#expanded) }
+            }
+            None => quote! { None },
+        };
+
+        SchemaFieldParts {
+            storage_name: self.primitive_storage_name(field, shared_overrides),
+            ty: quote! { <#ty as #toasty::Field>::field_ty(#storage_ty) },
+            nullable: quote! { <#ty as #toasty::Field>::NULLABLE },
+            deferred: quote! { <#ty as #toasty::Field>::DEFERRED },
+            shared,
+        }
+    }
+
+    /// A `#[column("name")]` on a variant field overrides its database column
+    /// name. For a `#[shared]` field, the override declared by any member of
+    /// the group applies to all of them.
+    fn primitive_storage_name(
+        &self,
+        field: &crate::model::schema::Field,
+        shared_overrides: &HashMap<String, &syn::LitStr>,
+    ) -> TokenStream {
+        let own_override = field.attrs.column.as_ref().and_then(|c| c.name.as_ref());
+        let group_override = || {
+            let ident = field.attrs.shared.as_ref()?.to_string();
+            shared_overrides.get(&ident).copied()
+        };
+
+        match own_override.or_else(group_override) {
+            Some(name) => quote! { Some(#name.to_string()) },
+            None => quote! { None },
+        }
+    }
+
+    /// Emits one schema `Field` expression, combining the per-kind `parts`
+    /// with the attributes common to every variant field.
+    fn expand_schema_field(
+        &self,
+        field: &crate::model::schema::Field,
+        parts: SchemaFieldParts,
+    ) -> TokenStream {
+        let toasty = &self.toasty;
+        let index = util::int(field.id);
+        let app_name = field.name.as_str();
+        let variant_index = field.variant.expect("enum field must have variant");
+        let variant_idx = util::int(variant_index);
+        let SchemaFieldParts {
+            storage_name,
+            ty,
+            nullable,
+            deferred,
+            shared,
+        } = parts;
+
+        quote! {
+            #toasty::core::schema::app::Field {
+                id: #toasty::core::schema::app::FieldId {
+                    model: id,
+                    index: #index,
+                },
+                name: #toasty::core::schema::app::FieldName {
+                    app: Some(#app_name.to_string()),
+                    storage: #storage_name,
+                },
+                ty: #ty,
+                nullable: #nullable,
+                primary_key: false,
+                auto: None,
+                versionable: false,
+                deferred: #deferred,
+                constraints: vec![],
+                variant: Some(#toasty::core::schema::app::VariantId {
+                    model: id,
+                    index: #variant_idx,
+                }),
+                shared: #shared,
+            }
+        }
     }
 
     /// Emits compile-time checks for variant fields that declare a shared
@@ -916,6 +955,16 @@ impl Expand<'_> {
             }
         }
     }
+}
+
+/// The pieces of a schema `Field` expression that differ between relation
+/// and primitive variant fields; `expand_schema_field` supplies the rest.
+struct SchemaFieldParts {
+    storage_name: TokenStream,
+    ty: TokenStream,
+    nullable: TokenStream,
+    deferred: TokenStream,
+    shared: TokenStream,
 }
 
 fn primitive_ty_unwrap(field: &crate::model::schema::Field) -> &syn::Type {

--- a/crates/toasty-macros/src/model/expand/fields.rs
+++ b/crates/toasty-macros/src/model/expand/fields.rs
@@ -60,6 +60,16 @@ impl Expand<'_> {
                 let field_ident = &field.name.ident;
                 let field_offset = util::int(offset);
 
+                // Relation fields in embedded types have no filter path yet;
+                // only their key fields are queryable. The offset comes from
+                // the enumeration above, so skipping does not shift later
+                // fields.
+                if !matches!(self.model.kind, ModelKind::Root(_))
+                    && !matches!(&field.ty, Primitive(_))
+                {
+                    return TokenStream::new();
+                }
+
                 match &field.ty {
                     Primitive(ty) => {
                         // The accessor resolves its path through the field
@@ -249,6 +259,12 @@ impl Expand<'_> {
             .map(move |(offset, field)| {
                 let field_ident = &field.name.ident;
                 let field_offset = util::int(offset);
+
+                // Relation fields in embedded types have no filter path yet;
+                // see `expand_field_struct`.
+                if !is_root && !matches!(&field.ty, Primitive(_)) {
+                    return TokenStream::new();
+                }
 
                 match &field.ty {
                     Primitive(_) if field.attrs.document.is_some() => TokenStream::new(),

--- a/crates/toasty-macros/src/model/expand/model.rs
+++ b/crates/toasty-macros/src/model/expand/model.rs
@@ -458,11 +458,22 @@ impl Expand<'_> {
         let toasty = &self.toasty;
 
         // For embedded types, create a record expression from all fields
-        // Currently only primitive fields are supported in embedded types
         let field_exprs = self.model.fields.iter().enumerate().map(|(index, field)| {
             let ty = match &field.ty {
                 FieldTy::Primitive(ty) => ty,
-                _ => panic!("only primitive fields are supported in embedded types"),
+                FieldTy::BelongsTo(_) => {
+                    // The relation slot encodes as `Null`; the sibling key
+                    // fields carry the storage.
+                    let access = if fields_named {
+                        let field_ident = &field.name.ident;
+                        quote!(self.#field_ident)
+                    } else {
+                        let idx = syn::Index::from(index);
+                        quote!(self.#idx)
+                    };
+                    return quote!(#toasty::embedded_relation_expr(&#access));
+                }
+                _ => panic!("only primitive and belongs_to fields are supported in embedded types"),
             };
 
             let value = if fields_named {

--- a/crates/toasty-macros/src/model/expand/update.rs
+++ b/crates/toasty-macros/src/model/expand/update.rs
@@ -38,7 +38,7 @@ impl Expand<'_> {
             // A relation in an embedded type cannot be assigned; re-point it
             // by assigning its key field(s) or replacing the whole embed
             // value.
-            if is_embedded && !matches!(&field.ty, FieldTy::Primitive(_)) {
+            if is_embedded && !field.ty.is_primitive() {
                 return TokenStream::new();
             }
 

--- a/crates/toasty-macros/src/model/expand/update.rs
+++ b/crates/toasty-macros/src/model/expand/update.rs
@@ -35,6 +35,13 @@ impl Expand<'_> {
             let field_ident = &field.name.ident;
             let set_field_ident = &field.set_ident;
 
+            // A relation in an embedded type cannot be assigned; re-point it
+            // by assigning its key field(s) or replacing the whole embed
+            // value.
+            if is_embedded && !matches!(&field.ty, FieldTy::Primitive(_)) {
+                return TokenStream::new();
+            }
+
             let index = util::int(field_index);
             let projection = if is_embedded {
                 quote! {{

--- a/crates/toasty-macros/src/model/expand/upsert.rs
+++ b/crates/toasty-macros/src/model/expand/upsert.rs
@@ -30,7 +30,7 @@ impl Upsert {
 
                 if target_fields
                     .iter()
-                    .any(|&field| !matches!(model.fields[field].ty, FieldTy::Primitive(_)))
+                    .any(|&field| !model.fields[field].ty.is_primitive())
                 {
                     return None;
                 }

--- a/crates/toasty-macros/src/model/schema/field.rs
+++ b/crates/toasty-macros/src/model/schema/field.rs
@@ -84,6 +84,12 @@ pub(crate) enum FieldTy {
     HasOne(HasOne),
 }
 
+impl FieldTy {
+    pub(crate) fn is_primitive(&self) -> bool {
+        matches!(self, FieldTy::Primitive(_))
+    }
+}
+
 impl FieldAttr {
     pub(crate) fn is_indexed(&self) -> bool {
         self.unique || self.index

--- a/crates/toasty-macros/src/model/schema/field.rs
+++ b/crates/toasty-macros/src/model/schema/field.rs
@@ -312,9 +312,15 @@ impl Field {
                         "field has more than one relation attribute",
                     ));
                 } else {
+                    let Some(field_ident) = field.ident.as_ref() else {
+                        return Err(syn::Error::new_spanned(
+                            attr,
+                            "#[belongs_to] requires a named field",
+                        ));
+                    };
                     ty = Some(FieldTy::BelongsTo(BelongsTo::from_ast(
                         attr,
-                        field.ident.as_ref().unwrap(),
+                        field_ident,
                         &field.ty,
                         names,
                     )?));

--- a/crates/toasty-macros/src/model/schema/model.rs
+++ b/crates/toasty-macros/src/model/schema/model.rs
@@ -200,10 +200,7 @@ impl Model {
                         ));
                     }
 
-                    if is_embedded
-                        && !matches!(field.ty, FieldTy::Primitive(_))
-                        && field.attrs.is_indexed()
-                    {
+                    if is_embedded && !field.ty.is_primitive() && field.attrs.is_indexed() {
                         errs.push(syn::Error::new_spanned(
                             &field.name.ident,
                             "a relation field cannot be indexed; index its foreign \
@@ -538,7 +535,7 @@ impl Model {
         // do not apply: sharing and indexing target the sibling key fields
         // that own the storage.
         for field in &all_fields {
-            if matches!(field.ty, FieldTy::Primitive(_)) {
+            if field.ty.is_primitive() {
                 continue;
             }
             if let Some(shared) = &field.attrs.shared {

--- a/crates/toasty-macros/src/model/schema/model.rs
+++ b/crates/toasty-macros/src/model/schema/model.rs
@@ -200,7 +200,7 @@ impl Model {
                         ));
                     }
 
-                    if is_embedded && !field.ty.is_primitive() && field.attrs.is_indexed() {
+                    if !field.ty.is_primitive() && field.attrs.is_indexed() {
                         errs.push(syn::Error::new_spanned(
                             &field.name.ident,
                             "a relation field cannot be indexed; index its foreign \
@@ -211,6 +211,28 @@ impl Model {
                     fields.push(field);
                 }
                 Err(err) => errs.push(err),
+            }
+        }
+
+        // Struct-level #[index(...)] / #[unique(...)] targets must own
+        // storage; a relation field maps to no column. `KeyAttr::from_ast`
+        // validates that each name exists, so an unresolved name here means
+        // an earlier field failed to parse and its error is already queued.
+        for index_attr in &model_attr.indices {
+            for ident in index_attr.partition.iter().chain(&index_attr.local) {
+                let field = names
+                    .iter()
+                    .position(|name| name == ident)
+                    .and_then(|offset| fields.get(offset));
+                if let Some(field) = field
+                    && !field.ty.is_primitive()
+                {
+                    errs.push(syn::Error::new_spanned(
+                        ident,
+                        "a relation field cannot be indexed; index its foreign \
+                         key field(s) instead",
+                    ));
+                }
             }
         }
 
@@ -866,6 +888,14 @@ fn resolve_enum_index_field(
                         "`{variant_ident}::{field_ident}` declares #[shared({shared})]; \
                          reference the shared field instead: `{shared}`"
                     ),
+                ));
+            }
+
+            if !field.ty.is_primitive() {
+                return Err(syn::Error::new_spanned(
+                    path,
+                    "a relation field cannot be indexed; index its foreign \
+                     key field(s) instead",
                 ));
             }
 

--- a/crates/toasty-macros/src/model/schema/model.rs
+++ b/crates/toasty-macros/src/model/schema/model.rs
@@ -1,5 +1,5 @@
 use super::{
-    Column, ColumnType, ErrorSet, Field, Index, IndexField, IndexScope, ModelAttr, Name,
+    Column, ColumnType, ErrorSet, Field, FieldTy, Index, IndexField, IndexScope, ModelAttr, Name,
     PrimaryKey, Variant, VariantValue,
 };
 use heck::ToSnakeCase;
@@ -197,6 +197,17 @@ impl Model {
                             shared,
                             "#[shared] is only supported on enum variant fields; \
                              it declares a logical field shared across variants",
+                        ));
+                    }
+
+                    if is_embedded
+                        && !matches!(field.ty, FieldTy::Primitive(_))
+                        && field.attrs.is_indexed()
+                    {
+                        errs.push(syn::Error::new_spanned(
+                            &field.name.ident,
+                            "a relation field cannot be indexed; index its foreign \
+                             key field(s) instead",
                         ));
                     }
 
@@ -456,10 +467,20 @@ impl Model {
                 .filter_map(|ast_field| ast_field.ident.clone())
                 .collect::<Vec<_>>();
 
+            let variant_base = global_field_index;
             for (index, ast_field) in ast_fields.iter().enumerate() {
                 let mut field =
                     Field::from_ast(ast_field, &model_ident, global_field_index, index, &names)?;
                 field.variant = Some(variant_index);
+                // `BelongsTo::from_ast` resolves `key` against the variant's
+                // own field list, so the recorded source indices are
+                // variant-local. Schema `FieldId`s use global indices; shift
+                // by the variant's base offset.
+                if let FieldTy::BelongsTo(rel) = &mut field.ty {
+                    for fk_field in &mut rel.foreign_key {
+                        fk_field.source += variant_base;
+                    }
+                }
                 all_fields.push(field);
                 global_field_index += 1;
             }
@@ -509,6 +530,29 @@ impl Model {
                         s,
                         s.len()
                     ),
+                ));
+            }
+        }
+
+        // A relation field maps to no column, so storage-shaping attributes
+        // do not apply: sharing and indexing target the sibling key fields
+        // that own the storage.
+        for field in &all_fields {
+            if matches!(field.ty, FieldTy::Primitive(_)) {
+                continue;
+            }
+            if let Some(shared) = &field.attrs.shared {
+                errs.push(syn::Error::new_spanned(
+                    shared,
+                    "#[shared] cannot be used on a relation field; declare it \
+                     on the foreign key field instead",
+                ));
+            }
+            if field.attrs.is_indexed() {
+                errs.push(syn::Error::new_spanned(
+                    &field.name.ident,
+                    "a relation field cannot be indexed; index its foreign \
+                     key field(s) instead",
                 ));
             }
         }

--- a/crates/toasty/src/codegen_support.rs
+++ b/crates/toasty/src/codegen_support.rs
@@ -65,6 +65,22 @@ pub fn into_untyped_expr<T, V: IntoExpr<T>>(value: V) -> core::stmt::Expr {
     expr.into()
 }
 
+/// Encode a relation field stored in an embedded type.
+///
+/// The relation itself has no storage — the sibling foreign key field(s) own
+/// the columns — so its record slot encodes as `Null`. Setting the relation
+/// from a model value is not supported; the key fields must be set
+/// explicitly and the relation left unloaded.
+pub fn embedded_relation_expr<T>(value: &Deferred<T>) -> core::stmt::Expr {
+    assert!(
+        value.is_unloaded(),
+        "a relation stored in an embedded type cannot be set from a model \
+         value; set the foreign key field(s) explicitly and leave the \
+         relation unloaded (`Deferred::default()`)"
+    );
+    core::stmt::Expr::null()
+}
+
 /// Continue a `has_many` traversal from `query` along `path`.
 ///
 /// If `query` was already scoped from a relation traversal, append

--- a/crates/toasty/src/engine/lower/include.rs
+++ b/crates/toasty/src/engine/lower/include.rs
@@ -276,6 +276,12 @@ impl LowerStatement<'_, '_> {
                 .zip(&variant_mapping.fields)
                 .enumerate()
             {
+                // A relation in a variant has no include support; its slot
+                // stays `Null` (the unloaded state). The enumeration index is
+                // taken before this skip, so later fields keep their slots.
+                if var_field.ty.is_relation() {
+                    continue;
+                }
                 let field_includes = partition_includes(&arm_sub_includes, j);
                 self.process_field(
                     &mut arm_record[j + 1],

--- a/crates/toasty/src/engine/simplify/expr_binary_op.rs
+++ b/crates/toasty/src/engine/simplify/expr_binary_op.rs
@@ -94,6 +94,25 @@ impl Simplify<'_> {
                 let match_expr = rhs.take();
                 Some(self.eliminate_match_in_binary_op(op, match_expr, other, false))
             }
+            // Decode-cast stripping on comparisons with a constant. A stored
+            // column whose type differs from the model type decodes through
+            // `cast(col, <model ty>)` (see `map_table_column_to_model`). When
+            // such a cast surfaces in a comparison — e.g. out of an enum
+            // decode `Match` arm, which only unfolds via match elimination
+            // after lowering has run — move the conversion onto the constant
+            // side so the driver compares the stored form directly. Other
+            // cast shapes are handled during lowering
+            // (`lower_expr_binary_op`); this rule fires only on the
+            // post-lower column shape.
+            (Expr::Cast(cast), Expr::Value(value)) | (Expr::Value(value), Expr::Cast(cast))
+                if (op.is_eq() || op.is_ne()) && cast.from.is_none() && cast.expr.is_column() =>
+            {
+                let target_ty = self.capability.native_type_for(&cast.ty);
+                let value = target_ty
+                    .cast(self.cx.schema(), value.take())
+                    .expect("failed to cast value");
+                Some(Expr::binary_op(cast.expr.take(), op, value))
+            }
             // Self-comparison with projections, e.g.,
             //
             //  - `address.city = address.city` → `true`

--- a/crates/toasty/src/engine/simplify/expr_binary_op.rs
+++ b/crates/toasty/src/engine/simplify/expr_binary_op.rs
@@ -107,11 +107,7 @@ impl Simplify<'_> {
             (Expr::Cast(cast), Expr::Value(value)) | (Expr::Value(value), Expr::Cast(cast))
                 if (op.is_eq() || op.is_ne()) && cast.from.is_none() && cast.expr.is_column() =>
             {
-                let target_ty = self.capability.native_type_for(&cast.ty);
-                let value = target_ty
-                    .cast(self.cx.schema(), value.take())
-                    .expect("failed to cast value");
-                Some(Expr::binary_op(cast.expr.take(), op, value))
+                self.strip_decode_cast_comparison(op, cast, value)
             }
             // Self-comparison with projections, e.g.,
             //
@@ -148,6 +144,33 @@ impl Simplify<'_> {
         // Relation-path-comparison and IN-subquery lifting fire in the
         // pre-lowering `lower::lift_in_subquery::*` pass, not here.
         None
+    }
+
+    /// `cast(col, T) <eq/ne> const` → `col <eq/ne> const'`, where `const'` is
+    /// the constant converted to `col`'s stored type.
+    ///
+    /// The target type comes from the referenced column, not from
+    /// `Capability::native_type_for(T)`: a `#[column(type = ...)]` override
+    /// can store the value in a different type than the backend's default
+    /// (e.g. a text-stored UUID on SQLite, whose default UUID storage is a
+    /// blob). Bails on anything that does not resolve to a physical column.
+    fn strip_decode_cast_comparison(
+        &mut self,
+        op: stmt::BinaryOp,
+        cast: &mut stmt::ExprCast,
+        value: &mut stmt::Value,
+    ) -> Option<Expr> {
+        let expr_reference = cast.expr.as_expr_reference()?;
+
+        let ResolvedRef::Column(column) = self.cx.resolve_expr_reference(expr_reference) else {
+            return None;
+        };
+
+        let value = column
+            .ty
+            .cast(self.cx.schema(), value.take())
+            .expect("failed to cast value");
+        Some(Expr::binary_op(cast.expr.take(), op, value))
     }
 
     /// Returns `true` if `expr` is a column reference that resolves to a

--- a/crates/toasty/src/engine/simplify/expr_binary_op.rs
+++ b/crates/toasty/src/engine/simplify/expr_binary_op.rs
@@ -146,8 +146,11 @@ impl Simplify<'_> {
         None
     }
 
-    /// `cast(col, T) <eq/ne> const` → `col <eq/ne> const'`, where `const'` is
-    /// the constant converted to `col`'s stored type.
+    /// Rewrites `cast(col, T) <eq/ne> const` so the conversion happens on
+    /// the constant instead of the column: converts `const` to `col`'s
+    /// stored type once, here, and emits `col <eq/ne> const'` so the driver
+    /// compares the bare column against the converted constant rather than
+    /// casting the column on every row.
     ///
     /// The target type comes from the referenced column, not from
     /// `Capability::native_type_for(T)`: a `#[column(type = ...)]` override

--- a/docs/dev/design/polymorphic-relations.md
+++ b/docs/dev/design/polymorphic-relations.md
@@ -543,11 +543,19 @@ The work ships in steps, each providing user value on its own.
 1. **Relations stored in embedded types.** `#[belongs_to]` fields are
    accepted inside embedded enums and structs: schema entries, no columns
    for the relation itself, key fields as ordinary indexed columns.
-   Creating and updating supply the variant value with explicit keys;
    `match` gives direct access to the stored keys, and the owner loads
-   with an ordinary `find_by_*`. No `.include()`, no inverse yet — but the
-   polymorphic shape is fully modelable, storable, and queryable by key
-   through the existing variant filter paths.
+   with an ordinary `find_by_*` — the polymorphic shape is fully
+   modelable, storable, and queryable by key through the existing
+   variant filter paths. Three limitations remain, each lifted by a
+   later step:
+   - The relation cannot be set or filtered by model value. Writes set
+     the key fields explicitly and leave the relation unloaded
+     (`Owner::Bot { serial, bot: Deferred::default() }`); a loaded value
+     is rejected at runtime. Lifted in step 2.
+   - The relation field must be declared `Deferred`, and no `.include()`
+     exists to load it. Lifted in step 3.
+   - No inverse: `has_many` / `has_one` cannot pair into the embedding.
+     Lifted in steps 4 (queries) and 5 (mutations).
 2. **Referencing the embedded relation with a model value.** The
    centralized rewrite: a reference to a relation reached through embed
    steps expands into the key comparison with the fused `is_variant`
@@ -555,12 +563,15 @@ The work ships in steps, each providing user value on its own.
    traversal (`.matches(|v| v.human().name().eq("Alice"))`); in `create!`
    and update assignments it enables passing the parent by reference
    (`Owner::Human { human: &alice }`) with the key fields filled in.
+   This lifts step 1's explicit-keys restriction: a loaded relation
+   value in a write is rewritten to its key assignments instead of
+   rejected.
 3. **Preloading with `.include()`.** `.include(Object::fields().owner())`
    issues one query per variant present and merges results into each
-   row's enum value. This step also lifts the `Deferred`-only requirement
-   on embedded relation fields: a non-deferred field (`human: Human`)
-   needs its value present on every load, which only works once includes
-   can populate it — with them, it behaves as at model level.
+   row's enum value. This lifts step 1's `Deferred`-only requirement on
+   embedded relation fields: a non-deferred field (`human: Human`) needs
+   its value present on every load, which only works once includes can
+   populate it — with them, it behaves as at model level.
 4. **Inverse pairs, queries.** `pair` paths, the `Pair` struct, the
    per-embedding instance records, linker recursion, and the removals
    listed above land together; `has_many` / `has_one` declarations on

--- a/docs/dev/design/polymorphic-relations.md
+++ b/docs/dev/design/polymorphic-relations.md
@@ -557,7 +557,10 @@ The work ships in steps, each providing user value on its own.
    (`Owner::Human { human: &alice }`) with the key fields filled in.
 3. **Preloading with `.include()`.** `.include(Object::fields().owner())`
    issues one query per variant present and merges results into each
-   row's enum value.
+   row's enum value. This step also lifts the `Deferred`-only requirement
+   on embedded relation fields: a non-deferred field (`human: Human`)
+   needs its value present on every load, which only works once includes
+   can populate it — with them, it behaves as at model level.
 4. **Inverse pairs, queries.** `pair` paths, the `Pair` struct, the
    per-embedding instance records, linker recursion, and the removals
    listed above land together; `has_many` / `has_one` declarations on

--- a/docs/dev/design/polymorphic-relations.md
+++ b/docs/dev/design/polymorphic-relations.md
@@ -486,9 +486,7 @@ declarable.
 
 Declaration uses what embedded enums already define: field-level
 `#[index]` on a per-variant key, and enum-level `#[index(<ident>)]` on a
-shared key. The enum-level non-unique form is designed in
-[enums-and-embedded-structs](enums-and-embedded-structs.md) but only
-`#[unique]` has shipped — shipping it is a prerequisite of this feature.
+shared key.
 
 On DynamoDB the rule guarantees a GSI on the key attribute, which is what
 makes the pair query executable at all. A per-variant key yields a sparse
@@ -542,12 +540,7 @@ Checked for redundancy and deliberately kept:
 
 The work ships in steps, each providing user value on its own.
 
-1. **Enum-level `#[index(...)]`.** The non-unique form designed in
-   [enums-and-embedded-structs](enums-and-embedded-structs.md); only
-   `#[unique]` has shipped. Value independent of this design — non-unique
-   indexes on shared columns for existing embedded-enum users — and a
-   prerequisite for pair queries on shared keys passing the verify rule.
-2. **Relations stored in embedded types.** `#[belongs_to]` fields are
+1. **Relations stored in embedded types.** `#[belongs_to]` fields are
    accepted inside embedded enums and structs: schema entries, no columns
    for the relation itself, key fields as ordinary indexed columns.
    Creating and updating supply the variant value with explicit keys;
@@ -555,22 +548,22 @@ The work ships in steps, each providing user value on its own.
    with an ordinary `find_by_*`. No `.include()`, no inverse yet — but the
    polymorphic shape is fully modelable, storable, and queryable by key
    through the existing variant filter paths.
-3. **Referencing the embedded relation with a model value.** The
+2. **Referencing the embedded relation with a model value.** The
    centralized rewrite: a reference to a relation reached through embed
    steps expands into the key comparison with the fused `is_variant`
    gate. In filters this enables `owner().human().eq(&alice)` and
    traversal (`.matches(|v| v.human().name().eq("Alice"))`); in `create!`
    and update assignments it enables passing the parent by reference
    (`Owner::Human { human: &alice }`) with the key fields filled in.
-4. **Preloading with `.include()`.** `.include(Object::fields().owner())`
+3. **Preloading with `.include()`.** `.include(Object::fields().owner())`
    issues one query per variant present and merges results into each
    row's enum value.
-5. **Inverse pairs, queries.** `pair` paths, the `Pair` struct, the
+4. **Inverse pairs, queries.** `pair` paths, the `Pair` struct, the
    per-embedding instance records, linker recursion, and the removals
    listed above land together; `has_many` / `has_one` declarations on
    owner models pair into embeddings and read through them
    (`human.objects()`).
-6. **Inverse pairs, mutations.** Creating, associating, and
+5. **Inverse pairs, mutations.** Creating, associating, and
    disassociating through the pair — `has_many` create builders, update
    assignments, and delete behavior over the paired embedding.
 

--- a/tests/tests/ui/belongs_to_field_indexed.rs
+++ b/tests/tests/ui/belongs_to_field_indexed.rs
@@ -1,0 +1,24 @@
+// A relation field maps to no column, so there is nothing to index; the
+// index belongs on the foreign key field(s). Same rule as embedded types,
+// applied to a root model.
+
+#[derive(Debug, toasty::Model)]
+struct Human {
+    #[key]
+    #[auto]
+    id: uuid::Uuid,
+}
+
+#[derive(Debug, toasty::Model)]
+struct Post {
+    #[key]
+    #[auto]
+    id: uuid::Uuid,
+
+    author_id: uuid::Uuid,
+    #[index]
+    #[belongs_to(key = author_id, references = id)]
+    author: toasty::BelongsTo<Human>,
+}
+
+fn main() {}

--- a/tests/tests/ui/belongs_to_field_indexed.stderr
+++ b/tests/tests/ui/belongs_to_field_indexed.stderr
@@ -1,0 +1,5 @@
+error: a relation field cannot be indexed; index its foreign key field(s) instead
+  --> tests/ui/belongs_to_field_indexed.rs:21:5
+   |
+21 |     author: toasty::BelongsTo<Human>,
+   |     ^^^^^^

--- a/tests/tests/ui/embed_enum_index_on_relation.rs
+++ b/tests/tests/ui/embed_enum_index_on_relation.rs
@@ -1,0 +1,21 @@
+// A relation field maps to no column, so there is nothing to index; an
+// enum-level #[index(...)] must name the foreign key field(s) instead.
+
+#[derive(Debug, toasty::Model)]
+struct Human {
+    #[key]
+    #[auto]
+    id: uuid::Uuid,
+}
+
+#[derive(Debug, toasty::Embed)]
+#[index(human::human)]
+enum Owner {
+    Human {
+        id: uuid::Uuid,
+        #[belongs_to(key = id)]
+        human: toasty::Deferred<Human>,
+    },
+}
+
+fn main() {}

--- a/tests/tests/ui/embed_enum_index_on_relation.stderr
+++ b/tests/tests/ui/embed_enum_index_on_relation.stderr
@@ -1,0 +1,5 @@
+error: a relation field cannot be indexed; index its foreign key field(s) instead
+  --> tests/ui/embed_enum_index_on_relation.rs:12:9
+   |
+12 | #[index(human::human)]
+   |         ^^^^^^^^^^^^

--- a/tests/tests/ui/embed_relation_indexed.rs
+++ b/tests/tests/ui/embed_relation_indexed.rs
@@ -1,0 +1,19 @@
+// A relation field maps to no column, so there is nothing to index; the
+// index belongs on the foreign key field(s).
+
+#[derive(Debug, toasty::Model)]
+struct Human {
+    #[key]
+    #[auto]
+    id: uuid::Uuid,
+}
+
+#[derive(Debug, toasty::Embed)]
+struct Attribution {
+    author_id: uuid::Uuid,
+    #[index]
+    #[belongs_to(key = author_id)]
+    author: toasty::Deferred<Human>,
+}
+
+fn main() {}

--- a/tests/tests/ui/embed_relation_indexed.stderr
+++ b/tests/tests/ui/embed_relation_indexed.stderr
@@ -1,0 +1,5 @@
+error: a relation field cannot be indexed; index its foreign key field(s) instead
+  --> tests/ui/embed_relation_indexed.rs:16:5
+   |
+16 |     author: toasty::Deferred<Human>,
+   |     ^^^^^^

--- a/tests/tests/ui/embed_relation_not_deferred.rs
+++ b/tests/tests/ui/embed_relation_not_deferred.rs
@@ -1,0 +1,22 @@
+// A relation stored in an embedded type carries no storage; its record slot
+// always decodes from `Null`, which only `toasty::Deferred<..>` represents
+// (as the unloaded state). A bare model type could never load.
+
+#[derive(Debug, toasty::Model)]
+struct Human {
+    #[key]
+    #[auto]
+    id: uuid::Uuid,
+}
+
+#[derive(Debug, toasty::Embed)]
+enum Owner {
+    Human {
+        #[index]
+        id: uuid::Uuid,
+        #[belongs_to(key = id)]
+        human: Human,
+    },
+}
+
+fn main() {}

--- a/tests/tests/ui/embed_relation_not_deferred.stderr
+++ b/tests/tests/ui/embed_relation_not_deferred.stderr
@@ -1,0 +1,41 @@
+error[E0080]: evaluation panicked: a relation stored in an embedded type must be wrapped in `toasty::Deferred`
+  --> tests/ui/embed_relation_not_deferred.rs:18:16
+   |
+18 |         human: Human,
+   |                ^^^^^ evaluation of `_::_` failed here
+
+error[E0308]: mismatched types
+  --> tests/ui/embed_relation_not_deferred.rs:12:17
+   |
+12 | #[derive(Debug, toasty::Embed)]
+   |                 ^^^^^^^^^^^^^
+   |                 |
+   |                 expected `&Deferred<_>`, found `&Human`
+   |                 arguments to this function are incorrect
+   |
+   = note: expected reference `&Deferred<_>`
+              found reference `&Human`
+note: function defined here
+  --> $WORKSPACE/crates/toasty/src/codegen_support.rs
+   |
+   | pub fn embedded_relation_expr<T>(value: &Deferred<T>) -> core::stmt::Expr {
+   |        ^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the derive macro `toasty::Embed` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui/embed_relation_not_deferred.rs:12:17
+   |
+12 | #[derive(Debug, toasty::Embed)]
+   |                 ^^^^^^^^^^^^^
+   |                 |
+   |                 expected `&Deferred<_>`, found `&&Human`
+   |                 arguments to this function are incorrect
+   |
+   = note: expected reference `&Deferred<_>`
+              found reference `&&Human`
+note: function defined here
+  --> $WORKSPACE/crates/toasty/src/codegen_support.rs
+   |
+   | pub fn embedded_relation_expr<T>(value: &Deferred<T>) -> core::stmt::Expr {
+   |        ^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the derive macro `toasty::Embed` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/tests/ui/embed_relation_shared.rs
+++ b/tests/tests/ui/embed_relation_shared.rs
@@ -1,0 +1,22 @@
+// `#[shared]` merges variant columns, but a relation field has no column to
+// merge; sharing is declared on the foreign key field that owns the storage.
+
+#[derive(Debug, toasty::Model)]
+struct Human {
+    #[key]
+    #[auto]
+    id: uuid::Uuid,
+}
+
+#[derive(Debug, toasty::Embed)]
+enum Owner {
+    Human {
+        #[shared(id)]
+        id: uuid::Uuid,
+        #[shared(rel)]
+        #[belongs_to(key = id)]
+        human: toasty::Deferred<Human>,
+    },
+}
+
+fn main() {}

--- a/tests/tests/ui/embed_relation_shared.stderr
+++ b/tests/tests/ui/embed_relation_shared.stderr
@@ -1,0 +1,5 @@
+error: #[shared] cannot be used on a relation field; declare it on the foreign key field instead
+  --> tests/ui/embed_relation_shared.rs:16:18
+   |
+16 |         #[shared(rel)]
+   |                  ^^^

--- a/tests/tests/ui/model_unique_on_relation.rs
+++ b/tests/tests/ui/model_unique_on_relation.rs
@@ -1,0 +1,26 @@
+// A relation field maps to no column, so it cannot serve as a unique
+// column; a model-level #[unique(...)] must name the foreign key field(s)
+// instead.
+
+#[derive(Debug, toasty::Model)]
+struct Human {
+    #[key]
+    #[auto]
+    id: uuid::Uuid,
+}
+
+#[derive(Debug, toasty::Model)]
+#[unique(author, slug)]
+struct Post {
+    #[key]
+    #[auto]
+    id: uuid::Uuid,
+
+    author_id: uuid::Uuid,
+    #[belongs_to(key = author_id, references = id)]
+    author: toasty::BelongsTo<Human>,
+
+    slug: String,
+}
+
+fn main() {}

--- a/tests/tests/ui/model_unique_on_relation.stderr
+++ b/tests/tests/ui/model_unique_on_relation.stderr
@@ -1,0 +1,5 @@
+error: a relation field cannot be indexed; index its foreign key field(s) instead
+  --> tests/ui/model_unique_on_relation.rs:13:10
+   |
+13 | #[unique(author, slug)]
+   |          ^^^^^^


### PR DESCRIPTION
## Summary

Implements step 1 of the polymorphic-relations design: `#[belongs_to]` fields are accepted inside `#[derive(Embed)]` structs and enum variants.

The relation field registers its schema entry (target + foreign key resolved against sibling fields of the same struct/variant) but maps to **no columns** — the key fields own the storage and are indexed with the existing field-level / enum-level forms. The field must be `toasty::Deferred<..>` (enforced by a const assertion): its record slot encodes as `Null` on write and decodes to the unloaded state on read. Creating and updating supply the embed value with explicit keys, `match` reads the stored keys back, the owner loads with an ordinary `get_by_*`, and key fields stay queryable through the existing variant filter paths — discriminant-gated, so a `#[shared]` key column never cross-matches variants.

Not in this step (per the design's implementation order): `.include()`, setting the relation from a model value (`Owner::Human { human: &alice }`), and inverse `has_many` pairing. Field-level `#[shared]`/`#[index]` on a relation field and non-`Deferred` relation types are compile errors.

Also fixes a pre-existing engine bug this surfaced: filtering a variant field whose model type differs from its stored column type (e.g. `uuid::Uuid` stored as text) panicked in the SQL serializer, because the decode cast inside the enum's `Match` arm only unfolds during post-lower simplify, after the lowering-time cast rule has run. Simplify now strips the cast and converts the constant side (separate commit, with a no-relations regression test).

The branch also carries a small doc correction: the design doc listed enum-level non-unique `#[index(...)]` as unshipped step 1, but it shipped in #1078; the step list is renumbered.

## Type of change

- [x] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`): [polymorphic-relations.md](https://github.com/tokio-rs/toasty/blob/main/docs/dev/design/polymorphic-relations.md)

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes (SQLite full suite; DynamoDB full suite against local DynamoDB)
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior

## Notes for reviewers

- `mapping::Field::Relation` was already the "maps to no columns" mapping for root models; the builder change is only lifting the root-only `assert!(!force_nullable)` so it applies inside enum variants and nullable struct embeds.
- Foreign-key `source` indices for enum variants are remapped from variant-local to the embed's global field indices at parse time (`from_enum_ast`), since `BelongsTo::from_ast` resolves `key` against the variant's own field list.
- Relation fields keep their positional record slot everywhere (schema `FieldId`, encode, decode, reload) rather than being skipped — positional indexing is load-bearing in ~6 places, and root models already use the slot-holds-`Null` convention.
- Generated API surface deliberately omits what step 1 cannot support: no fields-struct accessors, no update-builder setters, and no include processing for embedded relation fields. `codegen_support::embedded_relation_expr` rejects a loaded `Deferred` at runtime with a message pointing at explicit keys.
- New suite `embed_relation.rs` (5 tests: enum + struct embeds, shared and per-variant keys, optional embed, variant-switch update, gated key filter); three trybuild UI tests cover the error paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmiM72YpE84pdWmp6Qxd2R
