### PR TITLE
fix: add wasm32 build support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,27 @@ jobs:
       - name: cargo clippy
         run: cargo clippy --workspace --all-features
 
+  check-wasm:
+    needs: check
+    name: cargo check (wasm32)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE_VERSION }}
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      # Only the backend-agnostic crates are checked: every driver binds a
+      # native client (rusqlite's bundled C, tokio sockets, the AWS SDK), so
+      # the driver features stay off. A wasm consumer supplies its own driver.
+      - name: cargo check
+        run: cargo check --target wasm32-unknown-unknown -p toasty -p toasty-core -p toasty-sql
+      - name: cargo check with optional features
+        run: cargo check --target wasm32-unknown-unknown -p toasty --no-default-features --features migration,serde,jiff,rust_decimal,bigdecimal
+
   feature-combinations:
     needs: check
     name: Check feature combinations (${{ matrix.package }})

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,9 @@ cargo test --features dynamodb --no-default-features -- --test-threads=1
 # DynamoDB + SQLite
 cargo test --features dynamodb -- --test-threads=1
 
+# Check the WASM build (backend-agnostic crates only; no driver builds for wasm)
+cargo check --target wasm32-unknown-unknown -p toasty -p toasty-core -p toasty-sql
+
 # Lint
 cargo clippy
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ turso = "0.7"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 trybuild = { version = "1.0.116", features = ["diff"] }
 url = "2.5.8"
-uuid = { version = "1.23.0", features = ["v4", "v7", "fast-rng"] }
+uuid = { version = "1.23.0", features = ["v4", "v7", "fast-rng", "js"] }
 
 [profile.dev]
 debug = "line-tables-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ toml = "1.1.0"
 toml_edit = "0.25.8"
 tempfile = "3.27"
 proptest = "1"
-tokio = { version = "1.50", features = ["full"] }
+tokio = { version = "1.50", default-features = false, features = ["macros", "rt", "sync", "time"] }
 tokio-postgres = "0.7.17"
 tokio-postgres-rustls = { version = "0.14.0", default-features = false }
 rustls = { version = "0.23", default-features = false, features = ["std", "ring"] }

--- a/crates/toasty/src/db/pool.rs
+++ b/crates/toasty/src/db/pool.rs
@@ -175,7 +175,17 @@ pub(super) struct Manager {
     engine: Engine,
     sweep_waker: Arc<SweepWaker>,
     pre_ping: bool,
+    // Enforcing these caps needs the connection's age, which deadpool only
+    // tracks off wasm32 (`std::time::Instant` has no wasm32 implementation).
+    #[cfg_attr(
+        target_arch = "wasm32",
+        expect(dead_code, reason = "connection age is unavailable on wasm32")
+    )]
     max_connection_lifetime: Option<Duration>,
+    #[cfg_attr(
+        target_arch = "wasm32",
+        expect(dead_code, reason = "connection age is unavailable on wasm32")
+    )]
     max_connection_idle_time: Option<Duration>,
     /// Per-connection configuration handed to `Driver::connect` for every
     /// connection the pool creates.
@@ -213,9 +223,15 @@ impl deadpool::managed::Manager for Manager {
     async fn recycle(
         &self,
         obj: &mut Self::Type,
+        #[cfg_attr(
+            target_arch = "wasm32",
+            expect(unused_variables, reason = "no timestamps on wasm32")
+        )]
         metrics: &deadpool::managed::Metrics,
     ) -> deadpool::managed::RecycleResult<Self::Error> {
-        // deadpool::managed::Metrics::age() only exist when the target is not wasm32
+        // `Metrics::age()` and `Metrics::last_used()` only exist off wasm32:
+        // deadpool records no timestamps there because `std::time::Instant`
+        // has no wasm32 implementation, so neither cap can be enforced.
         #[cfg(not(target_arch = "wasm32"))]
         if let Some(max) = self.max_connection_lifetime
             && metrics.age() >= max
@@ -225,7 +241,6 @@ impl deadpool::managed::Manager for Manager {
                 "connection exceeded max lifetime",
             ));
         }
-        // deadpool::managed::Metrics::last_used() only exist when the target is not wasm32
         #[cfg(not(target_arch = "wasm32"))]
         if let Some(max) = self.max_connection_idle_time
             && metrics.last_used() >= max

--- a/crates/toasty/src/db/pool.rs
+++ b/crates/toasty/src/db/pool.rs
@@ -215,6 +215,8 @@ impl deadpool::managed::Manager for Manager {
         obj: &mut Self::Type,
         metrics: &deadpool::managed::Metrics,
     ) -> deadpool::managed::RecycleResult<Self::Error> {
+        // deadpool::managed::Metrics::age() only exist when the target is not wasm32
+        #[cfg(not(target_arch = "wasm32"))]
         if let Some(max) = self.max_connection_lifetime
             && metrics.age() >= max
         {
@@ -223,6 +225,8 @@ impl deadpool::managed::Manager for Manager {
                 "connection exceeded max lifetime",
             ));
         }
+        // deadpool::managed::Metrics::last_used() only exist when the target is not wasm32
+        #[cfg(not(target_arch = "wasm32"))]
         if let Some(max) = self.max_connection_idle_time
             && metrics.last_used() >= max
         {

--- a/examples/cms-article-fields/Cargo.toml
+++ b/examples/cms-article-fields/Cargo.toml
@@ -15,7 +15,9 @@ sqlite = [ "toasty/sqlite" ]
 
 [dependencies]
 toasty = { workspace = true, features = [ "jiff", "serde" ] }
-tokio.workspace = true
+# `#[tokio::main]` defaults to the multi-thread runtime, which the lean
+# workspace tokio feature set (kept wasm-compatible for `toasty`) omits.
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 uuid.workspace = true
 serde.workspace = true
 jiff.workspace = true

--- a/examples/crm-embedded/Cargo.toml
+++ b/examples/crm-embedded/Cargo.toml
@@ -15,7 +15,9 @@ sqlite = [ "toasty/sqlite" ]
 
 [dependencies]
 toasty.workspace = true
-tokio.workspace = true
+# `#[tokio::main]` defaults to the multi-thread runtime, which the lean
+# workspace tokio feature set (kept wasm-compatible for `toasty`) omits.
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 uuid.workspace = true
 
 [lints]

--- a/examples/forum-relationships/Cargo.toml
+++ b/examples/forum-relationships/Cargo.toml
@@ -15,7 +15,9 @@ sqlite = [ "toasty/sqlite" ]
 
 [dependencies]
 toasty.workspace = true
-tokio.workspace = true
+# `#[tokio::main]` defaults to the multi-thread runtime, which the lean
+# workspace tokio feature set (kept wasm-compatible for `toasty`) omits.
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 uuid.workspace = true
 
 [lints]

--- a/examples/product-search/Cargo.toml
+++ b/examples/product-search/Cargo.toml
@@ -15,7 +15,9 @@ sqlite = [ "toasty/sqlite" ]
 
 [dependencies]
 toasty.workspace = true
-tokio.workspace = true
+# `#[tokio::main]` defaults to the multi-thread runtime, which the lean
+# workspace tokio feature set (kept wasm-compatible for `toasty`) omits.
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 uuid.workspace = true
 
 [lints]

--- a/examples/quickstart-blog/Cargo.toml
+++ b/examples/quickstart-blog/Cargo.toml
@@ -15,7 +15,9 @@ sqlite = [ "toasty/sqlite" ]
 
 [dependencies]
 toasty.workspace = true
-tokio.workspace = true
+# `#[tokio::main]` defaults to the multi-thread runtime, which the lean
+# workspace tokio feature set (kept wasm-compatible for `toasty`) omits.
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 uuid.workspace = true
 
 [lints]

--- a/examples/service-ops/Cargo.toml
+++ b/examples/service-ops/Cargo.toml
@@ -17,7 +17,9 @@ sqlite = [ "toasty/sqlite" ]
 [dependencies]
 toasty.workspace = true
 toasty-cli.workspace = true
-tokio.workspace = true
+# `#[tokio::main]` defaults to the multi-thread runtime, which the lean
+# workspace tokio feature set (kept wasm-compatible for `toasty`) omits.
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 uuid.workspace = true
 anyhow = "1"
 tracing-subscriber.workspace = true

--- a/examples/store-operations/Cargo.toml
+++ b/examples/store-operations/Cargo.toml
@@ -16,7 +16,9 @@ sqlite = [ "toasty/sqlite" ]
 [dependencies]
 toasty.workspace = true
 toasty-core.workspace = true
-tokio.workspace = true
+# `#[tokio::main]` defaults to the multi-thread runtime, which the lean
+# workspace tokio feature set (kept wasm-compatible for `toasty`) omits.
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 uuid.workspace = true
 
 [lints]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -35,7 +35,9 @@ toasty = { workspace = true, features = ["rust_decimal", "bigdecimal", "jiff", "
 toasty-cli.workspace = true
 toasty-core.workspace = true
 toasty-macros.workspace = true
-tokio.workspace = true
+# `tokio::runtime::Runtime::new` builds a multi-thread runtime, which the lean
+# workspace tokio feature set (kept wasm-compatible for `toasty`) omits.
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 # Integration test suite
 toasty-driver-integration-suite.workspace = true


### PR DESCRIPTION
AI disclosure: GPT-5.6 Sol assisted with this PR. I personally reviewed and tested every changed line.

This PR makes Toasty compile for wasm32 by:

  - Replacing Tokio’s full feature with the required portable features.
  - Enabling UUID’s js feature.
  - Disabling Deadpool connection lifetime and idle-time checks on wasm32,
    where their metrics are unavailable.

  Native behavior remains unchanged.