### PR TITLE
feat: re-export external statement value types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     # Tests
     "tests",
     "tests/tests/fixtures/post",
+    "tests/tests/fixtures/stmt-reexports",
     "tests/tests/fixtures/user",
 ]
 # Driver crates are excluded so `cargo test` (no `-p`/`--workspace`) and CI's
@@ -53,6 +54,7 @@ default-members = [
     "examples/store-operations",
     "tests",
     "tests/tests/fixtures/post",
+    "tests/tests/fixtures/stmt-reexports",
     "tests/tests/fixtures/user",
 ]
 

--- a/crates/toasty-core/src/stmt.rs
+++ b/crates/toasty-core/src/stmt.rs
@@ -273,10 +273,20 @@ pub use table_with_joins::TableWithJoins;
 mod ty;
 pub use ty::Type;
 
+#[cfg(feature = "bigdecimal")]
+pub use bigdecimal::BigDecimal;
 #[cfg(feature = "net")]
 pub use cidr::{IpCidr, IpInet};
+#[cfg(feature = "jiff")]
+pub use jiff::{
+    Timestamp, Zoned,
+    civil::{Date, DateTime, Time},
+};
 #[cfg(feature = "net")]
 pub use macaddr::{MacAddr6, MacAddr8};
+#[cfg(feature = "rust_decimal")]
+pub use rust_decimal::Decimal;
+pub use uuid::Uuid;
 
 mod ty_union;
 pub use ty_union::TypeUnion;

--- a/crates/toasty-macros/src/lib.rs
+++ b/crates/toasty-macros/src/lib.rs
@@ -87,7 +87,7 @@ pub fn embed_migrations(input: TokenStream) -> TokenStream {
 /// #[key(partition = user_id, local = id)]
 /// struct Todo {
 ///     #[auto]
-///     id: uuid::Uuid,
+///     id: toasty::stmt::Uuid,
 ///     user_id: String,
 ///     title: String,
 /// }
@@ -157,16 +157,16 @@ pub fn embed_migrations(input: TokenStream) -> TokenStream {
 ///
 /// | Syntax | Behavior |
 /// |--------|----------|
-/// | `#[auto]` on `uuid::Uuid` | UUID v7 (timestamp-sortable) |
+/// | `#[auto]` on `toasty::stmt::Uuid` | UUID v7 (timestamp-sortable) |
 /// | `#[auto(uuid(v4))]` | UUID v4 (random) |
 /// | `#[auto(uuid(v7))]` | UUID v7 (explicit) |
 /// | `#[auto]` on integer types (`i8`–`i64`, `u8`–`u64`) | Auto-increment |
 /// | `#[auto(increment)]` | Auto-increment (explicit) |
-/// | `#[auto]` on a field named `created_at` | Expands to `#[default(jiff::Timestamp::now())]` |
-/// | `#[auto]` on a field named `updated_at` | Expands to `#[update(jiff::Timestamp::now())]` |
+/// | `#[auto]` on a field named `created_at` | Expands to `#[default(toasty::stmt::Timestamp::now())]` |
+/// | `#[auto]` on a field named `updated_at` | Expands to `#[update(toasty::stmt::Timestamp::now())]` |
 ///
 /// The `created_at`/`updated_at` expansion requires the `jiff` feature and
-/// a field type compatible with `jiff::Timestamp`.
+/// a field type compatible with `toasty::stmt::Timestamp`.
 ///
 /// Cannot be combined with `#[default]` or `#[update]` on the same field.
 ///
@@ -211,8 +211,8 @@ pub fn embed_migrations(input: TokenStream) -> TokenStream {
 /// #     #[key]
 /// #     #[auto]
 /// #     id: i64,
-/// #[update(jiff::Timestamp::now())]
-/// updated_at: jiff::Timestamp,
+/// #[update(toasty::stmt::Timestamp::now())]
+/// updated_at: toasty::stmt::Timestamp,
 /// # }
 /// ```
 ///
@@ -792,11 +792,11 @@ pub fn embed_migrations(input: TokenStream) -> TokenStream {
 ///
 ///     name: String,
 ///
-///     #[default(jiff::Timestamp::now())]
-///     created_at: jiff::Timestamp,
+///     #[default(toasty::stmt::Timestamp::now())]
+///     created_at: toasty::stmt::Timestamp,
 ///
-///     #[update(jiff::Timestamp::now())]
-///     updated_at: jiff::Timestamp,
+///     #[update(toasty::stmt::Timestamp::now())]
+///     updated_at: toasty::stmt::Timestamp,
 ///
 ///     #[has_many]
 ///     posts: toasty::Deferred<Vec<Post>>,
@@ -1016,7 +1016,7 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
 ///
 /// ```
 /// #[derive(toasty::Embed)]
-/// struct UserId(uuid::Uuid);
+/// struct UserId(toasty::stmt::Uuid);
 ///
 /// #[derive(toasty::Model)]
 /// struct User {
@@ -1247,13 +1247,13 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
 /// # struct Human {
 /// #     #[key]
 /// #     #[auto]
-/// #     id: uuid::Uuid,
+/// #     id: toasty::stmt::Uuid,
 /// # }
 /// #[derive(Debug, toasty::Embed)]
 /// enum Owner {
 ///     Human {
 ///         #[index]
-///         id: uuid::Uuid,
+///         id: toasty::stmt::Uuid,
 ///         #[belongs_to(key = id)]
 ///         human: toasty::Deferred<Human>,
 ///     },

--- a/crates/toasty-macros/src/model/schema/field.rs
+++ b/crates/toasty-macros/src/model/schema/field.rs
@@ -362,13 +362,13 @@ impl Field {
         }
 
         // Expand #[auto] on timestamp fields:
-        //   created_at → #[default(jiff::Timestamp::now())]
-        //   updated_at → #[update(jiff::Timestamp::now())]
+        //   created_at → #[default(toasty::stmt::Timestamp::now())]
+        //   updated_at → #[update(toasty::stmt::Timestamp::now())]
         if matches!(&attrs.auto, Some(AutoStrategy::Unspecified))
             && let Some(ident) = &field.ident
         {
             let field_name = ident.to_string();
-            let now_expr: syn::Expr = syn::parse_quote!(jiff::Timestamp::now());
+            let now_expr: syn::Expr = syn::parse_quote!(_toasty::stmt::Timestamp::now());
 
             if field_name == "created_at" {
                 attrs.auto = None;

--- a/crates/toasty/src/stmt.rs
+++ b/crates/toasty/src/stmt.rs
@@ -75,9 +75,15 @@ pub use update::Update;
 mod upsert;
 pub use upsert::Upsert;
 
+#[cfg(feature = "bigdecimal")]
+pub use toasty_core::stmt::BigDecimal;
+#[cfg(feature = "rust_decimal")]
+pub use toasty_core::stmt::Decimal;
+#[cfg(feature = "jiff")]
+pub use toasty_core::stmt::{Date, DateTime, Time, Timestamp, Zoned};
 #[cfg(feature = "net")]
 pub use toasty_core::stmt::{IpCidr, IpInet, MacAddr6, MacAddr8};
-pub use toasty_core::stmt::{OrderBy, Projection, Type, Value};
+pub use toasty_core::stmt::{OrderBy, Projection, Type, Uuid, Value};
 
 use toasty_core::stmt;
 

--- a/tests/tests/fixtures/stmt-reexports/Cargo.toml
+++ b/tests/tests/fixtures/stmt-reexports/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "tests-fixture-stmt-reexports"
+version = "0.0.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+publish = false
+
+[dependencies]
+toasty = {
+    workspace = true,
+    features = ["bigdecimal", "jiff", "net", "rust_decimal"],
+}

--- a/tests/tests/fixtures/stmt-reexports/src/lib.rs
+++ b/tests/tests/fixtures/stmt-reexports/src/lib.rs
@@ -1,0 +1,25 @@
+#![allow(dead_code)]
+
+#[derive(toasty::Model)]
+struct ExternalStatementTypes {
+    #[key]
+    #[auto]
+    id: toasty::stmt::Uuid,
+
+    decimal: toasty::stmt::Decimal,
+    big_decimal: toasty::stmt::BigDecimal,
+
+    #[auto]
+    created_at: toasty::stmt::Timestamp,
+    #[auto]
+    updated_at: toasty::stmt::Timestamp,
+    zoned: toasty::stmt::Zoned,
+    date: toasty::stmt::Date,
+    time: toasty::stmt::Time,
+    date_time: toasty::stmt::DateTime,
+
+    cidr: toasty::stmt::IpCidr,
+    inet: toasty::stmt::IpInet,
+    mac_addr: toasty::stmt::MacAddr6,
+    mac_addr_8: toasty::stmt::MacAddr8,
+}

--- a/tests/tests/net_exports.rs
+++ b/tests/tests/net_exports.rs
@@ -1,17 +1,30 @@
-use toasty::stmt::{IpCidr, IpInet, MacAddr6, MacAddr8};
+use std::marker::PhantomData;
+
+use toasty::stmt::{
+    BigDecimal, Date, DateTime, Decimal, IpCidr, IpInet, MacAddr6, MacAddr8, Time, Timestamp, Uuid,
+    Zoned,
+};
 use toasty_core::stmt::{
-    IpCidr as CoreIpCidr, IpInet as CoreIpInet, MacAddr6 as CoreMacAddr6, MacAddr8 as CoreMacAddr8,
+    BigDecimal as CoreBigDecimal, Date as CoreDate, DateTime as CoreDateTime,
+    Decimal as CoreDecimal, IpCidr as CoreIpCidr, IpInet as CoreIpInet, MacAddr6 as CoreMacAddr6,
+    MacAddr8 as CoreMacAddr8, Time as CoreTime, Timestamp as CoreTimestamp, Uuid as CoreUuid,
+    Zoned as CoreZoned,
 };
 
 #[test]
-fn network_types_are_reexported_from_stmt() {
-    let _: IpCidr = "192.0.2.0/24".parse().unwrap();
-    let _: IpInet = "192.0.2.1/24".parse().unwrap();
-    let _: MacAddr6 = "ac:de:48:23:45:67".parse().unwrap();
-    let _: MacAddr8 = "ac:de:48:23:45:67:89:ab".parse().unwrap();
+fn external_types_are_reexported_from_stmt() {
+    fn assert_same<T>(_: PhantomData<T>) {}
 
-    let _: CoreIpCidr = "192.0.2.0/24".parse().unwrap();
-    let _: CoreIpInet = "192.0.2.1/24".parse().unwrap();
-    let _: CoreMacAddr6 = "ac:de:48:23:45:67".parse().unwrap();
-    let _: CoreMacAddr8 = "ac:de:48:23:45:67:89:ab".parse().unwrap();
+    assert_same::<Uuid>(PhantomData::<CoreUuid>);
+    assert_same::<Decimal>(PhantomData::<CoreDecimal>);
+    assert_same::<BigDecimal>(PhantomData::<CoreBigDecimal>);
+    assert_same::<Timestamp>(PhantomData::<CoreTimestamp>);
+    assert_same::<Zoned>(PhantomData::<CoreZoned>);
+    assert_same::<Date>(PhantomData::<CoreDate>);
+    assert_same::<Time>(PhantomData::<CoreTime>);
+    assert_same::<DateTime>(PhantomData::<CoreDateTime>);
+    assert_same::<IpCidr>(PhantomData::<CoreIpCidr>);
+    assert_same::<IpInet>(PhantomData::<CoreIpInet>);
+    assert_same::<MacAddr6>(PhantomData::<CoreMacAddr6>);
+    assert_same::<MacAddr8>(PhantomData::<CoreMacAddr8>);
 }

--- a/tests/tests/ui/auto_uuid_on_bool.stderr
+++ b/tests/tests/ui/auto_uuid_on_bool.stderr
@@ -6,7 +6,7 @@ error[E0277]: field type `bool` is not compatible with the requested auto strate
   |
   = help: the trait `toasty::codegen_support::auto::AutoCompatible<toasty::codegen_support::auto::tag::Uuid>` is not implemented for `bool`
   = note: see `toasty::codegen_support::auto` for the compatibility table
-help: the trait `toasty::codegen_support::auto::AutoCompatible<toasty::codegen_support::auto::tag::Uuid>` is implemented for `uuid::Uuid`
+help: the trait `toasty::codegen_support::auto::AutoCompatible<toasty::codegen_support::auto::tag::Uuid>` is implemented for `toasty::stmt::Uuid`
  --> $WORKSPACE/crates/toasty/src/codegen_support/auto.rs
   |
   | impl AutoCompatible<tag::Uuid> for uuid::Uuid {}

--- a/tests/tests/ui/embed_newtype_inner_not_auto.stderr
+++ b/tests/tests/ui/embed_newtype_inner_not_auto.stderr
@@ -16,7 +16,7 @@ help: the trait `Auto` is not implemented for `UserId`
              i64
              i8
              isize
+             toasty::stmt::Uuid
              u16
              u32
-             u64
            and $N others


### PR DESCRIPTION
## Summary

Re-export UUID, decimal, and Jiff value types from toasty_core::stmt and toasty::stmt so callers can import statement value types through Toasty.

Extend the existing export test to verify that both module paths name identical types.

## Type of change

- [x] Small / obvious change — public API aliases and test coverage

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] cargo fmt and cargo clippy are clean — cargo fmt passed; cargo clippy was not run locally
- [ ] cargo test passes — the targeted export test passed; the full suite was not rerun
- [ ] Touches a public API → a design doc under docs/dev/design/ describes the behavior — this only adds aliases for existing supported types

## Notes for reviewers

The aliases preserve the existing feature gates. CI will run the full checks.