### PR TITLE
fix(macros)!: name a new-type's field `inner` instead of `_0`

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/embed_newtype.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embed_newtype.rs
@@ -21,7 +21,7 @@ pub async fn basic_newtype_embed(test: &mut Test) {
 
 /// Tests that a newtype field produces a single column whose name matches the
 /// parent field — `email: Email` where `struct Email(String)` produces column
-/// `email`, not `email_0`.
+/// `email`, not `email_inner`.
 #[driver_test(requires(sql), scenario(crate::scenarios::user_with_email))]
 pub async fn newtype_column_name(test: &mut Test) {
     let db = setup(test).await;
@@ -495,7 +495,7 @@ pub async fn nested_newtype(t: &mut Test) -> Result<()> {
 
 /// Tests ordering operations directly on a newtype field path: `ne`,
 /// `gt`, `ge`, `lt`, and `le` accept the wrapper value and compare the
-/// single underlying column, and `asc`/`desc` sort by it, so no `._0()`
+/// single underlying column, and `asc`/`desc` sort by it, so no `.inner()`
 /// step is needed. These methods are generated only for canonical
 /// newtypes — a newtype is a pass-through to its inner column, so each
 /// backend keeps its own ordering semantics for the inner type.

--- a/crates/toasty-driver-integration-suite/src/tests/filter_embedded_in_list.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/filter_embedded_in_list.rs
@@ -1,6 +1,6 @@
 //! `IN`-list lowering where the list's left side projects into an embedded
 //! field. The simplifier folds `x == a OR x == b` into `x IN (a, b)`, so an OR
-//! over `name._0` lowers to `name._0 IN (...)` — an `IN` list whose LHS is a
+//! over `name.inner` lowers to `name.inner IN (...)` — an `IN` list whose LHS is a
 //! projection, not a plain column reference.
 
 use crate::prelude::*;
@@ -9,7 +9,7 @@ use crate::prelude::*;
 struct Name(String);
 
 /// An embedded newtype field referenced twice under an OR — folds to
-/// `name._0 IN (...)`, exercising the `Expr::Project` LHS in `lower_expr_in_list`.
+/// `name.inner IN (...)`, exercising the `Expr::Project` LHS in `lower_expr_in_list`.
 #[driver_test(requires(sql))]
 pub async fn or_over_embedded_field_folds_to_in_list(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
@@ -34,9 +34,9 @@ pub async fn or_over_embedded_field_folds_to_in_list(t: &mut Test) -> Result<()>
     let topics: Vec<Topic> = Topic::filter(
         Topic::fields()
             .name()
-            ._0()
+            .inner()
             .eq("one")
-            .or(Topic::fields().name()._0().eq("two")),
+            .or(Topic::fields().name().inner().eq("two")),
     )
     .exec(&mut db)
     .await?;
@@ -47,7 +47,7 @@ pub async fn or_over_embedded_field_folds_to_in_list(t: &mut Test) -> Result<()>
 }
 
 /// The same fold reached through a `.any()` over a `BelongsTo → HasMany` chain:
-/// the `name._0 IN (...)` lands inside the lifted subquery.
+/// the `name.inner IN (...)` lands inside the lifted subquery.
 #[driver_test(requires(sql))]
 pub async fn any_with_or_over_embedded_field(t: &mut Test) -> Result<()> {
     #[derive(Debug, toasty::Model)]
@@ -114,9 +114,9 @@ pub async fn any_with_or_over_embedded_field(t: &mut Test) -> Result<()> {
         Release::fields().project().topics().any(
             Topic::fields()
                 .name()
-                ._0()
+                .inner()
                 .eq("one")
-                .or(Topic::fields().name()._0().eq("two")),
+                .or(Topic::fields().name().inner().eq("two")),
         ),
     )
     .exec(&mut db)

--- a/crates/toasty-macros/src/lib.rs
+++ b/crates/toasty-macros/src/lib.rs
@@ -874,6 +874,25 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
 /// - An `Update` struct used by the parent model's update builder for
 ///   partial field updates.
 ///
+/// A field accessor is named after the field it reads. A newtype's field is
+/// unnamed, so its accessor is `inner()`. It returns a path to the single
+/// column the newtype maps to, which compares against the wrapped type:
+///
+/// ```
+/// #[derive(toasty::Embed)]
+/// struct Email(String);
+///
+/// #[derive(toasty::Model)]
+/// struct User {
+///     #[key]
+///     #[auto]
+///     id: i64,
+///     email: Email,
+/// }
+///
+/// let query = User::filter(User::fields().email().inner().eq("alice@example.com"));
+/// ```
+///
 /// Multi-field structs do not get the ordering methods — multi-column
 /// values have no ordering shared across backends:
 ///

--- a/crates/toasty-macros/src/model/schema/field.rs
+++ b/crates/toasty-macros/src/model/schema/field.rs
@@ -290,16 +290,19 @@ impl Field {
         field: &syn::Field,
         model_ident: &syn::Ident,
         id: usize,
-        index: usize,
         names: &[syn::Ident],
     ) -> syn::Result<Self> {
         let (name, span) = match &field.ident {
             Some(ident) => (Name::from_ident(ident), ident.span()),
             None => {
+                // A new-type is the only tuple shape Toasty supports (see
+                // `collect_ast_fields`), so the one unnamed field is named
+                // `inner`. Rust's own `_0` would name the generated methods
+                // and bindings `_0`, which clippy's `used_underscore_binding`
+                // and `used_underscore_items` report against the user's struct
+                // definition, where there is nothing to fix.
                 let span = field.ty.span();
-                let ident = syn::Ident::new(&format!("_{index}"), span);
-                let name = Name::from_ident(&ident);
-                (name, span)
+                (Name::from_ident(&syn::Ident::new("inner", span)), span)
             }
         };
 

--- a/crates/toasty-macros/src/model/schema/model.rs
+++ b/crates/toasty-macros/src/model/schema/model.rs
@@ -181,7 +181,7 @@ impl Model {
         }
 
         for (index, node) in ast_fields.iter().enumerate() {
-            match Field::from_ast(node, &ast.ident, index, index, &names) {
+            match Field::from_ast(node, &ast.ident, index, &names) {
                 Ok(field) => {
                     if model_attr.key.is_some()
                         && let Some(field) = &field.attrs.key
@@ -487,9 +487,9 @@ impl Model {
                 .collect::<Vec<_>>();
 
             let variant_base = global_field_index;
-            for (index, ast_field) in ast_fields.iter().enumerate() {
+            for ast_field in &ast_fields {
                 let mut field =
-                    Field::from_ast(ast_field, &model_ident, global_field_index, index, &names)?;
+                    Field::from_ast(ast_field, &model_ident, global_field_index, &names)?;
                 field.variant = Some(variant_index);
                 // `BelongsTo::from_ast` resolves `key` against the variant's
                 // own field list, so the recorded source indices are

--- a/crates/toasty-macros/src/model/schema/name.rs
+++ b/crates/toasty-macros/src/model/schema/name.rs
@@ -27,17 +27,7 @@ impl Name {
             None => (false, src),
         };
 
-        // TODO: improve logic. There are a bunch of issues going on here. The
-        // big one is, unnamed fields call this method passing in names like
-        // `_0`. `to_snake_case` strips leading underscores (e.g. "_0" → "0"),
-        // so we work aorund it by checking if the first character is a digit.
-        // Lame, but it works (for now) without a bigger refactor. Preserve the
         let snake = src.to_snake_case();
-        let snake = if snake.starts_with(|c: char| c.is_ascii_digit()) {
-            src.to_string()
-        } else {
-            snake
-        };
         let parts: Vec<_> = snake.split("_").map(String::from).collect();
 
         let snake_case = parts.join("_");
@@ -61,14 +51,7 @@ impl Name {
 
     pub(crate) fn with_prefix(&self, prefix: &str) -> String {
         // Use the bare name (without any `r#` prefix) so the result is a valid
-        // Rust identifier. Another hack: handles the `_0` case described in
-        // `from_str` by checking for a leading underscore.
-        let name = &self.snake_case;
-
-        if name.starts_with("_") {
-            format!("{prefix}{name}")
-        } else {
-            format!("{prefix}_{name}")
-        }
+        // Rust identifier.
+        format!("{prefix}_{}", self.snake_case)
     }
 }

--- a/docs/dev/design/enums-and-embedded-structs.md
+++ b/docs/dev/design/enums-and-embedded-structs.md
@@ -24,8 +24,8 @@ if f.unnamed.len() > 1 {
 
 Downstream codegen is already tuple-aware: `Primitive::load` / `IntoExpr` in
 `model/expand/embedded_enum.rs` emit tuple construction and destructuring, and
-`schema/field.rs` synthesizes `_0` / `_1` names. The gap is column naming and
-lifting the rejection.
+`schema/field.rs` names the one unnamed field `inner`. The gaps are per-position
+names for multi-field tuples, column naming, and lifting the rejection.
 
 ### Design
 

--- a/docs/guide/src/embedded-types.md
+++ b/docs/guide/src/embedded-types.md
@@ -34,7 +34,7 @@ parent field's name — no prefix is added:
 CREATE TABLE users (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name TEXT NOT NULL,
-    email TEXT NOT NULL     -- not "email_0"
+    email TEXT NOT NULL     -- not "email_inner"
 );
 ```
 
@@ -64,6 +64,16 @@ let users = User::filter(User::fields().email().eq(Email("alice@example.com".int
 // Update a newtype field
 user.update()
     .email(Email("new@example.com".into()))
+    .exec(&mut db)
+    .await?;
+```
+
+The wrapped value has its own field accessor, `inner()`. It returns a path to
+the single column the newtype maps to, so a filter can compare against the
+inner type instead of constructing a wrapper:
+
+```rust,ignore
+let users = User::filter(User::fields().email().inner().eq("alice@example.com"))
     .exec(&mut db)
     .await?;
 ```


### PR DESCRIPTION
## Summary

An unnamed field took Rust's positional name, `_0`, so the generated accessor, setter, and
update-builder methods were named `_0` and their parameter and pattern bindings read `_0`. Those
tokens carry the user's spans, so clippy reports `used_underscore_binding` and
`used_underscore_items` against the user's own struct definition, where there is nothing to fix. A
library-side `allow` cannot suppress the item lint either — it fires at the caller.

A new-type is the only tuple shape Toasty supports (`collect_ast_fields` rejects anything wider, for
structs and enum variants alike), so the positional name buys nothing. This names the field `inner`.
That also lets the two `_0` workarounds in `Name` go — the digit-leading snake-case hack and the
leading-underscore branch in `with_prefix` are now unreachable.

Closes #1179

Breaking:

- `._0()` → `.inner()` on a new-type's fields struct; `set_0()` / `_0()` → `set_inner()` /
  `inner()` on the update builder.
- A new-type field inside an **enum variant** now maps to column `{field}_inner` instead of
  `{field}__0`. New-type embed structs are unaffected — they still flatten to the parent field's own
  column name (`email`, not `email_inner`), since that path keys off the field being unnamed rather
  than off its name.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [ ] Touches a public API → a design doc under `docs/dev/design/` describes the behavior — no
      design doc: this renames one generated accessor in response to a bug report rather than adding
      API surface. The user guide and the `Embed` rustdoc now document `inner()`.

## Notes for reviewers

The fix is one line in `schema/field.rs`; the rest is fallout — dropping the now-unused `index`
argument to `Field::from_ast`, deleting the dead `Name` workarounds, and updating `._0()` call sites
and stale `_0` mentions in the suite, guide, and enums design doc.

Verified on the issue's reproducer under `clippy::pedantic`, extended with a tuple-variant embed enum
and a call site for the accessor: zero warnings, and it compiles under
`#![deny(clippy::used_underscore_binding, clippy::used_underscore_items)]`. Before the rename the
same file produced three binding warnings plus the item warning at the call site.

The enum-variant column rename is the part worth a second look. The `{field}__0` name it replaces was
never covered by a test or snapshot, and the enums design doc flags positional column naming as an
open question.
