### PR TITLE
fix(sql): quote PostgreSQL enum type names

### DIFF
--- a/crates/toasty-core/src/schema/diff/ty.rs
+++ b/crates/toasty-core/src/schema/diff/ty.rs
@@ -1,6 +1,6 @@
 use crate::schema::db;
 
-use hashbrown::HashMap;
+use hashbrown::{HashMap, HashSet};
 
 /// A single change to a named enum type between two schema versions.
 ///
@@ -10,6 +10,14 @@ use hashbrown::HashMap;
 pub enum Type<'a> {
     /// A new named enum type must be created.
     Create(&'a db::TypeEnum),
+
+    /// An existing named enum type is renamed without changing its identity.
+    Rename {
+        /// The enum type before the rename.
+        previous: &'a db::TypeEnum,
+        /// The enum type after the rename.
+        next: &'a db::TypeEnum,
+    },
 
     /// An existing named enum type has new variants appended.
     AddVariants {
@@ -24,7 +32,8 @@ impl<'a> Type<'a> {
     /// Computes the enum type diff between two schemas.
     ///
     /// Collects all named `TypeEnum` types from column definitions in both
-    /// schemas, matches them by name, and produces the appropriate changes.
+    /// schemas. A new name is a rename when the same columns use the type in
+    /// both schemas; otherwise, it creates a distinct type.
     ///
     /// # Panics
     ///
@@ -35,41 +44,31 @@ impl<'a> Type<'a> {
         let next_types = collect_named_enums(next);
 
         let mut changes = Vec::new();
+        let mut renamed = HashSet::new();
 
-        for (name, next_ty) in &next_types {
+        for (name, next_type) in &next_types {
             match prev_types.get(name) {
                 None => {
-                    changes.push(Self::Create(next_ty));
+                    let rename = prev_types.iter().find(|(previous_name, previous_type)| {
+                        !next_types.contains_key(*previous_name)
+                            && !renamed.contains(*previous_name)
+                            && previous_type.columns == next_type.columns
+                            && variants_are_prefix(previous_type.ty, next_type.ty)
+                    });
+
+                    if let Some((previous_name, previous_type)) = rename {
+                        changes.push(Self::Rename {
+                            previous: previous_type.ty,
+                            next: next_type.ty,
+                        });
+                        renamed.insert(*previous_name);
+                        add_variants(&mut changes, name, previous_type.ty, next_type.ty);
+                    } else {
+                        changes.push(Self::Create(next_type.ty));
+                    }
                 }
-                Some(prev_ty) => {
-                    let prev_names: Vec<&str> =
-                        prev_ty.variants.iter().map(|v| v.name.as_str()).collect();
-                    let next_names: Vec<&str> =
-                        next_ty.variants.iter().map(|v| v.name.as_str()).collect();
-
-                    assert!(
-                        next_names.len() >= prev_names.len(),
-                        "enum type `{name}`: removing variants is not supported; \
-                         previous had {} variants, next has {}",
-                        prev_names.len(),
-                        next_names.len()
-                    );
-
-                    for (i, prev_name) in prev_names.iter().enumerate() {
-                        assert!(
-                            next_names[i] == *prev_name,
-                            "enum type `{name}`: variant at position {i} changed from \
-                             `{prev_name}` to `{}`; reordering or renaming variants \
-                             is not supported",
-                            next_names[i]
-                        );
-                    }
-
-                    if next_names.len() > prev_names.len() {
-                        let added: Vec<&'a db::EnumVariant> =
-                            next_ty.variants[prev_names.len()..].iter().collect();
-                        changes.push(Self::AddVariants { ty: next_ty, added });
-                    }
+                Some(previous_type) => {
+                    add_variants(&mut changes, name, previous_type.ty, next_type.ty)
                 }
             }
         }
@@ -78,16 +77,72 @@ impl<'a> Type<'a> {
     }
 }
 
-fn collect_named_enums(schema: &db::Schema) -> HashMap<&str, &db::TypeEnum> {
+struct NamedEnum<'a> {
+    ty: &'a db::TypeEnum,
+    columns: HashSet<(&'a str, &'a str, bool)>,
+}
+
+fn collect_named_enums(schema: &db::Schema) -> HashMap<&str, NamedEnum<'_>> {
     let mut result = HashMap::new();
     for table in &schema.tables {
         for column in &table.columns {
             if let Some(type_enum) = column.storage_ty.named_enum()
                 && let Some(name) = &type_enum.name
             {
-                result.entry(name.as_str()).or_insert(type_enum);
+                result
+                    .entry(name.as_str())
+                    .or_insert_with(|| NamedEnum {
+                        ty: type_enum,
+                        columns: HashSet::new(),
+                    })
+                    .columns
+                    .insert((
+                        table.name.as_str(),
+                        column.name.as_str(),
+                        matches!(column.storage_ty, db::Type::List(_)),
+                    ));
             }
         }
     }
     result
+}
+
+fn variants_are_prefix(previous: &db::TypeEnum, next: &db::TypeEnum) -> bool {
+    previous.variants.len() <= next.variants.len()
+        && previous
+            .variants
+            .iter()
+            .zip(&next.variants)
+            .all(|(previous, next)| previous.name == next.name)
+}
+
+fn add_variants<'a>(
+    changes: &mut Vec<Type<'a>>,
+    name: &str,
+    previous: &'a db::TypeEnum,
+    next: &'a db::TypeEnum,
+) {
+    assert!(
+        next.variants.len() >= previous.variants.len(),
+        "enum type `{name}`: removing variants is not supported; previous had {} variants, next has {}",
+        previous.variants.len(),
+        next.variants.len()
+    );
+
+    for (i, (previous, next)) in previous.variants.iter().zip(&next.variants).enumerate() {
+        assert!(
+            previous.name == next.name,
+            "enum type `{name}`: variant at position {i} changed from `{}` to `{}`; \
+             reordering or renaming variants is not supported",
+            previous.name,
+            next.name
+        );
+    }
+
+    if next.variants.len() > previous.variants.len() {
+        changes.push(Type::AddVariants {
+            ty: next,
+            added: next.variants[previous.variants.len()..].iter().collect(),
+        });
+    }
 }

--- a/crates/toasty-driver-integration-suite/src/tests/embed_enum_native_ops.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embed_enum_native_ops.rs
@@ -219,7 +219,7 @@ pub async fn native_enum_multiple_fields(t: &mut Test) -> Result<()> {
 #[driver_test]
 pub async fn native_enum_custom_type_name(t: &mut Test) -> Result<()> {
     #[derive(Debug, PartialEq, toasty::Embed)]
-    #[column(type = enum("task_priority"))]
+    #[column(type = enum("TaskPriority"))]
     enum Priority {
         Low,
         Medium,

--- a/crates/toasty-sql/src/migration.rs
+++ b/crates/toasty-sql/src/migration.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, collections::HashSet};
 
 use toasty_core::{
     driver::Capability,
@@ -10,10 +10,13 @@ use toasty_core::{
 
 use crate::stmt::{AlterColumnChanges, AlterTable, AlterTableAction, DropTable, Name, Statement};
 
-/// Returns `true` if the only difference between two columns is the variant
-/// list of a named enum type. These changes are handled by `diff::Type`
-/// (`ALTER TYPE ... ADD VALUE`) and should not produce column-level DDL.
-fn is_named_enum_variant_only_change(previous: &Column, next: &Column) -> bool {
+/// Returns `true` if a named enum change is handled at the type level and
+/// should not produce column-level DDL.
+fn is_named_enum_type_only_change(
+    previous: &Column,
+    next: &Column,
+    renamed_types: &HashSet<(&str, &str)>,
+) -> bool {
     if previous.name != next.name
         || previous.nullable != next.nullable
         || previous.primary_key != next.primary_key
@@ -29,17 +32,20 @@ fn is_named_enum_variant_only_change(previous: &Column, next: &Column) -> bool {
         (Type::Enum(_), Type::Enum(_)) | (Type::List(_), Type::List(_))
     );
 
-    same_shape
-        && matches!(
-            (
-                previous.storage_ty.named_enum(),
-                next.storage_ty.named_enum(),
-            ),
-            (
-                Some(TypeEnum { name: Some(a), .. }),
-                Some(TypeEnum { name: Some(b), .. }),
-            ) if a == b
-        )
+    if !same_shape {
+        return false;
+    }
+
+    matches!(
+        (
+            previous.storage_ty.named_enum(),
+            next.storage_ty.named_enum(),
+        ),
+        (
+            Some(TypeEnum { name: Some(a), .. }),
+            Some(TypeEnum { name: Some(b), .. }),
+        ) if a == b || renamed_types.contains(&(a.as_str(), b.as_str()))
+    )
 }
 
 /// A migration step pairing a DDL [`Statement`] with the [`Schema`] it applies against.
@@ -66,17 +72,36 @@ impl<'a> MigrationStatement<'a> {
     /// full table recreation sequence.
     pub fn from_diff(schema_diff: &'a diff::Schema<'a>, capability: &Capability) -> Vec<Self> {
         let mut result = Vec::new();
+        let types_diff = schema_diff.types();
+        let renamed_types: HashSet<(&str, &str)> = types_diff
+            .iter()
+            .filter_map(|item| match item {
+                diff::Type::Rename { previous, next } => Some((
+                    previous.name.as_deref().expect("named enum type"),
+                    next.name.as_deref().expect("named enum type"),
+                )),
+                _ => None,
+            })
+            .collect();
 
         // Emit enum type changes before table changes (tables may reference
         // newly created types).
         if capability.named_enum_types {
-            let types_diff = schema_diff.types();
             for item in types_diff.iter() {
                 match item {
                     diff::Type::Create(ty) => {
                         result.push(Self::new(
                             Statement::create_enum_type(ty),
                             Cow::Borrowed(schema_diff.next()),
+                        ));
+                    }
+                    diff::Type::Rename { previous, next } => {
+                        result.push(Self::new(
+                            Statement::rename_type(
+                                previous.name.as_deref().expect("named enum type"),
+                                next.name.as_deref().expect("named enum type"),
+                            ),
+                            Cow::Borrowed(schema_diff.previous()),
                         ));
                     }
                     diff::Type::AddVariants { ty, added } => {
@@ -140,7 +165,11 @@ impl<'a> MigrationStatement<'a> {
                                     next: next_col
                                 } if AlterColumnChanges::from_diff(prev_col, next_col).has_type_change()
                                     && !(capability.named_enum_types
-                                        && is_named_enum_variant_only_change(prev_col, next_col))
+                                        && is_named_enum_type_only_change(
+                                            prev_col,
+                                            next_col,
+                                            &renamed_types,
+                                        ))
                             )
                         });
 
@@ -180,6 +209,7 @@ impl<'a> MigrationStatement<'a> {
                             previous.id,
                             columns,
                             capability,
+                            &renamed_types,
                         );
                     }
 
@@ -310,6 +340,7 @@ impl<'a> MigrationStatement<'a> {
         table: TableId,
         columns: &[diff::Column<'_>],
         capability: &Capability,
+        renamed_types: &HashSet<(&str, &str)>,
     ) {
         for item in columns.iter() {
             match item {
@@ -326,10 +357,10 @@ impl<'a> MigrationStatement<'a> {
                     previous,
                     next: col_next,
                 } => {
-                    // Skip column-level DDL for named enum variant changes — those
-                    // are handled by diff::Type (ALTER TYPE ... ADD VALUE).
+                    // Skip column-level DDL for named enum changes handled by
+                    // ALTER TYPE.
                     if capability.named_enum_types
-                        && is_named_enum_variant_only_change(previous, col_next)
+                        && is_named_enum_type_only_change(previous, col_next, renamed_types)
                     {
                         continue;
                     }

--- a/crates/toasty-sql/src/serializer/statement.rs
+++ b/crates/toasty-sql/src/serializer/statement.rs
@@ -116,7 +116,16 @@ impl ToSql for &stmt::AlterColumn {
                     new_not_null: None,
                     new_auto_increment: None,
                 } => {
-                    fmt!(&mut f, "ALTER TABLE " table_name " ALTER COLUMN " column_name " TYPE " ty)
+                    fmt!(&mut f, "ALTER TABLE " table_name " ALTER COLUMN " column_name " TYPE " ty);
+
+                    if let Some(intermediate_ty) =
+                        enum_change_intermediate_ty(&self.column_def.ty, ty)
+                    {
+                        fmt!(
+                            &mut f,
+                            " USING " Ident(&self.column_def.name) "::" intermediate_ty "::" ty
+                        );
+                    }
                 }
                 AlterColumnChanges {
                     new_name: None,
@@ -195,6 +204,23 @@ impl ToSql for &stmt::AlterColumn {
     }
 }
 
+fn enum_change_intermediate_ty(previous: &db::Type, next: &db::Type) -> Option<&'static str> {
+    match (previous, next) {
+        (db::Type::Enum(previous), db::Type::Enum(next)) if previous.name != next.name => {
+            Some("TEXT")
+        }
+        (db::Type::List(previous), db::Type::List(next)) => {
+            match (previous.as_ref(), next.as_ref()) {
+                (db::Type::Enum(previous), db::Type::Enum(next)) if previous.name != next.name => {
+                    Some("TEXT[]")
+                }
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
 impl ToSql for &stmt::AlterTable {
     fn to_sql(self, f: &mut super::Formatter<'_>) {
         match &self.action {
@@ -258,6 +284,15 @@ impl ToSql for &stmt::AlterType {
 
         fmt!(f, "ALTER TYPE " name " ADD VALUE ");
         Value::String(self.variant.name.clone()).to_sql(f);
+    }
+}
+
+impl ToSql for &stmt::RenameType {
+    fn to_sql(self, f: &mut super::Formatter<'_>) {
+        fmt!(
+            f,
+            "ALTER TYPE " Ident(&self.type_name) " RENAME TO " Ident(&self.new_name)
+        );
     }
 }
 
@@ -577,6 +612,7 @@ impl ToSql for &stmt::Statement {
             stmt::Statement::DropIndex(stmt) => stmt.to_sql(f),
             stmt::Statement::DropTable(stmt) => stmt.to_sql(f),
             stmt::Statement::Pragma(stmt) => stmt.to_sql(f),
+            stmt::Statement::RenameType(stmt) => stmt.to_sql(f),
             stmt::Statement::Delete(stmt) => stmt.to_sql(f),
             stmt::Statement::Insert(stmt) => stmt.to_sql(f),
             stmt::Statement::Query(stmt) => stmt.to_sql(f),

--- a/crates/toasty-sql/src/serializer/statement.rs
+++ b/crates/toasty-sql/src/serializer/statement.rs
@@ -204,6 +204,10 @@ impl ToSql for &stmt::AlterColumn {
     }
 }
 
+/// Returns the text type used to convert between distinct PostgreSQL enum types.
+/// PostgreSQL does not define casts between separately declared enums, even when
+/// their variants match, so `ALTER COLUMN ... TYPE` must cast each value through
+/// its textual label. See <https://wiki.postgresql.org/wiki/Mass_type_replacement>.
 fn enum_change_intermediate_ty(previous: &db::Type, next: &db::Type) -> Option<&'static str> {
     match (previous, next) {
         (db::Type::Enum(previous), db::Type::Enum(next)) if previous.name != next.name => {

--- a/crates/toasty-sql/src/serializer/ty.rs
+++ b/crates/toasty-sql/src/serializer/ty.rs
@@ -1,4 +1,4 @@
-use super::{Dialect, ToSql};
+use super::{Dialect, Ident, ToSql};
 
 use toasty_core::schema::db;
 
@@ -125,7 +125,7 @@ impl ToSql for &db::Type {
                         .name
                         .as_deref()
                         .expect("PostgreSQL enums require a type name");
-                    fmt!(f, name);
+                    fmt!(f, Ident(name));
                 }
                 // MySQL: inline ENUM('label1', 'label2', ...) column type.
                 Dialect::Mysql => {

--- a/crates/toasty-sql/src/stmt.rs
+++ b/crates/toasty-sql/src/stmt.rs
@@ -46,6 +46,9 @@ pub use name::Name;
 mod pragma;
 pub use pragma::Pragma;
 
+mod rename_type;
+pub use rename_type::RenameType;
+
 mod table_name;
 pub use table_name::TableName;
 
@@ -60,7 +63,7 @@ pub enum Statement {
     AlterColumn(AlterColumn),
     /// Alter an existing table (e.g. rename).
     AlterTable(AlterTable),
-    /// Alter a type (e.g. `ALTER TYPE ... ADD VALUE '...'`).
+    /// Add a value to an enum type.
     AlterType(AlterType),
     /// Copy rows from one table to another.
     CopyTable(CopyTable),
@@ -78,6 +81,8 @@ pub enum Statement {
     DropIndex(DropIndex),
     /// A SQLite PRAGMA statement.
     Pragma(Pragma),
+    /// Rename a type.
+    RenameType(RenameType),
     /// A DELETE statement.
     Delete(Delete),
     /// An INSERT statement.

--- a/crates/toasty-sql/src/stmt/rename_type.rs
+++ b/crates/toasty-sql/src/stmt/rename_type.rs
@@ -1,0 +1,27 @@
+use super::Statement;
+
+/// An `ALTER TYPE ... RENAME TO ...` statement.
+#[derive(Debug, Clone)]
+pub struct RenameType {
+    /// The current type name.
+    pub type_name: String,
+    /// The new type name.
+    pub new_name: String,
+}
+
+impl Statement {
+    /// Creates an `ALTER TYPE <name> RENAME TO <new_name>` statement.
+    pub fn rename_type(type_name: &str, new_name: &str) -> Self {
+        RenameType {
+            type_name: type_name.to_string(),
+            new_name: new_name.to_string(),
+        }
+        .into()
+    }
+}
+
+impl From<RenameType> for Statement {
+    fn from(value: RenameType) -> Self {
+        Self::RenameType(value)
+    }
+}

--- a/crates/toasty-sql/tests/migration_enum_type.rs
+++ b/crates/toasty-sql/tests/migration_enum_type.rs
@@ -73,11 +73,31 @@ fn serialize_migration(stmts: &[MigrationStatement<'_>], flavor: &str) -> Vec<St
         .collect()
 }
 
+fn serialize_postgresql_enum_type_change(previous: Type, next: Type) -> Vec<String> {
+    let schema = |storage_ty| Schema {
+        tables: vec![make_table(
+            0,
+            "jobs",
+            vec![
+                make_column(0, 0, "id", Type::Integer(8)),
+                make_column(0, 1, "job_type", storage_ty),
+            ],
+        )],
+    };
+    let from = schema(previous);
+    let to = schema(next);
+    let hints = diff::RenameHints::new();
+    let diff = diff::Schema::from(&from, &to, &hints);
+    let stmts = MigrationStatement::from_diff(&diff, &Capability::POSTGRESQL);
+
+    serialize_migration(&stmts, "postgresql")
+}
+
 // --- PostgreSQL: CREATE TYPE before CREATE TABLE ---
 
 #[test]
 fn create_table_with_enum_postgresql() {
-    let status_enum = make_enum_type("status", &["pending", "active", "done"]);
+    let status_enum = make_enum_type("TaskStatus", &["pending", "active", "done"]);
 
     let from = Schema::default();
     let to = Schema {
@@ -100,10 +120,80 @@ fn create_table_with_enum_postgresql() {
     assert_eq!(sql.len(), 2);
     assert_eq!(
         sql[0],
-        "CREATE TYPE \"status\" AS ENUM ('pending', 'active', 'done');"
+        "CREATE TYPE \"TaskStatus\" AS ENUM ('pending', 'active', 'done');"
     );
     assert!(sql[1].starts_with("CREATE TABLE \"tasks\""));
-    assert!(sql[1].contains("\"status\" status NOT NULL"));
+    assert!(sql[1].contains("\"status\" \"TaskStatus\" NOT NULL"));
+}
+
+#[test]
+fn rename_enum_type_postgresql() {
+    assert_eq!(
+        serialize_postgresql_enum_type_change(
+            Type::Enum(make_enum_type("jobtype", &["process"])),
+            Type::Enum(make_enum_type("JobType", &["process"])),
+        ),
+        ["ALTER TYPE \"jobtype\" RENAME TO \"JobType\";"]
+    );
+}
+
+#[test]
+fn rename_enum_array_type_postgresql() {
+    assert_eq!(
+        serialize_postgresql_enum_type_change(
+            Type::list(Type::Enum(make_enum_type("jobtype", &["process"]))),
+            Type::list(Type::Enum(make_enum_type("JobType", &["process"]))),
+        ),
+        ["ALTER TYPE \"jobtype\" RENAME TO \"JobType\";"]
+    );
+}
+
+#[test]
+fn rename_enum_type_and_add_variant_postgresql() {
+    assert_eq!(
+        serialize_postgresql_enum_type_change(
+            Type::Enum(make_enum_type("jobtype", &["process"])),
+            Type::Enum(make_enum_type("JobType", &["process", "archive"])),
+        ),
+        [
+            "ALTER TYPE \"jobtype\" RENAME TO \"JobType\";",
+            "ALTER TYPE \"JobType\" ADD VALUE 'archive';",
+        ]
+    );
+}
+
+#[test]
+fn split_shared_enum_type_postgresql() {
+    let schema = |job_type, retry_type| Schema {
+        tables: vec![make_table(
+            0,
+            "jobs",
+            vec![
+                make_column(0, 0, "id", Type::Integer(8)),
+                make_column(0, 1, "job_type", job_type),
+                make_column(0, 2, "retry_type", retry_type),
+            ],
+        )],
+    };
+    let from = schema(
+        Type::Enum(make_enum_type("jobtype", &["process"])),
+        Type::Enum(make_enum_type("jobtype", &["process"])),
+    );
+    let to = schema(
+        Type::Enum(make_enum_type("JobType", &["process"])),
+        Type::Enum(make_enum_type("jobtype", &["process"])),
+    );
+    let hints = diff::RenameHints::new();
+    let diff = diff::Schema::from(&from, &to, &hints);
+    let stmts = MigrationStatement::from_diff(&diff, &Capability::POSTGRESQL);
+
+    assert_eq!(
+        serialize_migration(&stmts, "postgresql"),
+        [
+            "CREATE TYPE \"JobType\" AS ENUM ('process');",
+            "ALTER TABLE \"jobs\" ALTER COLUMN \"job_type\" TYPE \"JobType\" USING \"job_type\"::TEXT::\"JobType\";",
+        ]
+    );
 }
 
 // --- PostgreSQL: ALTER TYPE ADD VALUE ---
@@ -415,7 +505,7 @@ fn create_table_with_enum_array_postgresql() {
         "CREATE TYPE \"status\" AS ENUM ('pending', 'active', 'done');"
     );
     assert!(
-        sql[1].contains("\"statuses\" status[] NOT NULL"),
+        sql[1].contains("\"statuses\" \"status\"[] NOT NULL"),
         "got: {}",
         sql[1]
     );

--- a/crates/toasty-sql/tests/serialize_types.rs
+++ b/crates/toasty-sql/tests/serialize_types.rs
@@ -813,12 +813,12 @@ fn network_types_postgresql() {
 
 #[test]
 fn enum_postgresql_named_type() {
-    let status = make_enum_type(Some("status"), &["pending", "active", "done"]);
+    let status = make_enum_type(Some("TaskStatus"), &["pending", "active", "done"]);
     expect![[r#"
-        CREATE TYPE "status" AS ENUM ('pending', 'active', 'done');
+        CREATE TYPE "TaskStatus" AS ENUM ('pending', 'active', 'done');
         CREATE TABLE "t" (
             "id" BIGINT NOT NULL,
-            "col" status NOT NULL,
+            "col" "TaskStatus" NOT NULL,
             PRIMARY KEY ("id")
         );"#]]
     .assert_eq(&render_type("postgresql", Type::Enum(status)).join("\n"));


### PR DESCRIPTION
## Summary

Fixes #1185.

Quote PostgreSQL enum type references consistently with `CREATE TYPE`, preserving mixed-case custom names in table definitions and casts.

When every column using an enum changes to the same new type name, emit `ALTER TYPE ... RENAME TO` so PostgreSQL preserves the type identity and avoids rewriting those columns. When only part of a shared enum moves to a new type, create the distinct type and cast the affected scalar or array columns through text.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

Rename detection compares the complete set of table and column uses. The regression coverage includes mixed-case schema creation, scalar and array renames, rename-plus-variant changes, and splitting one use from a shared enum type.