### PR TITLE
test: drop deprecated assert_struct! anonymous-struct syntax

### DIFF
--- a/crates/toasty-driver-integration-suite/src/tests/crud_sort_limit.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/crud_sort_limit.rs
@@ -32,7 +32,7 @@ pub async fn sort_asc(test: &mut Test) -> Result<()> {
     let (op, resp) = test.log().pop();
     assert_struct!(op, Operation::QuerySql({
         stmt: Statement::Query({
-            body: ExprSet::Select({ .. }),
+            body: ExprSet::Select({}),
             order_by: Some(_),
         }),
     }));
@@ -54,7 +54,7 @@ pub async fn sort_asc(test: &mut Test) -> Result<()> {
     let (op, resp) = test.log().pop();
     assert_struct!(op, Operation::QuerySql({
         stmt: Statement::Query({
-            body: ExprSet::Select({ .. }),
+            body: ExprSet::Select({}),
             order_by: Some(_),
         }),
     }));
@@ -88,7 +88,7 @@ pub async fn paginate(test: &mut Test) -> Result<()> {
     let (op, resp) = test.log().pop();
     assert_struct!(op, Operation::QuerySql({
         stmt: Statement::Query({
-            body: ExprSet::Select({ .. }),
+            body: ExprSet::Select({}),
             order_by: Some(_),
             limit: Some(_),
         }),
@@ -147,12 +147,12 @@ pub async fn limit_offset(t: &mut Test) -> Result<()> {
     if t.capability().sql() {
         assert_struct!(op, Operation::QuerySql({
             stmt: Statement::Query({
-                body: ExprSet::Select({ .. }),
+                body: ExprSet::Select({}),
                 limit: Some(_),
             }),
         }));
     } else {
-        assert_struct!(op, Operation::QueryPk({ .. }));
+        assert_struct!(op, Operation::QueryPk({}));
     }
 
     t.log().clear();
@@ -172,13 +172,13 @@ pub async fn limit_offset(t: &mut Test) -> Result<()> {
     if t.capability().sql() {
         assert_struct!(op, Operation::QuerySql({
             stmt: Statement::Query({
-                body: ExprSet::Select({ .. }),
+                body: ExprSet::Select({}),
                 order_by: Some(_),
                 limit: Some(_),
             }),
         }));
     } else {
-        assert_struct!(op, Operation::QueryPk({ .. }));
+        assert_struct!(op, Operation::QueryPk({}));
     }
 
     t.log().clear();
@@ -223,7 +223,7 @@ pub async fn first_narrows_to_single_row(t: &mut Test) -> Result<()> {
         .first()
         .exec(&mut db)
         .await?;
-    assert_struct!(youngest, Some(_ { name: "Bob", .. }));
+    assert_struct!(youngest, Some({ name: "Bob" }));
 
     let (op, _) = t.log().pop();
     assert_struct!(op, Operation::QuerySql({
@@ -241,7 +241,7 @@ pub async fn first_narrows_to_single_row(t: &mut Test) -> Result<()> {
         .first()
         .exec(&mut db)
         .await?;
-    assert_struct!(oldest, Some(_ { name: "Carol", .. }));
+    assert_struct!(oldest, Some({ name: "Carol" }));
 
     Ok(())
 }
@@ -266,7 +266,7 @@ pub async fn first_respects_offset(t: &mut Test) -> Result<()> {
         .exec(&mut db)
         .await?;
 
-    assert_struct!(user, Some(_ { name: "Alice", .. }));
+    assert_struct!(user, Some({ name: "Alice" }));
 
     Ok(())
 }

--- a/crates/toasty-driver-integration-suite/src/tests/crud_update_arithmetic.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/crud_update_arithmetic.rs
@@ -103,13 +103,11 @@ pub async fn arithmetic_update_cases(t: &mut Test) -> Result<()> {
                 target: UpdateTarget::Table(== counter_table_id),
                 assignments: #{ [1]: Assignment::Add(_) },
             }),
-            ..
         }));
     } else {
         assert_struct!(op, Operation::UpdateByKey({
             table: == counter_table_id,
             assignments: #{ [1]: Assignment::Add(_) },
-            ..
         }));
     }
 
@@ -208,7 +206,7 @@ pub async fn arithmetic_chains_with_other_updates(t: &mut Test) -> Result<()> {
         .await?;
 
     let reloaded = Profile::get_by_id(&mut db, &profile.id).await?;
-    assert_struct!(reloaded, _ { name: "alice2", login_count: 6, .. });
+    assert_struct!(reloaded, { name: "alice2", login_count: 6 });
     Ok(())
 }
 

--- a/crates/toasty-driver-integration-suite/src/tests/crud_update_macro.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/crud_update_macro.rs
@@ -227,10 +227,10 @@ pub async fn update_macro_value_reads_target_field(test: &mut Test) -> Result<()
     .exec(&mut db)
     .await?;
 
-    assert_struct!(user, _ { active: true, age: 31, .. });
+    assert_struct!(user, { active: true, age: 31 });
 
     let reloaded = User::get_by_id(&mut db, &user.id).await?;
-    assert_struct!(reloaded, _ { active: true, age: 31, .. });
+    assert_struct!(reloaded, { active: true, age: 31 });
 
     Ok(())
 }

--- a/crates/toasty-driver-integration-suite/src/tests/crud_upsert.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/crud_upsert.rs
@@ -31,10 +31,10 @@ pub async fn upsert_update_increments_version(test: &mut Test) -> Result<()> {
     seed.delete().exec(&mut db).await?;
 
     let mut stale = Item::upsert_by_id(id).name("first").exec(&mut db).await?;
-    assert_struct!(stale, _ { name: "first", version: 1, .. });
+    assert_struct!(stale, { name: "first", version: 1 });
 
     let updated = Item::upsert_by_id(id).name("second").exec(&mut db).await?;
-    assert_struct!(updated, _ { name: "second", version: 2, .. });
+    assert_struct!(updated, { name: "second", version: 2 });
 
     let result: Result<()> = stale.update().name("stale").exec(&mut db).await;
     assert!(result.is_err(), "expected stale update to fail");
@@ -320,11 +320,10 @@ pub async fn upsert_explicit_assignments_override_model_defaults(test: &mut Test
         .branch_defaults("created explicitly")
         .exec(&mut db)
         .await?;
-    assert_struct!(created, _ {
+    assert_struct!(created, {
         default_only: "created explicitly",
         update_only: "created explicitly",
         branch_defaults: "created explicitly",
-        ..
     });
 
     let updated = Item::upsert_by_id(id)
@@ -333,11 +332,10 @@ pub async fn upsert_explicit_assignments_override_model_defaults(test: &mut Test
         .branch_defaults("updated explicitly")
         .exec(&mut db)
         .await?;
-    assert_struct!(updated, _ {
+    assert_struct!(updated, {
         default_only: "updated explicitly",
         update_only: "updated explicitly",
         branch_defaults: "updated explicitly",
-        ..
     });
 
     assert_none!(Item::upsert_by_id(id).or_ignore().exec(&mut db).await?);
@@ -479,14 +477,14 @@ pub async fn upsert_shared_mutations_apply_declared_defaults(test: &mut Test) ->
         .tags(toasty::stmt::push("a"))
         .exec(&mut db)
         .await?;
-    assert_struct!(created, _ { count: 7, tags: ["base", "a"] });
+    assert_struct!(created, { count: 7, tags: ["base", "a"] });
 
     let updated = Item::upsert_by_id("item")
         .count(toasty::stmt::subtract(3))
         .tags(toasty::stmt::push("b"))
         .exec(&mut db)
         .await?;
-    assert_struct!(updated, _ { count: 4, tags: ["base", "a", "b"] });
+    assert_struct!(updated, { count: 4, tags: ["base", "a", "b"] });
     Ok(())
 }
 

--- a/crates/toasty-driver-integration-suite/src/tests/embed_enum_data.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embed_enum_data.rs
@@ -14,12 +14,10 @@ pub async fn data_carrying_enum_schema(t: &mut Test) {
             {
                 name.upper_camel_case(): "Email",
                 discriminant: toasty_core::stmt::Value::I64(1),
-                ..
             },
             {
                 name.upper_camel_case(): "Phone",
                 discriminant: toasty_core::stmt::Value::I64(2),
-                ..
             },
         ],
         fields: [
@@ -43,17 +41,14 @@ pub async fn mixed_enum_schema(t: &mut Test) {
             {
                 name.upper_camel_case(): "Pending",
                 discriminant: toasty_core::stmt::Value::I64(1),
-                ..
             },
             {
                 name.upper_camel_case(): "Failed",
                 discriminant: toasty_core::stmt::Value::I64(2),
-                ..
             },
             {
                 name.upper_camel_case(): "Done",
                 discriminant: toasty_core::stmt::Value::I64(3),
-                ..
             },
         ],
         fields: [

--- a/crates/toasty-driver-integration-suite/src/tests/embed_enum_optional.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embed_enum_optional.rs
@@ -60,10 +60,9 @@ pub async fn option_enum_crud(test: &mut Test) -> Result<()> {
     .await?;
 
     let full = Account::get_by_id(&mut db, "full").await?;
-    assert_struct!(full, _ {
+    assert_struct!(full, {
         contact: Some(== Contact::Email { address: "a@x.com".to_string() }),
         status: Some(== Status::Active),
-        ..
     });
 
     let empty = Account::get_by_id(&mut db, "empty").await?;
@@ -103,18 +102,18 @@ pub async fn option_enum_filter_presence(test: &mut Test) -> Result<()> {
     let present = Account::filter(Account::fields().contact().is_some())
         .exec(&mut db)
         .await?;
-    assert_struct!(present, [_ { id: "full", .. }]);
+    assert_struct!(present, [{ id: "full" }]);
 
     let absent = Account::filter(Account::fields().contact().is_none())
         .exec(&mut db)
         .await?;
-    assert_struct!(absent, [_ { id: "empty", .. }]);
+    assert_struct!(absent, [{ id: "empty" }]);
 
     // Unit enum.
     let status_absent = Account::filter(Account::fields().status().is_none())
         .exec(&mut db)
         .await?;
-    assert_struct!(status_absent, [_ { id: "empty", .. }]);
+    assert_struct!(status_absent, [{ id: "empty" }]);
 
     Ok(())
 }
@@ -159,12 +158,12 @@ pub async fn option_enum_filter_eq(test: &mut Test) -> Result<()> {
     })))
     .exec(&mut db)
     .await?;
-    assert_struct!(email, [_ { id: "alice", .. }]);
+    assert_struct!(email, [{ id: "alice" }]);
 
     let active = Account::filter(Account::fields().status().eq(Some(Status::Active)))
         .exec(&mut db)
         .await?;
-    assert_struct!(active, [_ { id: "alice", .. }]);
+    assert_struct!(active, [{ id: "alice" }]);
 
     Ok(())
 }

--- a/crates/toasty-driver-integration-suite/src/tests/embed_enum_shared_column.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embed_enum_shared_column.rs
@@ -35,9 +35,9 @@ pub async fn shared_column_schema_fields(t: &mut Test) {
     let creature = &schema.app.models[&Creature::id()];
     assert_struct!(creature, toasty::schema::app::Model::EmbeddedEnum({
         fields: [
-            { name.app: Some("name"), shared: Some(_ { parts: ["name"] }) },
+            { name.app: Some("name"), shared: Some({ parts: ["name"] }) },
             { name.app: Some("profession"), shared: None },
-            { name.app: Some("name"), shared: Some(_ { parts: ["name"] }) },
+            { name.app: Some("name"), shared: Some({ parts: ["name"] }) },
             { name.app: Some("species"), shared: None },
         ],
     }));
@@ -69,8 +69,8 @@ pub async fn raw_shared_identifier_uses_bare_name(t: &mut Test) {
 
     assert_struct!(schema.app.models[&Value::id()], toasty::schema::app::Model::EmbeddedEnum({
         fields: [
-            { shared: Some(_ { parts: ["type"] }), .. },
-            { shared: Some(_ { parts: ["type"] }), .. },
+            { shared: Some({ parts: ["type"] }) },
+            { shared: Some({ parts: ["type"] }) },
         ],
     }));
     assert_struct!(schema.db.tables, [{
@@ -79,7 +79,6 @@ pub async fn raw_shared_identifier_uses_bare_name(t: &mut Test) {
             { name: "value" },
             { name: "value_type" },
         ],
-        ..
     }]);
 }
 

--- a/crates/toasty-driver-integration-suite/src/tests/embed_enum_shared_index.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embed_enum_shared_index.rs
@@ -518,7 +518,7 @@ pub async fn shared_field_column_override(test: &mut Test) -> Result<()> {
 
     assert_struct!(
         Character::get_by_id(&mut db, &"1".to_string()).await?,
-        _ { creature: Creature::Human { name: "Bob", .. }, .. }
+        { creature: Creature::Human { name: "Bob", .. } }
     );
 
     Ok(())

--- a/crates/toasty-driver-integration-suite/src/tests/embed_enum_unit.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embed_enum_unit.rs
@@ -263,9 +263,9 @@ pub async fn basic_embedded_enum(test: &mut Test) {
     assert_struct!(status, toasty::schema::app::Model::EmbeddedEnum({
         name.upper_camel_case(): "Status",
         variants: [
-            _ { name.upper_camel_case(): "Pending", discriminant: toasty_core::stmt::Value::I64(1), .. },
-            _ { name.upper_camel_case(): "Active", discriminant: toasty_core::stmt::Value::I64(2), .. },
-            _ { name.upper_camel_case(): "Done", discriminant: toasty_core::stmt::Value::I64(3), .. },
+            { name.upper_camel_case(): "Pending", discriminant: toasty_core::stmt::Value::I64(1) },
+            { name.upper_camel_case(): "Active", discriminant: toasty_core::stmt::Value::I64(2) },
+            { name.upper_camel_case(): "Done", discriminant: toasty_core::stmt::Value::I64(3) },
         ],
     }));
 }

--- a/crates/toasty-driver-integration-suite/src/tests/embed_struct_optional.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/embed_struct_optional.rs
@@ -60,7 +60,7 @@ pub async fn option_embed_crud(test: &mut Test) -> Result<()> {
     .await?;
 
     let with = Document::get_by_id(&mut db, "with").await?;
-    assert_struct!(with.metadata, Some(_ {
+    assert_struct!(with.metadata, Some({
         author: "alice",
         note: "hi",
     }));
@@ -95,12 +95,12 @@ pub async fn option_embed_filter_presence(test: &mut Test) -> Result<()> {
     let present = Document::filter(Document::fields().metadata().is_some())
         .exec(&mut db)
         .await?;
-    assert_struct!(present, [_ { id: "with", .. }]);
+    assert_struct!(present, [{ id: "with" }]);
 
     let absent = Document::filter(Document::fields().metadata().is_none())
         .exec(&mut db)
         .await?;
-    assert_struct!(absent, [_ { id: "without", .. }]);
+    assert_struct!(absent, [{ id: "without" }]);
 
     Ok(())
 }
@@ -141,7 +141,7 @@ pub async fn option_embed_filter_eq(test: &mut Test) -> Result<()> {
     })))
     .exec(&mut db)
     .await?;
-    assert_struct!(matches, [_ { id: "alice", .. }]);
+    assert_struct!(matches, [{ id: "alice" }]);
 
     Ok(())
 }
@@ -184,7 +184,7 @@ pub async fn option_embed_update(test: &mut Test) -> Result<()> {
         }))
         .exec(&mut db)
         .await?;
-    assert_struct!(Document::get_by_id(&mut db, "b").await?.metadata, Some(_ {
+    assert_struct!(Document::get_by_id(&mut db, "b").await?.metadata, Some({
         author: "bob",
         note: "yo",
     }));
@@ -385,12 +385,12 @@ pub async fn option_newtype_filter_presence(test: &mut Test) -> Result<()> {
     let present = Document::filter(Document::fields().code().is_some())
         .exec(&mut db)
         .await?;
-    assert_struct!(present, [_ { id: "with", .. }]);
+    assert_struct!(present, [{ id: "with" }]);
 
     let absent = Document::filter(Document::fields().code().is_none())
         .exec(&mut db)
         .await?;
-    assert_struct!(absent, [_ { id: "without", .. }]);
+    assert_struct!(absent, [{ id: "without" }]);
 
     Ok(())
 }
@@ -505,7 +505,7 @@ pub async fn option_newtype_filter_eq(test: &mut Test) -> Result<()> {
     let matches = Document::filter(Document::fields().code().eq(Some(Code("abc".to_string()))))
         .exec(&mut db)
         .await?;
-    assert_struct!(matches, [_ { id: "alice", .. }]);
+    assert_struct!(matches, [{ id: "alice" }]);
 
     Ok(())
 }
@@ -587,7 +587,7 @@ pub async fn option_struct_nullable_inner_disambiguates(test: &mut Test) -> Resu
 
     assert_struct!(
         Document::get_by_id(&mut db, "some_none").await?.wrapper,
-        Some(_ { value: None })
+        Some({ value: None })
     );
     assert_none!(Document::get_by_id(&mut db, "none").await?.wrapper);
 

--- a/crates/toasty-driver-integration-suite/src/tests/field_version.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/field_version.rs
@@ -43,7 +43,7 @@ pub async fn relative_update_increments_value_and_version(test: &mut Test) -> Re
     let mut db = setup(test).await;
 
     let mut counter = toasty::create!(Counter { value: 10 }).exec(&mut db).await?;
-    assert_struct!(counter, _ { value: 10, version: 1, .. });
+    assert_struct!(counter, { value: 10, version: 1 });
 
     counter
         .update()
@@ -53,11 +53,11 @@ pub async fn relative_update_increments_value_and_version(test: &mut Test) -> Re
 
     // The handle is reloaded from the update's returning row: `value` is read
     // back from the driver, `version` is bumped to 2.
-    assert_struct!(counter, _ { value: 11, version: 2, .. });
+    assert_struct!(counter, { value: 11, version: 2 });
 
     // And it is durable.
     let reloaded = Counter::filter_by_id(counter.id).get(&mut db).await?;
-    assert_struct!(reloaded, _ { value: 11, version: 2, .. });
+    assert_struct!(reloaded, { value: 11, version: 2 });
 
     Ok(())
 }
@@ -357,7 +357,7 @@ pub async fn query_relative_update_increments_value_and_version(test: &mut Test)
     let mut db = setup(test).await;
 
     let counter = toasty::create!(Counter { value: 10 }).exec(&mut db).await?;
-    assert_struct!(counter, _ { value: 10, version: 1, .. });
+    assert_struct!(counter, { value: 10, version: 1 });
 
     Counter::filter_by_id(counter.id)
         .update()
@@ -366,7 +366,7 @@ pub async fn query_relative_update_increments_value_and_version(test: &mut Test)
         .await?;
 
     let reloaded = Counter::filter_by_id(counter.id).get(&mut db).await?;
-    assert_struct!(reloaded, _ { value: 11, version: 2, .. });
+    assert_struct!(reloaded, { value: 11, version: 2 });
 
     Ok(())
 }
@@ -470,10 +470,10 @@ pub async fn update_with_float_field_works(test: &mut Test) -> Result<()> {
     let mut gauge = toasty::create!(Gauge { value: 1.5 }).exec(&mut db).await?;
 
     gauge.update().value(2.5).exec(&mut db).await?;
-    assert_struct!(gauge, _ { value: 2.5, version: 2, .. });
+    assert_struct!(gauge, { value: 2.5, version: 2 });
 
     let reloaded = Gauge::filter_by_id(gauge.id).get(&mut db).await?;
-    assert_struct!(reloaded, _ { value: 2.5, version: 2, .. });
+    assert_struct!(reloaded, { value: 2.5, version: 2 });
 
     Ok(())
 }

--- a/crates/toasty-driver-integration-suite/src/tests/key_unsigned.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/key_unsigned.rs
@@ -18,10 +18,10 @@ pub async fn key_u8(t: &mut Test) -> Result<()> {
     })
     .exec(&mut db)
     .await?;
-    assert_struct!(item, _ { id: 1_u8, val: "hello" });
+    assert_struct!(item, { id: 1_u8, val: "hello" });
 
     let read = Item::get_by_id(&mut db, &1_u8).await?;
-    assert_struct!(read, _ { id: 1_u8, val: "hello" });
+    assert_struct!(read, { id: 1_u8, val: "hello" });
 
     item.delete().exec(&mut db).await?;
     Ok(())
@@ -45,10 +45,10 @@ pub async fn key_u16(t: &mut Test) -> Result<()> {
     })
     .exec(&mut db)
     .await?;
-    assert_struct!(item, _ { id: 1_u16, val: "hello" });
+    assert_struct!(item, { id: 1_u16, val: "hello" });
 
     let read = Item::get_by_id(&mut db, &1_u16).await?;
-    assert_struct!(read, _ { id: 1_u16, val: "hello" });
+    assert_struct!(read, { id: 1_u16, val: "hello" });
 
     item.delete().exec(&mut db).await?;
     Ok(())
@@ -72,10 +72,10 @@ pub async fn key_u32(t: &mut Test) -> Result<()> {
     })
     .exec(&mut db)
     .await?;
-    assert_struct!(item, _ { id: 1_u32, val: "hello" });
+    assert_struct!(item, { id: 1_u32, val: "hello" });
 
     let read = Item::get_by_id(&mut db, &1_u32).await?;
-    assert_struct!(read, _ { id: 1_u32, val: "hello" });
+    assert_struct!(read, { id: 1_u32, val: "hello" });
 
     item.delete().exec(&mut db).await?;
     Ok(())
@@ -99,10 +99,10 @@ pub async fn key_u64(t: &mut Test) -> Result<()> {
     })
     .exec(&mut db)
     .await?;
-    assert_struct!(item, _ { id: 42_u64, val: "hello" });
+    assert_struct!(item, { id: 42_u64, val: "hello" });
 
     let read = Item::get_by_id(&mut db, &42_u64).await?;
-    assert_struct!(read, _ { id: 42_u64, val: "hello" });
+    assert_struct!(read, { id: 42_u64, val: "hello" });
 
     item.delete().exec(&mut db).await?;
     Ok(())

--- a/crates/toasty-driver-integration-suite/src/tests/paginate_include.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/paginate_include.rs
@@ -37,15 +37,15 @@ pub async fn include_preserves_pagination_cursor(test: &mut Test) -> Result<()> 
         .exec(&mut db)
         .await?;
 
-    assert_struct!(first.items, [_ { id: 1, .. }, _ { id: 2, .. }]);
-    assert_struct!(first.items[0].author.get(), Some(_ { id: 1 }));
+    assert_struct!(first.items, [{ id: 1 }, { id: 2 }]);
+    assert_struct!(first.items[0].author.get(), Some({ id: 1 }));
     assert!(first.has_next());
 
     let second = first.next(&mut db).await?.unwrap();
-    assert_struct!(second.items, [_ { id: 3, .. }]);
+    assert_struct!(second.items, [{ id: 3 }]);
 
     let first_again = second.prev(&mut db).await?.unwrap();
-    assert_struct!(first_again.items, [_ { id: 1, .. }, _ { id: 2, .. }]);
+    assert_struct!(first_again.items, [{ id: 1 }, { id: 2 }]);
 
     Ok(())
 }

--- a/crates/toasty-driver-integration-suite/src/tests/paginate_multi_column.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/paginate_multi_column.rs
@@ -159,14 +159,14 @@ pub async fn paginate_single_non_unique_column(test: &mut Test) -> Result<()> {
         .paginate(2)
         .exec(&mut db)
         .await?;
-    assert_struct!(first.items, [_ { id: 1, .. }, _ { id: 2, .. }]);
+    assert_struct!(first.items, [{ id: 1 }, { id: 2 }]);
     assert_eq!(cursor_len(first.next_cursor.as_ref()), 2);
 
     let second = first.next(&mut db).await?.unwrap();
-    assert_struct!(second.items, [_ { id: 3, .. }, _ { id: 4, .. }]);
+    assert_struct!(second.items, [{ id: 3 }, { id: 4 }]);
 
     let first_again = second.prev(&mut db).await?.unwrap();
-    assert_struct!(first_again.items, [_ { id: 1, .. }, _ { id: 2, .. }]);
+    assert_struct!(first_again.items, [{ id: 1 }, { id: 2 }]);
 
     Ok(())
 }
@@ -240,11 +240,11 @@ pub async fn paginate_accepts_cursor_without_hidden_primary_key(test: &mut Test)
         .after(0_i64)
         .exec(&mut db)
         .await?;
-    assert_struct!(first.items, [_ { id: 1, .. }, _ { id: 2, .. }]);
+    assert_struct!(first.items, [{ id: 1 }, { id: 2 }]);
     assert_eq!(cursor_len(first.next_cursor.as_ref()), 2);
 
     let second = first.next(&mut db).await?.unwrap();
-    assert_struct!(second.items, [_ { id: 3, .. }]);
+    assert_struct!(second.items, [{ id: 3 }]);
 
     Ok(())
 }
@@ -378,10 +378,10 @@ pub async fn paginate_multi_column_equal_leading_values(test: &mut Test) -> Resu
         .paginate(2)
         .exec(&mut db)
         .await?;
-    assert_struct!(page.items, [_ { id: 1, .. }, _ { id: 2, .. }]);
+    assert_struct!(page.items, [{ id: 1 }, { id: 2 }]);
 
     let page: Page<Item> = page.next(&mut db).await?.unwrap();
-    assert_struct!(page.items, [_ { id: 3, .. }]);
+    assert_struct!(page.items, [{ id: 3 }]);
 
     Ok(())
 }
@@ -412,10 +412,10 @@ pub async fn paginate_multi_column_mixed_directions(test: &mut Test) -> Result<(
         .paginate(2)
         .exec(&mut db)
         .await?;
-    assert_struct!(page.items, [_ { id: 3, .. }, _ { id: 4, .. }]);
+    assert_struct!(page.items, [{ id: 3 }, { id: 4 }]);
 
     let page: Page<Item> = page.next(&mut db).await?.unwrap();
-    assert_struct!(page.items, [_ { id: 1, .. }, _ { id: 2, .. }]);
+    assert_struct!(page.items, [{ id: 1 }, { id: 2 }]);
 
     Ok(())
 }

--- a/crates/toasty-driver-integration-suite/src/tests/relation_belongs_to_inferred.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_belongs_to_inferred.rs
@@ -75,7 +75,7 @@ pub async fn infers_optional_relation(test: &mut Test) -> Result<()> {
     assert_eq!(post.user_id, Some(user.id));
 
     let loaded = post.user().exec(&mut db).await?;
-    assert_struct!(loaded, Some(_ { id: == user.id }));
+    assert_struct!(loaded, Some({ id: == user.id }));
 
     Ok(())
 }

--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_composite_key.rs
@@ -751,7 +751,7 @@ pub async fn composite_fk_belongs_to_preload(test: &mut Test) -> Result<()> {
             .get(&mut db)
             .await?;
 
-        assert_struct!(todo.user.get(), _ { id: == user.id, name: == user.name, .. });
+        assert_struct!(todo.user.get(), { id: == user.id, name: == user.name });
     }
     Ok(())
 }

--- a/crates/toasty-driver-integration-suite/src/tests/relation_has_many_via.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_has_many_via.rs
@@ -71,9 +71,8 @@ pub async fn include_with_newtype_foreign_key(test: &mut Test) -> Result<()> {
         .exec(&mut db)
         .await?;
 
-    assert_struct!(users, [_ {
+    assert_struct!(users, [{
         commented_articles.get().len(): 1,
-        ..
     }]);
 
     Ok(())
@@ -148,9 +147,8 @@ pub async fn include_with_unit_enum_foreign_key(test: &mut Test) -> Result<()> {
         .exec(&mut db)
         .await?;
 
-    assert_struct!(users, [_ {
+    assert_struct!(users, [{
         commented_articles.get().len(): 1,
-        ..
     }]);
 
     Ok(())

--- a/crates/toasty-driver-integration-suite/src/tests/relation_preload_options.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/relation_preload_options.rs
@@ -252,8 +252,7 @@ pub async fn preload_has_many_repeated_ordering_last_wins(test: &mut Test) -> Re
 
     let _ = test.log().pop_last_op(); // transaction commit
     assert_struct!(test.log().pop_last_op(), Operation::QuerySql({
-        stmt: Statement::Query({ order_by: None, .. }),
-        ..
+        stmt: Statement::Query({ order_by: None }),
     }));
 
     Ok(())

--- a/crates/toasty-driver-integration-suite/src/tests/type_document.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/type_document.rs
@@ -376,7 +376,6 @@ pub async fn struct_embed_update_returning_constantized(t: &mut Test) -> Result<
     assert_struct!(op, toasty_core::driver::Operation::QuerySql({
         stmt: toasty_core::stmt::Statement::Update(_),
         ret: None,
-        ..
     }));
     assert!(t.log().is_empty());
 

--- a/crates/toasty-driver-integration-suite/src/tests/type_net.rs
+++ b/crates/toasty-driver-integration-suite/src/tests/type_net.rs
@@ -45,7 +45,7 @@ pub async fn network_address_round_trip(test: &mut Test) -> Result<(), BoxError>
         .await?;
         let read = Item::get_by_id(&mut db, &created.id).await?;
 
-        assert_struct!(read, _ {
+        assert_struct!(read, {
             cidr: == cidr,
             inet: == inet,
             macaddr: == macaddr,


### PR DESCRIPTION
## Summary

assert-struct 0.4 deprecates the `_` prefix and the trailing `..` on anonymous structs: anonymous
structs always match partially, so both are redundant. This rewrites every such use in the
integration suite.

```rust
// before
assert_struct!(counter, _ { value: 10, version: 1, .. });
assert_struct!(first.items, [_ { id: 1, .. }, _ { id: 2, .. }]);
assert_struct!(op, Operation::QueryPk({ .. }));

// after
assert_struct!(counter, { value: 10, version: 1 });
assert_struct!(first.items, [{ id: 1 }, { id: 2 }]);
assert_struct!(op, Operation::QueryPk({}));
```

`..` still drives partial matching on named structs, enum struct variants, slice patterns, and
`#{ .. }` map patterns, so those are left in place.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

Mechanical rewrite — no assertion changes meaning, since the dropped tokens were no-ops. The one
shape worth a glance is `{ .. }` collapsing to `{}` (an anonymous struct asserting nothing), which
appears in `crud_sort_limit.rs`.

An audit pass over every `assert_struct!` body confirms no `_ {` and no anonymous-struct `..`
remain; the 45 struct-rests still in the suite are all named-struct or map patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)