### PR TITLE
fix: get Connect max_connection from driver

### DIFF
--- a/crates/toasty/src/db/connect.rs
+++ b/crates/toasty/src/db/connect.rs
@@ -133,6 +133,10 @@ impl Driver for Connect {
         self.driver.connect(cx).await
     }
 
+    fn max_connections(&self) -> Option<usize> {
+        self.driver.max_connections()
+    }
+
     fn generate_migration(&self, schema_diff: &diff::Schema<'_>) -> Migration {
         self.driver.generate_migration(schema_diff)
     }


### PR DESCRIPTION
<!--
PR title uses Conventional Commits, e.g.
    feat: add upsert support
    fix: handle composite key in IN-list rewrite
See CONTRIBUTING.md for the full process.
-->

## Summary

Have Connect implement max_connection that is retrieved from the underlying driver
fixes #1125 having multiple connection to sqlite-memory failing since sqlite-memory does not support connection pool

## Type of change

<!-- Check one. -->

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

