### PR TITLE
fix(macros): allow fields named path and from_path

### DIFF
--- a/crates/toasty-macros/src/model/expand.rs
+++ b/crates/toasty-macros/src/model/expand.rs
@@ -516,8 +516,8 @@ impl Expand<'_> {
 
         quote_spanned! { span=>
             #vis fn #field_ident(&self) -> <<#ty as #field_trait>::Target as #toasty::Model>::OneField<__Origin> {
-                <<<#ty as #field_trait>::Target as #toasty::Model>::OneField<__Origin>>::from_path(
-                    self.path().chain(
+                <<#ty as #field_trait>::Target as #toasty::ModelCodegen>::new_one_field(
+                    self.path.clone().chain(
                         <#model_ident as #schema_trait>::path_field(#field_offset)
                     )
                 )
@@ -536,6 +536,7 @@ impl Expand<'_> {
         field_ident: &syn::Ident,
         ty: &syn::Type,
         field_offset: &TokenStream,
+        parent_path: &TokenStream,
     ) -> TokenStream {
         let toasty = &self.toasty;
         let vis = &self.model.vis;
@@ -550,7 +551,7 @@ impl Expand<'_> {
         quote_spanned! { span=>
             #vis fn #field_ident(&self) -> <#ty as #toasty::Field>::Path<__Origin> {
                 <#ty as #toasty::Field>::new_path(
-                    self.path().chain(
+                    #parent_path.chain(
                         <#model_ident as #schema_trait>::path_field::<<#ty as #toasty::Field>::ExprTarget>(#field_offset)
                     )
                 )

--- a/crates/toasty-macros/src/model/expand/embedded_enum.rs
+++ b/crates/toasty-macros/src/model/expand/embedded_enum.rs
@@ -241,6 +241,7 @@ impl Expand<'_> {
                         path: #toasty::Path<__Origin, #model_ident>,
                     }
 
+                    #[allow(dead_code)]
                     impl<__Origin> #variant_handle_ident<__Origin> {
                         #vis fn matches(
                             self,
@@ -274,6 +275,7 @@ impl Expand<'_> {
                 path: #toasty::Path<__Origin, #model_ident>,
             }
 
+            #[allow(dead_code)]
             impl<__Origin> #field_struct_ident<__Origin> {
                 #( #is_variant_methods )*
 

--- a/crates/toasty-macros/src/model/expand/embedded_enum.rs
+++ b/crates/toasty-macros/src/model/expand/embedded_enum.rs
@@ -104,7 +104,7 @@ impl Expand<'_> {
         quote! {
             {
                 let path_stmt: #toasty::core::stmt::Expr = {
-                    let p: #toasty::core::stmt::Path = self.path().into();
+                    let p: #toasty::core::stmt::Path = self.path.clone().into();
                     p.into_stmt()
                 };
                 let variant_id = #toasty::core::schema::app::VariantId {
@@ -119,7 +119,7 @@ impl Expand<'_> {
     }
 
     /// Generates delegated comparison methods (`eq`, `ne`, `in_list`) that
-    /// forward to `self.path()`. Ordered comparisons (`gt`, `ge`, `lt`, `le`)
+    /// forward to the stored path. Ordered comparisons (`gt`, `ge`, `lt`, `le`)
     /// are intentionally excluded because enums have no meaningful ordering.
     fn expand_comparison_methods(&self) -> TokenStream {
         let toasty = &self.toasty;
@@ -130,7 +130,7 @@ impl Expand<'_> {
             let method_ident = syn::Ident::new(name, proc_macro2::Span::call_site());
             quote! {
                 #vis fn #method_ident(&self, rhs: impl #toasty::stmt::IntoExpr<#model_ident>) -> #toasty::stmt::Expr<bool> {
-                    self.path().#method_ident(rhs)
+                    self.path.clone().#method_ident(rhs)
                 }
             }
         });
@@ -139,7 +139,7 @@ impl Expand<'_> {
             #( #methods )*
 
             #vis fn in_list(&self, rhs: impl #toasty::stmt::IntoExpr<#toasty::List<#model_ident>>) -> #toasty::stmt::Expr<bool> {
-                self.path().in_list(rhs)
+                self.path.clone().in_list(rhs)
             }
         }
     }
@@ -184,7 +184,7 @@ impl Expand<'_> {
                 quote! {
                     #vis fn #method_name(&self) -> #variant_handle_ident<__Origin> {
                         #variant_handle_ident {
-                            path: self.path()
+                            path: self.path.clone()
                         }
                     }
                 }
@@ -194,14 +194,9 @@ impl Expand<'_> {
         // Generate one struct per data-carrying variant. The same struct is
         // both the entry point returned by `email()` (used for `.matches(...)`
         // filters and direct `.eq()`/include path access) and the namespace
-        // for variant-field accessors. The struct stores the parent path
-        // (the path to the embed enum field) and exposes:
-        //
-        // - `parent_path()` — model-rooted path to the enum field. Used by
-        //   `matches()` to build the `is_variant` gate and by every filter
-        //   method on a variant-rooted Path to inject the implicit gate.
-        // - `path()` — variant-rooted path. Field accessors chain off this
-        //   so that the produced Path knows its variant context.
+        // for variant-field accessors. The struct stores the model-rooted path
+        // to the enum field. `matches()` uses it to build the `is_variant` gate,
+        // while field accessors add the variant step before chaining the field.
         let variant_field_structs: Vec<_> = embedded_enum
             .variants
             .iter()
@@ -210,6 +205,13 @@ impl Expand<'_> {
             .map(|(variant_index, variant)| {
                 let variant_handle_ident = variant.variant_handle_ident.as_ref().unwrap();
                 let variant_idx = util::int(variant_index);
+                let variant_path = quote! {{
+                    let variant_id = #toasty::core::schema::app::VariantId {
+                        model: <#model_ident as #toasty::Embed>::id(),
+                        index: #variant_idx,
+                    };
+                    self.path.clone().into_variant(variant_id)
+                }};
 
                 let field_methods: Vec<_> = self
                     .variant_fields(variant_index)
@@ -229,6 +231,7 @@ impl Expand<'_> {
                             field_ident,
                             field_ty,
                             &field_offset,
+                            &variant_path,
                         ))
                     })
                     .collect();
@@ -239,24 +242,12 @@ impl Expand<'_> {
                     }
 
                     impl<__Origin> #variant_handle_ident<__Origin> {
-                        fn parent_path(&self) -> #toasty::Path<__Origin, #model_ident> {
-                            self.path.clone()
-                        }
-
-                        fn path(&self) -> #toasty::Path<__Origin, #model_ident> {
-                            let variant_id = #toasty::core::schema::app::VariantId {
-                                model: <#model_ident as #toasty::Embed>::id(),
-                                index: #variant_idx,
-                            };
-                            self.parent_path().into_variant(variant_id)
-                        }
-
                         #vis fn matches(
                             self,
                             f: impl FnOnce(Self) -> #toasty::stmt::Expr<bool>,
                         ) -> #toasty::stmt::Expr<bool> {
                             let parent_stmt: #toasty::core::stmt::Expr = {
-                                let p: #toasty::core::stmt::Path = self.parent_path().into();
+                                let p: #toasty::core::stmt::Path = self.path.clone().into();
                                 p.into_stmt()
                             };
                             let variant_id = #toasty::core::schema::app::VariantId {
@@ -284,10 +275,6 @@ impl Expand<'_> {
             }
 
             impl<__Origin> #field_struct_ident<__Origin> {
-                fn path(&self) -> #toasty::Path<__Origin, #model_ident> {
-                    self.path.clone()
-                }
-
                 #( #is_variant_methods )*
 
                 #( #variant_accessor_methods )*

--- a/crates/toasty-macros/src/model/expand/fields.rs
+++ b/crates/toasty-macros/src/model/expand/fields.rs
@@ -140,6 +140,7 @@ impl Expand<'_> {
         quote!(
             #struct_def
 
+            #[allow(dead_code)]
             impl<__Origin> #field_struct_ident<__Origin> {
                 #vis fn in_query(self, rhs: impl #toasty::IntoStatement<Returning = #toasty::List<#model_ident>>) -> #toasty::stmt::Expr<bool> {
                     self.path.in_query(rhs)
@@ -404,6 +405,7 @@ impl Expand<'_> {
         quote!(
             #struct_def
 
+            #[allow(dead_code)]
             impl<__Origin> #field_list_struct_ident<__Origin> {
                 #any_method
 

--- a/crates/toasty-macros/src/model/expand/fields.rs
+++ b/crates/toasty-macros/src/model/expand/fields.rs
@@ -5,8 +5,6 @@ use proc_macro2::TokenStream;
 use quote::{quote, quote_spanned};
 
 const FIELD_STRUCT_RESERVED_METHODS: &[&str] = &[
-    "from_path",
-    "path",
     "eq",
     "ne",
     "in_query",
@@ -16,15 +14,7 @@ const FIELD_STRUCT_RESERVED_METHODS: &[&str] = &[
     "create",
 ];
 
-const FIELD_LIST_STRUCT_RESERVED_METHODS: &[&str] = &[
-    "from_path",
-    "path",
-    "any",
-    "all",
-    "filter",
-    "order_by",
-    "create",
-];
+const FIELD_LIST_STRUCT_RESERVED_METHODS: &[&str] = &["any", "all", "filter", "order_by", "create"];
 
 impl Expand<'_> {
     pub(super) fn expand_field_struct(&self) -> TokenStream {
@@ -79,7 +69,12 @@ impl Expand<'_> {
                         // `#[document]`) yields a chainable Fields handle
                         // (`profile().name()`), a `Vec<_>` collection yields a
                         // list leaf.
-                        self.expand_primitive_field_method(field_ident, ty, &field_offset)
+                        self.expand_primitive_field_method(
+                            field_ident,
+                            ty,
+                            &field_offset,
+                            &quote!(self.path.clone()),
+                        )
                     }
                     BelongsTo(rel) => {
                         self.expand_one_relation_field_method(
@@ -101,7 +96,7 @@ impl Expand<'_> {
                         let ty = &rel.ty;
                         let span = field_ident.span();
                         let path = quote! {
-                            self.path().chain(<#model_ident as #field_schema_trait>::path_field(#field_offset))
+                            self.path.clone().chain(<#model_ident as #field_schema_trait>::path_field(#field_offset))
                         };
 
                         if rel.via.is_some() {
@@ -122,7 +117,7 @@ impl Expand<'_> {
                         } else {
                             quote_spanned! { span=>
                                 #vis fn #field_ident(&self) -> <<#ty as #toasty::RelationManyField>::Target as #toasty::Model>::ManyField<__Origin> {
-                                    <<<#ty as #toasty::RelationManyField>::Target as #toasty::Model>::ManyField<__Origin>>::from_path(#path)
+                                    <<#ty as #toasty::RelationManyField>::Target as #toasty::Model>::new_many_field(#path)
                                 }
                             }
                         }
@@ -146,14 +141,6 @@ impl Expand<'_> {
             #struct_def
 
             impl<__Origin> #field_struct_ident<__Origin> {
-                #vis const fn from_path(path: #toasty::Path<__Origin, #model_ident>) -> #field_struct_ident<__Origin> {
-                    #field_struct_ident { path }
-                }
-
-                fn path(&self) -> #toasty::Path<__Origin, #model_ident> {
-                    self.path.clone()
-                }
-
                 #vis fn in_query(self, rhs: impl #toasty::IntoStatement<Returning = #toasty::List<#model_ident>>) -> #toasty::stmt::Expr<bool> {
                     self.path.in_query(rhs)
                 }
@@ -167,7 +154,9 @@ impl Expand<'_> {
                 #[doc(hidden)]
                 pub fn into_root(self) -> #field_struct_ident<#model_ident> {
                     let _ = self;
-                    #field_struct_ident::from_path(<#model_ident as #schema_trait>::path_root())
+                    #field_struct_ident {
+                        path: <#model_ident as #schema_trait>::path_root(),
+                    }
                 }
 
                 #include_modifier_methods
@@ -349,7 +338,7 @@ impl Expand<'_> {
                         quote_spanned! { span=>
                             #vis fn #field_ident(&self) -> #toasty::ViaPath<#ty, __Origin> {
                                 <<#ty as #toasty::ViaManyField>::Target as #toasty::ViaTarget>::new_path(
-                                    self.path().chain(
+                                    self.path.clone().chain(
                                         <#model_ident as #schema_trait>::path_field(#field_offset)
                                     )
                                 )
@@ -416,14 +405,6 @@ impl Expand<'_> {
             #struct_def
 
             impl<__Origin> #field_list_struct_ident<__Origin> {
-                #vis const fn from_path(path: #toasty::Path<__Origin, #toasty::List<#model_ident>>) -> #field_list_struct_ident<__Origin> {
-                    #field_list_struct_ident { path }
-                }
-
-                fn path(&self) -> #toasty::Path<__Origin, #toasty::List<#model_ident>> {
-                    self.path.clone()
-                }
-
                 #any_method
 
                 #include_modifier_methods
@@ -555,7 +536,7 @@ impl Expand<'_> {
         quote_spanned! { span=>
             #vis fn #field_ident(&self) -> <#ty as #toasty::Field>::ListPath<__Origin> {
                 <#ty as #toasty::Field>::new_list_path(
-                    self.path().chain(
+                    self.path.clone().chain(
                         <#model_ident as #schema_trait>::path_field(#field_offset)
                     )
                 )
@@ -580,8 +561,8 @@ impl Expand<'_> {
 
         quote_spanned! { span=>
             #vis fn #field_ident(&self) -> <<#ty as #field_trait>::Target as #toasty::Model>::ManyField<__Origin> {
-                <<<#ty as #field_trait>::Target as #toasty::Model>::ManyField<__Origin>>::from_path(
-                    self.path().chain(
+                <<#ty as #field_trait>::Target as #toasty::Model>::new_many_field(
+                    self.path.clone().chain(
                         <#model_ident as #schema_trait>::path_field(#field_offset)
                     )
                 )

--- a/crates/toasty-macros/src/model/expand/model.rs
+++ b/crates/toasty-macros/src/model/expand/model.rs
@@ -143,13 +143,13 @@ impl Expand<'_> {
                 }
 
                 fn new_path<__Origin>(path: #toasty::Path<__Origin, Self>) -> Self::Path<__Origin> {
-                    #field_struct_ident::from_path(path)
+                    #field_struct_ident { path }
                 }
 
                 fn new_many_field<__Origin>(
                     path: #toasty::Path<__Origin, #toasty::List<Self>>,
                 ) -> #field_list_struct_ident<__Origin> {
-                    #field_list_struct_ident::from_path(path)
+                    #field_list_struct_ident { path }
                 }
 
                 fn find_by_primary_key(
@@ -177,6 +177,14 @@ impl Expand<'_> {
                 }
 
                 #field_name_to_id
+            }
+
+            impl #toasty::ModelCodegen for #model_ident {
+                fn new_one_field<__Origin>(
+                    path: #toasty::Path<__Origin, Self>,
+                ) -> Self::OneField<__Origin> {
+                    #field_struct_ident { path }
+                }
             }
 
             // A relation-terminal `#[has_many(via = …)]` reaching this model

--- a/crates/toasty-macros/src/model/expand/query.rs
+++ b/crates/toasty-macros/src/model/expand/query.rs
@@ -258,7 +258,7 @@ impl Expand<'_> {
                 type Create = #create_builder_ident;
 
                 fn new_path<__Origin>(path: #toasty::Path<__Origin, Self::Item>) -> Self::Path<__Origin> {
-                    #field_list_struct_ident::from_path(path)
+                    <#model_ident as #toasty::Model>::new_many_field(path)
                 }
 
                 fn new_create() -> Self::Create {
@@ -266,7 +266,9 @@ impl Expand<'_> {
                 }
 
                 fn new_path_root() -> Self::Path<Self::Item> {
-                    #field_list_struct_ident::from_path(<#model_ident as #toasty::Model>::path_model_list())
+                    <#model_ident as #toasty::Model>::new_many_field(
+                        <#model_ident as #toasty::Model>::path_model_list()
+                    )
                 }
 
                 fn create_in_scope(self) -> Self::Create {
@@ -281,7 +283,7 @@ impl Expand<'_> {
                 type Create = #create_builder_ident;
 
                 fn new_path<__Origin>(path: #toasty::Path<__Origin, Self::Item>) -> Self::Path<__Origin> {
-                    #field_struct_ident::from_path(path)
+                    <#model_ident as #toasty::Model>::new_path(path)
                 }
 
                 fn new_create() -> Self::Create {
@@ -289,7 +291,7 @@ impl Expand<'_> {
                 }
 
                 fn new_path_root() -> Self::Path<Self::Item> {
-                    #field_struct_ident::from_path(<#model_ident as #toasty::Model>::path_root())
+                    <#model_ident as #toasty::Model>::new_root_path()
                 }
 
                 fn create_in_scope(self) -> Self::Create {
@@ -304,7 +306,7 @@ impl Expand<'_> {
                 type Create = #create_builder_ident;
 
                 fn new_path<__Origin>(path: #toasty::Path<__Origin, Self::Item>) -> Self::Path<__Origin> {
-                    #field_struct_ident::from_path(path)
+                    <#model_ident as #toasty::Model>::new_path(path)
                 }
 
                 fn new_create() -> Self::Create {
@@ -312,7 +314,7 @@ impl Expand<'_> {
                 }
 
                 fn new_path_root() -> Self::Path<Self::Item> {
-                    #field_struct_ident::from_path(<#model_ident as #toasty::Model>::path_root())
+                    <#model_ident as #toasty::Model>::new_root_path()
                 }
 
                 fn create_in_scope(self) -> Self::Create {

--- a/crates/toasty/src/codegen_support.rs
+++ b/crates/toasty/src/codegen_support.rs
@@ -37,6 +37,12 @@ pub use toasty_core as core;
 /// signatures (and out of the compiler errors they produce).
 pub type FieldExprTarget<F> = <F as Field>::ExprTarget;
 
+/// Internal constructors used by generated model field accessors.
+pub trait ModelCodegen: Model {
+    /// Construct the field accessor for a singular relation to this model.
+    fn new_one_field<Origin>(path: Path<Origin, Self>) -> Self::OneField<Origin>;
+}
+
 /// Infer the [`Scope`] type from a scope expression and return its fields
 /// path.
 ///

--- a/tests/tests/ui-pass/fields_named_path.rs
+++ b/tests/tests/ui-pass/fields_named_path.rs
@@ -1,0 +1,74 @@
+#![allow(dead_code)]
+
+#[derive(Debug, toasty::Model)]
+struct Parent {
+    #[key]
+    id: i64,
+
+    #[unique]
+    path: String,
+
+    #[unique]
+    from_path: String,
+
+    #[has_many(pair = parent)]
+    children: toasty::Deferred<Vec<Child>>,
+}
+
+#[derive(Debug, toasty::Model)]
+struct Child {
+    #[key]
+    id: i64,
+
+    path: String,
+    from_path: String,
+
+    #[index]
+    parent_id: i64,
+
+    #[belongs_to(key = parent_id, references = id)]
+    parent: toasty::Deferred<Parent>,
+}
+
+#[derive(Debug, toasty::Embed)]
+struct Metadata {
+    path: String,
+    from_path: String,
+}
+
+#[derive(Debug, toasty::Embed)]
+enum Locator {
+    Named {
+        path: String,
+        from_path: String,
+    },
+}
+
+#[derive(Debug, toasty::Model)]
+struct Document {
+    #[key]
+    id: i64,
+
+    metadata: Metadata,
+    locator: Locator,
+}
+
+fn main() {
+    let _: toasty::stmt::Path<Parent, String> = Parent::fields().path();
+    let _: toasty::stmt::Path<Parent, String> = Parent::fields().from_path();
+    let _: toasty::stmt::Path<Parent, toasty::stmt::List<String>> =
+        Parent::fields().children().path();
+    let _: toasty::stmt::Path<Parent, toasty::stmt::List<String>> =
+        Parent::fields().children().from_path();
+    let _: toasty::stmt::Path<Child, String> = Child::fields().parent().path();
+    let _: toasty::stmt::Path<Child, String> = Child::fields().parent().from_path();
+
+    let _ = Parent::filter_by_path("path");
+    let _ = Parent::filter_by_from_path("from_path");
+
+    let _: toasty::stmt::Path<Document, String> = Document::fields().metadata().path();
+    let _: toasty::stmt::Path<Document, String> = Document::fields().metadata().from_path();
+    let _: toasty::stmt::Path<Document, String> = Document::fields().locator().named().path();
+    let _: toasty::stmt::Path<Document, String> =
+        Document::fields().locator().named().from_path();
+}


### PR DESCRIPTION
## Summary

Allow `#[derive(Model)]` and `#[derive(Embed)]` fields named `path` or `from_path`.

Remove colliding inherent helpers from generated field handles and use stored paths plus an internal codegen constructor for singular relations. Add compile-pass coverage for model fields, generated unique filters, relation traversal, embedded structs, and embedded enum variants.

Addresses the `path` and `from_path` field-name collision reported in #1193.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

`ModelCodegen` remains under `codegen_support` and only constructs singular relation field handles. This avoids adding a required method to the public `Model` trait.