### PR TITLE
fix(macros): allow Vec newtypes to derive Embed

### DIFF
--- a/crates/toasty-macros/src/lib.rs
+++ b/crates/toasty-macros/src/lib.rs
@@ -932,8 +932,9 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
 /// let _ = Pin::all().order_by(Pin::fields().location().asc());
 /// ```
 ///
-/// A tuple-newtype must wrap a single-column type. Wrapping a multi-field embed
-/// (or a data-carrying enum) fails to derive.
+/// A tuple-newtype can wrap a non-indexable type, but the wrapper can only
+/// participate in an index when its inner type can. Toasty checks that
+/// requirement when a model uses the wrapper in an index or unique constraint.
 ///
 /// ```compile_fail
 /// # #[derive(toasty::Embed)]
@@ -941,9 +942,15 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
 /// #     x: i64,
 /// #     y: i64,
 /// # }
-/// // Error: `Point` spans multiple columns, so `Outer` cannot forward to it
 /// #[derive(toasty::Embed)]
 /// struct Outer(Point);
+/// # #[derive(toasty::Model)]
+/// # struct Pin {
+/// #     #[key]
+/// #     id: i64,
+/// #     #[index]
+/// #     location: Outer,
+/// # }
 /// ```
 ///
 /// ## Nesting

--- a/crates/toasty-macros/src/model/expand.rs
+++ b/crates/toasty-macros/src/model/expand.rs
@@ -475,26 +475,23 @@ impl Expand<'_> {
     /// would conflict with the `Box<T>` forwarding impl in
     /// `codegen_support::index`, because `Box` is `#[fundamental]`.
     ///
-    /// The where clause names a concrete type, so Rust's trivial-bounds
-    /// rule evaluates it at the impl rather than at use sites: deriving a
-    /// newtype over a non-indexable inner (a multi-field embed, a
-    /// data-carrying enum) is a compile error, not an unindexable-but-valid
-    /// type. Other newtype codegen relies on that rejection — see
-    /// `expand_field_struct_comparison_methods`, whose ordering methods
-    /// assume
-    /// every derivable newtype has a single-column inner.
+    /// Route the inner type through a generic parameter constrained by
+    /// `NewtypeOf::Inner`. This defers the `IndexableField` obligation until an
+    /// index uses the newtype instead of rejecting every non-indexable wrapper
+    /// at its derive site.
     fn expand_embedded_indexable_impl(&self) -> TokenStream {
-        let Some(inner_ty) = self.canonical_newtype_inner() else {
+        if self.canonical_newtype_inner().is_none() {
             return quote! {};
-        };
+        }
 
         let toasty = &self.toasty;
         let model_ident = &self.model.ident;
 
         quote! {
-            impl #toasty::index::IndexableField for #model_ident
+            impl<__Inner> #toasty::index::IndexableField for #model_ident
             where
-                #inner_ty: #toasty::index::IndexableField,
+                #model_ident: #toasty::newtype::NewtypeOf<Inner = __Inner>,
+                __Inner: #toasty::index::IndexableField,
             {}
         }
     }

--- a/crates/toasty-macros/src/model/expand/fields.rs
+++ b/crates/toasty-macros/src/model/expand/fields.rs
@@ -198,11 +198,9 @@ impl Expand<'_> {
     /// root model they compare a model reference (lowering to its primary
     /// key), on an embedded struct the engine decomposes the record
     /// across columns (AND for eq, OR for ne). The ordering methods —
-    /// `gt`/`ge`/`lt`/`le` and `asc`/`desc` — are newtype-only: a single
-    /// column keeps the backend's own ordering, while record ordering has
-    /// no shared cross-backend definition. The syntactic newtype check
-    /// suffices because a newtype over a non-single-column inner fails to
-    /// derive — see `expand_embedded_indexable_impl`.
+    /// `gt`/`ge`/`lt`/`le` and `asc`/`desc` — are tuple-newtype-only.
+    /// Multi-field structs do not expose record ordering because backends do
+    /// not share the same semantics.
     fn expand_field_struct_comparison_methods(&self) -> TokenStream {
         let toasty = &self.toasty;
         let vis = &self.model.vis;

--- a/crates/toasty-macros/src/model/expand/model.rs
+++ b/crates/toasty-macros/src/model/expand/model.rs
@@ -486,24 +486,24 @@ impl Expand<'_> {
 
             let value = if fields_named {
                 let field_ident = &field.name.ident;
-                if by_ref {
-                    quote!((&self.#field_ident))
-                } else {
-                    quote!(self.#field_ident)
-                }
+                quote!(self.#field_ident)
             } else {
                 let idx = syn::Index::from(index);
-                if by_ref {
-                    quote!((&self.#idx))
-                } else {
-                    quote!(self.#idx)
-                }
+                quote!(self.#idx)
             };
 
             // Bind through `Field::ExprTarget` so wrappers such as
             // `Deferred<T>` encode the underlying expression type.
             let target_ty = quote!(FieldExprTarget<#ty>);
-            quote!(#toasty::into_untyped_expr::<#target_ty, _>(#value))
+            if by_ref {
+                quote!({
+                    let expr: #toasty::core::stmt::Expr =
+                        <#ty as #toasty::IntoExpr<#target_ty>>::by_ref(&#value).into();
+                    expr
+                })
+            } else {
+                quote!(#toasty::into_untyped_expr::<#target_ty, _>(#value))
+            }
         });
 
         quote! {

--- a/crates/toasty-macros/src/model/expand/schema.rs
+++ b/crates/toasty-macros/src/model/expand/schema.rs
@@ -521,11 +521,11 @@ impl Expand<'_> {
     /// `#[index(...)]` / `#[unique(...)]`) that the field's Rust type implements
     /// `codegen_support::index::IndexableField`.
     ///
-    /// Scalars satisfy the bound directly; newtype embeds via the `NewtypeOf`
-    /// blanket; unit (data-less) enums via the impl emitted by
-    /// `#[derive(Embed)]`. Data-carrying enums and multi-field embedded structs
-    /// span multiple columns and do not implement it, so naming one in an index
-    /// is a compile error instead of a runtime panic.
+    /// Scalars satisfy the bound directly; newtype embeds and unit (data-less)
+    /// enums use impls emitted by `#[derive(Embed)]`. Data-carrying enums and
+    /// multi-field embedded structs span multiple columns and do not implement
+    /// it, so naming one in an index is a compile error instead of a runtime
+    /// panic.
     ///
     /// The primary key is excluded: keys are validated through their own paths.
     pub(super) fn expand_indexable_checks(&self) -> TokenStream {

--- a/tests/tests/embed_newtype_vec.rs
+++ b/tests/tests/embed_newtype_vec.rs
@@ -1,0 +1,7 @@
+#[derive(toasty::Embed)]
+struct List(Vec<String>);
+
+#[test]
+fn derive_embed_for_vec_newtype() {
+    let _ = List(vec!["one".to_owned()]);
+}


### PR DESCRIPTION
## Summary

- allow `#[derive(Embed)]` for tuple newtypes whose inner field is not indexable
- defer `IndexableField` checks until a model uses the newtype in an index
- encode borrowed embedded `Vec<T>` fields through `IntoExpr::by_ref`
- add a regression test for `struct List(Vec<String>)`

Addresses part of #1193.

## Type of change

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes

## Notes for reviewers

The indexed case remains rejected when the inner type does not implement `IndexableField`.