### PR TITLE
feat: add Model::primary_key_order_bys for deterministic pagination

### DIFF
--- a/crates/toasty/src/schema/model.rs
+++ b/crates/toasty/src/schema/model.rs
@@ -1,5 +1,5 @@
 use super::Load;
-use crate::stmt::{Expr, IntoExpr, IntoInsert, List, Path};
+use crate::stmt::{Expr, IntoExpr, IntoInsert, List, OrderByExpr, Path};
 
 use toasty_core::schema::app::{self, FieldId, ModelId, ModelSet};
 
@@ -61,6 +61,28 @@ pub trait Model: Load<Output = Self> + Sized {
 
     /// Returns the schema definition for this model.
     fn schema() -> app::Model;
+
+    /// Ascending [`OrderByExpr`]s for each primary-key field, in primary-key
+    /// order.
+    ///
+    /// With a struct-level `#[key(partition = (…), local = (…))]`, partition
+    /// fields come first, then local — not necessarily field declaration
+    /// order.
+    ///
+    /// Intended as pagination tie-breakers: append these after a user-chosen
+    /// `order_by` so cursor order is deterministic.
+    fn primary_key_order_bys() -> Vec<OrderByExpr> {
+        Self::schema()
+            .as_root_unwrap()
+            .primary_key
+            .fields
+            .iter()
+            .map(|field_id| OrderByExpr {
+                expr: toasty_core::stmt::Expr::ref_self_field(*field_id),
+                order: Some(toasty_core::stmt::Direction::Asc),
+            })
+            .collect()
+    }
 
     /// Register this model and all models reachable through its fields into
     /// the given [`ModelSet`].

--- a/tests/tests/model_primary_key_order_bys.rs
+++ b/tests/tests/model_primary_key_order_bys.rs
@@ -1,0 +1,61 @@
+//! `Model::primary_key_order_bys` returns one ascending order-by per
+//! primary-key field, in primary-key order — partition fields before local,
+//! regardless of field declaration order.
+
+use toasty::schema::Model;
+
+#[derive(Debug, toasty::Model)]
+struct User {
+    #[key]
+    id: i64,
+    name: String,
+}
+
+#[derive(Debug, toasty::Model)]
+struct Membership {
+    #[key]
+    org_id: i64,
+    #[key]
+    user_id: i64,
+}
+
+// `id` is declared first but is the *local* key: the primary-key order must
+// put the partition field first.
+#[derive(Debug, toasty::Model)]
+#[key(partition = tenant, local = id)]
+struct TenantRecord {
+    id: i64,
+    tenant: String,
+}
+
+#[test]
+fn appends_pk_asc_after_user_order_by() {
+    let mut order_bys = vec![User::fields().name().asc()];
+    order_bys.extend(User::primary_key_order_bys());
+    assert_eq!(
+        order_bys,
+        vec![User::fields().name().asc(), User::fields().id().asc()]
+    );
+}
+
+#[test]
+fn composite_pk_fields_in_declaration_order() {
+    assert_eq!(
+        Membership::primary_key_order_bys(),
+        vec![
+            Membership::fields().org_id().asc(),
+            Membership::fields().user_id().asc(),
+        ]
+    );
+}
+
+#[test]
+fn partition_fields_come_before_local() {
+    assert_eq!(
+        TenantRecord::primary_key_order_bys(),
+        vec![
+            TenantRecord::fields().tenant().asc(),
+            TenantRecord::fields().id().asc(),
+        ]
+    );
+}


### PR DESCRIPTION
## Summary

Adds `Model::primary_key_order_bys()` — ascending `OrderByExpr`s for
each primary-key field, as pagination tie-breakers:
`order.extend(User::primary_key_order_bys())` after a user-chosen
`order_by`. Without it, callers need `Expr::ref_self_field` and
`Direction`, which are not user-facing.

## Type of change

- [x] Small / obvious change

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [ ] Touches a public API → a design doc under `docs/dev/design/`
      describes the behavior — read-only views over the existing app
      schema; no new behavior or driver contract

Edit: already solved in https://github.com/tokio-rs/toasty/commit/beca003034760bf2a54460b6a759523a79ca491f