### PR TITLE
feat(turso)!: connect to Turso Cloud over HTTP (serverless)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,7 +293,16 @@ jobs:
         id: turso-sync
         env:
           TOASTY_TEST_TURSO_SYNC_URL: ${{ steps.turso-sync.outputs.sync-url }}
-      - run: cargo test -p toasty-driver-turso --features sync
+      - name: driver tests (sync)
+        run: cargo test -p toasty-driver-turso --features sync
+      # Sync and serverless must compose: same tests plus the combined-mode
+      # matrix, with both features enabled.
+      - name: driver tests (sync + serverless)
+        run: cargo test -p toasty-driver-turso --features sync,serverless
+      # The embedded integration suite must be unaffected by enabling every
+      # turso feature.
+      - name: embedded suite (all turso features)
+        run: cargo test -p tests --features turso,turso-sync,turso-serverless --test turso
 
   test-all-os:
     needs: check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,7 @@ rustls-webpki = { version = "0.103", default-features = false, features = ["allo
 tokio-stream = { version = "0.1.18", default-features = false }
 tracing = "0.1"
 turso = "0.7"
+turso_serverless = "0.1.3"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 trybuild = { version = "1.0.116", features = ["diff"] }
 url = "2.5.8"

--- a/crates/toasty-driver-turso/Cargo.toml
+++ b/crates/toasty-driver-turso/Cargo.toml
@@ -16,6 +16,7 @@ documentation = "https://docs.rs/toasty-driver-turso"
 [features]
 default = []
 sync = ["turso/sync"]
+serverless = ["dep:turso_serverless"]
 rust_decimal = ["toasty-core/rust_decimal", "toasty-sql/rust_decimal"]
 bigdecimal = ["toasty-core/bigdecimal", "toasty-sql/bigdecimal"]
 jiff = ["toasty-core/jiff", "toasty-sql/jiff"]
@@ -29,6 +30,7 @@ serde.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 turso.workspace = true
+turso_serverless = { workspace = true, optional = true }
 uuid.workspace = true
 
 [dev-dependencies]

--- a/crates/toasty-driver-turso/src/conn.rs
+++ b/crates/toasty-driver-turso/src/conn.rs
@@ -1,0 +1,234 @@
+//! Runtime dispatch between the embedded `turso` connection and the
+//! serverless (`turso_serverless`) HTTP connection.
+//!
+//! The serverless crate deliberately mirrors the embedded driver's API,
+//! so each wrapper here is a two-armed enum whose methods forward
+//! verbatim. Values are normalized to [`turso::Value`] at the row
+//! boundary and errors are classified into Toasty errors right here, so
+//! the rest of the driver is independent of which transport produced a
+//! result.
+
+use toasty_core::Result;
+use turso::Value as TursoValue;
+
+use crate::error::classify_turso_error;
+#[cfg(feature = "serverless")]
+use crate::{
+    error::classify_serverless_error,
+    value::{from_serverless, to_serverless},
+};
+
+#[cfg(feature = "serverless")]
+fn to_serverless_params(params: Vec<TursoValue>) -> Vec<turso_serverless::Value> {
+    params.into_iter().map(to_serverless).collect()
+}
+
+pub(crate) enum AnyConn {
+    Embedded(turso::Connection),
+    #[cfg(feature = "serverless")]
+    Serverless(turso_serverless::Connection),
+}
+
+impl AnyConn {
+    /// Whether this connection talks to a remote serverless database.
+    pub(crate) fn is_serverless(&self) -> bool {
+        match self {
+            Self::Embedded(_) => false,
+            #[cfg(feature = "serverless")]
+            Self::Serverless(_) => true,
+        }
+    }
+
+    pub(crate) async fn execute(&self, sql: &str, params: Vec<TursoValue>) -> Result<u64> {
+        match self {
+            Self::Embedded(conn) => conn
+                .execute(sql, params)
+                .await
+                .map_err(classify_turso_error),
+            #[cfg(feature = "serverless")]
+            Self::Serverless(conn) => conn
+                .execute(sql, to_serverless_params(params))
+                .await
+                .map_err(classify_serverless_error),
+        }
+    }
+
+    /// Executes parameterized statements atomically inside a
+    /// `BEGIN IMMEDIATE` transaction. On the serverless transport the
+    /// whole batch — transaction control included — is one HTTP request.
+    /// On failure nothing stays applied, so callers may simply retry.
+    pub(crate) async fn transactional_batch(
+        &self,
+        stmts: &[(String, Vec<TursoValue>)],
+    ) -> Result<()> {
+        match self {
+            Self::Embedded(conn) => {
+                conn.execute("BEGIN IMMEDIATE", ())
+                    .await
+                    .map_err(classify_turso_error)?;
+                for (sql, params) in stmts {
+                    if let Err(err) = conn.execute(sql, params.clone()).await {
+                        let _ = conn.execute("ROLLBACK", ()).await;
+                        return Err(classify_turso_error(err));
+                    }
+                }
+                if let Err(err) = conn.execute("COMMIT", ()).await {
+                    let _ = conn.execute("ROLLBACK", ()).await;
+                    return Err(classify_turso_error(err));
+                }
+                Ok(())
+            }
+            #[cfg(feature = "serverless")]
+            Self::Serverless(conn) => {
+                let stmts = stmts
+                    .iter()
+                    .map(|(sql, params)| {
+                        turso_serverless::BatchStatement::new(
+                            sql,
+                            to_serverless_params(params.clone()),
+                        )
+                    })
+                    .collect::<turso_serverless::Result<Vec<_>>>()
+                    .map_err(classify_serverless_error)?;
+                conn.transactional_batch(stmts, turso_serverless::TransactionBehavior::Immediate)
+                    .await
+                    .map(|_| ())
+                    .map_err(classify_serverless_error)
+            }
+        }
+    }
+
+    pub(crate) async fn query(&self, sql: &str, params: Vec<TursoValue>) -> Result<AnyRows> {
+        match self {
+            Self::Embedded(conn) => conn
+                .query(sql, params)
+                .await
+                .map(AnyRows::Embedded)
+                .map_err(classify_turso_error),
+            #[cfg(feature = "serverless")]
+            Self::Serverless(conn) => conn
+                .query(sql, to_serverless_params(params))
+                .await
+                .map(AnyRows::Serverless)
+                .map_err(classify_serverless_error),
+        }
+    }
+
+    pub(crate) async fn prepare_cached(&self, sql: &str) -> Result<AnyStatement> {
+        match self {
+            Self::Embedded(conn) => conn
+                .prepare_cached(sql)
+                .await
+                .map(AnyStatement::Embedded)
+                .map_err(classify_turso_error),
+            #[cfg(feature = "serverless")]
+            Self::Serverless(conn) => conn
+                .prepare_cached(sql)
+                .await
+                .map(AnyStatement::Serverless)
+                .map_err(classify_serverless_error),
+        }
+    }
+
+    pub(crate) async fn pragma_update(&self, pragma: &str, value: &str) -> Result<()> {
+        match self {
+            Self::Embedded(conn) => conn
+                .pragma_update(pragma, value)
+                .await
+                .map(|_| ())
+                .map_err(classify_turso_error),
+            #[cfg(feature = "serverless")]
+            Self::Serverless(conn) => conn
+                .pragma_update(pragma, value)
+                .await
+                .map(|_| ())
+                .map_err(classify_serverless_error),
+        }
+    }
+}
+
+pub(crate) enum AnyStatement {
+    Embedded(turso::Statement),
+    #[cfg(feature = "serverless")]
+    Serverless(turso_serverless::Statement),
+}
+
+impl AnyStatement {
+    pub(crate) async fn execute(&mut self, params: Vec<TursoValue>) -> Result<u64> {
+        match self {
+            Self::Embedded(stmt) => stmt.execute(params).await.map_err(classify_turso_error),
+            #[cfg(feature = "serverless")]
+            Self::Serverless(stmt) => stmt
+                .execute(to_serverless_params(params))
+                .await
+                .map_err(classify_serverless_error),
+        }
+    }
+
+    pub(crate) async fn query(&mut self, params: Vec<TursoValue>) -> Result<AnyRows> {
+        match self {
+            Self::Embedded(stmt) => stmt
+                .query(params)
+                .await
+                .map(AnyRows::Embedded)
+                .map_err(classify_turso_error),
+            #[cfg(feature = "serverless")]
+            Self::Serverless(stmt) => stmt
+                .query(to_serverless_params(params))
+                .await
+                .map(AnyRows::Serverless)
+                .map_err(classify_serverless_error),
+        }
+    }
+}
+
+pub(crate) enum AnyRows {
+    Embedded(turso::Rows),
+    #[cfg(feature = "serverless")]
+    Serverless(turso_serverless::Rows),
+}
+
+impl AnyRows {
+    pub(crate) async fn next(&mut self) -> Result<Option<AnyRow>> {
+        match self {
+            Self::Embedded(rows) => rows
+                .next()
+                .await
+                .map(|row| row.map(AnyRow::Embedded))
+                .map_err(classify_turso_error),
+            #[cfg(feature = "serverless")]
+            Self::Serverless(rows) => rows
+                .next()
+                .await
+                .map(|row| row.map(AnyRow::Serverless))
+                .map_err(classify_serverless_error),
+        }
+    }
+}
+
+pub(crate) enum AnyRow {
+    Embedded(turso::Row),
+    #[cfg(feature = "serverless")]
+    Serverless(turso_serverless::Row),
+}
+
+impl AnyRow {
+    pub(crate) fn column_count(&self) -> usize {
+        match self {
+            Self::Embedded(row) => row.column_count(),
+            #[cfg(feature = "serverless")]
+            Self::Serverless(row) => row.column_count(),
+        }
+    }
+
+    pub(crate) fn get_value(&self, index: usize) -> Result<TursoValue> {
+        match self {
+            Self::Embedded(row) => row.get_value(index).map_err(classify_turso_error),
+            #[cfg(feature = "serverless")]
+            Self::Serverless(row) => row
+                .get_value(index)
+                .map(from_serverless)
+                .map_err(classify_serverless_error),
+        }
+    }
+}

--- a/crates/toasty-driver-turso/src/error.rs
+++ b/crates/toasty-driver-turso/src/error.rs
@@ -27,3 +27,29 @@ pub(crate) fn classify_turso_error(err: TursoError) -> Error {
         _ => Error::driver_operation_failed(err),
     }
 }
+
+/// Classifies a [`turso_serverless::Error`] into a Toasty [`Error`].
+///
+/// Same mapping as [`classify_turso_error`], with two transport-specific
+/// deltas: [`Http`](turso_serverless::Error::Http) (the serverless
+/// analogue of `IoError`) maps to [`Error::connection_lost`], and
+/// `"Database schema changed"` — the backend aborting a transaction that
+/// spanned a concurrent schema commit — is a retryable
+/// [`Error::serialization_failure`].
+#[cfg(feature = "serverless")]
+pub(crate) fn classify_serverless_error(err: turso_serverless::Error) -> Error {
+    use turso_serverless::Error as ServerlessError;
+    match err {
+        ServerlessError::Busy(msg) | ServerlessError::BusySnapshot(msg) => {
+            Error::serialization_failure(msg)
+        }
+        ServerlessError::Error(msg)
+            if msg.contains("conflict") || msg.contains("schema changed") =>
+        {
+            Error::serialization_failure(msg)
+        }
+        ServerlessError::Readonly(msg) => Error::read_only_transaction(msg),
+        ServerlessError::Http(_) => Error::connection_lost(err),
+        _ => Error::driver_operation_failed(err),
+    }
+}

--- a/crates/toasty-driver-turso/src/lib.rs
+++ b/crates/toasty-driver-turso/src/lib.rs
@@ -1484,6 +1484,97 @@ mod serverless_tests {
     }
 }
 
+/// With both the `sync` and `serverless` features enabled, the three
+/// engines coexist and the driver's configuration picks exactly one:
+/// the connection URL's shape selects serverless, sync options select
+/// the sync engine, and an unconfigured driver stays local.
+#[cfg(all(test, feature = "sync", feature = "serverless"))]
+mod combined_mode_tests {
+    use super::{AnyDatabase, Turso};
+
+    fn remote() -> Turso {
+        Turso::new("turso://my-db.aws-us-east-1.turso.io").unwrap()
+    }
+
+    /// A remote (serverless) URL wins over sync mode: `with_auth_token`
+    /// implies sync for file-backed databases, but against a Turso Cloud
+    /// URL the token is a serverless credential, not a request to sync.
+    #[tokio::test]
+    async fn remote_url_with_auth_token_is_serverless() {
+        let driver = remote().with_auth_token("token");
+        assert!(!driver.is_sync());
+
+        // Building a serverless handle performs no network I/O.
+        assert!(matches!(
+            driver.database().await.unwrap(),
+            AnyDatabase::Serverless(_)
+        ));
+    }
+
+    /// Sync replicates a local file; pointing a sync-configured driver at
+    /// a remote (serverless) URL is contradictory and rejected, not
+    /// resolved by precedence.
+    #[tokio::test]
+    async fn sync_options_with_remote_url_are_rejected() {
+        let driver = remote().with_sync();
+        assert!(
+            driver.database().await.is_err(),
+            "sync mode against a serverless URL must be rejected"
+        );
+
+        let driver = remote().with_remote_url("http://elsewhere");
+        assert!(
+            driver.database().await.is_err(),
+            "with_remote_url against a serverless URL must be rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn unconfigured_driver_is_local() {
+        assert!(matches!(
+            Turso::in_memory().database().await.unwrap(),
+            AnyDatabase::Local(_)
+        ));
+    }
+
+    /// The rotating-token callback follows the same credential rules as
+    /// the static token (see `sync_mode_tests`): here it must feed the
+    /// serverless engine, not select sync.
+    #[tokio::test]
+    async fn auth_token_fn_is_a_shared_credential() {
+        let serverless = remote().with_auth_token_fn(|| async { Ok("tok".to_string()) });
+        assert!(!serverless.is_sync());
+        assert!(matches!(
+            serverless.database().await.unwrap(),
+            AnyDatabase::Serverless(_)
+        ));
+    }
+
+    /// A remote encryption key against a serverless URL is a serverless
+    /// credential (sent as the `x-turso-encryption-key` header), not a
+    /// sync request.
+    #[tokio::test]
+    async fn remote_encryption_key_passes_through_for_serverless() {
+        let driver = remote().with_remote_encryption_key("a2V5");
+        assert!(!driver.is_sync(), "an encryption key is not a mode request");
+        assert!(
+            matches!(driver.database().await.unwrap(), AnyDatabase::Serverless(_)),
+            "the key must ride along to the serverless engine"
+        );
+    }
+
+    /// Sync operations must be rejected for a serverless database even
+    /// when the `sync` feature is compiled in.
+    #[tokio::test]
+    async fn sync_operations_rejected_for_serverless() {
+        let driver = remote().with_auth_token("token");
+        assert!(
+            driver.sync_database().await.is_err(),
+            "a serverless database has no local replica to sync"
+        );
+    }
+}
+
 #[cfg(all(test, feature = "sync"))]
 mod sync_tests {
     use super::{Turso, TursoValue};

--- a/crates/toasty-driver-turso/src/lib.rs
+++ b/crates/toasty-driver-turso/src/lib.rs
@@ -10,6 +10,13 @@
 //! toggles for Turso's experimental features (`experimental_encryption`,
 //! `experimental_attach`, etc.) that mirror [`turso::Builder`].
 //!
+//! Cargo features only make capabilities available; which engine a driver
+//! opens is decided at runtime by its configuration. With the `sync`
+//! feature, a driver configured with [`Turso::with_remote_url`] (or any
+//! other sync option, or [`Turso::with_sync`]) opens Turso's sync engine;
+//! an unconfigured driver always opens the plain local engine, feature or
+//! not.
+//!
 //! [toasty-driver-sqlite]: https://docs.rs/toasty-driver-sqlite
 //!
 //! # Examples
@@ -68,10 +75,8 @@ use toasty_core::{
 use toasty_sql::{self as sql};
 use tokio::sync::Mutex;
 #[cfg(feature = "sync")]
-use turso::sync::{AuthTokenFn, Builder, Database};
-#[cfg(not(feature = "sync"))]
-use turso::{Builder, Database};
-use turso::{Connection as TursoConn, Statement, Value as TursoValue};
+use turso::sync::{AuthTokenFn, Builder as SyncBuilder, Database as SyncDatabase};
+use turso::{Builder, Connection as TursoConn, Database, Statement, Value as TursoValue};
 
 enum SqlReturn {
     Count,
@@ -108,21 +113,22 @@ enum TursoPath {
     InMemory,
 }
 
-/// Driver builder options applied when opening a [`turso::Database`].
+/// Driver builder options applied when opening a database.
+///
+/// Local and sync options coexist; which set applies is decided at
+/// [`Turso::database`] time by the driver's mode, not at compile time.
 #[derive(Debug, Default, Clone)]
 struct BuilderOptions {
     index_method: bool,
 
-    #[cfg(not(feature = "sync"))]
     local_options: LocalBuilderOptions,
 
     #[cfg(feature = "sync")]
     sync_options: SyncBuilderOptions,
 }
 
-#[cfg(not(feature = "sync"))]
 impl BuilderOptions {
-    fn apply(&self, mut b: Builder) -> Builder {
+    fn apply_local(&self, mut b: Builder) -> Builder {
         b = self.local_options.apply(b);
         if self.index_method {
             b = b.experimental_index_method(true);
@@ -135,7 +141,6 @@ impl BuilderOptions {
 /// `turso::Builder::experimental_*` method and is applied in
 /// [`LocalBuilderOptions::apply`] when the driver constructs a fresh
 /// [`turso::Builder`] at connection time.
-#[cfg(not(feature = "sync"))]
 #[derive(Debug, Default, Clone)]
 struct LocalBuilderOptions {
     encryption: Option<EncryptionOpts>,
@@ -148,8 +153,21 @@ struct LocalBuilderOptions {
     without_rowid: bool,
 }
 
-#[cfg(not(feature = "sync"))]
 impl LocalBuilderOptions {
+    /// Whether any local-engine option was configured. Used to reject
+    /// configurations that combine local-only options with sync mode.
+    #[cfg(feature = "sync")]
+    fn any_set(&self) -> bool {
+        self.encryption.is_some()
+            || self.attach
+            || self.custom_types
+            || self.generated_columns
+            || self.materialized_views
+            || self.vacuum
+            || self.multiprocess_wal
+            || self.without_rowid
+    }
+
     fn apply(&self, mut b: Builder) -> Builder {
         if let Some(opts) = &self.encryption {
             // Upstream requires *both* the feature flag and the
@@ -248,7 +266,7 @@ impl fmt::Debug for SyncBuilderOptions {
 
 #[cfg(feature = "sync")]
 impl BuilderOptions {
-    fn apply(&self, mut b: Builder) -> Builder {
+    fn apply_sync(&self, mut b: SyncBuilder) -> SyncBuilder {
         if let Some(remote_url) = &self.sync_options.remote_url {
             b = b.with_remote_url(remote_url)
         }
@@ -322,12 +340,28 @@ pub struct Turso {
     path: TursoPath,
     options: BuilderOptions,
     concurrent_writes: bool,
-    /// Shared `turso::Database` reused across every `connect()` call so that
+    /// Whether the driver opens the sync engine instead of the plain
+    /// local one. Set by [`Turso::with_sync`] and implied by the
+    /// mode-selecting sync options (`with_remote_url`, `with_client_name`,
+    /// ...) — but never by credentials.
+    #[cfg(feature = "sync")]
+    sync_mode: bool,
+    /// Shared database handle reused across every `connect()` call so that
     /// all pool slots see the same underlying database. Without this, each
     /// connection to `:memory:` would open a fresh empty database; even
     /// file-backed handles open faster after the first builder run.
     /// Cleared by [`Driver::reset_db`] so the next `connect()` starts fresh.
-    database: Arc<Mutex<Option<Database>>>,
+    database: Arc<Mutex<Option<AnyDatabase>>>,
+}
+
+/// The engine behind a [`Turso`] driver, selected at runtime by the
+/// driver's configuration: the plain local engine, or (with the `sync`
+/// feature) the sync engine that replicates to a remote database.
+#[derive(Clone)]
+enum AnyDatabase {
+    Local(Database),
+    #[cfg(feature = "sync")]
+    Sync(SyncDatabase),
 }
 
 impl Turso {
@@ -368,8 +402,37 @@ impl Turso {
             path,
             options: BuilderOptions::default(),
             concurrent_writes: false,
+            #[cfg(feature = "sync")]
+            sync_mode: false,
             database: Arc::new(Mutex::new(None)),
         }
+    }
+
+    /// Whether this driver opens the sync engine.
+    fn is_sync(&self) -> bool {
+        #[cfg(feature = "sync")]
+        {
+            self.sync_mode
+        }
+        #[cfg(not(feature = "sync"))]
+        {
+            false
+        }
+    }
+
+    /// Open the database with the sync engine even though no sync option
+    /// is set. Mirrors `turso::sync::Builder::new_remote` without a
+    /// remote URL: a file that was previously synced loads its remote URL
+    /// from on-disk metadata.
+    ///
+    /// Every mode-selecting sync option ([`Self::with_remote_url`],
+    /// [`Self::with_client_name`], ...) implies this; it only needs to be
+    /// called explicitly for the metadata-reopen case (credentials such as
+    /// [`Self::with_auth_token`] select nothing by themselves).
+    #[cfg(feature = "sync")]
+    pub fn with_sync(mut self) -> Self {
+        self.sync_mode = true;
+        self
     }
 
     /// Allow transactions to run concurrently instead of serializing on a
@@ -392,9 +455,10 @@ impl Turso {
         self
     }
 
-    /// Enable Turso's experimental index methods. With the `sync` feature,
-    /// mirrors `turso::sync::Builder::experimental_index_method`; otherwise
-    /// mirrors `turso::Builder::experimental_index_method`.
+    /// Enable Turso's experimental index methods. Mirrors
+    /// `turso::Builder::experimental_index_method` (and its
+    /// `turso::sync::Builder` counterpart when the driver is configured
+    /// for sync).
     pub fn experimental_index_method(mut self, on: bool) -> Self {
         self.options.index_method = on;
         self
@@ -404,7 +468,6 @@ impl Turso {
     /// key. Bundles `turso::Builder::experimental_encryption(true)` with
     /// `turso::Builder::with_encryption(opts)` so callers cannot enable
     /// encryption without supplying a key.
-    #[cfg(not(feature = "sync"))]
     pub fn experimental_encryption(mut self, opts: EncryptionOpts) -> Self {
         self.options.local_options.encryption = Some(opts);
         self
@@ -412,7 +475,6 @@ impl Turso {
 
     /// Enable Turso's experimental `ATTACH DATABASE` support. Mirrors
     /// `turso::Builder::experimental_attach`.
-    #[cfg(not(feature = "sync"))]
     pub fn experimental_attach(mut self, on: bool) -> Self {
         self.options.local_options.attach = on;
         self
@@ -420,7 +482,6 @@ impl Turso {
 
     /// Enable Turso's experimental custom types. Mirrors
     /// `turso::Builder::experimental_custom_types`.
-    #[cfg(not(feature = "sync"))]
     pub fn experimental_custom_types(mut self, on: bool) -> Self {
         self.options.local_options.custom_types = on;
         self
@@ -428,7 +489,6 @@ impl Turso {
 
     /// Enable Turso's experimental generated columns. Mirrors
     /// `turso::Builder::experimental_generated_columns`.
-    #[cfg(not(feature = "sync"))]
     pub fn experimental_generated_columns(mut self, on: bool) -> Self {
         self.options.local_options.generated_columns = on;
         self
@@ -436,7 +496,6 @@ impl Turso {
 
     /// Enable Turso's experimental materialized views. Mirrors
     /// `turso::Builder::experimental_materialized_views`.
-    #[cfg(not(feature = "sync"))]
     pub fn experimental_materialized_views(mut self, on: bool) -> Self {
         self.options.local_options.materialized_views = on;
         self
@@ -444,7 +503,6 @@ impl Turso {
 
     /// Enable Turso's experimental `VACUUM`. Mirrors
     /// `turso::Builder::experimental_vacuum`.
-    #[cfg(not(feature = "sync"))]
     pub fn experimental_vacuum(mut self, on: bool) -> Self {
         self.options.local_options.vacuum = on;
         self
@@ -452,7 +510,6 @@ impl Turso {
 
     /// Enable Turso's experimental multi-process WAL. Mirrors
     /// `turso::Builder::experimental_multiprocess_wal`.
-    #[cfg(not(feature = "sync"))]
     pub fn experimental_multiprocess_wal(mut self, on: bool) -> Self {
         self.options.local_options.multiprocess_wal = on;
         self
@@ -460,7 +517,6 @@ impl Turso {
 
     /// Enable Turso's experimental `WITHOUT ROWID` support. Mirrors
     /// `turso::Builder::experimental_without_rowid`.
-    #[cfg(not(feature = "sync"))]
     pub fn experimental_without_rowid(mut self, on: bool) -> Self {
         self.options.local_options.without_rowid = on;
         self
@@ -474,6 +530,7 @@ impl Turso {
     /// was previously synced, Turso loads the URL from on-disk metadata.
     #[cfg(feature = "sync")]
     pub fn with_remote_url(mut self, remote_url: impl Into<String>) -> Self {
+        self.sync_mode = true;
         self.options.sync_options.remote_url = Some(remote_url.into());
         self
     }
@@ -483,6 +540,10 @@ impl Turso {
     ///
     /// The token is sent as a `Bearer` header (without the prefix in this
     /// argument). Overridden by [`Self::with_auth_token_fn`] if called later.
+    ///
+    /// A token is a credential, not a mode request: it does not select the
+    /// sync engine by itself. Configuring a token on a driver that opens a
+    /// plain local database is rejected when the database opens.
     #[cfg(feature = "sync")]
     pub fn with_auth_token(mut self, token: impl Into<String>) -> Self {
         let token = token.into();
@@ -519,6 +580,7 @@ impl Turso {
     /// Defaults to `turso-sync-rust` when unset.
     #[cfg(feature = "sync")]
     pub fn with_client_name(mut self, name: impl Into<String>) -> Self {
+        self.sync_mode = true;
         self.options.sync_options.client_name = Some(name.into());
         self
     }
@@ -527,6 +589,7 @@ impl Turso {
     /// `turso::sync::Builder::with_long_poll_timeout`.
     #[cfg(feature = "sync")]
     pub fn with_long_poll_timeout(mut self, timeout: Duration) -> Self {
+        self.sync_mode = true;
         self.options.sync_options.long_poll_timeout = Some(timeout);
         self
     }
@@ -535,6 +598,9 @@ impl Turso {
     /// Cloud database. Mirrors `turso::sync::Builder::with_remote_encryption`.
     ///
     /// The cipher determines `reserved_bytes` for page layout during bootstrap.
+    ///
+    /// Like [`Self::with_auth_token`], the key is a credential, not a mode
+    /// request.
     #[cfg(feature = "sync")]
     pub fn with_remote_encryption(
         mut self,
@@ -569,6 +635,7 @@ impl Turso {
     /// attaching to an existing local file).
     #[cfg(feature = "sync")]
     pub fn bootstrap_if_empty(mut self, enable: bool) -> Self {
+        self.sync_mode = true;
         self.options.sync_options.bootstrap_if_empty = enable;
         self
     }
@@ -577,6 +644,7 @@ impl Turso {
     /// `turso::sync::Builder::with_partial_sync_opts_experimental`.
     #[cfg(feature = "sync")]
     pub fn experimental_with_partial_sync_opts(mut self, opts: PartialSyncOpts) -> Self {
+        self.sync_mode = true;
         self.options.sync_options.partial_sync_config_experimental = Some(opts);
         self
     }
@@ -588,7 +656,7 @@ impl Turso {
     /// so all connections in the pool see the same pending changes.
     #[cfg(feature = "sync")]
     pub async fn push(&self) -> Result<()> {
-        self.database()
+        self.sync_database()
             .await?
             .push()
             .await
@@ -602,7 +670,7 @@ impl Turso {
     /// when changes were applied, `false` when the remote had nothing new.
     #[cfg(feature = "sync")]
     pub async fn pull(&self) -> Result<bool> {
-        self.database()
+        self.sync_database()
             .await?
             .pull()
             .await
@@ -613,7 +681,7 @@ impl Turso {
     /// [`turso::sync::Database::checkpoint`].
     #[cfg(feature = "sync")]
     pub async fn checkpoint(&self) -> Result<()> {
-        self.database()
+        self.sync_database()
             .await?
             .checkpoint()
             .await
@@ -624,7 +692,7 @@ impl Turso {
     /// [`turso::sync::Database::stats`].
     #[cfg(feature = "sync")]
     pub async fn stats(&self) -> Result<DatabaseSyncStats> {
-        self.database()
+        self.sync_database()
             .await?
             .stats()
             .await
@@ -638,26 +706,73 @@ impl Turso {
         }
     }
 
-    /// Returns the cached `turso::Database`, opening it on first use.
+    /// Returns the cached database handle, opening it on first use.
     ///
     /// All connections handed out by [`Driver::connect`] go through the
     /// same `Database` so that `:memory:` is genuinely shared across pool
     /// slots (each `Builder::new_local(":memory:").build()` would otherwise
     /// produce a fresh, empty database).
-    async fn database(&self) -> Result<Database> {
+    async fn database(&self) -> Result<AnyDatabase> {
         let mut slot = self.database.lock().await;
         if let Some(db) = slot.as_ref() {
             return Ok(db.clone());
         }
 
-        #[cfg(not(feature = "sync"))]
-        let builder = self.options.apply(Builder::new_local(self.path_str()));
-        #[cfg(feature = "sync")]
-        let builder = self.options.apply(Builder::new_remote(self.path_str()));
+        let db = if self.is_sync() {
+            #[cfg(feature = "sync")]
+            {
+                // The sync engine has no counterpart for the local
+                // experimental toggles; reject the combination instead of
+                // silently dropping options.
+                if self.options.local_options.any_set() {
+                    return Err(toasty_core::Error::unsupported_feature(
+                        "local experimental options are not supported when the driver \
+                         is configured for sync",
+                    ));
+                }
+                let builder = self
+                    .options
+                    .apply_sync(SyncBuilder::new_remote(self.path_str()));
+                AnyDatabase::Sync(builder.build().await.map_err(classify_turso_error)?)
+            }
+            #[cfg(not(feature = "sync"))]
+            unreachable!("is_sync() is false without the `sync` feature")
+        } else {
+            // A credential (auth token, remote encryption key) is not a
+            // mode request, so it never selects an engine — but a
+            // credential on a plain local database is a configuration
+            // error, not something to drop silently.
+            #[cfg(feature = "sync")]
+            if self.options.sync_options.auth_token.is_some()
+                || self.options.sync_options.remote_encryption_key.is_some()
+            {
+                return Err(toasty_core::Error::unsupported_feature(
+                    "a remote credential (auth token or encryption key) is configured \
+                     but the driver opens a plain local database; add with_remote_url() \
+                     or with_sync() to sync",
+                ));
+            }
+            let builder = self
+                .options
+                .apply_local(Builder::new_local(self.path_str()));
+            AnyDatabase::Local(builder.build().await.map_err(classify_turso_error)?)
+        };
 
-        let db = builder.build().await.map_err(classify_turso_error)?;
         *slot = Some(db.clone());
         Ok(db)
+    }
+
+    /// Returns the sync engine handle for the sync-only operations
+    /// ([`Self::push`], [`Self::pull`], ...). Errors when the driver is
+    /// not configured for sync.
+    #[cfg(feature = "sync")]
+    async fn sync_database(&self) -> Result<SyncDatabase> {
+        match self.database().await? {
+            AnyDatabase::Sync(db) => Ok(db),
+            AnyDatabase::Local(_) => Err(toasty_core::Error::unsupported_feature(
+                "the driver is not configured for sync; call with_remote_url() or with_sync()",
+            )),
+        }
     }
 }
 
@@ -685,12 +800,11 @@ impl Driver for Turso {
     }
 
     async fn connect(&self, cx: &ConnectContext) -> Result<Box<dyn toasty_core::Connection>> {
-        let db = self.database().await?;
-
-        #[cfg(not(feature = "sync"))]
-        let conn = db.connect().map_err(classify_turso_error)?;
-        #[cfg(feature = "sync")]
-        let conn = db.connect().await.map_err(classify_turso_error)?;
+        let conn = match self.database().await? {
+            AnyDatabase::Local(db) => db.connect().map_err(classify_turso_error)?,
+            #[cfg(feature = "sync")]
+            AnyDatabase::Sync(db) => db.connect().await.map_err(classify_turso_error)?,
+        };
 
         if self.concurrent_writes {
             // `PRAGMA journal_mode = ...` returns the new mode as a row; the
@@ -996,6 +1110,60 @@ impl toasty_core::driver::Connection for Connection {
     }
 }
 
+/// The driver's engine is selected by configuration, not by the `sync`
+/// cargo feature: unconfigured drivers stay local, and any sync option
+/// (or `with_sync()`) flips to the sync engine.
+#[cfg(all(test, feature = "sync"))]
+mod sync_mode_tests {
+    use super::Turso;
+
+    #[test]
+    fn unconfigured_driver_stays_local() {
+        assert!(!Turso::in_memory().is_sync());
+        assert!(!Turso::file("/tmp/db").is_sync());
+        assert!(!Turso::file("/tmp/db").concurrent_writes().is_sync());
+        assert!(!Turso::file("/tmp/db").experimental_attach(true).is_sync());
+    }
+
+    #[test]
+    fn sync_options_imply_sync_mode() {
+        assert!(Turso::file("/tmp/db").with_sync().is_sync());
+        assert!(Turso::file("/tmp/db").with_remote_url("http://x").is_sync());
+        assert!(Turso::file("/tmp/db").with_client_name("c").is_sync());
+    }
+
+    /// A credential (auth token, remote encryption key) is not a mode
+    /// request: it selects nothing by itself, and a credential the
+    /// selected engine cannot use is rejected when the database opens.
+    #[tokio::test]
+    async fn credentials_do_not_imply_sync_mode() {
+        let driver = Turso::file("/tmp/db").with_auth_token("t");
+        assert!(!driver.is_sync());
+        assert!(
+            driver.database().await.is_err(),
+            "a token on a plain local database must be rejected"
+        );
+
+        let driver = Turso::file("/tmp/db").with_remote_encryption_key("a2V5");
+        assert!(!driver.is_sync());
+        assert!(
+            driver.database().await.is_err(),
+            "an encryption key on a plain local database must be rejected"
+        );
+    }
+
+    /// Local experimental options have no sync-engine counterpart; the
+    /// combination is rejected when the database is opened.
+    #[tokio::test]
+    async fn local_options_with_sync_mode_are_rejected() {
+        let driver = Turso::in_memory().experimental_attach(true).with_sync();
+        assert!(
+            driver.database().await.is_err(),
+            "local experimental options must be rejected in sync mode"
+        );
+    }
+}
+
 #[cfg(all(test, feature = "sync"))]
 mod sync_tests {
     use super::{Turso, TursoValue};
@@ -1021,7 +1189,7 @@ mod sync_tests {
                     break;
                 }
                 if Instant::now() >= deadline {
-                    panic!("Turso sync server did not become ready within 30s; url={db_url}");
+                    panic!("Turso sync server did not become ready within 5s; url={db_url}");
                 }
                 sleep(Duration::from_millis(100)).await;
             }
@@ -1065,7 +1233,13 @@ mod sync_tests {
         server.run_sql("DROP TABLE IF EXISTS t").await;
 
         let driver = Turso::in_memory().with_remote_url(&server.db_url);
-        let conn = driver.database().await.unwrap().connect().await.unwrap();
+        let conn = driver
+            .sync_database()
+            .await
+            .unwrap()
+            .connect()
+            .await
+            .unwrap();
 
         conn.execute("DROP TABLE IF EXISTS t", ()).await.unwrap();
         conn.execute("CREATE TABLE t (x TEXT)", ()).await.unwrap();
@@ -1099,12 +1273,24 @@ mod sync_tests {
         assert_eq!(values, vec!["test", "test-2", "test-3"]);
     }
 
+    /// With the `sync` feature enabled but no sync option configured, the
+    /// driver must open the plain local engine — enabling the feature is
+    /// not supposed to change behavior.
     #[tokio::test]
     async fn test_local_db_without_remote_url() {
-        let server = TursoTestServer::new().await;
-        server.run_sql("DROP TABLE IF EXISTS t").await;
-
         let driver = Turso::in_memory();
-        let _ = driver.database().await.unwrap().connect().await.unwrap();
+        match driver.database().await.unwrap() {
+            super::AnyDatabase::Local(db) => {
+                db.connect().unwrap();
+            }
+            super::AnyDatabase::Sync(_) => {
+                panic!("an unconfigured driver must open the local engine")
+            }
+        }
+
+        assert!(
+            driver.sync_database().await.is_err(),
+            "sync operations must be rejected when the driver is not configured for sync"
+        );
     }
 }

--- a/crates/toasty-driver-turso/src/lib.rs
+++ b/crates/toasty-driver-turso/src/lib.rs
@@ -17,6 +17,11 @@
 //! an unconfigured driver always opens the plain local engine, feature or
 //! not.
 //!
+//! With the `serverless` feature, the driver also connects to a remote
+//! Turso Cloud database over HTTP via the [`turso_serverless`] crate. A
+//! connection URL with a host selects serverless mode; a URL with only a
+//! path (or `:memory:`) selects the embedded engine.
+//!
 //! [toasty-driver-sqlite]: https://docs.rs/toasty-driver-sqlite
 //!
 //! # Examples
@@ -33,10 +38,20 @@
 //! // Allow transactions to run concurrently instead of serializing writers
 //! let driver = Turso::file("path/to/db").concurrent_writes();
 //! ```
+//!
+//! ```rust,ignore
+//! // Turso Cloud over HTTP (requires the `serverless` feature)
+//! let driver = Turso::new("turso://my-db.aws-us-east-1.turso.io")?
+//!     .with_auth_token("<token>");
+//! ```
 
+mod conn;
 mod error;
 mod value;
 
+use conn::AnyConn;
+#[cfg(feature = "serverless")]
+use error::classify_serverless_error;
 use error::classify_turso_error;
 
 /// Encryption configuration for Turso. Re-exported from the upstream
@@ -49,10 +64,9 @@ pub use turso::sync::{
 };
 
 use async_trait::async_trait;
-#[cfg(feature = "sync")]
+#[cfg(any(feature = "sync", feature = "serverless"))]
 use std::future::Future;
-#[cfg(feature = "sync")]
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use std::{
     borrow::Cow,
     fmt,
@@ -76,7 +90,7 @@ use toasty_sql::{self as sql};
 use tokio::sync::Mutex;
 #[cfg(feature = "sync")]
 use turso::sync::{AuthTokenFn, Builder as SyncBuilder, Database as SyncDatabase};
-use turso::{Builder, Connection as TursoConn, Database, Statement, Value as TursoValue};
+use turso::{Builder, Database, Value as TursoValue};
 
 enum SqlReturn {
     Count,
@@ -107,10 +121,55 @@ fn create_table_stmts(schema: &db::Schema, table: &Table) -> Vec<String> {
     stmts
 }
 
+/// Retries an operation while the database reports a retryable
+/// conflict (busy write lock, serialization failure).
+///
+/// A lock-taking `BEGIN` fails fast with "busy" while contended, and the
+/// serverless backend has no server-side busy timeout, so the wait
+/// happens here, with backoff. Retrying is safe for the two callers: a
+/// busy `BEGIN` acquired nothing, and a failed transactional batch is
+/// atomic — it leaves nothing applied on either transport.
+async fn retry_while_busy<T, F, Fut>(mut op: F) -> Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T>>,
+{
+    const RETRY_FOR: Duration = Duration::from_secs(10);
+
+    let deadline = Instant::now() + RETRY_FOR;
+    let mut delay = Duration::from_millis(10);
+    loop {
+        match op().await {
+            Err(err) if err.is_serialization_failure() && Instant::now() < deadline => {
+                tokio::time::sleep(delay).await;
+                delay = (delay * 2).min(Duration::from_millis(250));
+            }
+            res => return res,
+        }
+    }
+}
+
+async fn exec_ddl(
+    conn: &AnyConn,
+    statements: impl IntoIterator<Item = impl AsRef<str>>,
+) -> Result<()> {
+    let stmts: Vec<(String, Vec<TursoValue>)> = statements
+        .into_iter()
+        .map(|sql| (sql.as_ref().to_string(), vec![]))
+        .collect();
+
+    retry_while_busy(|| conn.transactional_batch(&stmts)).await
+}
+
 #[derive(Debug, Clone)]
 enum TursoPath {
     File(PathBuf),
     InMemory,
+    /// A remote Turso Cloud database reached over HTTP ("serverless").
+    /// Holds the connection URL with any `authToken` query parameter
+    /// stripped.
+    #[cfg(feature = "serverless")]
+    Remote(String),
 }
 
 /// Driver builder options applied when opening a database.
@@ -125,6 +184,58 @@ struct BuilderOptions {
 
     #[cfg(feature = "sync")]
     sync_options: SyncBuilderOptions,
+
+    #[cfg(feature = "serverless")]
+    serverless_options: ServerlessBuilderOptions,
+}
+
+/// Options for a remote ("serverless") database, applied when the driver
+/// constructs a [`turso_serverless::Builder`].
+#[cfg(feature = "serverless")]
+#[derive(Default, Clone)]
+struct ServerlessBuilderOptions {
+    auth_token: Option<String>,
+    /// Overrides `auth_token` when set, mirroring the sync engine's
+    /// precedence.
+    auth_token_fn: Option<turso_serverless::AuthTokenFn>,
+    remote_encryption_key: Option<String>,
+}
+
+#[cfg(feature = "serverless")]
+impl BuilderOptions {
+    fn apply_serverless(&self, mut b: turso_serverless::Builder) -> turso_serverless::Builder {
+        let opts = &self.serverless_options;
+        if let Some(token_fn) = &opts.auth_token_fn {
+            let token_fn = token_fn.clone();
+            b = b.with_auth_token_fn(move || token_fn());
+        } else if let Some(token) = &opts.auth_token {
+            b = b.with_auth_token(token.clone());
+        }
+        if let Some(key) = &opts.remote_encryption_key {
+            b = b.with_remote_encryption_key(key.clone());
+        }
+        b
+    }
+}
+
+#[cfg(feature = "serverless")]
+impl fmt::Debug for ServerlessBuilderOptions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ServerlessBuilderOptions")
+            .field(
+                "auth_token",
+                &self.auth_token.as_ref().map(|_| "<redacted>"),
+            )
+            .field(
+                "auth_token_fn",
+                &self.auth_token_fn.as_ref().map(|_| "<callback>"),
+            )
+            .field(
+                "remote_encryption_key",
+                &self.remote_encryption_key.as_ref().map(|_| "<redacted>"),
+            )
+            .finish()
+    }
 }
 
 impl BuilderOptions {
@@ -155,8 +266,9 @@ struct LocalBuilderOptions {
 
 impl LocalBuilderOptions {
     /// Whether any local-engine option was configured. Used to reject
-    /// configurations that combine local-only options with sync mode.
-    #[cfg(feature = "sync")]
+    /// configurations that combine local-only options with a remote
+    /// engine (sync or serverless).
+    #[cfg(any(feature = "sync", feature = "serverless"))]
     fn any_set(&self) -> bool {
         self.encryption.is_some()
             || self.attach
@@ -355,13 +467,16 @@ pub struct Turso {
 }
 
 /// The engine behind a [`Turso`] driver, selected at runtime by the
-/// driver's configuration: the plain local engine, or (with the `sync`
-/// feature) the sync engine that replicates to a remote database.
+/// driver's configuration: the plain local engine, the sync engine that
+/// replicates to a remote database (`sync` feature), or a remote Turso
+/// Cloud database reached over HTTP (`serverless` feature).
 #[derive(Clone)]
 enum AnyDatabase {
     Local(Database),
     #[cfg(feature = "sync")]
     Sync(SyncDatabase),
+    #[cfg(feature = "serverless")]
+    Serverless(turso_serverless::Database),
 }
 
 impl Turso {
@@ -369,9 +484,25 @@ impl Turso {
     ///
     /// The URL scheme must be `turso` (e.g. `turso::memory:` or
     /// `turso:/path/to/db`).
+    ///
+    /// With the `serverless` feature, an authority-form URL with a host
+    /// selects a remote Turso Cloud database reached over HTTP:
+    /// `turso://my-db.turso.io` (the form `turso db show --url` prints).
+    /// The `libsql`, `https` and `http` schemes are also accepted for
+    /// remote URLs, and an `authToken` query parameter is honored as if
+    /// passed to [`Self::with_auth_token`] (and stripped from the URL the
+    /// driver stores and reports). Scheme-relative and path forms
+    /// (`turso:todos.db`, `turso:/path/to/db`) always name local files;
+    /// without the feature, authority form resolves to a file path as
+    /// well.
     pub fn new(url: impl Into<String>) -> Result<Self> {
         let url_str = url.into();
         let url = ConnectionUrl::parse(&url_str)?;
+
+        #[cfg(feature = "serverless")]
+        if let Some(driver) = Self::try_remote(&url) {
+            return Ok(driver);
+        }
 
         if !url.has_scheme("turso") {
             return Err(toasty_core::Error::invalid_connection_url(format!(
@@ -385,6 +516,35 @@ impl Turso {
         }
 
         Ok(Self::with_path(TursoPath::File(path)))
+    }
+
+    /// Builds a serverless driver when the connection URL names a remote
+    /// database: a remote scheme (`libsql`, `https`, `http`), or a
+    /// `turso` URL whose authority parses as a non-empty host. An
+    /// authority that is not host-shaped (for example `turso://:memory:`)
+    /// falls through to the file interpretation.
+    #[cfg(feature = "serverless")]
+    fn try_remote(url: &ConnectionUrl<'_>) -> Option<Self> {
+        let is_remote_scheme =
+            url.has_scheme("libsql") || url.has_scheme("https") || url.has_scheme("http");
+        let has_host = url.host().ok().flatten().is_some();
+        if !is_remote_scheme && !(url.has_scheme("turso") && has_host) {
+            return None;
+        }
+
+        let auth_token = url
+            .query_pairs()
+            .find(|(key, _)| key == "authToken")
+            .map(|(_, value)| value.into_owned());
+
+        let remote = url.as_str();
+        let remote = remote.split_once('?').map_or(remote, |(base, _)| base);
+
+        let mut driver = Self::with_path(TursoPath::Remote(remote.to_string()));
+        if let Some(token) = auth_token {
+            driver = driver.with_auth_token(token);
+        }
+        Some(driver)
     }
 
     /// Create an in-memory Turso database.
@@ -406,6 +566,28 @@ impl Turso {
             sync_mode: false,
             database: Arc::new(Mutex::new(None)),
         }
+    }
+
+    /// Whether a remote credential (auth token or remote encryption key)
+    /// is configured, under any feature.
+    fn has_remote_credentials(&self) -> bool {
+        #[cfg(feature = "sync")]
+        if self.options.sync_options.auth_token.is_some()
+            || self.options.sync_options.remote_encryption_key.is_some()
+        {
+            return true;
+        }
+        #[cfg(feature = "serverless")]
+        if self.options.serverless_options.auth_token.is_some()
+            || self
+                .options
+                .serverless_options
+                .remote_encryption_key
+                .is_some()
+        {
+            return true;
+        }
+        false
     }
 
     /// Whether this driver opens the sync engine.
@@ -450,6 +632,10 @@ impl Turso {
     /// [`TransactionMode`](toasty_core::driver::operation::TransactionMode):
     /// `Deferred` falls back to plain `BEGIN`, while `Immediate` and
     /// `Exclusive` issue `BEGIN IMMEDIATE` / `BEGIN EXCLUSIVE` respectively.
+    ///
+    /// On a serverless (Turso Cloud) database this is a no-op: those
+    /// databases are MVCC-native and transactions already run under
+    /// `BEGIN CONCURRENT` by default.
     pub fn concurrent_writes(mut self) -> Self {
         self.concurrent_writes = true;
         self
@@ -535,42 +721,70 @@ impl Turso {
         self
     }
 
-    /// Set a static authorization token for sync HTTP requests. Mirrors
-    /// `turso::sync::Builder::with_auth_token`.
+    /// Set a static authorization token for remote HTTP requests — sync
+    /// requests with the `sync` feature, statement execution against Turso
+    /// Cloud with the `serverless` feature. Mirrors
+    /// `turso::sync::Builder::with_auth_token` and
+    /// `turso_serverless::Builder::with_auth_token`.
     ///
     /// The token is sent as a `Bearer` header (without the prefix in this
-    /// argument). Overridden by [`Self::with_auth_token_fn`] if called later.
+    /// argument). With the `sync` feature, overridden by
+    /// [`Self::with_auth_token_fn`] if called later.
     ///
-    /// A token is a credential, not a mode request: it does not select the
-    /// sync engine by itself. Configuring a token on a driver that opens a
+    /// A token is a credential, not a mode request: it does not select an
+    /// engine by itself. Configuring a token on a driver that opens a
     /// plain local database is rejected when the database opens.
-    #[cfg(feature = "sync")]
+    #[cfg(any(feature = "sync", feature = "serverless"))]
     pub fn with_auth_token(mut self, token: impl Into<String>) -> Self {
         let token = token.into();
-        self.options.sync_options.auth_token = Some(Arc::new(move || {
+        #[cfg(feature = "sync")]
+        {
             let token = token.clone();
-            Box::pin(async move { Ok(token) })
-        }));
+            self.options.sync_options.auth_token = Some(Arc::new(move || {
+                let token = token.clone();
+                Box::pin(async move { Ok(token) })
+            }));
+        }
+        #[cfg(feature = "serverless")]
+        {
+            self.options.serverless_options.auth_token = Some(token);
+        }
         self
     }
 
     /// Set an async callback that produces an auth token on demand. Mirrors
-    /// `turso::sync::Builder::with_auth_token_fn`.
+    /// `turso::sync::Builder::with_auth_token_fn` and
+    /// `turso_serverless::Builder::with_auth_token_fn`.
     ///
     /// The callback runs before every HTTP request, so it can return a freshly
     /// rotated token (for example from a secrets manager or OAuth refresh). If
-    /// the callback returns an error, the in-flight sync operation fails with
+    /// the callback returns an error, the in-flight operation fails with
     /// that error.
     ///
-    /// Overrides any previously configured static token from
-    /// [`Self::with_auth_token`].
-    #[cfg(feature = "sync")]
+    /// Like [`Self::with_auth_token`], the callback is a credential, not a
+    /// mode request. Overrides any previously configured static token.
+    #[cfg(any(feature = "sync", feature = "serverless"))]
     pub fn with_auth_token_fn<F, Fut>(mut self, f: F) -> Self
     where
         F: Fn() -> Fut + Send + Sync + 'static,
         Fut: Future<Output = turso::Result<String>> + Send + 'static,
     {
-        self.options.sync_options.auth_token = Some(Arc::new(move || Box::pin(f())));
+        let f = Arc::new(f);
+        #[cfg(feature = "sync")]
+        {
+            let f = f.clone();
+            self.options.sync_options.auth_token = Some(Arc::new(move || Box::pin(f())));
+        }
+        #[cfg(feature = "serverless")]
+        {
+            self.options.serverless_options.auth_token_fn = Some(Arc::new(move || {
+                let f = f.clone();
+                Box::pin(async move {
+                    f().await
+                        .map_err(|e| turso_serverless::Error::Error(e.to_string()))
+                })
+            }));
+        }
         self
     }
 
@@ -613,16 +827,29 @@ impl Turso {
         self
     }
 
-    /// Set a base64-encoded encryption key for the remote Turso Cloud database.
-    /// Mirrors `turso::sync::Builder::with_remote_encryption_key`.
+    /// Set a base64-encoded encryption key for the remote Turso Cloud
+    /// database. Mirrors `turso::sync::Builder::with_remote_encryption_key`
+    /// and `turso_serverless::Builder::with_remote_encryption_key`.
     ///
-    /// The key is sent as the `x-turso-encryption-key` header on sync HTTP
-    /// requests. For deferred sync without an initial bootstrap, prefer
-    /// [`Self::with_remote_encryption`] so the cipher is set for correct
-    /// `reserved_bytes` calculation.
-    #[cfg(feature = "sync")]
+    /// The key is sent as the `x-turso-encryption-key` header on remote
+    /// HTTP requests — sync requests with the `sync` feature, statement
+    /// execution with the `serverless` feature. For deferred sync without
+    /// an initial bootstrap, prefer [`Self::with_remote_encryption`] so the
+    /// cipher is set for correct `reserved_bytes` calculation.
+    ///
+    /// Like [`Self::with_auth_token`], the key is a credential, not a mode
+    /// request.
+    #[cfg(any(feature = "sync", feature = "serverless"))]
     pub fn with_remote_encryption_key(mut self, base64_key: impl Into<String>) -> Self {
-        self.options.sync_options.remote_encryption_key = Some(base64_key.into());
+        let base64_key = base64_key.into();
+        #[cfg(feature = "sync")]
+        {
+            self.options.sync_options.remote_encryption_key = Some(base64_key.clone());
+        }
+        #[cfg(feature = "serverless")]
+        {
+            self.options.serverless_options.remote_encryption_key = Some(base64_key);
+        }
         self
     }
 
@@ -703,6 +930,8 @@ impl Turso {
         match &self.path {
             TursoPath::File(p) => p.to_str().unwrap_or(":memory:"),
             TursoPath::InMemory => ":memory:",
+            #[cfg(feature = "serverless")]
+            TursoPath::Remote(url) => url,
         }
     }
 
@@ -718,44 +947,69 @@ impl Turso {
             return Ok(db.clone());
         }
 
-        let db = if self.is_sync() {
-            #[cfg(feature = "sync")]
-            {
-                // The sync engine has no counterpart for the local
-                // experimental toggles; reject the combination instead of
-                // silently dropping options.
-                if self.options.local_options.any_set() {
+        let db = match &self.path {
+            #[cfg(feature = "serverless")]
+            TursoPath::Remote(url) => {
+                // Sync replicates a local file against a remote; a
+                // serverless URL leaves no local file to replicate. The
+                // combination is contradictory, not something to resolve
+                // by precedence.
+                if self.is_sync() {
                     return Err(toasty_core::Error::unsupported_feature(
-                        "local experimental options are not supported when the driver \
-                         is configured for sync",
+                        "the driver is configured for sync but the connection URL names \
+                         a remote Turso Cloud database; sync replicates a local file — \
+                         use a file path with with_remote_url() instead",
+                    ));
+                }
+                if self.options.local_options.any_set() || self.options.index_method {
+                    return Err(toasty_core::Error::unsupported_feature(
+                        "local experimental options are not supported for a serverless \
+                         (remote HTTP) database",
                     ));
                 }
                 let builder = self
                     .options
-                    .apply_sync(SyncBuilder::new_remote(self.path_str()));
-                AnyDatabase::Sync(builder.build().await.map_err(classify_turso_error)?)
+                    .apply_serverless(turso_serverless::Builder::new_remote(url.clone()));
+                AnyDatabase::Serverless(builder.build().await.map_err(classify_serverless_error)?)
             }
-            #[cfg(not(feature = "sync"))]
-            unreachable!("is_sync() is false without the `sync` feature")
-        } else {
-            // A credential (auth token, remote encryption key) is not a
-            // mode request, so it never selects an engine — but a
-            // credential on a plain local database is a configuration
-            // error, not something to drop silently.
-            #[cfg(feature = "sync")]
-            if self.options.sync_options.auth_token.is_some()
-                || self.options.sync_options.remote_encryption_key.is_some()
-            {
-                return Err(toasty_core::Error::unsupported_feature(
-                    "a remote credential (auth token or encryption key) is configured \
-                     but the driver opens a plain local database; add with_remote_url() \
-                     or with_sync() to sync",
-                ));
+            _ if self.is_sync() => {
+                #[cfg(feature = "sync")]
+                {
+                    // The sync engine has no counterpart for the local
+                    // experimental toggles; reject the combination instead of
+                    // silently dropping options.
+                    if self.options.local_options.any_set() {
+                        return Err(toasty_core::Error::unsupported_feature(
+                            "local experimental options are not supported when the driver \
+                             is configured for sync",
+                        ));
+                    }
+                    let builder = self
+                        .options
+                        .apply_sync(SyncBuilder::new_remote(self.path_str()));
+                    AnyDatabase::Sync(builder.build().await.map_err(classify_turso_error)?)
+                }
+                #[cfg(not(feature = "sync"))]
+                unreachable!("is_sync() is false without the `sync` feature")
             }
-            let builder = self
-                .options
-                .apply_local(Builder::new_local(self.path_str()));
-            AnyDatabase::Local(builder.build().await.map_err(classify_turso_error)?)
+            _ => {
+                // A credential (auth token, remote encryption key) is not
+                // a mode request, so it never selects an engine — but a
+                // credential on a plain local database is a configuration
+                // error, not something to drop silently.
+                if self.has_remote_credentials() {
+                    return Err(toasty_core::Error::unsupported_feature(
+                        "a remote credential (auth token or encryption key) is \
+                         configured but the driver opens a plain local database; a \
+                         credential requires a sync remote (with_remote_url() or \
+                         with_sync()) or a Turso Cloud connection URL",
+                    ));
+                }
+                let builder = self
+                    .options
+                    .apply_local(Builder::new_local(self.path_str()));
+                AnyDatabase::Local(builder.build().await.map_err(classify_turso_error)?)
+            }
         };
 
         *slot = Some(db.clone());
@@ -764,13 +1018,18 @@ impl Turso {
 
     /// Returns the sync engine handle for the sync-only operations
     /// ([`Self::push`], [`Self::pull`], ...). Errors when the driver is
-    /// not configured for sync.
+    /// not configured for sync — including when it points at a serverless
+    /// (remote HTTP) database, which has no local replica to sync.
     #[cfg(feature = "sync")]
     async fn sync_database(&self) -> Result<SyncDatabase> {
         match self.database().await? {
             AnyDatabase::Sync(db) => Ok(db),
             AnyDatabase::Local(_) => Err(toasty_core::Error::unsupported_feature(
                 "the driver is not configured for sync; call with_remote_url() or with_sync()",
+            )),
+            #[cfg(feature = "serverless")]
+            AnyDatabase::Serverless(_) => Err(toasty_core::Error::unsupported_feature(
+                "sync operations are not available for a serverless (remote HTTP) database",
             )),
         }
     }
@@ -792,6 +1051,8 @@ impl Driver for Turso {
         match &self.path {
             TursoPath::InMemory => Cow::Borrowed("turso::memory:"),
             TursoPath::File(path) => Cow::Owned(format!("turso:{}", path.display())),
+            #[cfg(feature = "serverless")]
+            TursoPath::Remote(url) => Cow::Borrowed(url),
         }
     }
 
@@ -801,28 +1062,47 @@ impl Driver for Turso {
 
     async fn connect(&self, cx: &ConnectContext) -> Result<Box<dyn toasty_core::Connection>> {
         let conn = match self.database().await? {
-            AnyDatabase::Local(db) => db.connect().map_err(classify_turso_error)?,
+            AnyDatabase::Local(db) => {
+                AnyConn::Embedded(db.connect().map_err(classify_turso_error)?)
+            }
             #[cfg(feature = "sync")]
-            AnyDatabase::Sync(db) => db.connect().await.map_err(classify_turso_error)?,
+            AnyDatabase::Sync(db) => {
+                AnyConn::Embedded(db.connect().await.map_err(classify_turso_error)?)
+            }
+            #[cfg(feature = "serverless")]
+            AnyDatabase::Serverless(db) => {
+                AnyConn::Serverless(db.connect().map_err(classify_serverless_error)?)
+            }
         };
 
-        if self.concurrent_writes {
+        if self.concurrent_writes && !conn.is_serverless() {
             // `PRAGMA journal_mode = ...` returns the new mode as a row; the
             // `execute` path errors with "unexpected row during execution"
             // on any pragma that emits one. Use `pragma_update` so the row
             // is consumed.
-            conn.pragma_update("journal_mode", "'mvcc'")
-                .await
-                .map_err(classify_turso_error)?;
+            //
+            // Serverless databases skip the pragma: Turso Cloud databases
+            // created with `--tursodb` are MVCC-native and the backend
+            // rejects the statement ("SQL not allowed"); `BEGIN CONCURRENT`
+            // alone provides the concurrent-writes semantics there.
+            conn.pragma_update("journal_mode", "'mvcc'").await?;
         }
+
+        // Serverless databases are MVCC-native (Turso Cloud, created with
+        // `--tursodb`), so transactions default to `BEGIN CONCURRENT` —
+        // the same semantics `concurrent_writes()` opts into for the
+        // embedded engine, which makes that flag a no-op here. Callers can
+        // still choose classic locking per transaction with
+        // `TransactionMode::Deferred`/`Immediate`/`Exclusive`.
+        let default_begin_sql = if conn.is_serverless() || self.concurrent_writes {
+            "BEGIN CONCURRENT"
+        } else {
+            "BEGIN"
+        };
 
         Ok(Box::new(Connection {
             conn,
-            default_begin_sql: if self.concurrent_writes {
-                "BEGIN CONCURRENT"
-            } else {
-                "BEGIN"
-            },
+            default_begin_sql,
             query_log: cx.query_log,
         }))
     }
@@ -839,6 +1119,37 @@ impl Driver for Turso {
     }
 
     async fn reset_db(&self) -> Result<()> {
+        // There is no file to delete on a remote database; drop every user
+        // table instead (indexes and triggers go down with their table).
+        #[cfg(feature = "serverless")]
+        if let TursoPath::Remote(_) = &self.path {
+            let AnyDatabase::Serverless(db) = self.database().await? else {
+                unreachable!("a Remote path always opens a serverless database");
+            };
+            let conn = AnyConn::Serverless(db.connect().map_err(classify_serverless_error)?);
+
+            // `__turso_%` covers tursodb-internal system tables (e.g.
+            // `__turso_internal_mvcc_meta`), which cannot be dropped.
+            let mut rows = conn
+                .query(
+                    "SELECT name FROM sqlite_master \
+                     WHERE type = 'table' \
+                       AND name NOT LIKE 'sqlite_%' \
+                       AND name NOT LIKE '\\_\\_turso\\_%' ESCAPE '\\'",
+                    vec![],
+                )
+                .await?;
+
+            let mut drops = vec![];
+            while let Some(row) = rows.next().await? {
+                if let TursoValue::Text(name) = row.get_value(0)? {
+                    drops.push(format!("DROP TABLE IF EXISTS \"{name}\""));
+                }
+            }
+
+            return exec_ddl(&conn, &drops).await;
+        }
+
         // Drop the cached Database so subsequent `connect()` calls open a
         // fresh one. For in-memory this is the only way to wipe state;
         // for file-backed databases the file is also removed below.
@@ -856,7 +1167,7 @@ impl Driver for Turso {
 
 /// An open connection to a Turso database.
 pub struct Connection {
-    conn: TursoConn,
+    conn: AnyConn,
     /// SQL to issue for [`TransactionMode::Default`]. Resolved by the
     /// driver at `connect()` time — either `"BEGIN"` for classic
     /// deferred locking, or `"BEGIN CONCURRENT"` when the driver was
@@ -905,52 +1216,38 @@ impl Connection {
             .map(|tv| value::to_turso(&tv.value))
             .collect();
 
-        let mut stmt: Statement = self
-            .conn
-            .prepare_cached(sql_str)
-            .await
-            .map_err(classify_turso_error)?;
+        let mut stmt = self.conn.prepare_cached(sql_str).await?;
 
         if matches!(ret, SqlReturn::Count) {
-            let count = stmt.execute(params).await.map_err(classify_turso_error)?;
+            let count = stmt.execute(params).await?;
 
             return Ok(ExecResponse::count(count as _));
         }
 
-        let mut rows = stmt.query(params).await.map_err(classify_turso_error)?;
+        let mut rows = stmt.query(params).await?;
 
         let mut values = vec![];
 
-        loop {
-            match rows.next().await {
-                Ok(Some(row)) => {
-                    let items = match &ret {
-                        SqlReturn::Count => unreachable!(),
-                        SqlReturn::Infer => {
-                            let mut items = vec![];
-                            for index in 0..row.column_count() {
-                                let turso_val =
-                                    row.get_value(index).map_err(classify_turso_error)?;
-                                items.push(value::from_turso_infer(turso_val));
-                            }
-                            items
-                        }
-                        SqlReturn::Types(ret_tys) => {
-                            let mut items = Vec::with_capacity(ret_tys.len());
-                            for (index, ret_ty) in ret_tys.iter().enumerate() {
-                                let turso_val =
-                                    row.get_value(index).map_err(classify_turso_error)?;
-                                items.push(value::from_turso(turso_val, ret_ty));
-                            }
-                            items
-                        }
-                    };
-
-                    values.push(stmt::ValueRecord::from_vec(items).into());
+        while let Some(row) = rows.next().await? {
+            let items = match &ret {
+                SqlReturn::Count => unreachable!(),
+                SqlReturn::Infer => {
+                    let mut items = vec![];
+                    for index in 0..row.column_count() {
+                        items.push(value::from_turso_infer(row.get_value(index)?));
+                    }
+                    items
                 }
-                Ok(None) => break,
-                Err(err) => return Err(classify_turso_error(err)),
-            }
+                SqlReturn::Types(ret_tys) => {
+                    let mut items = Vec::with_capacity(ret_tys.len());
+                    for (index, ret_ty) in ret_tys.iter().enumerate() {
+                        items.push(value::from_turso(row.get_value(index)?, ret_ty));
+                    }
+                    items
+                }
+            };
+
+            values.push(stmt::ValueRecord::from_vec(items).into());
         }
 
         log.rows(values.len() as u64);
@@ -991,10 +1288,18 @@ impl toasty_core::driver::Connection for Connection {
                 let sql_str =
                     sql::Serializer::sqlite_with_default_begin(&schema.db, self.default_begin_sql)
                         .serialize_transaction(&op);
-                self.conn
-                    .execute(&sql_str, ())
-                    .await
-                    .map_err(classify_turso_error)?;
+                // On serverless there is no server-side busy timeout, so a
+                // lock-taking BEGIN waits here instead of surfacing every
+                // transient conflict. Embedded connections keep fail-fast
+                // busy semantics.
+                if self.conn.is_serverless()
+                    && matches!(&op, Transaction::Start { .. })
+                    && sql_str.starts_with("BEGIN")
+                {
+                    retry_while_busy(|| self.conn.execute(&sql_str, vec![])).await?;
+                } else {
+                    self.conn.execute(&sql_str, vec![]).await?;
+                }
                 return Ok(ExecResponse::count(0));
             }
             _ => todo!("op={:#?}", op),
@@ -1011,44 +1316,32 @@ impl toasty_core::driver::Connection for Connection {
     }
 
     async fn push_schema(&mut self, schema: &Schema) -> Result<()> {
+        let mut statements = vec![];
         for table in &schema.db.tables {
             tracing::debug!(table = %table.name, "creating table");
-            for sql in create_table_stmts(&schema.db, table) {
-                self.conn
-                    .execute(&sql, ())
-                    .await
-                    .map_err(classify_turso_error)?;
-            }
+            statements.extend(create_table_stmts(&schema.db, table));
         }
 
-        Ok(())
+        exec_ddl(&self.conn, &statements).await
     }
 
     async fn applied_migrations(
         &mut self,
     ) -> Result<Vec<toasty_core::schema::db::AppliedMigration>> {
-        self.conn
-            .execute(CREATE_MIGRATIONS_TABLE, ())
-            .await
-            .map_err(classify_turso_error)?;
+        exec_ddl(&self.conn, [CREATE_MIGRATIONS_TABLE]).await?;
 
         let mut rows = self
             .conn
-            .query("SELECT id FROM __toasty_migrations ORDER BY applied_at", ())
-            .await
-            .map_err(classify_turso_error)?;
+            .query(
+                "SELECT id FROM __toasty_migrations ORDER BY applied_at",
+                vec![],
+            )
+            .await?;
 
         let mut migrations = vec![];
-        loop {
-            match rows.next().await {
-                Ok(Some(row)) => {
-                    let val = row.get_value(0).map_err(classify_turso_error)?;
-                    if let TursoValue::Integer(id) = val {
-                        migrations.push(toasty_core::schema::db::AppliedMigration::new(id as u64));
-                    }
-                }
-                Ok(None) => break,
-                Err(err) => return Err(classify_turso_error(err)),
+        while let Some(row) = rows.next().await? {
+            if let TursoValue::Integer(id) = row.get_value(0)? {
+                migrations.push(toasty_core::schema::db::AppliedMigration::new(id as u64));
             }
         }
 
@@ -1063,50 +1356,24 @@ impl toasty_core::driver::Connection for Connection {
     ) -> Result<()> {
         tracing::info!(id = id, name = %name, "applying migration");
 
-        self.conn
-            .execute(CREATE_MIGRATIONS_TABLE, ())
-            .await
-            .map_err(classify_turso_error)?;
-
-        self.conn
-            .execute("BEGIN", ())
-            .await
-            .map_err(classify_turso_error)?;
-
+        // The whole migration — DDL plus the parameterized bookkeeping
+        // INSERT — is one atomic transactional batch: a single HTTP
+        // request on the serverless transport.
+        let mut stmts: Vec<(String, Vec<TursoValue>)> =
+            vec![(CREATE_MIGRATIONS_TABLE.to_string(), vec![])];
         for statement in migration.statements() {
-            if let Err(e) = self
-                .conn
-                .execute(statement, ())
-                .await
-                .map_err(classify_turso_error)
-            {
-                let _ = self.conn.execute("ROLLBACK", ()).await;
-                return Err(e);
-            }
+            stmts.push((statement.to_string(), vec![]));
         }
+        stmts.push((
+            "INSERT INTO __toasty_migrations (id, name, applied_at) VALUES (?1, ?2, datetime('now'))"
+                .to_string(),
+            vec![
+                TursoValue::Integer(id as i64),
+                TursoValue::Text(name.to_string()),
+            ],
+        ));
 
-        if let Err(e) = self
-            .conn
-            .execute(
-                "INSERT INTO __toasty_migrations (id, name, applied_at) VALUES (?1, ?2, datetime('now'))",
-                vec![
-                    TursoValue::Integer(id as i64),
-                    TursoValue::Text(name.to_string()),
-                ],
-            )
-            .await
-            .map_err(classify_turso_error)
-        {
-            let _ = self.conn.execute("ROLLBACK", ()).await;
-            return Err(e);
-        }
-
-        self.conn
-            .execute("COMMIT", ())
-            .await
-            .map_err(classify_turso_error)?;
-
-        Ok(())
+        retry_while_busy(|| self.conn.transactional_batch(&stmts)).await
     }
 }
 
@@ -1161,6 +1428,59 @@ mod sync_mode_tests {
             driver.database().await.is_err(),
             "local experimental options must be rejected in sync mode"
         );
+    }
+}
+
+#[cfg(all(test, feature = "serverless"))]
+mod serverless_tests {
+    use super::{Turso, TursoPath};
+
+    /// An authority-form URL with a host selects a remote Turso Cloud
+    /// database — the form `turso db show --url` prints. The `libsql`
+    /// scheme is accepted as an alias; host-less forms keep resolving to
+    /// local files.
+    #[test]
+    fn new_url_with_host_is_remote() {
+        let driver = Turso::new("turso://my-db.aws-us-east-1.turso.io").unwrap();
+        assert!(matches!(
+            &driver.path,
+            TursoPath::Remote(url) if url == "turso://my-db.aws-us-east-1.turso.io"
+        ));
+
+        let driver = Turso::new("libsql://my-db.aws-us-east-1.turso.io").unwrap();
+        assert!(matches!(
+            &driver.path,
+            TursoPath::Remote(url) if url == "libsql://my-db.aws-us-east-1.turso.io"
+        ));
+
+        // Scheme-relative and path forms always name local files.
+        assert!(matches!(
+            Turso::new("turso:todos.db").unwrap().path,
+            TursoPath::File(path) if path == std::path::Path::new("todos.db")
+        ));
+        assert!(matches!(
+            Turso::new("turso:///tmp/db.sqlite").unwrap().path,
+            TursoPath::File(_)
+        ));
+        assert!(matches!(
+            Turso::new("turso://:memory:").unwrap().path,
+            TursoPath::InMemory
+        ));
+    }
+
+    /// An `authToken` query parameter is applied as the auth token and
+    /// must never leak — not through [`Driver::url`], not through `Debug`.
+    #[test]
+    fn new_extracts_and_strips_auth_token() {
+        use toasty_core::driver::Driver;
+
+        let driver = Turso::new("turso://my-db.turso.io?authToken=sekrit").unwrap();
+        assert_eq!(driver.url(), "turso://my-db.turso.io");
+        assert_eq!(
+            driver.options.serverless_options.auth_token.as_deref(),
+            Some("sekrit")
+        );
+        assert!(!format!("{driver:?}").contains("sekrit"));
     }
 }
 
@@ -1283,9 +1603,7 @@ mod sync_tests {
             super::AnyDatabase::Local(db) => {
                 db.connect().unwrap();
             }
-            super::AnyDatabase::Sync(_) => {
-                panic!("an unconfigured driver must open the local engine")
-            }
+            _ => panic!("an unconfigured driver must open the local engine"),
         }
 
         assert!(

--- a/crates/toasty-driver-turso/src/value.rs
+++ b/crates/toasty-driver-turso/src/value.rs
@@ -87,6 +87,33 @@ pub(crate) fn from_turso_infer(value: TursoValue) -> CoreValue {
     }
 }
 
+/// Converts a [`turso::Value`] to a [`turso_serverless::Value`]. The two
+/// enums are structurally identical (SQLite's five storage classes).
+#[cfg(feature = "serverless")]
+pub(crate) fn to_serverless(value: TursoValue) -> turso_serverless::Value {
+    use turso_serverless::Value as ServerlessValue;
+    match value {
+        TursoValue::Null => ServerlessValue::Null,
+        TursoValue::Integer(v) => ServerlessValue::Integer(v),
+        TursoValue::Real(v) => ServerlessValue::Real(v),
+        TursoValue::Text(v) => ServerlessValue::Text(v),
+        TursoValue::Blob(v) => ServerlessValue::Blob(v),
+    }
+}
+
+/// Converts a [`turso_serverless::Value`] to a [`turso::Value`].
+#[cfg(feature = "serverless")]
+pub(crate) fn from_serverless(value: turso_serverless::Value) -> TursoValue {
+    use turso_serverless::Value as ServerlessValue;
+    match value {
+        ServerlessValue::Null => TursoValue::Null,
+        ServerlessValue::Integer(v) => TursoValue::Integer(v),
+        ServerlessValue::Real(v) => TursoValue::Real(v),
+        ServerlessValue::Text(v) => TursoValue::Text(v),
+        ServerlessValue::Blob(v) => TursoValue::Blob(v),
+    }
+}
+
 fn value_to_json_text(value: &CoreValue) -> String {
     toasty_sql::json::to_string(value).expect("serialize document value to JSON")
 }

--- a/crates/toasty/Cargo.toml
+++ b/crates/toasty/Cargo.toml
@@ -24,6 +24,7 @@ rustls = ["toasty-driver-mysql?/rustls"]
 sqlite = ["dep:toasty-driver-sqlite"]
 turso = ["dep:toasty-driver-turso"]
 turso-sync = ["turso", "toasty-driver-turso?/sync"]
+turso-serverless = ["turso", "toasty-driver-turso?/serverless"]
 rust_decimal = [
 	"dep:rust_decimal",
 	"toasty-core/rust_decimal",

--- a/crates/toasty/Cargo.toml
+++ b/crates/toasty/Cargo.toml
@@ -23,6 +23,7 @@ postgresql = ["dep:toasty-driver-postgresql"]
 rustls = ["toasty-driver-mysql?/rustls"]
 sqlite = ["dep:toasty-driver-sqlite"]
 turso = ["dep:toasty-driver-turso"]
+turso-sync = ["turso", "toasty-driver-turso?/sync"]
 rust_decimal = [
 	"dep:rust_decimal",
 	"toasty-core/rust_decimal",

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -16,6 +16,7 @@ default = ["sqlite"]
 sql = ["sqlite", "mysql", "postgresql"]
 sqlite = ["toasty/sqlite", "dep:toasty-driver-sqlite"]
 turso = ["toasty/turso", "dep:toasty-driver-turso"]
+turso-sync = ["turso", "toasty/turso-sync"]
 mysql = [
     "toasty/mysql",
     "dep:toasty-driver-mysql",

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -17,6 +17,13 @@ sql = ["sqlite", "mysql", "postgresql"]
 sqlite = ["toasty/sqlite", "dep:toasty-driver-sqlite"]
 turso = ["toasty/turso", "dep:toasty-driver-turso"]
 turso-sync = ["turso", "toasty/turso-sync"]
+turso-serverless = [
+    "turso",
+    "toasty/turso-serverless",
+    "dep:turso_serverless",
+    "dep:reqwest",
+    "dep:serde_json",
+]
 mysql = [
     "toasty/mysql",
     "dep:toasty-driver-mysql",
@@ -46,6 +53,13 @@ toasty-driver-integration-suite.workspace = true
 # Database drivers
 toasty-driver-sqlite = { workspace = true, optional = true }
 toasty-driver-turso = { workspace = true, optional = true }
+turso_serverless = { workspace = true, optional = true }
+reqwest = { version = "0.13", default-features = false, features = [
+	"blocking",
+	"json",
+	"rustls",
+], optional = true }
+serde_json = { workspace = true, optional = true }
 toasty-driver-mysql = { workspace = true, optional = true }
 toasty-driver-postgresql = { workspace = true, optional = true }
 toasty-driver-dynamodb = { workspace = true, optional = true }

--- a/tests/tests/turso.rs
+++ b/tests/tests/turso.rs
@@ -297,11 +297,7 @@ async fn experimental_encryption_smoke() {
         hexkey: "0".repeat(64),
     };
 
-    let tmp = std::env::temp_dir().join(format!(
-        "toasty-turso-encryption-smoke-{}.db",
-        std::process::id()
-    ));
-    let _ = std::fs::remove_file(&tmp);
+    let tmp = temp_db_path("encryption-smoke");
 
     let db = toasty::Db::builder()
         .models(toasty::models!())
@@ -309,6 +305,91 @@ async fn experimental_encryption_smoke() {
         .await
         .unwrap();
     db.push_schema().await.unwrap();
+
+    let _ = std::fs::remove_file(&tmp);
+}
+
+/// A per-process temp database path, cleared of leftovers from prior runs.
+fn temp_db_path(tag: &str) -> std::path::PathBuf {
+    let tmp = std::env::temp_dir().join(format!("toasty-turso-{tag}-{}.db", std::process::id()));
+    let _ = std::fs::remove_file(&tmp);
+    tmp
+}
+
+#[derive(Debug, toasty::Model)]
+struct Secret {
+    #[key]
+    id: i64,
+    payload: String,
+}
+
+fn encryption_opts(hex_digit: &str) -> EncryptionOpts {
+    EncryptionOpts {
+        cipher: "aes256gcm".into(),
+        hexkey: hex_digit.repeat(64),
+    }
+}
+
+async fn open_encrypted(
+    path: &std::path::Path,
+    opts: EncryptionOpts,
+) -> toasty::Result<toasty::Db> {
+    toasty::Db::builder()
+        .models(toasty::models!(Secret))
+        .build(Turso::file(path).experimental_encryption(opts))
+        .await
+}
+
+/// Local at-rest encryption must actually round-trip: data written with a
+/// key is readable when reopening the file with the same key, and the
+/// file is unreadable without it. Pins the behavior so refactors of the
+/// driver's option handling cannot silently drop local encryption.
+#[tokio::test]
+async fn local_encryption_round_trip() {
+    let tmp = temp_db_path("encryption-roundtrip");
+
+    // Write with key A.
+    let mut db = open_encrypted(&tmp, encryption_opts("a")).await.unwrap();
+    db.push_schema().await.unwrap();
+    toasty::create!(Secret {
+        id: 1,
+        payload: "classified"
+    })
+    .exec(&mut db)
+    .await
+    .unwrap();
+    drop(db);
+
+    // Reopen with the same key: data must be readable.
+    let mut db = open_encrypted(&tmp, encryption_opts("a")).await.unwrap();
+    let read = Secret::get_by_id(&mut db, &1).await.unwrap();
+    assert_eq!(read.payload, "classified");
+    drop(db);
+
+    // Reopen with the wrong key: the database must be unreadable.
+    let wrong_key = async {
+        let mut db = open_encrypted(&tmp, encryption_opts("b")).await?;
+        Secret::get_by_id(&mut db, &1).await
+    }
+    .await;
+    assert!(
+        wrong_key.is_err(),
+        "the wrong key must not decrypt the database"
+    );
+
+    // Reopen with no key at all: the database must be unreadable.
+    let no_key = async {
+        let mut db = toasty::Db::builder()
+            .models(toasty::models!(Secret))
+            .build(Turso::file(&tmp))
+            .await?;
+        Secret::get_by_id(&mut db, &1).await
+    }
+    .await;
+    assert!(
+        no_key.is_err(),
+        "an encrypted database must not open without its key"
+    );
 
     let _ = std::fs::remove_file(&tmp);
 }

--- a/tests/tests/turso_serverless.rs
+++ b/tests/tests/turso_serverless.rs
@@ -1,0 +1,323 @@
+#![cfg(feature = "turso-serverless")]
+
+//! Runs the driver integration suite against Turso Cloud through the
+//! serverless (SQL over HTTP) mode of the Turso driver.
+//!
+//! Tests lease disposable databases (created through the Turso Platform
+//! API with `use_tursodb`) from a small pool: each database serves one
+//! test at a time, so no two tests ever share schema state concurrently,
+//! while the pool keeps platform API traffic to roughly one create per
+//! unit of parallelism instead of one per test. Leftover `toasty-t-*`
+//! databases from previous runs are destroyed when a run starts.
+//!
+//! ```console
+//! $ export TOASTY_TEST_TURSO_API_TOKEN=<platform token>
+//! $ export TOASTY_TEST_TURSO_ORG=<org slug>
+//! $ export TOASTY_TEST_TURSO_GROUP=<group>
+//! $ cargo test -p tests --features turso-serverless --test turso_serverless
+//! ```
+
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+static DB_COUNTER: AtomicU32 = AtomicU32::new(0);
+/// Databases returned by finished tests, ready for the next lease.
+static DB_POOL: std::sync::Mutex<Vec<DisposableDb>> = std::sync::Mutex::new(Vec::new());
+/// One bearer token authenticates to every database in the group; minted
+/// once per run to keep platform API traffic to a minimum.
+static GROUP_TOKEN: OnceLock<String> = OnceLock::new();
+/// Destroys leftovers from previous runs, once per process.
+static SWEEP: std::sync::Once = std::sync::Once::new();
+
+/// A pool lease: derefs to the database and returns it to the pool on
+/// drop — including on panic, since drops run during unwinding.
+struct DbLease(Option<DisposableDb>);
+
+impl std::ops::Deref for DbLease {
+    type Target = DisposableDb;
+    fn deref(&self) -> &DisposableDb {
+        self.0
+            .as_ref()
+            .expect("lease holds a database until dropped")
+    }
+}
+
+impl Drop for DbLease {
+    fn drop(&mut self) {
+        if let Some(db) = self.0.take() {
+            DB_POOL.lock().unwrap().push(db);
+        }
+    }
+}
+
+fn env(name: &str) -> String {
+    std::env::var(name)
+        .unwrap_or_else(|_| panic!("set {name} to run the serverless suite against Turso Cloud"))
+}
+
+/// Calls the Turso Platform API, retrying transient failures — including
+/// rate limiting, which needs a long cool-down — and returns the response
+/// body. Runs on a fresh thread so the blocking client works from within
+/// the tests' async runtimes.
+fn platform_api(method: &str, path: &str, body: Option<serde_json::Value>) -> serde_json::Value {
+    let url = format!(
+        "https://api.turso.tech/v1/organizations/{}/{path}",
+        env("TOASTY_TEST_TURSO_ORG")
+    );
+    let token = env("TOASTY_TEST_TURSO_API_TOKEN");
+    let method = method.to_string();
+    std::thread::spawn(move || {
+        let client = reqwest::blocking::Client::new();
+        let mut last = String::new();
+        for delay_ms in [0u64, 500, 2_000, 8_000, 20_000, 45_000] {
+            if delay_ms > 0 {
+                std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+            }
+            let mut req = client
+                .request(method.parse().unwrap(), &url)
+                .bearer_auth(&token);
+            if let Some(body) = &body {
+                req = req.json(body);
+            }
+            match req.send().and_then(|resp| resp.error_for_status()) {
+                Ok(resp) => {
+                    return resp.json().unwrap_or(serde_json::Value::Null);
+                }
+                Err(err) => last = err.to_string(),
+            }
+        }
+        panic!("{method} {url} failed: {last}");
+    })
+    .join()
+    .expect("platform API call panicked")
+}
+
+/// A disposable Turso Cloud database: created through the platform API,
+/// leased to one test at a time.
+struct DisposableDb {
+    url: String,
+    token: String,
+}
+
+impl DisposableDb {
+    /// Leases a database: reuses one returned by a finished test, or
+    /// creates a fresh one.
+    fn lease() -> DbLease {
+        SWEEP.call_once(|| {
+            let listing = platform_api("GET", "databases", None);
+            for db in listing["databases"].as_array().into_iter().flatten() {
+                if let Some(name) = db["Name"].as_str()
+                    && name.starts_with("toasty-t-")
+                {
+                    platform_api("DELETE", &format!("databases/{name}"), None);
+                }
+            }
+        });
+        let db = DB_POOL.lock().unwrap().pop().unwrap_or_else(Self::create);
+        DbLease(Some(db))
+    }
+
+    fn create() -> Self {
+        let name = format!(
+            "toasty-t-{}-{}",
+            std::process::id(),
+            DB_COUNTER.fetch_add(1, Ordering::Relaxed)
+        );
+        let created = platform_api(
+            "POST",
+            "databases",
+            Some(serde_json::json!({
+                "name": name,
+                "group": env("TOASTY_TEST_TURSO_GROUP"),
+                "use_tursodb": true,
+            })),
+        );
+        let hostname = created["database"]["Hostname"]
+            .as_str()
+            .unwrap_or_else(|| panic!("database creation returned no hostname: {created}"))
+            .to_string();
+        let token = GROUP_TOKEN
+            .get_or_init(|| {
+                let group = env("TOASTY_TEST_TURSO_GROUP");
+                platform_api("POST", &format!("groups/{group}/auth/tokens"), None)["jwt"]
+                    .as_str()
+                    .expect("group token mint returned no jwt")
+                    .to_string()
+            })
+            .clone();
+        Self {
+            url: format!("turso://{hostname}"),
+            token,
+        }
+    }
+
+    fn driver(&self) -> toasty_driver_turso::Turso {
+        toasty_driver_turso::Turso::new(&self.url)
+            .expect("failed to create Turso driver")
+            .with_auth_token(&self.token)
+    }
+
+    /// Connection URL carrying the token, for the `Db::builder().connect()`
+    /// entry-point tests.
+    fn connect_url(&self) -> String {
+        format!("{}?authToken={}", self.url, self.token)
+    }
+}
+
+struct TursoServerlessSetup {
+    db: OnceLock<DbLease>,
+}
+
+impl TursoServerlessSetup {
+    fn new() -> Self {
+        Self {
+            db: OnceLock::new(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl toasty_driver_integration_suite::Setup for TursoServerlessSetup {
+    fn driver(&self) -> Box<dyn toasty_core::driver::Driver> {
+        Box::new(self.db.get_or_init(DisposableDb::lease).driver())
+    }
+
+    /// Drops the test's (uniquely prefixed) tables so the database goes
+    /// back to the pool lean. Best effort: the lease guarantees nobody
+    /// else is using the database, and a missed drop only leaves an
+    /// unreferenced table behind.
+    async fn delete_table(&self, name: &str) {
+        let Some(db) = self.db.get() else { return };
+        let Ok(handle) = turso_serverless::Builder::new_remote(db.url.clone())
+            .with_auth_token(db.token.clone())
+            .build()
+            .await
+        else {
+            return;
+        };
+        if let Ok(conn) = handle.connect() {
+            let _ = conn
+                .execute(&format!("DROP TABLE IF EXISTS \"{name}\""), ())
+                .await;
+        }
+    }
+}
+
+// Generate all driver tests. Capability flags match the embedded Turso
+// setup in `turso.rs`: the cloud runs the same engine, only the transport
+// differs.
+toasty_driver_integration_suite::generate_driver_tests!(
+    TursoServerlessSetup::new(),
+    native_decimal: false,
+    bigdecimal_implemented: false,
+    decimal_arbitrary_precision: false,
+    native_timestamp: false,
+    native_date: false,
+    native_time: false,
+    native_datetime: false,
+    native_cidr: false,
+    native_inet: false,
+    native_macaddr: false,
+    native_macaddr8: false,
+    native_array: false,
+    native_ilike: false,
+    native_json: false,
+    native_jsonb: false,
+    native_enum: false,
+    unique_list_index: false,
+    vec_scalar: true,
+    vec_remove: false,
+    vec_pop: false,
+    vec_remove_at: false,
+    test_connection_pool: true,
+);
+
+#[derive(Debug, toasty::Model)]
+struct MvccCounter {
+    #[key]
+    id: i64,
+    tally: i64,
+}
+
+/// Integration-owned MVCC facts: the driver's serverless default runs
+/// transactions under `BEGIN CONCURRENT`, and a write-write conflict
+/// comes back classified as a retryable serialization failure. The
+/// engine's MVCC semantics themselves are turso's conformance suite's
+/// job, not ours.
+#[tokio::test]
+async fn mvcc_conflicts_classify_as_serialization_failures() {
+    let disposable = DisposableDb::lease();
+
+    let mut db = toasty::Db::builder()
+        .models(toasty::models!(MvccCounter))
+        .max_pool_size(4)
+        .build(disposable.driver())
+        .await
+        .unwrap();
+    db.push_schema().await.unwrap();
+    toasty::create!(MvccCounter { id: 1, tally: 0 })
+        .exec(&mut db)
+        .await
+        .unwrap();
+
+    let mut db_a = db.clone();
+    let mut db_b = db.clone();
+    let mut tx_a = db_a.transaction().await.unwrap();
+    let mut tx_b = db_b.transaction().await.unwrap();
+    MvccCounter::filter_by_id(1i64)
+        .update()
+        .tally(1)
+        .exec(&mut tx_a)
+        .await
+        .unwrap();
+    let conflict = async {
+        MvccCounter::filter_by_id(1i64)
+            .update()
+            .tally(2)
+            .exec(&mut tx_b)
+            .await?;
+        tx_b.commit().await
+    }
+    .await;
+    tx_a.commit().await.expect("winning commit must succeed");
+
+    let err = conflict.expect_err("colliding BEGIN CONCURRENT writers must conflict");
+    assert!(
+        err.is_serialization_failure(),
+        "expected serialization failure, got: {err}"
+    );
+}
+
+#[derive(Debug, toasty::Model)]
+struct SmokeItem {
+    #[key]
+    id: i64,
+    name: String,
+}
+
+/// The single entry point every backend uses: one connection URL into
+/// `Db::builder().connect()`. Scheme routing picks the Turso driver, the
+/// host selects serverless mode, and the `authToken` query parameter
+/// carries the credential. Everything past the connection is the
+/// generated suite's job.
+#[tokio::test]
+async fn connect_via_url_with_auth_token() {
+    let disposable = DisposableDb::lease();
+
+    let mut db = toasty::Db::builder()
+        .models(toasty::models!(SmokeItem))
+        .connect(&disposable.connect_url())
+        .await
+        .unwrap();
+    db.push_schema().await.unwrap();
+
+    toasty::create!(SmokeItem {
+        id: 1,
+        name: "hello"
+    })
+    .exec(&mut db)
+    .await
+    .unwrap();
+    let read = SmokeItem::get_by_id(&mut db, &1).await.unwrap();
+    assert_eq!(read.name, "hello");
+}


### PR DESCRIPTION
## Summary

Adds a serverless mode to the Turso driver: a connection URL with a host (`turso://my-db.turso.io`, also `libsql://`/`https://`) reaches Turso Cloud over HTTP via the `turso_serverless` crate, behind a `serverless` feature (`turso-serverless` on `toasty`). The entry point and the credential API (`with_auth_token`, rotating `with_auth_token_fn`, `with_remote_encryption_key`) are identical across local, sync, and serverless — same driver, different deployment option.

To make the modes compose, the `sync` feature is first refactored from a compile-time engine swap into an additive feature: both engines compile in and the driver's *configuration* selects one at runtime. Sync-protocol options select sync mode; credentials select nothing; contradictory configurations (sync options against a serverless URL, credentials on a plain local database) are rejected when the database opens.

Serverless specifics: Turso Cloud databases are MVCC-native, so transactions default to `BEGIN CONCURRENT` (`concurrent_writes()` becomes a no-op there) and write-write conflicts surface as retryable serialization failures. Schema pushes, migrations, and resets execute as single-request `BEGIN IMMEDIATE` transactional batches with client-side busy retry.

Testing: the full driver integration suite runs against Turso Cloud (797 tests, 16-way parallel), with every test leasing a disposable database created through the platform API so no two tests ever share schema state concurrently. CI runs the driver and embedded suite across all feature combinations — local only, no cloud dependency in CI.

## Type of change

- [x] Other: new driver capability plus a breaking driver-feature refactor, designed interactively with @glommer; no standalone design doc

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [ ] Touches a public API → a design doc under `docs/dev/design/` describes the behavior — *no design doc; the option-classification rules (mode-selecting vs credential), the runtime engine selection, and the serverless transaction defaults are documented in rustdoc and the commit messages. Can write one as a follow-up if wanted.*

## Notes for reviewers

- Best reviewed commit by commit; each of the four is self-contained: (1) pins local at-rest encryption behavior before anything moves, (2) the breaking sync refactor (`BREAKING CHANGE`: reopening a previously-synced file via on-disk metadata now requires `.with_sync()`), (3) serverless support, (4) the sync+serverless combined-mode matrix and CI coverage.
- The runtime dispatch (`conn.rs`) is enums, not trait objects: single-variant builds compile to zero overhead, and the serverless value conversions are discriminant remaps that move payloads (upstream's two structurally-identical value types force the bridge).
- Requires `turso_serverless >= 0.1.3` (transactional batches, rotating tokens, encryption header — all added upstream during this work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
