### PR TITLE
feat(core): accept borrowed values in JSON setters

### DIFF
--- a/crates/toasty/src/stmt/json.rs
+++ b/crates/toasty/src/stmt/json.rs
@@ -253,6 +253,55 @@ where
     }
 }
 
+/// Accept a borrowed `T` wherever the API expects `IntoExpr<Json<T>>`, so a
+/// caller that still needs the value afterwards doesn't have to clone it.
+/// The value is serialized out of the borrow.
+///
+/// This doesn't overlap the `IntoExpr<Json<T>> for T` blanket: unifying the
+/// two would require `T == &T`.
+impl<T> IntoExpr<Json<T>> for &T
+where
+    T: serde_core::Serialize,
+{
+    fn into_expr(self) -> Expr<Json<T>> {
+        json_expr(self)
+    }
+
+    fn by_ref(&self) -> Expr<Json<T>> {
+        json_expr(*self)
+    }
+}
+
+/// Same, for the explicit `Json(&value)` form.
+impl<T> IntoExpr<Json<T>> for Json<&T>
+where
+    T: serde_core::Serialize,
+{
+    fn into_expr(self) -> Expr<Json<T>> {
+        json_expr(self.0)
+    }
+
+    fn by_ref(&self) -> Expr<Json<T>> {
+        json_expr(self.0)
+    }
+}
+
+/// `Json(&value)` on an `Option<Json<T>>` field, mirroring the
+/// `IntoExpr<Option<T>> for T` blanket that lets the owned `Json(value)`
+/// skip the `Some(...)`.
+impl<T> IntoExpr<Option<Json<T>>> for Json<&T>
+where
+    T: serde_core::Serialize,
+{
+    fn into_expr(self) -> Expr<Option<Json<T>>> {
+        json_expr::<Json<T>>(self.0).cast()
+    }
+
+    fn by_ref(&self) -> Expr<Option<Json<T>>> {
+        json_expr::<Json<T>>(self.0).cast()
+    }
+}
+
 impl<T> super::assignment::Assign<Json<T>> for Json<T>
 where
     T: serde_core::Serialize,
@@ -274,6 +323,37 @@ where
 {
     fn into_assignment(self) -> super::assignment::Assignment<Json<T>> {
         super::set(<Self as IntoExpr<Json<T>>>::into_expr(self))
+    }
+}
+
+/// Mirrors the borrowed `IntoExpr` impls on the assignment side, so the
+/// update builders take a reference too.
+impl<T> super::assignment::Assign<Json<T>> for &T
+where
+    T: serde_core::Serialize,
+{
+    fn into_assignment(self) -> super::assignment::Assignment<Json<T>> {
+        super::set(<Self as IntoExpr<Json<T>>>::into_expr(self))
+    }
+}
+
+/// Same, for the explicit `Json(&value)` form.
+impl<T> super::assignment::Assign<Json<T>> for Json<&T>
+where
+    T: serde_core::Serialize,
+{
+    fn into_assignment(self) -> super::assignment::Assignment<Json<T>> {
+        super::set(<Self as IntoExpr<Json<T>>>::into_expr(self))
+    }
+}
+
+/// `Json(&value)` assigned to an `Option<Json<T>>` field.
+impl<T> super::assignment::Assign<Option<Json<T>>> for Json<&T>
+where
+    T: serde_core::Serialize,
+{
+    fn into_assignment(self) -> super::assignment::Assignment<Option<Json<T>>> {
+        super::set(<Self as IntoExpr<Option<Json<T>>>>::into_expr(self))
     }
 }
 

--- a/tests/tests/json_borrowed_setters.rs
+++ b/tests/tests/json_borrowed_setters.rs
@@ -1,0 +1,117 @@
+//! Borrowed JSON setters: `&value` and `Json(&value)` are accepted wherever
+//! the owned forms are, so a caller that still needs the value afterwards
+//! doesn't have to clone it.
+//!
+//! The borrowed impls serialize through the same path as the owned ones, so
+//! there is nothing driver-specific to check. What is worth checking is that
+//! each setter entry point resolves the borrowed impl at all — a compile-time
+//! property. One in-memory SQLite pass covers that and confirms the value
+//! actually round-trips.
+
+#![cfg(feature = "sqlite")]
+
+use toasty::{Deferred, Json};
+
+#[derive(Debug, toasty::Model)]
+struct Item {
+    #[key]
+    #[auto]
+    id: uuid::Uuid,
+
+    // set with `&value`
+    #[column(type = text)]
+    tags: Json<Vec<String>>,
+
+    // set with `Json(&value)`
+    #[column(type = text)]
+    extra: Json<Vec<String>>,
+
+    // nullable: takes `Json(&value)` for the same reason the owned form takes
+    // `Json(value)` — the `Some(...)` is optional, the wrapper is not.
+    #[column(type = text)]
+    data: Option<Json<Vec<String>>>,
+
+    // the borrowed setters resolve through `Deferred`'s expression target too
+    #[column(type = text)]
+    deferred: Deferred<Json<Vec<String>>>,
+}
+
+async fn setup() -> toasty::Db {
+    let db = toasty::Db::builder()
+        .models(toasty::models!(Item))
+        .build(toasty_driver_sqlite::Sqlite::in_memory())
+        .await
+        .unwrap();
+
+    db.push_schema().await.unwrap();
+    db
+}
+
+#[tokio::test]
+async fn borrowed_values_set_json_fields() {
+    let mut db = setup().await;
+
+    let one = vec!["rust".to_string(), "toasty".to_string()];
+    let two = vec!["b".to_string()];
+
+    // `create!`, then the create builder — both borrow the same value.
+    let record = toasty::create!(Item {
+        tags: &one,
+        extra: Json(&one),
+        data: Json(&one),
+        deferred: &one,
+    })
+    .exec(&mut db)
+    .await
+    .unwrap();
+    assert_stored(&mut db, &record.id, &one).await;
+    assert_eq!(record.deferred.get().0, one);
+
+    let mut record = Item::create()
+        .tags(&one)
+        .extra(Json(&one))
+        .data(Json(&one))
+        .deferred(Json(&one))
+        .exec(&mut db)
+        .await
+        .unwrap();
+    assert_stored(&mut db, &record.id, &one).await;
+    assert_eq!(record.deferred.get().0, one);
+
+    // Update builder, then `update!`.
+    record
+        .update()
+        .tags(&two)
+        .extra(Json(&two))
+        .data(Json(&two))
+        .deferred(&two)
+        .exec(&mut db)
+        .await
+        .unwrap();
+    assert_stored(&mut db, &record.id, &two).await;
+    assert_eq!(record.deferred.get().0, two);
+
+    toasty::update!(record {
+        tags: &one,
+        extra: Json(&one),
+        data: Json(&one),
+        deferred: Json(&one),
+    })
+    .exec(&mut db)
+    .await
+    .unwrap();
+    assert_stored(&mut db, &record.id, &one).await;
+    assert_eq!(record.deferred.get().0, one);
+
+    // The borrowed values outlive every setter that took them.
+    assert_eq!(one, vec!["rust".to_string(), "toasty".to_string()]);
+    assert_eq!(two, vec!["b".to_string()]);
+}
+
+async fn assert_stored(db: &mut toasty::Db, id: &uuid::Uuid, expected: &[String]) {
+    let read = Item::get_by_id(db, id).await.unwrap();
+
+    assert_eq!(read.tags.0, expected);
+    assert_eq!(read.extra.0, expected);
+    assert_eq!(read.data.unwrap().0, expected);
+}


### PR DESCRIPTION
## Summary
Implements the `IntoExpr` and `Assign` traits to support passing json values by reference.

Closes #1205

<!-- What does this change and why? Link the issue it closes. -->

## Type of change

<!-- Check one. -->

- [x] Small / obvious change — bug fix, docs, internal cleanup, or test
- [ ] Implements a previously accepted design
      (link to the merged design doc under `docs/dev/design/`):
- [ ] Roadmap entry + design doc (no implementation in this PR)
- [ ] Other (please explain):

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes
- [x] Touches a public API → a design doc under `docs/dev/design/` describes the behavior
- [x] Touches the `Driver` trait or driver-observable behavior → the design doc covers it

## Notes for reviewers
N/A