### PR TITLE
fix(toasty-core): resolve enum fields by variant-local index

### DIFF
--- a/crates/toasty-core/src/schema/app/schema.rs
+++ b/crates/toasty-core/src/schema/app/schema.rs
@@ -204,12 +204,14 @@ impl Schema {
                             current_field = s.fields.get(*step)?;
                         }
                         Model::EmbeddedEnum(e) => {
-                            let variant = e.variants.get(*step)?;
+                            let variant_index = *step;
+                            let variant = e.variants.get(variant_index)?;
 
                             // Check if there's a field index step after the variant
                             if let Some(field_step) = steps.next() {
-                                // Two steps: variant disc + field index → field
-                                current_field = e.fields.get(*field_step)?;
+                                // Local index within the variant, not into
+                                // `EmbeddedEnum::fields`.
+                                current_field = e.variant_fields(variant_index).nth(*field_step)?;
                             } else {
                                 // Single step: variant discriminant only → variant
                                 return Some(Resolved::Variant(variant));

--- a/crates/toasty-core/tests/schema_resolve_field.rs
+++ b/crates/toasty-core/tests/schema_resolve_field.rs
@@ -105,7 +105,7 @@ fn embedded_field(model: ModelId, index: usize, name: &str, target: ModelId) -> 
 /// Schema:
 ///   User { id, name, status: Status, contact: ContactInfo, address: Address }
 ///   Status = enum { Active(0), Inactive(1) }  (unit variants only)
-///   ContactInfo = enum { Email(0, fields: [address]), Phone(1, fields: [number]) }
+///   ContactInfo = enum { Email(0, fields: [address]), Phone(1, fields: [country_code, number]) }
 ///   Address = struct { street, city }
 fn schema() -> Schema {
     let status = Model::EmbeddedEnum(EmbeddedEnum {
@@ -150,7 +150,8 @@ fn schema() -> Schema {
         ],
         fields: vec![
             variant_field(CONTACT_ENUM, 0, "address", 0),
-            variant_field(CONTACT_ENUM, 1, "number", 1),
+            variant_field(CONTACT_ENUM, 1, "country_code", 1),
+            variant_field(CONTACT_ENUM, 2, "number", 1),
         ],
         indices: vec![],
     });
@@ -253,7 +254,7 @@ fn resolve_embedded_struct_field() {
     assert_eq!(field.name.app.as_deref(), Some("city"));
 }
 
-// === Embedded enum (data-carrying) — valid two-step projection ===
+// === Embedded enum (data-carrying) — field step is local to the variant ===
 
 #[test]
 fn resolve_data_enum_variant_field() {
@@ -266,7 +267,13 @@ fn resolve_data_enum_variant_field() {
         .unwrap();
     assert_eq!(field.name.app.as_deref(), Some("address"));
 
-    // User.contact -> Phone(disc=1) -> number(global index=1) => [3, 1, 1]
+    // Phone local 0 = country_code => [3, 1, 0]
+    let field = s
+        .resolve_field(root, &stmt::Projection::from([3, 1, 0]))
+        .unwrap();
+    assert_eq!(field.name.app.as_deref(), Some("country_code"));
+
+    // Phone local 1 = number => [3, 1, 1]
     let field = s
         .resolve_field(root, &stmt::Projection::from([3, 1, 1]))
         .unwrap();
@@ -321,6 +328,23 @@ fn resolve_enum_invalid_field_in_variant_returns_none() {
     // User.contact -> Email(disc=0) -> field 99 doesn't exist
     assert!(
         s.resolve_field(root, &stmt::Projection::from([3, 0, 99]))
+            .is_none()
+    );
+}
+
+// Field steps must not leak across variants: [3, 0, 1] is Email + Phone's
+// field, and [3, 1, 2] is past Phone's two locals.
+#[test]
+fn resolve_enum_field_index_is_variant_local() {
+    let s = schema();
+    let root = s.model(USER);
+
+    assert!(
+        s.resolve_field(root, &stmt::Projection::from([3, 0, 1]))
+            .is_none()
+    );
+    assert!(
+        s.resolve_field(root, &stmt::Projection::from([3, 1, 2]))
             .is_none()
     );
 }

--- a/crates/toasty/src/engine/lower/include.rs
+++ b/crates/toasty/src/engine/lower/include.rs
@@ -518,8 +518,8 @@ fn query_has_modifiers(query: &Option<stmt::Query>) -> bool {
 /// `PathRoot::Variant` chain into a discriminant-index step.
 ///
 /// The result uses LOCAL field indices for variant fields (matching the IR's
-/// `Match` arm record convention), not the GLOBAL `EmbeddedEnum::fields`
-/// indices used by `Schema::resolve`. Include lowering walks the IR shape,
+/// `Match` arm record convention and the local convention also used by
+/// `Schema::resolve`). Include lowering walks the IR shape,
 /// not the schema, so LOCAL is what `process_enum_arms` needs.
 fn flatten_path(path: &stmt::Path) -> stmt::Projection {
     let mut acc = stmt::Projection::identity();


### PR DESCRIPTION
## Summary

`Schema::resolve` reads the field step after an enum variant as a global index into `EmbeddedEnum::fields`. The rest of the codebase uses a local index within the variant. This PR switches `resolve` to `variant_fields(variant).nth(local)`.

```rust
struct User {
    id: i64, // 0
    name: String, // 1
    status: Status, // 2
    contact: ContactInfo, // 3
}
enum ContactInfo {
    Email { address: String }, // variant 0
    Phone { country_code: String, number: String }, // variant 1
}

// before
assert_eq!(
    s.resolve_field(root, &Projection::from([3, 0, 1])).unwrap().name.app.as_deref(),
    Some("country_code")
);

// after
assert!(s.resolve_field(root, &Projection::from([3, 0, 1])).is_none());

```
## Type of change

- [x] Small / obvious change: bug fix, docs, internal cleanup, or test

## Checklist

- [x] PR title uses [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `cargo fmt` and `cargo clippy` are clean
- [x] `cargo test` passes